### PR TITLE
fix: 增加写入超时时间支持大请求体

### DIFF
--- a/src/api/handlers/base/chat_handler_base.py
+++ b/src/api/handlers/base/chat_handler_base.py
@@ -452,7 +452,7 @@ class ChatHandlerBase(BaseMessageHandler, ABC):
         timeout_config = httpx.Timeout(
             connect=10.0,
             read=float(endpoint.timeout),
-            write=10.0,
+            write=60.0,  # 写入超时增加到60秒，支持大请求体（如包含图片的长对话）
             pool=10.0,
         )
 

--- a/src/api/handlers/base/cli_handler_base.py
+++ b/src/api/handlers/base/cli_handler_base.py
@@ -505,7 +505,7 @@ class CliMessageHandlerBase(BaseMessageHandler):
         timeout_config = httpx.Timeout(
             connect=10.0,
             read=float(endpoint.timeout),
-            write=10.0,
+            write=60.0,  # 写入超时增加到60秒，支持大请求体（如包含图片的长对话）
             pool=10.0,
         )
 

--- a/src/clients/http_client.py
+++ b/src/clients/http_client.py
@@ -42,7 +42,7 @@ class HTTPClientPool:
                 timeout=httpx.Timeout(
                     connect=10.0,  # 连接超时
                     read=300.0,  # 读取超时(5分钟,适合流式响应)
-                    write=10.0,  # 写入超时
+                    write=60.0,  # 写入超时(60秒,支持大请求体)
                     pool=5.0,  # 连接池超时
                 ),
                 limits=httpx.Limits(


### PR DESCRIPTION
- 将 chat_handler_base 的写入超时从 10 秒增加到 60 秒
- 将 cli_handler_base 的写入超时从 10 秒增加到 60 秒
- 将 http_client 的写入超时从 10 秒增加到 60 秒
- 支持包含大量数据（如图片）的长对话请求