### PR TITLE
fix: 修复个人设置页面深色模式切换后刷新失效的问题

### DIFF
--- a/src/services/user/preference.py
+++ b/src/services/user/preference.py
@@ -71,8 +71,8 @@ class PreferenceService:
                 raise NotFoundException("Provider not found or inactive")
             preferences.default_provider_id = default_provider_id
         if theme is not None:
-            if theme not in ["light", "dark", "auto"]:
-                raise ValueError("Invalid theme. Must be 'light', 'dark', or 'auto'")
+            if theme not in ["light", "dark", "auto", "system"]:
+                raise ValueError("Invalid theme. Must be 'light', 'dark', 'auto', or 'system'")
             preferences.theme = theme
         if language is not None:
             preferences.language = language


### PR DESCRIPTION
- 前端使用 useDarkMode composable 统一主题切换逻辑
- 后端支持 system 主题值（之前只支持 auto）
- 主题以本地 localStorage 为准，避免刷新时被服务端旧值覆盖

Fixes #22