### PR TITLE
fix(api): 优化字节流迭代器以支持自动解压 gzip

### DIFF
--- a/src/api/handlers/base/cli_handler_base.py
+++ b/src/api/handlers/base/cli_handler_base.py
@@ -474,8 +474,8 @@ class CliMessageHandlerBase(BaseMessageHandler):
 
             stream_response.raise_for_status()
 
-            # 使用字节流迭代器（避免 aiter_lines 的性能问题）
-            byte_iterator = stream_response.aiter_raw()
+            # 使用字节流迭代器（避免 aiter_lines 的性能问题, aiter_bytes 会自动解压 gzip/deflate）
+            byte_iterator = stream_response.aiter_bytes()
 
             # 预读第一个数据块，检测嵌套错误（HTTP 200 但响应体包含错误）
             prefetched_chunks = await self._prefetch_and_check_embedded_error(
@@ -529,7 +529,7 @@ class CliMessageHandlerBase(BaseMessageHandler):
             # 检查是否需要格式转换
             needs_conversion = self._needs_format_conversion(ctx)
 
-            async for chunk in stream_response.aiter_raw():
+            async for chunk in stream_response.aiter_bytes():
                 # 在第一次输出数据前更新状态为 streaming
                 if not streaming_status_updated:
                     self._update_usage_to_streaming_with_ctx(ctx)


### PR DESCRIPTION
httpx 在流式模式下，使用 `aiter_raw()` 时，返回的是原始字节，不会自动处理 gzip
会导致部分服务商出错：
```log
提供商 'Privnode' 返回空流式响应 (收到 43 个非数据行), 可能是 endpoint base_url 配置错误
```
将 `aiter_raw()` 改为 `aiter_bytes()`，即可解决