### PR TITLE
feat(模型映射): 添加上游模型映射状态标记

### DIFF
--- a/frontend/src/api/endpoints/types.ts
+++ b/frontend/src/api/endpoints/types.ts
@@ -527,6 +527,7 @@ export interface UpstreamModel {
   owned_by?: string
   display_name?: string
   api_format?: string
+  mapped?: boolean
 }
 
 /**

--- a/frontend/src/features/providers/components/BatchAssignModelsDialog.vue
+++ b/frontend/src/features/providers/components/BatchAssignModelsDialog.vue
@@ -217,9 +217,18 @@
                         @click.stop
                       />
                       <div class="flex-1 min-w-0">
-                        <p class="font-medium text-sm truncate">
-                          {{ model.id }}
-                        </p>
+                        <div class="flex items-center gap-2">
+                          <p class="font-medium text-sm truncate">
+                            {{ model.id }}
+                          </p>
+                          <span
+                            v-if="model.mapped"
+                            class="shrink-0 px-1.5 py-0.5 text-xs rounded bg-primary/10 text-primary border border-primary/20"
+                            title="此模型已被映射"
+                          >
+                            已映射
+                          </span>
+                        </div>
                         <p class="text-xs text-muted-foreground truncate font-mono">
                           {{ model.owned_by || model.id }}
                         </p>

--- a/frontend/src/features/providers/components/ModelMappingDialog.vue
+++ b/frontend/src/features/providers/components/ModelMappingDialog.vue
@@ -158,9 +158,18 @@
                       :title="model.id"
                     >
                       <div class="flex-1 min-w-0">
-                        <p class="font-medium text-sm truncate">
-                          {{ model.id }}
-                        </p>
+                        <div class="flex items-center gap-2">
+                          <p class="font-medium text-sm truncate">
+                            {{ model.id }}
+                          </p>
+                          <span
+                            v-if="model.mapped"
+                            class="shrink-0 px-1.5 py-0.5 text-xs rounded bg-primary/10 text-primary border border-primary/20"
+                            title="此模型已被映射"
+                          >
+                            已映射
+                          </span>
+                        </div>
                         <p class="text-xs text-muted-foreground truncate font-mono">
                           {{ model.owned_by || model.id }}
                         </p>


### PR DESCRIPTION
- 在模型查询接口中添加 mapped 字段标识模型是否已被映射
- 在前后端界面中显示模型映射状态标签

关闭#52

| 图片1 | 图片2 | 描述 |
|-------|-------|------|
| <img height="150" alt="图片1" src="https://github.com/user-attachments/assets/1c18e5f8-e40a-46a2-a56f-0d138d7ed7d5" /> | <img height="150" alt="图片2" src="https://github.com/user-attachments/assets/201e7ffb-1d53-4158-98db-ebcc9ed0a440" /> | 示例图片 |