### PR TITLE
feat(models): sort models by release date within each provider

### DIFF
--- a/frontend/src/api/models-dev.ts
+++ b/frontend/src/api/models-dev.ts
@@ -192,10 +192,17 @@ export async function getModelsDevList(officialOnly: boolean = true): Promise<Mo
       }
     }
 
-    // 按 provider 名称和模型名称排序
+    // 按 provider 名称排序，provider 中的模型按 release_date 从近到远排序
     items.sort((a, b) => {
       const providerCompare = a.providerName.localeCompare(b.providerName)
       if (providerCompare !== 0) return providerCompare
+      
+      // 模型按 release_date 从近到远排序（没有日期的排到最后）
+      const aDate = a.releaseDate ? new Date(a.releaseDate).getTime() : 0
+      const bDate = b.releaseDate ? new Date(b.releaseDate).getTime() : 0
+      if (aDate !== bDate) return bDate - aDate // 降序：新的在前
+      
+      // 日期相同或都没有日期时，按模型名称排序
       return a.modelName.localeCompare(b.modelName)
     })
 


### PR DESCRIPTION
#67 
Models are now sorted by release date in descending order (newest first) within each provider group. Models without release dates are placed at the end. When release dates are identical or missing, models fall back to alphabetical sorting by name.