### PR TITLE
perf: 优化 HTTP 客户端连接池复用

### DIFF
--- a/src/clients/http_client.py
+++ b/src/clients/http_client.py
@@ -1,16 +1,50 @@
 """
 全局HTTP客户端池管理
 避免每次请求都创建新的AsyncClient,提高性能
+
+性能优化说明：
+1. 默认客户端：无代理场景，全局复用单一客户端
+2. 代理客户端缓存：相同代理配置复用同一客户端，避免重复创建
+3. 连接池复用：Keep-alive 连接减少 TCP 握手开销
 """
 
+import asyncio
+import hashlib
+import time
 from contextlib import asynccontextmanager
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 from urllib.parse import quote, urlparse
 
 import httpx
 
 from src.config import config
 from src.core.logger import logger
+
+# 模块级锁，避免类属性延迟初始化的竞态条件
+_proxy_clients_lock = asyncio.Lock()
+_default_client_lock = asyncio.Lock()
+
+
+def _compute_proxy_cache_key(proxy_config: Optional[Dict[str, Any]]) -> str:
+    """
+    计算代理配置的缓存键
+
+    Args:
+        proxy_config: 代理配置字典
+
+    Returns:
+        缓存键字符串，无代理时返回 "__no_proxy__"
+    """
+    if not proxy_config:
+        return "__no_proxy__"
+
+    # 构建代理 URL 作为缓存键的基础
+    proxy_url = build_proxy_url(proxy_config)
+    if not proxy_url:
+        return "__no_proxy__"
+
+    # 使用 MD5 哈希来避免过长的键名
+    return f"proxy:{hashlib.md5(proxy_url.encode()).hexdigest()[:16]}"
 
 
 def build_proxy_url(proxy_config: Dict[str, Any]) -> Optional[str]:
@@ -61,11 +95,20 @@ class HTTPClientPool:
     全局HTTP客户端池单例
 
     管理可重用的httpx.AsyncClient实例,避免频繁创建/销毁连接
+
+    性能优化：
+    1. 默认客户端：无代理场景复用
+    2. 代理客户端缓存：相同代理配置复用同一客户端
+    3. LRU 淘汰：代理客户端超过上限时淘汰最久未使用的
     """
 
     _instance: Optional["HTTPClientPool"] = None
     _default_client: Optional[httpx.AsyncClient] = None
     _clients: Dict[str, httpx.AsyncClient] = {}
+    # 代理客户端缓存：{cache_key: (client, last_used_time)}
+    _proxy_clients: Dict[str, Tuple[httpx.AsyncClient, float]] = {}
+    # 代理客户端缓存上限（避免内存泄漏）
+    _max_proxy_clients: int = 50
 
     def __new__(cls):
         if cls._instance is None:
@@ -73,11 +116,49 @@ class HTTPClientPool:
         return cls._instance
 
     @classmethod
-    def get_default_client(cls) -> httpx.AsyncClient:
+    async def get_default_client_async(cls) -> httpx.AsyncClient:
         """
-        获取默认的HTTP客户端
+        获取默认的HTTP客户端（异步线程安全版本）
 
         用于大多数HTTP请求,具有合理的默认配置
+        """
+        if cls._default_client is not None:
+            return cls._default_client
+
+        async with _default_client_lock:
+            # 双重检查，避免重复创建
+            if cls._default_client is None:
+                cls._default_client = httpx.AsyncClient(
+                    http2=False,  # 暂时禁用HTTP/2以提高兼容性
+                    verify=True,  # 启用SSL验证
+                    timeout=httpx.Timeout(
+                        connect=config.http_connect_timeout,
+                        read=config.http_read_timeout,
+                        write=config.http_write_timeout,
+                        pool=config.http_pool_timeout,
+                    ),
+                    limits=httpx.Limits(
+                        max_connections=config.http_max_connections,
+                        max_keepalive_connections=config.http_keepalive_connections,
+                        keepalive_expiry=config.http_keepalive_expiry,
+                    ),
+                    follow_redirects=True,  # 跟随重定向
+                )
+                logger.info(
+                    f"全局HTTP客户端池已初始化: "
+                    f"max_connections={config.http_max_connections}, "
+                    f"keepalive={config.http_keepalive_connections}, "
+                    f"keepalive_expiry={config.http_keepalive_expiry}s"
+                )
+        return cls._default_client
+
+    @classmethod
+    def get_default_client(cls) -> httpx.AsyncClient:
+        """
+        获取默认的HTTP客户端（同步版本，向后兼容）
+
+        ⚠️ 注意：此方法在高并发首次调用时可能存在竞态条件，
+        推荐使用 get_default_client_async() 异步版本。
         """
         if cls._default_client is None:
             cls._default_client = httpx.AsyncClient(
@@ -136,6 +217,101 @@ class HTTPClientPool:
         return cls._clients[name]
 
     @classmethod
+    def _get_proxy_clients_lock(cls) -> asyncio.Lock:
+        """获取代理客户端缓存锁（模块级单例，避免竞态条件）"""
+        return _proxy_clients_lock
+
+    @classmethod
+    async def _evict_lru_proxy_client(cls) -> None:
+        """淘汰最久未使用的代理客户端"""
+        if len(cls._proxy_clients) < cls._max_proxy_clients:
+            return
+
+        # 找到最久未使用的客户端
+        oldest_key = min(cls._proxy_clients.keys(), key=lambda k: cls._proxy_clients[k][1])
+        old_client, _ = cls._proxy_clients.pop(oldest_key)
+
+        # 异步关闭旧客户端
+        try:
+            await old_client.aclose()
+            logger.debug(f"淘汰代理客户端: {oldest_key}")
+        except Exception as e:
+            logger.warning(f"关闭代理客户端失败: {e}")
+
+    @classmethod
+    async def get_proxy_client(
+        cls,
+        proxy_config: Optional[Dict[str, Any]] = None,
+    ) -> httpx.AsyncClient:
+        """
+        获取代理客户端（带缓存复用）
+
+        相同代理配置会复用同一个客户端，大幅减少连接建立开销。
+        注意：返回的客户端使用默认超时配置，如需自定义超时请在请求时传递 timeout 参数。
+
+        Args:
+            proxy_config: 代理配置字典，包含 url, username, password
+
+        Returns:
+            可复用的 httpx.AsyncClient 实例
+        """
+        cache_key = _compute_proxy_cache_key(proxy_config)
+
+        # 无代理时返回默认客户端
+        if cache_key == "__no_proxy__":
+            return await cls.get_default_client_async()
+
+        lock = cls._get_proxy_clients_lock()
+        async with lock:
+            # 检查缓存
+            if cache_key in cls._proxy_clients:
+                client, _ = cls._proxy_clients[cache_key]
+                # 健康检查：如果客户端已关闭，移除并重新创建
+                if client.is_closed:
+                    del cls._proxy_clients[cache_key]
+                    logger.debug(f"代理客户端已关闭，将重新创建: {cache_key}")
+                else:
+                    # 更新最后使用时间
+                    cls._proxy_clients[cache_key] = (client, time.time())
+                    return client
+
+            # 淘汰旧客户端（如果超过上限）
+            await cls._evict_lru_proxy_client()
+
+            # 创建新客户端（使用默认超时，请求时可覆盖）
+            client_config: Dict[str, Any] = {
+                "http2": False,
+                "verify": True,
+                "follow_redirects": True,
+                "limits": httpx.Limits(
+                    max_connections=config.http_max_connections,
+                    max_keepalive_connections=config.http_keepalive_connections,
+                    keepalive_expiry=config.http_keepalive_expiry,
+                ),
+                "timeout": httpx.Timeout(
+                    connect=config.http_connect_timeout,
+                    read=config.http_read_timeout,
+                    write=config.http_write_timeout,
+                    pool=config.http_pool_timeout,
+                ),
+            }
+
+            # 添加代理配置
+            proxy_url = build_proxy_url(proxy_config) if proxy_config else None
+            if proxy_url:
+                client_config["proxy"] = proxy_url
+
+            client = httpx.AsyncClient(**client_config)
+            cls._proxy_clients[cache_key] = (client, time.time())
+
+            logger.debug(
+                f"创建代理客户端(缓存): {proxy_config.get('url', 'unknown') if proxy_config else 'none'}, "
+                f"缓存数量: {len(cls._proxy_clients)}"
+            )
+
+            return client
+
+    @classmethod
     async def close_all(cls):
         """关闭所有HTTP客户端"""
         if cls._default_client is not None:
@@ -148,6 +324,16 @@ class HTTPClientPool:
             logger.debug(f"命名HTTP客户端已关闭: {name}")
 
         cls._clients.clear()
+
+        # 关闭代理客户端缓存
+        for cache_key, (client, _) in cls._proxy_clients.items():
+            try:
+                await client.aclose()
+                logger.debug(f"代理客户端已关闭: {cache_key}")
+            except Exception as e:
+                logger.warning(f"关闭代理客户端失败: {e}")
+
+        cls._proxy_clients.clear()
         logger.info("所有HTTP客户端已关闭")
 
     @classmethod
@@ -190,13 +376,15 @@ class HTTPClientPool:
         """
         创建带代理配置的HTTP客户端
 
+        ⚠️ 性能警告：此方法每次都创建新客户端，推荐使用 get_proxy_client() 复用连接。
+
         Args:
             proxy_config: 代理配置字典，包含 url, username, password
             timeout: 超时配置
             **kwargs: 其他 httpx.AsyncClient 配置参数
 
         Returns:
-            配置好的 httpx.AsyncClient 实例
+            配置好的 httpx.AsyncClient 实例（调用者需要负责关闭）
         """
         client_config: Dict[str, Any] = {
             "http2": False,
@@ -218,10 +406,20 @@ class HTTPClientPool:
         proxy_url = build_proxy_url(proxy_config) if proxy_config else None
         if proxy_url:
             client_config["proxy"] = proxy_url
-            logger.debug(f"创建带代理的HTTP客户端: {proxy_config.get('url', 'unknown')}")
+            logger.debug(f"创建带代理的HTTP客户端(一次性): {proxy_config.get('url', 'unknown')}")
 
         client_config.update(kwargs)
         return httpx.AsyncClient(**client_config)
+
+    @classmethod
+    def get_pool_stats(cls) -> Dict[str, Any]:
+        """获取连接池统计信息"""
+        return {
+            "default_client_active": cls._default_client is not None,
+            "named_clients_count": len(cls._clients),
+            "proxy_clients_count": len(cls._proxy_clients),
+            "max_proxy_clients": cls._max_proxy_clients,
+        }
 
 
 # 便捷访问函数


### PR DESCRIPTION
## Summary
- 新增 `get_proxy_client()` 方法，相同代理配置复用同一客户端，减少连接建立开销
- 添加 LRU 淘汰策略，代理客户端上限 50 个防止内存泄漏
- 新增 `get_default_client_async()` 异步线程安全版本，使用双重检查锁定
- 优化 `ConcurrencyManager` 使用 Redis MGET 批量获取，减少网络往返

## Changes
| 文件 | 变更 |
|------|------|
| `http_client.py` | 新增代理客户端缓存池、LRU 淘汰、统计接口 |
| `chat_handler_base.py` | 使用 `get_proxy_client()` 复用连接 |
| `cli_handler_base.py` | 使用 `get_proxy_client()` 复用连接 |
| `concurrency_manager.py` | Redis MGET 批量优化 |

## Test plan
- [ ] 验证无代理场景正常工作
- [ ] 验证有代理场景连接复用
- [ ] 验证高并发下无竞态条件
- [ ] 验证 LRU 淘汰逻辑正确