### PR TITLE
feat(ui): add inline editing for API key rate multipliers

### DIFF
--- a/frontend/src/features/providers/components/ProviderDetailDrawer.vue
+++ b/frontend/src/features/providers/components/ProviderDetailDrawer.vue
@@ -321,7 +321,23 @@
                         :key="format"
                       >
                         <span v-if="idx > 0" class="text-muted-foreground/40">/</span>
-                        <span>{{ API_FORMAT_SHORT[format] || format }} {{ getKeyRateMultiplier(key, format) }}x</span>
+                        <span>{{ API_FORMAT_SHORT[format] || format }} </span>
+                        <span
+                          v-if="editingMultiplierKey !== key.id || editingMultiplierFormat !== format"
+                          title="点击编辑倍率"
+                          class="cursor-pointer hover:text-primary hover:underline"
+                          @click="startEditMultiplier(key, format)"
+                        >{{ getKeyRateMultiplier(key, format) }}x</span>
+                        <input
+                          v-else
+                          ref="multiplierInputRef"
+                          v-model="editingMultiplierValue"
+                          type="text"
+                          inputmode="decimal"
+                          class="w-10 h-5 px-1 text-[11px] text-center border rounded bg-background focus:outline-none focus:ring-1 focus:ring-primary"
+                          @keydown="(e) => handleMultiplierKeydown(e, key, format)"
+                          @blur="handleMultiplierBlur(key, format)"
+                        >
                       </template>
                       <span v-if="key.rate_limit">| {{ key.rate_limit }}rpm</span>
                       <span
@@ -604,6 +620,13 @@ const editingPriorityKey = ref<string | null>(null)
 const editingPriorityValue = ref<number>(0)
 const priorityInputRef = ref<HTMLInputElement[] | null>(null)
 const prioritySaving = ref(false)
+
+// 点击编辑倍率相关状态
+const editingMultiplierKey = ref<string | null>(null)
+const editingMultiplierFormat = ref<string | null>(null)
+const editingMultiplierValue = ref<number>(1.0)
+const multiplierInputRef = ref<HTMLInputElement[] | null>(null)
+const multiplierSaving = ref(false)
 
 // 任意模态窗口打开时,阻止抽屉被误关闭
 const hasBlockingDialogOpen = computed(() =>
@@ -1172,6 +1195,80 @@ async function savePriority(key: EndpointAPIKey) {
     emit('refresh')
   } catch (err: any) {
     showError(err.response?.data?.detail || '更新优先级失败', '错误')
+  }
+}
+
+// ===== 点击编辑倍率 =====
+function startEditMultiplier(key: EndpointAPIKey, format: string) {
+  editingMultiplierKey.value = key.id
+  editingMultiplierFormat.value = format
+  editingMultiplierValue.value = getKeyRateMultiplier(key, format)
+  multiplierSaving.value = false
+  nextTick(() => {
+    const input = Array.isArray(multiplierInputRef.value) ? multiplierInputRef.value[0] : multiplierInputRef.value
+    input?.focus()
+    input?.select()
+  })
+}
+
+function cancelEditMultiplier() {
+  editingMultiplierKey.value = null
+  editingMultiplierFormat.value = null
+  multiplierSaving.value = false
+}
+
+function handleMultiplierKeydown(e: KeyboardEvent, key: EndpointAPIKey, format: string) {
+  if (e.key === 'Enter') {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!multiplierSaving.value) {
+      multiplierSaving.value = true
+      saveMultiplier(key, format)
+    }
+  } else if (e.key === 'Escape') {
+    e.preventDefault()
+    cancelEditMultiplier()
+  }
+}
+
+function handleMultiplierBlur(key: EndpointAPIKey, format: string) {
+  if (multiplierSaving.value) return
+  saveMultiplier(key, format)
+}
+
+async function saveMultiplier(key: EndpointAPIKey, format: string) {
+  const keyId = editingMultiplierKey.value
+  const newMultiplier = parseFloat(String(editingMultiplierValue.value)) || 1.0
+
+  if (!keyId || newMultiplier < 0) {
+    cancelEditMultiplier()
+    return
+  }
+
+  // 如果倍率没有变化,直接取消编辑
+  if (getKeyRateMultiplier(key, format) === newMultiplier) {
+    cancelEditMultiplier()
+    return
+  }
+
+  cancelEditMultiplier()
+
+  try {
+    // 构建 rate_multipliers 对象
+    const rateMultipliers = { ...(key.rate_multipliers || {}) }
+    rateMultipliers[format] = newMultiplier
+
+    await updateProviderKey(keyId, { rate_multipliers: rateMultipliers })
+    showSuccess('倍率已更新')
+
+    // 更新本地数据
+    const keyToUpdate = providerKeys.value.find(k => k.id === keyId)
+    if (keyToUpdate) {
+      keyToUpdate.rate_multipliers = rateMultipliers
+    }
+    emit('refresh')
+  } catch (err: any) {
+    showError(err.response?.data?.detail || '更新倍率失败', '错误')
   }
 }
 


### PR DESCRIPTION

<img width="645" height="141" alt="image" src="https://github.com/user-attachments/assets/56238e90-8ca7-4123-9793-ae77c15748e3" />

Add click-to-edit functionality for rate multipliers in the provider detail drawer. Users can now click on any multiplier value to edit it inline, with support for keyboard shortcuts (Enter to save, Escape to cancel) and automatic focus management. The changes are immediately saved to the backend and reflected in the UI.