### PR TITLE
feat(model): add automatic model synchronization system

### DIFF
--- a/src/api/admin/models/global_models.py
+++ b/src/api/admin/models/global_models.py
@@ -349,6 +349,32 @@ class AdminCreateGlobalModelAdapter(AdminApiAdapter):
 
         logger.info(f"GlobalModel 已创建: id={global_model.id} name={global_model.name}")
 
+        # 如果新创建的 GlobalModel 包含别名规则，触发自动同步
+        if self.payload.config and "model_aliases" in self.payload.config:
+            model_aliases = self.payload.config.get("model_aliases", [])
+            if isinstance(model_aliases, list) and model_aliases:
+                logger.info(
+                    f"检测到新 GlobalModel '{global_model.name}' 包含别名规则 {model_aliases}，触发自动同步..."
+                )
+                try:
+                    from src.services.model.auto_sync_service import ModelAutoSyncService
+
+                    sync_result = ModelAutoSyncService.sync_models_for_global_model(
+                        db=context.db, global_model_id=global_model.id
+                    )
+                    logger.info(
+                        f"自动同步完成: GlobalModel '{global_model.name}' - "
+                        f"扫描 {sync_result['providers_scanned']} 个 Provider, "
+                        f"新增 {sync_result['models_created']} 个模型"
+                    )
+                    if sync_result["errors"]:
+                        logger.warning(
+                            f"自动同步存在错误: {len(sync_result['errors'])} 个错误"
+                        )
+                except Exception as e:
+                    # 同步失败不影响创建操作，仅记录日志
+                    logger.error(f"新建 GlobalModel 后自动同步失败: {str(e)}", exc_info=True)
+
         return GlobalModelResponse.model_validate(global_model)
 
 
@@ -390,6 +416,22 @@ class AdminUpdateGlobalModelAdapter(AdminApiAdapter):
             if "lock" in error_msg or "timeout" in error_msg:
                 raise InvalidRequestException("该模型正在被其他操作更新，请稍后重试")
             raise
+
+        # 检查别名规则是否发生变更
+        old_aliases = None
+        new_aliases = None
+        aliases_changed = False
+
+        if old_global_model:
+            old_config = old_global_model.config or {}
+            old_aliases = old_config.get("model_aliases", [])
+
+        if self.payload.config is not None:
+            new_config = self.payload.config or {}
+            new_aliases = new_config.get("model_aliases", [])
+            # 只要 config 被更新，就比较别名规则
+            aliases_changed = old_aliases != new_aliases
+
         old_model_name = old_global_model.name if old_global_model else None
 
         # 执行更新（此时仍持有行锁）
@@ -400,6 +442,31 @@ class AdminUpdateGlobalModelAdapter(AdminApiAdapter):
         )
 
         logger.info(f"GlobalModel 已更新: id={global_model.id} name={global_model.name}")
+
+        # 如果别名规则发生变更，触发自动同步
+        if aliases_changed:
+            logger.info(
+                f"检测到别名规则变更: GlobalModel '{global_model.name}' "
+                f"(旧: {old_aliases}, 新: {new_aliases})，触发自动同步..."
+            )
+            try:
+                from src.services.model.auto_sync_service import ModelAutoSyncService
+
+                sync_result = ModelAutoSyncService.sync_models_for_global_model(
+                    db=context.db, global_model_id=self.global_model_id
+                )
+                logger.info(
+                    f"自动同步完成: GlobalModel '{global_model.name}' - "
+                    f"扫描 {sync_result['providers_scanned']} 个 Provider, "
+                    f"新增 {sync_result['models_created']} 个模型"
+                )
+                if sync_result["errors"]:
+                    logger.warning(
+                        f"自动同步存在错误: {len(sync_result['errors'])} 个错误"
+                    )
+            except Exception as e:
+                # 同步失败不影响更新操作，仅记录日志
+                logger.error(f"别名规则变更后自动同步失败: {str(e)}", exc_info=True)
 
         # 更新成功后才失效缓存（避免回滚时缓存已被清除的竞态问题）
         # 注意：此时事务已提交（由 pipeline 管理），数据已持久化

--- a/src/api/admin/providers/__init__.py
+++ b/src/api/admin/providers/__init__.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter
 
+from .auto_sync import router as auto_sync_router
 from .models import router as models_router
 from .routes import router as routes_router
 from .summary import router as summary_router
@@ -16,5 +17,8 @@ router.include_router(summary_router)
 
 # Provider models management
 router.include_router(models_router)
+
+# Provider models auto sync
+router.include_router(auto_sync_router)
 
 __all__ = ["router"]

--- a/src/api/admin/providers/auto_sync.py
+++ b/src/api/admin/providers/auto_sync.py
@@ -1,0 +1,111 @@
+"""
+模型自动同步 API 端点
+
+提供手动触发模型同步的管理接口
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from src.api.base.admin_adapter import AdminApiAdapter
+from src.api.base.pipeline import ApiRequestPipeline
+from src.database import get_db
+from src.services.model.auto_sync_service import ModelAutoSyncService
+
+router = APIRouter(tags=["Model Auto Sync"])
+pipeline = ApiRequestPipeline()
+
+
+class SyncResult(BaseModel):
+    """同步结果响应"""
+
+    provider_id: Optional[str] = None
+    providers_scanned: Optional[int] = None
+    models_created: int
+    errors: List[str]
+
+
+@dataclass
+class SyncProviderModelsAdapter(AdminApiAdapter):
+    """同步单个 Provider 的模型"""
+
+    provider_id: str
+
+    async def handle(self, context):  # type: ignore[override]
+        db = context.db
+
+        result = ModelAutoSyncService.sync_models_for_provider(db, self.provider_id)
+
+        return SyncResult(
+            provider_id=result["provider_id"],
+            models_created=result["models_created"],
+            errors=result["errors"],
+        )
+
+
+@dataclass
+class SyncAllModelsAdapter(AdminApiAdapter):
+    """同步所有 Provider 的模型"""
+
+    async def handle(self, context):  # type: ignore[override]
+        db = context.db
+
+        result = ModelAutoSyncService.sync_all_provider_models(db)
+
+        return SyncResult(
+            providers_scanned=result["providers_scanned"],
+            models_created=result["models_created"],
+            errors=result["errors"],
+        )
+
+
+@router.post("/{provider_id}/sync-models", response_model=SyncResult)
+async def sync_provider_models(
+    provider_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> SyncResult:
+    """
+    同步单个 Provider 的模型
+
+    根据该 Provider 的所有 API Key 的 allowed_models 白名单,
+    自动添加匹配的全局模型到该 Provider 的模型列表。
+
+    **权限要求**: Admin
+
+    **路径参数**:
+    - `provider_id`: Provider ID
+
+    **返回**:
+    - `provider_id`: Provider ID
+    - `models_created`: 新创建的模型数量
+    - `errors`: 错误列表
+    """
+    adapter = SyncProviderModelsAdapter(provider_id=provider_id)
+    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+
+
+@router.post("/sync-all-models", response_model=SyncResult)
+async def sync_all_models(
+    request: Request,
+    db: Session = Depends(get_db),
+) -> SyncResult:
+    """
+    同步所有 Provider 的模型
+
+    遍历所有活跃的 Provider,根据其 API Key 的 allowed_models 白名单,
+    自动添加匹配的全局模型。
+
+    **权限要求**: Admin
+
+    **返回**:
+    - `providers_scanned`: 扫描的 Provider 数量
+    - `models_created`: 新创建的模型总数
+    - `errors`: 错误列表
+    """
+    adapter = SyncAllModelsAdapter()
+    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)

--- a/src/services/model/auto_sync_service.py
+++ b/src/services/model/auto_sync_service.py
@@ -1,0 +1,434 @@
+"""
+模型自动同步服务
+
+根据 Provider Key 的 allowed_models 白名单和全局模型的别名规则,
+自动将匹配的全局模型添加到 Provider 的模型列表中。
+"""
+
+import uuid
+from typing import Dict, List, Optional, Set
+
+from sqlalchemy.orm import Session
+
+from src.core.logger import logger
+from src.core.model_permissions import match_model_with_pattern, normalize_allowed_models
+from src.models.database import GlobalModel, Model, Provider, ProviderAPIKey
+
+
+class ModelAutoSyncService:
+    """模型自动同步服务"""
+
+    @staticmethod
+    def sync_models_for_global_model(db: Session, global_model_id: str) -> Dict:
+        """
+        为特定 GlobalModel 同步所有 Provider 的模型
+
+        当 GlobalModel 的别名规则变更时，重新扫描所有 Provider 的 allowed_models，
+        如果有新的匹配项则自动添加。
+
+        Args:
+            db: 数据库会话
+            global_model_id: GlobalModel ID
+
+        Returns:
+            同步结果统计:
+            {
+                "global_model_id": GlobalModel ID,
+                "providers_scanned": 扫描的 Provider 数量,
+                "models_created": 新创建的 Model 数量,
+                "errors": 错误列表
+            }
+        """
+        # 获取 GlobalModel
+        global_model = db.query(GlobalModel).filter(GlobalModel.id == global_model_id).first()
+        if not global_model:
+            raise ValueError(f"GlobalModel {global_model_id} 不存在")
+
+        logger.info(f"开始为 GlobalModel '{global_model.name}' 同步所有 Provider 的模型...")
+
+        # 获取所有活跃的 Provider
+        providers = db.query(Provider).filter(Provider.is_active.is_(True)).all()
+
+        total_created = 0
+        errors = []
+
+        for provider in providers:
+            try:
+                result = ModelAutoSyncService._sync_single_global_model_for_provider(
+                    db, provider, global_model
+                )
+                total_created += result["models_created"]
+                if result["errors"]:
+                    errors.extend(result["errors"])
+            except Exception as e:
+                error_msg = f"同步 Provider {provider.name} (ID: {provider.id}) 失败: {str(e)}"
+                logger.warning(error_msg)
+                errors.append(error_msg)
+                try:
+                    db.rollback()
+                except Exception:
+                    pass
+
+        logger.info(
+            f"GlobalModel '{global_model.name}' 同步完成: 扫描 {len(providers)} 个 Provider, "
+            f"新增 {total_created} 个模型"
+        )
+
+        return {
+            "global_model_id": global_model_id,
+            "providers_scanned": len(providers),
+            "models_created": total_created,
+            "errors": errors,
+        }
+
+    @staticmethod
+    def sync_all_provider_models(db: Session) -> Dict:
+        """
+        为所有 Provider 同步模型
+
+        Args:
+            db: 数据库会话
+
+        Returns:
+            同步结果统计:
+            {
+                "providers_scanned": 扫描的 Provider 数量,
+                "models_created": 新创建的 Model 数量,
+                "errors": 错误列表
+            }
+        """
+        logger.info("开始执行模型自动同步...")
+
+        # 获取所有活跃的 Provider
+        providers = db.query(Provider).filter(Provider.is_active.is_(True)).all()
+
+        total_created = 0
+        errors = []
+
+        for provider in providers:
+            try:
+                result = ModelAutoSyncService.sync_models_for_provider(db, provider.id)
+                total_created += result["models_created"]
+                if result["errors"]:
+                    errors.extend(result["errors"])
+            except Exception as e:
+                error_msg = f"同步 Provider {provider.name} (ID: {provider.id}) 失败: {str(e)}"
+                logger.warning(error_msg)
+                errors.append(error_msg)
+                try:
+                    db.rollback()
+                except Exception:
+                    pass
+
+        logger.info(
+            f"模型自动同步完成: 扫描 {len(providers)} 个 Provider, "
+            f"新增 {total_created} 个模型"
+        )
+
+        return {
+            "providers_scanned": len(providers),
+            "models_created": total_created,
+            "errors": errors,
+        }
+
+    @staticmethod
+    def sync_models_for_provider(db: Session, provider_id: str) -> Dict:
+        """
+        为单个 Provider 同步模型
+
+        Args:
+            db: 数据库会话
+            provider_id: Provider ID
+
+        Returns:
+            同步结果:
+            {
+                "provider_id": Provider ID,
+                "models_created": 新创建的 Model 数量,
+                "errors": 错误列表
+            }
+        """
+        # 获取 Provider
+        provider = db.query(Provider).filter(Provider.id == provider_id).first()
+        if not provider:
+            raise ValueError(f"Provider {provider_id} 不存在")
+
+        logger.debug(f"检查 Provider: {provider.name} (ID: {provider_id})")
+
+        # 获取所有活跃的全局模型(一次性加载,避免 N+1 查询)
+        all_global_models = (
+            db.query(GlobalModel).filter(GlobalModel.is_active.is_(True)).all()
+        )
+
+        # 收集该 Provider 下所有 API Key 的 allowed_models
+        all_allowed_model_names: Set[str] = set()
+
+        for key in provider.api_keys:
+            if key.allowed_models is None:
+                # None 表示不限制,跳过
+                continue
+
+            # 处理简单列表和按格式字典两种情况
+            # 由于我们不知道具体的 api_format,这里需要收集所有可能的模型名
+            if isinstance(key.allowed_models, list):
+                # 简单列表格式
+                allowed_set = normalize_allowed_models(key.allowed_models, None)
+                if allowed_set:
+                    all_allowed_model_names.update(allowed_set)
+            elif isinstance(key.allowed_models, dict):
+                # 按格式字典,遍历所有格式
+                for api_format, model_list in key.allowed_models.items():
+                    if model_list is None:
+                        continue
+                    allowed_set = normalize_allowed_models(
+                        key.allowed_models, api_format
+                    )
+                    if allowed_set:
+                        all_allowed_model_names.update(allowed_set)
+
+        if not all_allowed_model_names:
+            logger.debug(f"Provider {provider.name} 没有配置 allowed_models 白名单")
+            return {"provider_id": provider_id, "models_created": 0, "errors": []}
+
+        # 查找匹配的全局模型
+        matched_global_models = ModelAutoSyncService._find_matching_global_models(
+            all_global_models, all_allowed_model_names
+        )
+
+        # 创建缺失的 Model 记录
+        models_created = 0
+        errors = []
+
+        for global_model in matched_global_models:
+            try:
+                # 检查是否已存在
+                existing = (
+                    db.query(Model)
+                    .filter(
+                        Model.provider_id == provider_id,
+                        Model.global_model_id == global_model.id,
+                    )
+                    .first()
+                )
+
+                if existing:
+                    logger.debug(
+                        f"Model 已存在: {global_model.name} for provider {provider.name}"
+                    )
+                    continue
+
+                # 创建新的 Model 记录
+                new_model = Model(
+                    id=str(uuid.uuid4()),
+                    provider_id=provider_id,
+                    global_model_id=global_model.id,
+                    provider_model_name=global_model.name,
+                    # 价格和能力字段设为 None,继承 GlobalModel 默认值
+                    price_per_request=None,
+                    tiered_pricing=None,
+                    supports_vision=None,
+                    supports_function_calling=None,
+                    supports_streaming=None,
+                    supports_extended_thinking=None,
+                    supports_image_generation=None,
+                    is_active=True,
+                    is_available=True,
+                )
+                db.add(new_model)
+                db.commit()
+
+                models_created += 1
+                logger.info(
+                    f"为 Provider '{provider.name}' 创建模型: {global_model.name}"
+                )
+
+            except Exception as e:
+                error_msg = f"创建模型 {global_model.name} 失败: {str(e)}"
+                logger.warning(error_msg)
+                errors.append(error_msg)
+                try:
+                    db.rollback()
+                except Exception:
+                    pass
+
+        return {
+            "provider_id": provider_id,
+            "models_created": models_created,
+            "errors": errors,
+        }
+
+    @staticmethod
+    def _sync_single_global_model_for_provider(
+        db: Session, provider: Provider, global_model: GlobalModel
+    ) -> Dict:
+        """
+        为单个 Provider 同步单个 GlobalModel
+
+        Args:
+            db: 数据库会话
+            provider: Provider 实例
+            global_model: GlobalModel 实例
+
+        Returns:
+            同步结果:
+            {
+                "models_created": 新创建的 Model 数量,
+                "errors": 错误列表
+            }
+        """
+        logger.debug(
+            f"检查 Provider '{provider.name}' 是否匹配 GlobalModel '{global_model.name}'"
+        )
+
+        # 检查全局模型是否配置了别名
+        if not global_model.config or "model_aliases" not in global_model.config:
+            logger.debug(f"GlobalModel '{global_model.name}' 没有配置别名规则")
+            return {"models_created": 0, "errors": []}
+
+        model_aliases = global_model.config.get("model_aliases", [])
+        if not isinstance(model_aliases, list) or not model_aliases:
+            logger.debug(f"GlobalModel '{global_model.name}' 的别名规则为空")
+            return {"models_created": 0, "errors": []}
+
+        # 收集该 Provider 下所有 API Key 的 allowed_models
+        all_allowed_model_names: Set[str] = set()
+
+        for key in provider.api_keys:
+            if key.allowed_models is None:
+                # None 表示不限制，跳过
+                continue
+
+            # 处理简单列表和按格式字典两种情况
+            if isinstance(key.allowed_models, list):
+                # 简单列表格式
+                allowed_set = normalize_allowed_models(key.allowed_models, None)
+                if allowed_set:
+                    all_allowed_model_names.update(allowed_set)
+            elif isinstance(key.allowed_models, dict):
+                # 按格式字典，遍历所有格式
+                for api_format, model_list in key.allowed_models.items():
+                    if model_list is None:
+                        continue
+                    allowed_set = normalize_allowed_models(key.allowed_models, api_format)
+                    if allowed_set:
+                        all_allowed_model_names.update(allowed_set)
+
+        if not all_allowed_model_names:
+            logger.debug(f"Provider '{provider.name}' 没有配置 allowed_models 白名单")
+            return {"models_created": 0, "errors": []}
+
+        # 检查 GlobalModel 的别名是否匹配 Provider 的白名单
+        matched = False
+        for allowed_model_name in all_allowed_model_names:
+            for alias_pattern in model_aliases:
+                if match_model_with_pattern(alias_pattern, allowed_model_name):
+                    logger.debug(
+                        f"发现匹配: GlobalModel '{global_model.name}' "
+                        f"(别名: '{alias_pattern}') 匹配白名单 '{allowed_model_name}' "
+                        f"in Provider '{provider.name}'"
+                    )
+                    matched = True
+                    break
+            if matched:
+                break
+
+        if not matched:
+            logger.debug(
+                f"GlobalModel '{global_model.name}' 的别名规则不匹配 Provider '{provider.name}' 的白名单"
+            )
+            return {"models_created": 0, "errors": []}
+
+        # 检查是否已存在
+        existing = (
+            db.query(Model)
+            .filter(
+                Model.provider_id == provider.id,
+                Model.global_model_id == global_model.id,
+            )
+            .first()
+        )
+
+        if existing:
+            logger.debug(
+                f"Model 已存在: {global_model.name} for provider {provider.name}"
+            )
+            return {"models_created": 0, "errors": []}
+
+        # 创建新的 Model 记录
+        errors = []
+        try:
+            new_model = Model(
+                id=str(uuid.uuid4()),
+                provider_id=provider.id,
+                global_model_id=global_model.id,
+                provider_model_name=global_model.name,
+                # 价格和能力字段设为 None，继承 GlobalModel 默认值
+                price_per_request=None,
+                tiered_pricing=None,
+                supports_vision=None,
+                supports_function_calling=None,
+                supports_streaming=None,
+                supports_extended_thinking=None,
+                supports_image_generation=None,
+                is_active=True,
+                is_available=True,
+            )
+            db.add(new_model)
+            db.commit()
+
+            logger.info(
+                f"为 Provider '{provider.name}' 创建模型: {global_model.name} (自动同步)"
+            )
+            return {"models_created": 1, "errors": []}
+
+        except Exception as e:
+            error_msg = f"创建模型 {global_model.name} 失败: {str(e)}"
+            logger.warning(error_msg)
+            errors.append(error_msg)
+            try:
+                db.rollback()
+            except Exception:
+                pass
+            return {"models_created": 0, "errors": errors}
+
+    @staticmethod
+    def _find_matching_global_models(
+        all_global_models: List[GlobalModel], allowed_model_names: Set[str]
+    ) -> List[GlobalModel]:
+        """
+        根据白名单查找匹配的全局模型
+
+        Args:
+            all_global_models: 所有活跃的全局模型列表
+            allowed_model_names: 白名单中的模型名集合
+
+        Returns:
+            匹配的全局模型列表
+        """
+        matched_models = []
+
+        for allowed_model_name in allowed_model_names:
+            for global_model in all_global_models:
+                # 检查全局模型是否配置了别名
+                if not global_model.config or "model_aliases" not in global_model.config:
+                    continue
+
+                model_aliases = global_model.config.get("model_aliases", [])
+                if not isinstance(model_aliases, list):
+                    continue
+
+                # 检查白名单模型名是否匹配全局模型的任一别名
+                for alias_pattern in model_aliases:
+                    if match_model_with_pattern(alias_pattern, allowed_model_name):
+                        # 匹配成功
+                        logger.debug(
+                            f"发现匹配: GlobalModel '{global_model.name}' "
+                            f"(别名: '{alias_pattern}') 匹配白名单 '{allowed_model_name}'"
+                        )
+                        matched_models.append(global_model)
+                        break  # 匹配成功后跳出别名循环
+
+        # 去重(同一个全局模型可能匹配多个白名单项)
+        unique_models = list({model.id: model for model in matched_models}.values())
+
+        return unique_models

--- a/src/services/system/cleanup_scheduler.py
+++ b/src/services/system/cleanup_scheduler.py
@@ -100,6 +100,14 @@ class CleanupScheduler:
             name="审计日志清理",
         )
 
+        # 模型自动同步任务 - 每12小时执行一次
+        scheduler.add_interval_job(
+            self._scheduled_model_sync,
+            hours=12,
+            job_id="model_auto_sync",
+            name="模型自动同步",
+        )
+
         # 启动时执行一次初始化任务
         asyncio.create_task(self._run_startup_tasks())
 
@@ -157,6 +165,10 @@ class CleanupScheduler:
     async def _scheduled_audit_cleanup(self):
         """审计日志清理任务（定时调用）"""
         await self._perform_audit_cleanup()
+
+    async def _scheduled_model_sync(self):
+        """模型自动同步任务（定时调用）"""
+        await self._perform_model_sync()
 
     # ========== 实际任务实现 ==========
 
@@ -800,6 +812,41 @@ class CleanupScheduler:
                 break
 
         return total_deleted
+
+    async def _perform_model_sync(self):
+        """执行模型自动同步任务"""
+        db = create_session()
+        try:
+            # 检查是否启用自动同步
+            if not SystemConfigService.get_config(db, "enable_model_auto_sync", True):
+                logger.info("模型自动同步已禁用，跳过同步任务")
+                return
+
+            logger.info("开始执行模型自动同步...")
+
+            from src.services.model.auto_sync_service import ModelAutoSyncService
+
+            result = ModelAutoSyncService.sync_all_provider_models(db)
+
+            if result["models_created"] > 0:
+                logger.info(
+                    f"模型自动同步完成: 扫描 {result['providers_scanned']} 个 Provider, "
+                    f"新增 {result['models_created']} 个模型"
+                )
+            else:
+                logger.info("模型自动同步完成: 没有新增模型")
+
+            if result["errors"]:
+                logger.warning(f"同步过程中出现 {len(result['errors'])} 个错误")
+
+        except Exception as e:
+            logger.exception(f"模型自动同步任务执行失败: {e}")
+            try:
+                db.rollback()
+            except Exception:
+                pass
+        finally:
+            db.close()
 
 
 # 全局单例


### PR DESCRIPTION
Implement automatic model synchronization service that matches GlobalModel aliases with Provider API key whitelists. The system automatically creates Model records when GlobalModel alias rules match allowed_models patterns in Provider API keys.

Key features:
- Auto-sync on GlobalModel creation/update when alias rules change
- Manual sync endpoints for single Provider or all Providers
- Scheduled sync task running every 12 hours
- Pattern matching between GlobalModel aliases and Provider whitelists
- Comprehensive error handling and logging

The sync service scans Provider API keys' allowed_models configurations and creates Model records for matching GlobalModels, eliminating manual model setup overhead.