### PR TITLE
feat: 分页组件支持 pageSize 浏览器缓存

### DIFF
--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -59,6 +59,7 @@ export { default as AvatarImage } from './avatar-image.vue'
 
 // 分页组件
 export { default as Pagination } from './pagination.vue'
+export { getPageSizeCache } from './pagination-utils'
 
 // 操作按钮
 export { default as RefreshButton } from './refresh-button.vue'

--- a/frontend/src/components/ui/pagination-utils.ts
+++ b/frontend/src/components/ui/pagination-utils.ts
@@ -1,0 +1,21 @@
+/**
+ * 获取缓存的 pageSize 值
+ * @param cacheKey 缓存键名
+ * @param defaultValue 默认值
+ * @param validOptions 有效的选项列表，用于验证缓存值是否有效
+ * @returns 缓存的 pageSize 或默认值
+ */
+export function getPageSizeCache(
+  cacheKey: string,
+  defaultValue: number = 20,
+  validOptions: number[] = [10, 20, 50, 100]
+): number {
+  const cached = localStorage.getItem(cacheKey)
+  if (cached) {
+    const cachedSize = parseInt(cached, 10)
+    if (!isNaN(cachedSize) && validOptions.includes(cachedSize)) {
+      return cachedSize
+    }
+  }
+  return defaultValue
+}

--- a/frontend/src/components/ui/pagination.vue
+++ b/frontend/src/components/ui/pagination.vue
@@ -100,6 +100,8 @@ interface Props {
   pageSize?: number
   pageSizeOptions?: number[]
   showPageSizeSelector?: boolean
+  /** 缓存键名，设置后会将 pageSize 缓存到 localStorage */
+  cacheKey?: string
 }
 
 interface Emits {
@@ -170,9 +172,14 @@ function handlePageChange(page: number) {
 function handlePageSizeChange(value: string) {
   const newSize = parseInt(value)
   if (newSize !== props.pageSize) {
+    // 缓存到 localStorage
+    if (props.cacheKey) {
+      localStorage.setItem(props.cacheKey, value)
+    }
     emit('update:pageSize', newSize)
     // 切换每页数量时，重置到第一页
     emit('update:current', 1)
   }
 }
+
 </script>

--- a/frontend/src/features/usage/components/UsageRecordsTable.vue
+++ b/frontend/src/features/usage/components/UsageRecordsTable.vue
@@ -495,6 +495,7 @@
         :total="totalRecords"
         :page-size="pageSize"
         :page-size-options="pageSizeOptions"
+        cache-key="usage-records-page-size"
         @update:current="$emit('update:currentPage', $event)"
         @update:page-size="$emit('update:pageSize', $event)"
       />

--- a/frontend/src/views/admin/AuditLogs.vue
+++ b/frontend/src/views/admin/AuditLogs.vue
@@ -302,6 +302,7 @@
           :total="totalRecords"
           :page-size="pageSize"
           :page-size-options="[10, 20, 50, 100]"
+          cache-key="audit-logs-page-size"
           @update:current="handlePageChange"
           @update:page-size="pageSize = $event; currentPage = 1; loadLogs()"
         />
@@ -427,7 +428,8 @@ import {
   TableCell,
   Input,
   Pagination,
-  RefreshButton
+  RefreshButton,
+  getPageSizeCache
 } from '@/components/ui'
 import { auditApi } from '@/api/audit'
 import {
@@ -481,7 +483,7 @@ const filters = ref({
 const filtersDaysString = ref('7')
 
 const currentPage = ref(1)
-const pageSize = ref(20)
+const pageSize = ref(getPageSizeCache('audit-logs-page-size', 20))
 const totalRecords = ref(0)
 
 let loadTimeout: number

--- a/frontend/src/views/admin/CacheMonitoring.vue
+++ b/frontend/src/views/admin/CacheMonitoring.vue
@@ -11,6 +11,7 @@ import TableHeader from '@/components/ui/table-header.vue'
 import TableRow from '@/components/ui/table-row.vue'
 import Input from '@/components/ui/input.vue'
 import Pagination from '@/components/ui/pagination.vue'
+import { getPageSizeCache } from '@/components/ui/pagination-utils'
 import RefreshButton from '@/components/ui/refresh-button.vue'
 import Select from '@/components/ui/select.vue'
 import SelectTrigger from '@/components/ui/select-trigger.vue'
@@ -44,7 +45,7 @@ const tableKeyword = ref('')
 const matchedUserId = ref<string | null>(null)
 const clearingRowAffinityKey = ref<string | null>(null)
 const currentPage = ref(1)
-const pageSize = ref(20)
+const pageSize = ref(getPageSizeCache('cache-monitoring-page-size', 20))
 const currentTime = ref(Math.floor(Date.now() / 1000))
 const analysisHoursSelectOpen = ref(false)
 
@@ -702,6 +703,7 @@ onBeforeUnmount(() => {
         :current="currentPage"
         :total="affinityList.length"
         :page-size="pageSize"
+        cache-key="cache-monitoring-page-size"
         @update:current="currentPage = $event; handlePageChange()"
         @update:page-size="pageSize = $event"
       />

--- a/frontend/src/views/admin/ModelManagement.vue
+++ b/frontend/src/views/admin/ModelManagement.vue
@@ -402,6 +402,7 @@
           :current="catalogCurrentPage"
           :total="filteredGlobalModels.length"
           :page-size="catalogPageSize"
+          cache-key="model-management-page-size"
           @update:current="catalogCurrentPage = $event"
           @update:page-size="catalogPageSize = $event"
         />
@@ -614,6 +615,7 @@ import {
   Dialog,
   Pagination,
   RefreshButton,
+  getPageSizeCache,
 } from '@/components/ui'
 import {
   listGlobalModels,
@@ -647,7 +649,7 @@ const capabilities = ref<CapabilityDefinition[]>([])
 
 // 模型目录分页
 const catalogCurrentPage = ref(1)
-const catalogPageSize = ref(20)
+const catalogPageSize = ref(getPageSizeCache('model-management-page-size', 20))
 
 // 选中模型的详细数据
 const selectedModelProviders = ref<any[]>([])

--- a/frontend/src/views/admin/ProviderManagement.vue
+++ b/frontend/src/views/admin/ProviderManagement.vue
@@ -393,6 +393,7 @@
         :current="currentPage"
         :total="filteredProviders.length"
         :page-size="pageSize"
+        cache-key="provider-management-page-size"
         @update:current="currentPage = $event"
         @update:page-size="pageSize = $event"
       />
@@ -445,6 +446,7 @@ import TableRow from '@/components/ui/table-row.vue'
 import TableHead from '@/components/ui/table-head.vue'
 import TableCell from '@/components/ui/table-cell.vue'
 import Pagination from '@/components/ui/pagination.vue'
+import { getPageSizeCache } from '@/components/ui/pagination-utils'
 import RefreshButton from '@/components/ui/refresh-button.vue'
 import { ProviderFormDialog, PriorityManagementDialog } from '@/features/providers/components'
 import ProviderDetailDrawer from '@/features/providers/components/ProviderDetailDrawer.vue'
@@ -478,7 +480,7 @@ const searchQuery = ref('')
 
 // 分页
 const currentPage = ref(1)
-const pageSize = ref(20)
+const pageSize = ref(getPageSizeCache('provider-management-page-size', 20))
 
 // 优先级模式配置
 const priorityModeConfig = computed(() => {

--- a/frontend/src/views/admin/Users.vue
+++ b/frontend/src/views/admin/Users.vue
@@ -498,6 +498,7 @@
         :current="currentPage"
         :total="filteredUsers.length"
         :page-size="pageSize"
+        cache-key="users-page-size"
         @update:current="currentPage = $event"
         @update:page-size="pageSize = $event"
       />
@@ -750,7 +751,8 @@ import {
   Avatar,
   AvatarFallback,
   Pagination,
-  RefreshButton
+  RefreshButton,
+  getPageSizeCache
 } from '@/components/ui'
 
 import {
@@ -804,7 +806,7 @@ const filterRoleOpenMobile = ref(false)
 const filterStatusOpenMobile = ref(false)
 
 const currentPage = ref(1)
-const pageSize = ref(20)
+const pageSize = ref(getPageSizeCache('users-page-size', 20))
 
 const filteredUsers = computed(() => {
   let filtered = [...usersStore.users]

--- a/frontend/src/views/shared/Usage.vue
+++ b/frontend/src/views/shared/Usage.vue
@@ -100,6 +100,7 @@ import { useAuthStore } from '@/stores/auth'
 import { usageApi } from '@/api/usage'
 import { usersApi } from '@/api/users'
 import { meApi } from '@/api/me'
+import { getPageSizeCache } from '@/components/ui'
 import {
   UsageModelTable,
   UsageProviderTable,
@@ -131,7 +132,7 @@ const selectedPeriod = ref<PeriodValue>('today')
 
 // 分页状态
 const currentPage = ref(1)
-const pageSize = ref(20)
+const pageSize = ref(getPageSizeCache('usage-records-page-size', 20))
 const pageSizeOptions = [10, 20, 50, 100]
 
 // 筛选状态

--- a/frontend/src/views/user/Announcements.vue
+++ b/frontend/src/views/user/Announcements.vue
@@ -310,6 +310,7 @@
         :current="currentPage"
         :total="total"
         :page-size="pageSize"
+        cache-key="announcements-page-size"
         @update:current="loadAnnouncements($event)"
         @update:page-size="pageSize = $event; loadAnnouncements(1)"
       />
@@ -567,7 +568,8 @@ import {
   TableRow,
   TableHead,
   TableCell,
-  Switch
+  Switch,
+  getPageSizeCache
 } from '@/components/ui'
 import Select from '@/components/ui/select.vue'
 import SelectTrigger from '@/components/ui/select-trigger.vue'
@@ -590,7 +592,7 @@ const loading = ref(false)
 const total = ref(0)
 const unreadCount = ref(0)
 const currentPage = ref(1)
-const pageSize = ref(20)
+const pageSize = ref(getPageSizeCache('announcements-page-size', 20))
 
 // 对话框状态
 const dialogOpen = ref(false)

--- a/frontend/src/views/user/ManagementTokens.vue
+++ b/frontend/src/views/user/ManagementTokens.vue
@@ -301,6 +301,7 @@
         :current="currentPage"
         :total="totalTokens"
         :page-size="pageSize"
+        cache-key="management-tokens-page-size"
         @update:current="currentPage = $event"
         @update:page-size="handlePageSizeChange"
       />
@@ -520,7 +521,7 @@ import Button from '@/components/ui/button.vue'
 import Input from '@/components/ui/input.vue'
 import Label from '@/components/ui/label.vue'
 import Badge from '@/components/ui/badge.vue'
-import { Dialog, Pagination } from '@/components/ui'
+import { Dialog, Pagination, getPageSizeCache } from '@/components/ui'
 import { LoadingState, AlertDialog, EmptyState } from '@/components/common'
 import {
   Table,
@@ -560,7 +561,7 @@ const quota = ref<{ used: number; max: number } | null>(null)
 
 // 分页
 const currentPage = ref(1)
-const pageSize = ref(10)
+const pageSize = ref(getPageSizeCache('management-tokens-page-size', 10))
 
 const paginatedTokens = computed(() => tokens.value)
 

--- a/frontend/src/views/user/ModelCatalog.vue
+++ b/frontend/src/views/user/ModelCatalog.vue
@@ -312,6 +312,7 @@
         :current="currentPage"
         :total="filteredModels.length"
         :page-size="pageSize"
+        cache-key="model-catalog-page-size"
         @update:current="currentPage = $event"
         @update:page-size="pageSize = $event"
       />
@@ -355,6 +356,7 @@ import {
   Input,
   Pagination,
   RefreshButton,
+  getPageSizeCache,
 } from '@/components/ui'
 import {
   getPublicGlobalModels,
@@ -393,7 +395,7 @@ function openModelDetail(model: PublicGlobalModel, event: MouseEvent) {
 
 // 分页
 const currentPage = ref(1)
-const pageSize = ref(20)
+const pageSize = ref(getPageSizeCache('model-catalog-page-size', 20))
 
 // 能力筛选
 const capabilityFilters = ref({

--- a/frontend/src/views/user/MyApiKeys.vue
+++ b/frontend/src/views/user/MyApiKeys.vue
@@ -339,6 +339,7 @@
         :current="currentPage"
         :total="apiKeys.length"
         :page-size="pageSize"
+        cache-key="my-api-keys-page-size"
         @update:current="currentPage = $event"
         @update:page-size="pageSize = $event"
       />
@@ -483,7 +484,7 @@ import Button from '@/components/ui/button.vue'
 import Input from '@/components/ui/input.vue'
 import Label from '@/components/ui/label.vue'
 import Badge from '@/components/ui/badge.vue'
-import { Dialog, Pagination } from '@/components/ui'
+import { Dialog, Pagination, getPageSizeCache } from '@/components/ui'
 import { LoadingState, AlertDialog, EmptyState } from '@/components/common'
 import {
   Table,
@@ -508,7 +509,7 @@ const deleting = ref(false)
 
 // 分页相关
 const currentPage = ref(1)
-const pageSize = ref(10)
+const pageSize = ref(getPageSizeCache('my-api-keys-page-size', 10))
 
 const paginatedApiKeys = computed(() => {
   const start = (currentPage.value - 1) * pageSize.value


### PR DESCRIPTION
添加 cacheKey prop 和 getPageSizeCache 工具函数，允许将用户选择的
每页数量持久化到 localStorage，优化用户体验。