### PR TITLE
fix: OAuth 绑定支持通过 URL 参数传递认证令牌

### DIFF
--- a/frontend/src/views/user/Settings.vue
+++ b/frontend/src/views/user/Settings.vue
@@ -601,7 +601,11 @@ async function loadOAuthBindings() {
 function handleBind(providerType: string) {
   // 保存返回路径（OAuth callback 会读取）
   sessionStorage.setItem('redirectPath', route.fullPath)
-  window.location.href = getApiUrl(`/api/user/oauth/${providerType}/bind`)
+  // 浏览器跳转无法携带 Authorization header，需要通过 query 参数传递 token
+  const token = localStorage.getItem('access_token')
+  const bindUrl = getApiUrl(`/api/user/oauth/${providerType}/bind`)
+  const separator = bindUrl.includes('?') ? '&' : '?'
+  window.location.href = token ? `${bindUrl}${separator}access_token=${encodeURIComponent(token)}` : bindUrl
 }
 
 async function handleUnbind(providerType: string) {

--- a/src/api/base/pipeline.py
+++ b/src/api/base/pipeline.py
@@ -255,15 +255,28 @@ class ApiRequestPipeline:
     async def _authenticate_user(
         self, request: Request, db: Session
     ) -> Tuple[User, Optional["ManagementToken"]]:
-        """用户认证，支持 JWT 和 Management Token 两种方式"""
+        """用户认证，支持 JWT 和 Management Token 两种方式
+
+        认证来源优先级：
+        1. Authorization header (Bearer token)
+        2. URL query parameter (access_token) - 用于浏览器直接跳转场景如 OAuth 绑定
+        """
         from src.models.database import ManagementToken
         from src.utils.request_utils import get_client_ip
 
-        authorization = request.headers.get("authorization")
-        if not authorization or not authorization.lower().startswith("bearer "):
-            raise HTTPException(status_code=401, detail="缺少用户凭证")
+        token: Optional[str] = None
 
-        token = authorization[7:].strip()
+        # 优先从 Authorization header 获取
+        authorization = request.headers.get("authorization")
+        if authorization and authorization.lower().startswith("bearer "):
+            token = authorization[7:].strip()
+
+        # 如果 header 中没有，尝试从 query 参数获取（用于浏览器跳转场景）
+        if not token:
+            token = request.query_params.get("access_token")
+
+        if not token:
+            raise HTTPException(status_code=401, detail="缺少用户凭证")
 
         # 检查是否为 Management Token（ae_ 前缀）
         if token.startswith(ManagementToken.TOKEN_PREFIX):


### PR DESCRIPTION
浏览器直接跳转到 OAuth 绑定端点时无法携带 Authorization header，
导致认证失败并报错"缺少用户凭证"。

- 后端 _authenticate_user 新增支持从 query 参数 access_token 读取令牌
- 前端 handleBind 在跳转 URL 中附加 access_token 参数