### PR TITLE
feat: 使用记录显示 API 格式转换信息

### DIFF
--- a/frontend/src/features/usage/components/UsageRecordsTable.vue
+++ b/frontend/src/features/usage/components/UsageRecordsTable.vue
@@ -361,13 +361,39 @@
             </div>
           </TableCell>
           <TableCell class="py-4 w-[80px]">
-            <span
+            <div
               v-if="record.api_format"
-              class="inline-flex items-center px-2 py-0.5 rounded-full border border-border/60 text-[10px] font-medium whitespace-nowrap text-muted-foreground"
-              :title="record.api_format"
+              class="flex items-center gap-1"
             >
-              {{ formatApiFormat(record.api_format) }}
-            </span>
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded-full border border-border/60 text-[10px] font-medium whitespace-nowrap text-muted-foreground"
+                :title="getApiFormatDisplay(record).tooltip"
+              >
+                {{ getApiFormatDisplay(record).text }}
+              </span>
+              <!-- 格式转换标识 -->
+              <span
+                v-if="record.endpoint_api_format && record.api_format.toUpperCase() !== record.endpoint_api_format.toUpperCase()"
+                class="inline-flex items-center justify-center w-4 h-4 text-xs text-violet-600 dark:text-violet-400"
+                :title="`由 ${formatApiFormat(record.endpoint_api_format)} 转换`"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="w-3.5 h-3.5"
+                >
+                  <path d="M17 3v10" />
+                  <path d="m21 7-4-4-4 4" />
+                  <path d="M7 21V11" />
+                  <path d="m3 17 4 4 4-4" />
+                </svg>
+              </span>
+            </div>
             <span
               v-else
               class="text-muted-foreground text-xs"
@@ -683,6 +709,29 @@ function formatApiFormat(format: string): string {
     'GEMINI_CLI': 'Gemini CLI',
   }
   return formatMap[format.toUpperCase()] || format
+}
+
+// 获取 API 格式显示信息（包含转换提示）
+function getApiFormatDisplay(record: UsageRecord): { text: string; tooltip: string } {
+  const apiFormat = record.api_format
+  const endpointFormat = record.endpoint_api_format
+
+  if (!apiFormat) {
+    return { text: '-', tooltip: '' }
+  }
+
+  const displayFormat = formatApiFormat(apiFormat)
+
+  // 判断是否发生了格式转换
+  if (endpointFormat && apiFormat.toUpperCase() !== endpointFormat.toUpperCase()) {
+    const endpointDisplayFormat = formatApiFormat(endpointFormat)
+    return {
+      text: displayFormat,
+      tooltip: `用户请求格式: ${displayFormat}\n端点原生格式: ${endpointDisplayFormat}\n系统进行了 ${displayFormat} → ${endpointDisplayFormat} 格式转换`
+    }
+  }
+
+  return { text: displayFormat, tooltip: apiFormat }
 }
 
 // 获取实际使用的模型（优先 target_model，其次 model_version）

--- a/frontend/src/features/usage/types.ts
+++ b/frontend/src/features/usage/types.ts
@@ -72,6 +72,7 @@ export interface UsageRecord {
   model: string
   target_model?: string | null  // 映射后的目标模型名（若无映射则为空）
   api_format?: string
+  endpoint_api_format?: string  // 端点原生格式（用于判断是否发生格式转换）
   input_tokens: number
   output_tokens: number
   cache_creation_input_tokens?: number

--- a/src/api/admin/usage/routes.py
+++ b/src/api/admin/usage/routes.py
@@ -844,6 +844,7 @@ class AdminUsageRecordsAdapter(AdminApiAdapter):
                     "has_rectified": rectified_map.get(usage.request_id, False),
                     "api_format": usage.api_format
                     or (endpoint.api_format if endpoint and endpoint.api_format else None),
+                    "endpoint_api_format": endpoint.api_format if endpoint else None,
                     "api_key_name": provider_api_key.name if provider_api_key else None,
                     "request_metadata": usage.request_metadata,  # Provider 响应元数据
                 }


### PR DESCRIPTION
- 后端 API 新增返回 endpoint_api_format 字段（端点原生格式）
- 前端使用记录表格检测格式转换并显示紫色转换图标
- 悬停提示显示完整转换信息（用户请求格式 → 端点原生格式）