### PR TITLE
feat: 添加 API 密钥模型自动过滤功能

### DIFF
--- a/alembic/versions/20260127_1200_a589d11710b2_add_model_filter_patterns.py
+++ b/alembic/versions/20260127_1200_a589d11710b2_add_model_filter_patterns.py
@@ -1,0 +1,54 @@
+"""add model_include_patterns and model_exclude_patterns to provider_api_keys
+
+Revision ID: a589d11710b2
+Revises: 4b4c7b0df1a2
+Create Date: 2026-01-27 12:00:00.000000+00:00
+
+为 provider_api_keys 表添加模型过滤规则字段:
+1. model_include_patterns: 包含规则列表（支持 * 和 ? 通配符）
+2. model_exclude_patterns: 排除规则列表（支持 * 和 ? 通配符）
+
+注意: downgrade 操作会永久删除过滤规则配置
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision = 'a589d11710b2'
+down_revision = '4b4c7b0df1a2'
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    """Check if a column exists in the table"""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [col["name"] for col in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+def upgrade() -> None:
+    """添加模型过滤规则字段"""
+    if not _column_exists("provider_api_keys", "model_include_patterns"):
+        op.add_column(
+            "provider_api_keys",
+            sa.Column("model_include_patterns", sa.JSON(), nullable=True),
+        )
+
+    if not _column_exists("provider_api_keys", "model_exclude_patterns"):
+        op.add_column(
+            "provider_api_keys",
+            sa.Column("model_exclude_patterns", sa.JSON(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    """移除模型过滤规则字段"""
+    if _column_exists("provider_api_keys", "model_exclude_patterns"):
+        op.drop_column("provider_api_keys", "model_exclude_patterns")
+
+    if _column_exists("provider_api_keys", "model_include_patterns"):
+        op.drop_column("provider_api_keys", "model_include_patterns")

--- a/frontend/src/api/endpoints/keys.ts
+++ b/frontend/src/api/endpoints/keys.ts
@@ -98,6 +98,8 @@ export async function addProviderKey(
     capabilities?: Record<string, boolean>
     note?: string
     auto_fetch_models?: boolean  // 是否启用自动获取模型
+    model_include_patterns?: string[]  // 模型包含规则
+    model_exclude_patterns?: string[]  // 模型排除规则
   }
 ): Promise<EndpointAPIKey> {
   const response = await client.post(`/api/admin/endpoints/providers/${providerId}/keys`, data)
@@ -125,6 +127,8 @@ export async function updateProviderKey(
     is_active: boolean
     note: string
     auto_fetch_models: boolean  // 是否启用自动获取模型
+    model_include_patterns: string[]  // 模型包含规则
+    model_exclude_patterns: string[]  // 模型排除规则
   }>
 ): Promise<EndpointAPIKey> {
   const response = await client.put(`/api/admin/endpoints/keys/${keyId}`, data)

--- a/frontend/src/api/endpoints/types.ts
+++ b/frontend/src/api/endpoints/types.ts
@@ -189,6 +189,9 @@ export interface EndpointAPIKey {
   last_models_fetch_at?: string  // 最后获取模型时间
   last_models_fetch_error?: string  // 最后获取模型错误信息
   locked_models?: string[]  // 被锁定的模型列表
+  // 模型过滤规则（仅当 auto_fetch_models=true 时生效）
+  model_include_patterns?: string[]  // 模型包含规则（支持 * 和 ? 通配符）
+  model_exclude_patterns?: string[]  // 模型排除规则（支持 * 和 ? 通配符）
 }
 
 // 按格式的健康度数据
@@ -227,6 +230,9 @@ export interface EndpointAPIKeyUpdate {
   is_active?: boolean
   auto_fetch_models?: boolean  // 是否启用自动获取模型
   locked_models?: string[]  // 被锁定的模型列表
+  // 模型过滤规则（仅当 auto_fetch_models=true 时生效）
+  model_include_patterns?: string[]  // 模型包含规则（支持 * 和 ? 通配符）
+  model_exclude_patterns?: string[]  // 模型排除规则（支持 * 和 ? 通配符）
 }
 
 export interface EndpointHealthDetail {

--- a/frontend/src/features/providers/components/KeyAllowedModelsEditDialog.vue
+++ b/frontend/src/features/providers/components/KeyAllowedModelsEditDialog.vue
@@ -754,14 +754,12 @@ watch(() => props.open, async (open) => {
     // 加载全局模型
     await loadGlobalModels()
 
-    // 自动获取模式下，获取上游模型并刷新（保留锁定的模型）
+    // 自动获取模式下，获取上游模型用于显示（但选中状态使用已保存的 allowed_models）
     if (props.apiKey.auto_fetch_models) {
       await fetchUpstreamModels()
-      // 锁定的模型 + 最新上游模型（去重）
-      const newSelected = new Set(lockedModels.value)
-      upstreamModelNames.value.forEach(m => newSelected.add(m))
-      selectedModels.value = Array.from(newSelected)
-      initialSelectedModels.value = [...selectedModels.value]
+      // 注意：不再将所有上游模型自动标记为选中
+      // 因为后端有过滤规则，实际保存的 allowed_models 是过滤后的结果
+      // selectedModels 已在上面从 props.apiKey.allowed_models 初始化
     }
 
     // 提取自定义模型（不在全局模型和上游模型中的）

--- a/frontend/src/features/providers/components/KeyFormDialog.vue
+++ b/frontend/src/features/providers/components/KeyFormDialog.vue
@@ -211,20 +211,51 @@
       </div>
 
       <!-- 自动获取模型 -->
-      <div class="flex items-center justify-between py-2 px-3 rounded-md border border-border/60 bg-muted/30">
-        <div class="space-y-0.5">
-          <Label class="text-sm font-medium">自动获取上游可用模型</Label>
-          <p class="text-xs text-muted-foreground">
-            定时更新上游模型, 配合模型映射使用
-          </p>
-          <p
-            v-if="showAutoFetchWarning"
-            class="text-xs text-amber-600 dark:text-amber-400"
-          >
-            已配置的模型权限将在下次获取时被覆盖
-          </p>
+      <div class="space-y-3 py-2 px-3 rounded-md border border-border/60 bg-muted/30">
+        <div class="flex items-center justify-between">
+          <div class="space-y-0.5">
+            <Label class="text-sm font-medium">自动获取上游可用模型</Label>
+            <p class="text-xs text-muted-foreground">
+              定时更新上游模型, 配合模型映射使用
+            </p>
+            <p
+              v-if="showAutoFetchWarning"
+              class="text-xs text-amber-600 dark:text-amber-400"
+            >
+              已配置的模型权限将在下次获取时被覆盖
+            </p>
+          </div>
+          <Switch v-model="form.auto_fetch_models" />
         </div>
-        <Switch v-model="form.auto_fetch_models" />
+
+        <!-- 模型过滤规则（仅当开启自动获取时显示） -->
+        <div
+          v-if="form.auto_fetch_models"
+          class="space-y-2 pt-2 border-t border-border/40"
+        >
+          <div>
+            <Label class="text-xs">包含规则</Label>
+            <Input
+              v-model="form.model_include_patterns_text"
+              placeholder="gpt-*, claude-*, 留空包含全部"
+              class="h-8 text-sm"
+            />
+            <p class="text-xs text-muted-foreground mt-0.5">
+              逗号分隔，支持 * 和 ? 通配符
+            </p>
+          </div>
+          <div>
+            <Label class="text-xs">排除规则</Label>
+            <Input
+              v-model="form.model_exclude_patterns_text"
+              placeholder="*-preview, *-beta"
+              class="h-8 text-sm"
+            />
+            <p class="text-xs text-muted-foreground mt-0.5">
+              匹配的模型将被排除
+            </p>
+          </div>
+        </div>
       </div>
     </form>
 
@@ -335,7 +366,9 @@ const form = ref({
   note: '',
   is_active: true,
   capabilities: {} as Record<string, boolean>,
-  auto_fetch_models: false
+  auto_fetch_models: false,
+  model_include_patterns_text: '',  // 包含规则文本（逗号分隔）
+  model_exclude_patterns_text: ''   // 排除规则文本（逗号分隔）
 })
 
 // 加载能力列表
@@ -419,7 +452,9 @@ function resetForm() {
     note: '',
     is_active: true,
     capabilities: {},
-    auto_fetch_models: false
+    auto_fetch_models: false,
+    model_include_patterns_text: '',
+    model_exclude_patterns_text: ''
   }
 }
 
@@ -449,7 +484,9 @@ function loadKeyData() {
     note: props.editingKey.note || '',
     is_active: props.editingKey.is_active,
     capabilities: { ...(props.editingKey.capabilities || {}) },
-    auto_fetch_models: props.editingKey.auto_fetch_models ?? false
+    auto_fetch_models: props.editingKey.auto_fetch_models ?? false,
+    model_include_patterns_text: (props.editingKey.model_include_patterns || []).join(', '),
+    model_exclude_patterns_text: (props.editingKey.model_exclude_patterns || []).join(', ')
   }
 }
 
@@ -465,6 +502,16 @@ const { isEditMode, handleDialogUpdate, handleCancel } = useFormDialog({
 
 function createFieldNonce(): string {
   return Math.random().toString(36).slice(2, 10)
+}
+
+// 将逗号分隔的文本解析为数组（去空、去重）
+function parsePatternText(text: string): string[] | undefined {
+  if (!text.trim()) return undefined
+  const patterns = text
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+  return patterns.length > 0 ? [...new Set(patterns)] : undefined
 }
 
 async function handleSave() {
@@ -529,7 +576,9 @@ async function handleSave() {
         note: form.value.note,
         is_active: form.value.is_active,
         capabilities: capabilitiesData,
-        auto_fetch_models: form.value.auto_fetch_models
+        auto_fetch_models: form.value.auto_fetch_models,
+        model_include_patterns: parsePatternText(form.value.model_include_patterns_text),
+        model_exclude_patterns: parsePatternText(form.value.model_exclude_patterns_text)
       }
 
       if (form.value.api_key.trim()) {
@@ -551,7 +600,9 @@ async function handleSave() {
         max_probe_interval_minutes: form.value.max_probe_interval_minutes,
         note: form.value.note,
         capabilities: capabilitiesData || undefined,
-        auto_fetch_models: form.value.auto_fetch_models
+        auto_fetch_models: form.value.auto_fetch_models,
+        model_include_patterns: parsePatternText(form.value.model_include_patterns_text),
+        model_exclude_patterns: parsePatternText(form.value.model_exclude_patterns_text)
       })
       success('密钥已添加', '成功')
       // 添加模式：不关闭对话框，只清除名称和密钥以便继续添加

--- a/src/models/database.py
+++ b/src/models/database.py
@@ -1178,6 +1178,9 @@ class ProviderAPIKey(Base):
     last_models_fetch_at = Column(DateTime(timezone=True), nullable=True)  # 最后获取时间
     last_models_fetch_error = Column(Text, nullable=True)  # 最后获取错误信息
     locked_models = Column(JSON, nullable=True)  # 被锁定的模型列表（刷新时不会被删除）
+    # 模型过滤规则（支持 * 和 ? 通配符，如 "gpt-*", "claude-?-sonnet"）
+    model_include_patterns = Column(JSON, nullable=True)  # 包含规则列表，空表示不过滤（包含所有）
+    model_exclude_patterns = Column(JSON, nullable=True)  # 排除规则列表，空表示不排除
 
     # 时间戳
     created_at = Column(

--- a/src/models/endpoint_models.py
+++ b/src/models/endpoint_models.py
@@ -211,6 +211,14 @@ class EndpointAPIKeyCreate(BaseModel):
         default=None, description="被锁定的模型列表（刷新时不会被删除）"
     )
 
+    # 模型过滤规则（仅当 auto_fetch_models=True 时生效）
+    model_include_patterns: Optional[List[str]] = Field(
+        default=None, description="模型包含规则（支持 * 和 ? 通配符），空表示包含所有"
+    )
+    model_exclude_patterns: Optional[List[str]] = Field(
+        default=None, description="模型排除规则（支持 * 和 ? 通配符），空表示不排除"
+    )
+
     @field_validator("api_formats")
     @classmethod
     def validate_api_formats(cls, v: Optional[List[str]]) -> Optional[List[str]]:
@@ -344,6 +352,13 @@ class EndpointAPIKeyUpdate(BaseModel):
     )
     locked_models: Optional[List[str]] = Field(
         default=None, description="被锁定的模型列表（刷新时不会被删除）"
+    )
+    # 模型过滤规则（仅当 auto_fetch_models=True 时生效）
+    model_include_patterns: Optional[List[str]] = Field(
+        default=None, description="模型包含规则（支持 * 和 ? 通配符），空表示包含所有"
+    )
+    model_exclude_patterns: Optional[List[str]] = Field(
+        default=None, description="模型排除规则（支持 * 和 ? 通配符），空表示不排除"
     )
 
     @field_validator("api_formats")
@@ -502,6 +517,9 @@ class EndpointAPIKeyResponse(BaseModel):
     last_models_fetch_at: Optional[datetime] = Field(None, description="最后获取模型时间")
     last_models_fetch_error: Optional[str] = Field(None, description="最后获取模型错误信息")
     locked_models: Optional[List[str]] = Field(None, description="被锁定的模型列表")
+    # 模型过滤规则
+    model_include_patterns: Optional[List[str]] = Field(None, description="模型包含规则")
+    model_exclude_patterns: Optional[List[str]] = Field(None, description="模型排除规则")
 
     # 时间戳
     last_used_at: Optional[datetime] = None

--- a/src/services/model/fetch_scheduler.py
+++ b/src/services/model/fetch_scheduler.py
@@ -7,10 +7,12 @@
 - 扫描所有启用了 auto_fetch_models 的 ProviderAPIKey
 - 调用 Adapter.fetch_models() 获取模型列表
 - 更新 Key 的 allowed_models（保留 locked_models 中的模型）
+- 支持包含/排除规则过滤模型
 - 记录获取结果和错误信息
 """
 
 import asyncio
+import fnmatch
 import os
 from datetime import datetime, timezone
 from typing import Optional
@@ -40,6 +42,68 @@ KEY_FETCH_TIMEOUT_SECONDS = 120
 
 # 上游模型缓存 TTL（与定时任务间隔保持一致）
 UPSTREAM_MODELS_CACHE_TTL_SECONDS = MODEL_FETCH_INTERVAL_MINUTES * 60
+
+
+def _match_pattern(model_id: str, pattern: str) -> bool:
+    """
+    检查模型 ID 是否匹配模式
+
+    支持的通配符:
+    - * 匹配任意字符（包括空）
+    - ? 匹配单个字符
+
+    Args:
+        model_id: 模型 ID
+        pattern: 匹配模式
+
+    Returns:
+        是否匹配
+    """
+    return fnmatch.fnmatch(model_id.lower(), pattern.lower())
+
+
+def _filter_models_by_patterns(
+    model_ids: set[str],
+    include_patterns: list[str] | None,
+    exclude_patterns: list[str] | None,
+) -> set[str]:
+    """
+    根据包含/排除规则过滤模型列表
+
+    规则优先级:
+    1. 如果 include_patterns 为空或 None，则包含所有模型
+    2. 如果 include_patterns 不为空，则只包含匹配的模型
+    3. exclude_patterns 总是会排除匹配的模型（优先级高于 include）
+
+    Args:
+        model_ids: 原始模型 ID 集合
+        include_patterns: 包含规则列表（支持 * 和 ? 通配符）
+        exclude_patterns: 排除规则列表（支持 * 和 ? 通配符）
+
+    Returns:
+        过滤后的模型 ID 集合
+    """
+    result = set()
+
+    for model_id in model_ids:
+        # 步骤1: 检查是否应该包含
+        should_include = True
+        if include_patterns:
+            # 有包含规则时，必须匹配至少一个规则
+            should_include = any(_match_pattern(model_id, p) for p in include_patterns)
+
+        if not should_include:
+            continue
+
+        # 步骤2: 检查是否应该排除
+        should_exclude = False
+        if exclude_patterns:
+            should_exclude = any(_match_pattern(model_id, p) for p in exclude_patterns)
+
+        if not should_exclude:
+            result.add(model_id)
+
+    return result
 
 
 def _get_upstream_models_cache_key(provider_id: str, api_key_id: str) -> str:
@@ -341,7 +405,7 @@ class ModelFetchScheduler:
 
     def _update_key_allowed_models(self, key: ProviderAPIKey, fetched_model_ids: set[str]) -> bool:
         """
-        更新 Key 的 allowed_models，保留 locked_models
+        更新 Key 的 allowed_models，保留 locked_models，应用过滤规则
 
         Returns:
             bool: 是否有变化
@@ -349,9 +413,26 @@ class ModelFetchScheduler:
         # 获取当前锁定的模型
         locked_models = set(key.locked_models or [])
 
-        # 新的 allowed_models = 获取到的模型 + 锁定的模型
+        # 应用包含/排除过滤规则
+        include_patterns = key.model_include_patterns
+        exclude_patterns = key.model_exclude_patterns
+
+        filtered_model_ids = _filter_models_by_patterns(
+            fetched_model_ids, include_patterns, exclude_patterns
+        )
+
+        # 记录过滤结果
+        if include_patterns or exclude_patterns:
+            filtered_count = len(fetched_model_ids) - len(filtered_model_ids)
+            if filtered_count > 0:
+                logger.info(
+                    f"Key {key.id} 过滤规则生效: 原始 {len(fetched_model_ids)} 个模型, "
+                    f"过滤后 {len(filtered_model_ids)} 个 (排除 {filtered_count} 个)"
+                )
+
+        # 新的 allowed_models = 过滤后的模型 + 锁定的模型
         # 锁定模型无论上游是否返回都会保留
-        new_allowed_models = list(fetched_model_ids | locked_models)
+        new_allowed_models = list(filtered_model_ids | locked_models)
         new_allowed_models.sort()  # 保持顺序稳定
 
         # 检查是否有变化


### PR DESCRIPTION
支持通过通配符规则自动过滤从上游获取的模型列表，包括包含规则和排除规则。

主要变更：
- 数据库：添加 model_include_patterns 和 model_exclude_patterns 字段
- 后端：实现基于 fnmatch 的过滤逻辑（支持 * 和 ? 通配符）
- 前端：在密钥表单中添加过滤规则配置界面
- API：更新密钥创建/更新接口，支持过滤规则参数
- 逻辑：过滤规则变更时自动重新应用过滤

过滤优先级：先应用包含规则，再应用排除规则（排除优先级更高）