### PR TITLE
feat: 优化余额查询和签到检测

### DIFF
--- a/src/services/provider_ops/actions/new_api_balance.py
+++ b/src/services/provider_ops/actions/new_api_balance.py
@@ -155,7 +155,7 @@ class NewApiBalanceAction(BalanceAction):
                     return {"success": True, "message": message or "签到成功"}
                 else:
                     # 检查是否是"已签到"的情况
-                    already_indicators = ["already", "已签到", "今日已签", "重复签到"]
+                    already_indicators = ["already", "已签到", "今日已签", "重复签到", "已经签到"]
                     is_already = any(ind in message.lower() for ind in already_indicators)
                     if is_already:
                         logger.debug(f"[{site}] 今日已签到: {message}")

--- a/src/services/provider_ops/service.py
+++ b/src/services/provider_ops/service.py
@@ -658,11 +658,24 @@ class ProviderOpsService:
                 if p.config and p.config.get("provider_ops")
             ]
 
-        # 并行查询，使用缓存优先策略
-        tasks = [
-            self.query_balance_with_cache(provider_id, trigger_refresh=True)
-            for provider_id in provider_ids
-        ]
+        # 并行查询，使用缓存优先策略，每个查询有独立超时
+        SINGLE_QUERY_TIMEOUT = 15.0  # 单个查询最多 15 秒
+
+        async def query_with_timeout(provider_id: str) -> ActionResult:
+            try:
+                return await asyncio.wait_for(
+                    self.query_balance_with_cache(provider_id, trigger_refresh=True),
+                    timeout=SINGLE_QUERY_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(f"查询余额超时: provider_id={provider_id}")
+                return ActionResult(
+                    status=ActionStatus.UNKNOWN_ERROR,
+                    action_type=ProviderActionType.QUERY_BALANCE,
+                    message=f"查询超时（>{SINGLE_QUERY_TIMEOUT}秒）",
+                )
+
+        tasks = [query_with_timeout(provider_id) for provider_id in provider_ids]
         results_list = await asyncio.gather(*tasks, return_exceptions=True)
 
         results = {}


### PR DESCRIPTION
- 批量余额查询增加单个查询超时限制 (15秒)，避免单个慢查询阻塞整体
- 签到检测增加 "已经签到" 关键词识别