### PR TITLE
feat: 实现格式转换三态继承逻辑（端点 > 提供商 > 全局）

### DIFF
--- a/alembic/versions/20260202_1000_b3c4d5e6f7a8_make_provider_enable_format_conversion_nullable.py
+++ b/alembic/versions/20260202_1000_b3c4d5e6f7a8_make_provider_enable_format_conversion_nullable.py
@@ -1,0 +1,87 @@
+"""Make provider enable_format_conversion nullable for inheritance support
+
+Revision ID: b3c4d5e6f7a8
+Revises: a2f1b3c4d5e6
+Create Date: 2026-02-02 10:00:00+00:00
+
+Changes:
+1. providers 表: 修改 enable_format_conversion 字段为可空
+   - True: 明确开启格式转换
+   - False: 明确禁用格式转换
+   - None/NULL: 继承父级设置
+
+这支持三级继承逻辑：端点 > 提供商 > 全局
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision = "b3c4d5e6f7a8"
+down_revision = "a2f1b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def column_exists(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [col["name"] for col in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+def upgrade() -> None:
+    # 修改 enable_format_conversion 为可空
+    # 这允许 NULL 值表示"继承父级设置"
+    if table_exists("providers") and column_exists("providers", "enable_format_conversion"):
+        # 1. 移除 server_default
+        op.alter_column(
+            "providers",
+            "enable_format_conversion",
+            existing_type=sa.Boolean(),
+            server_default=None,
+        )
+        # 2. 设置为可空
+        op.alter_column(
+            "providers",
+            "enable_format_conversion",
+            existing_type=sa.Boolean(),
+            nullable=True,
+        )
+        # 3. 保留现有数据语义：True 和 False 都保持原值
+        # 只有新建的 Provider 才会使用 NULL（继承父级设置）
+        # 这避免了迁移意外改变已明确禁用格式转换的 Provider 的行为
+
+
+def downgrade() -> None:
+    # 回滚：将 NULL 值改为 False，然后设置为非空
+    if table_exists("providers") and column_exists("providers", "enable_format_conversion"):
+        # 1. 将 NULL 值改为 False
+        bind = op.get_bind()
+        bind.execute(
+            sa.text(
+                "UPDATE providers SET enable_format_conversion = false WHERE enable_format_conversion IS NULL"
+            )
+        )
+        # 2. 设置为非空
+        op.alter_column(
+            "providers",
+            "enable_format_conversion",
+            existing_type=sa.Boolean(),
+            nullable=False,
+        )
+        # 3. 恢复 server_default
+        op.alter_column(
+            "providers",
+            "enable_format_conversion",
+            existing_type=sa.Boolean(),
+            server_default=sa.text("false"),
+        )

--- a/frontend/src/api/endpoints/providers.ts
+++ b/frontend/src/api/endpoints/providers.ts
@@ -27,6 +27,8 @@ export async function updateProvider(
     description: string
     website: string
     provider_priority: number
+    keep_priority_on_conversion: boolean
+    enable_format_conversion: boolean | null  // 三态：true=启用，false=禁用，null=继承全局
     billing_type: 'monthly_quota' | 'pay_as_you_go' | 'free_tier'
     monthly_quota_usd: number
     quota_reset_day: number

--- a/frontend/src/api/endpoints/types.ts
+++ b/frontend/src/api/endpoints/types.ts
@@ -119,9 +119,9 @@ export type HeaderRule = HeaderRuleSet | HeaderRuleDrop | HeaderRuleRename
  * 用于控制端点是否接受来自不同 API 格式的请求，并自动进行格式转换
  */
 export interface FormatAcceptanceConfig {
-  enabled: boolean                // 是否启用格式转换
-  accept_formats?: string[]       // 白名单：接受哪些格式的请求
-  reject_formats?: string[]       // 黑名单：拒绝哪些格式（优先级高于白名单）
+  enabled?: boolean | null      // 是否启用格式转换（null=继承父级）
+  accept_formats?: string[]     // 白名单：接受哪些格式的请求
+  reject_formats?: string[]     // 黑名单：拒绝哪些格式（优先级高于白名单）
 }
 
 export interface ProviderEndpoint {
@@ -137,8 +137,11 @@ export interface ProviderEndpoint {
   is_active: boolean
   config?: Record<string, any>
   proxy?: ProxyConfig | null
-  // 格式转换配置
+  // 格式转换配置（三态）
   format_acceptance_config?: FormatAcceptanceConfig | null
+  // 格式转换有效值和继承信息
+  format_conversion_effective: boolean    // 计算继承后的实际生效值
+  format_conversion_inherited_from?: 'provider' | 'global' | null  // 继承来源
   total_keys: number
   active_keys: number
   created_at: string
@@ -340,7 +343,11 @@ export interface ProviderWithEndpointsSummary {
   website?: string
   provider_priority: number
   keep_priority_on_conversion: boolean  // 格式转换时是否保持优先级
-  enable_format_conversion: boolean  // 是否允许格式转换（提供商级别开关）
+  // 三态格式转换配置
+  enable_format_conversion?: boolean | null  // 是否允许格式转换（null=继承全局）
+  // 格式转换有效值和继承信息
+  format_conversion_effective: boolean    // 计算继承后的实际生效值
+  format_conversion_inherited_from?: 'global' | null  // 继承来源（'global' 或 null=自身设置）
   billing_type?: 'monthly_quota' | 'pay_as_you_go' | 'free_tier'
   monthly_quota_usd?: number
   monthly_used_usd?: number

--- a/frontend/src/features/providers/components/EndpointFormDialog.vue
+++ b/frontend/src/features/providers/components/EndpointFormDialog.vue
@@ -41,12 +41,20 @@
                   variant="ghost"
                   size="icon"
                   class="h-7 w-7 mr-1"
-                  :class="endpoint.format_acceptance_config?.enabled ? 'text-primary' : ''"
-                  :title="endpoint.format_acceptance_config?.enabled ? '已启用格式转换（点击关闭）' : '启用格式转换'"
+                  :class="getEndpointFormatConversionClass(endpoint)"
+                  :title="getEndpointFormatConversionTitle(endpoint)"
                   :disabled="togglingFormatEndpointId === endpoint.id"
                   @click="handleToggleFormatConversion(endpoint)"
                 >
-                  <Shuffle class="w-3.5 h-3.5" />
+                  <!-- 继承状态用 Link2 图标，其他状态用 Shuffle -->
+                  <Link2
+                    v-if="isEndpointInherited(endpoint)"
+                    class="w-3.5 h-3.5"
+                  />
+                  <Shuffle
+                    v-else
+                    class="w-3.5 h-3.5"
+                  />
                 </Button>
                 <!-- 启用/停用 -->
                 <Button
@@ -397,7 +405,7 @@ import {
   CollapsibleTrigger,
   CollapsibleContent,
 } from '@/components/ui'
-import { Settings, Trash2, Check, X, Power, ChevronRight, Plus, ArrowRight, Shuffle, RotateCcw } from 'lucide-vue-next'
+import { Settings, Trash2, Check, X, Power, ChevronRight, Plus, ArrowRight, Shuffle, RotateCcw, Link2 } from 'lucide-vue-next'
 import { useToast } from '@/composables/useToast'
 import { log } from '@/utils/logger'
 import AlertDialog from '@/components/common/AlertDialog.vue'
@@ -861,22 +869,98 @@ async function saveEndpoint(endpoint: ProviderEndpoint) {
   }
 }
 
-// 切换格式转换（直接保存）
+// 切换格式转换（三态循环：null → true → false → null，直接保存）
+// 保留 format_acceptance_config 中的其他字段（如 accept_formats、reject_formats）
 async function handleToggleFormatConversion(endpoint: ProviderEndpoint) {
-  const currentEnabled = endpoint.format_acceptance_config?.enabled || false
-  const newEnabled = !currentEnabled
+  const currentConfig = endpoint.format_acceptance_config
+  const currentEnabled = currentConfig?.enabled
+  let newConfig: Record<string, any> | null
+  let message: string
+
+  if (currentEnabled === null || currentEnabled === undefined) {
+    // null → true：保留原有配置，只更新 enabled
+    newConfig = { ...currentConfig, enabled: true }
+    message = '已启用格式转换'
+  } else if (currentEnabled === true) {
+    // true → false：保留原有配置，只更新 enabled
+    newConfig = { ...currentConfig, enabled: false }
+    message = '已禁用格式转换'
+  } else {
+    // false → null（继承父级）：清除 enabled 字段，保留其他配置
+    if (currentConfig) {
+      const { enabled: _, ...restConfig } = currentConfig
+      // 如果除 enabled 外还有其他配置，保留它们
+      newConfig = Object.keys(restConfig).length > 0 ? restConfig : null
+    } else {
+      newConfig = null
+    }
+    message = '已切换为继承父级设置'
+  }
 
   togglingFormatEndpointId.value = endpoint.id
   try {
     await updateEndpoint(endpoint.id, {
-      format_acceptance_config: newEnabled ? { enabled: true } : null,
+      format_acceptance_config: newConfig,
     })
-    success(newEnabled ? '已启用格式转换' : '已关闭格式转换')
+    success(message)
     emit('endpointUpdated')
   } catch (error: any) {
     showError(error.response?.data?.detail || '操作失败', '错误')
   } finally {
     togglingFormatEndpointId.value = null
+  }
+}
+
+// 判断端点是否处于继承状态
+function isEndpointInherited(endpoint: ProviderEndpoint): boolean {
+  const enabled = endpoint.format_acceptance_config?.enabled
+  return enabled === null || enabled === undefined
+}
+
+// 获取端点格式转换按钮的样式类
+function getEndpointFormatConversionClass(endpoint: ProviderEndpoint): string {
+  const enabled = endpoint.format_acceptance_config?.enabled
+  if (enabled === true) {
+    // 明确启用 - 橘黄色
+    return 'text-orange-500'
+  } else if (enabled === false) {
+    // 明确禁用 - 默认色
+    return ''
+  } else {
+    // 继承 - 蓝色
+    return 'text-blue-500'
+  }
+}
+
+// 获取端点格式转换按钮的 title
+function getEndpointFormatConversionTitle(endpoint: ProviderEndpoint): string {
+  const enabled = endpoint.format_acceptance_config?.enabled
+  if (enabled === true) {
+    return '已启用格式转换（点击切换为禁用）'
+  } else if (enabled === false) {
+    return '已禁用格式转换（点击切换为继承父级）'
+  } else {
+    // 继承状态 - 判断继承来源
+    const inheritedFrom = endpoint.format_conversion_inherited_from
+    const effective = endpoint.format_conversion_effective
+    const effectiveLabel = effective ? '启用' : '禁用'
+
+    if (inheritedFrom === 'provider') {
+      // 端点继承提供商，检查提供商是否也是继承状态
+      const providerValue = props.provider?.enable_format_conversion
+      if (providerValue === null || providerValue === undefined) {
+        // 提供商也是继承全局
+        return `继承提供商设置（当前提供商：继承全局 → ${effectiveLabel}）（点击切换为启用）`
+      } else {
+        // 提供商有明确值
+        return `继承提供商设置（当前提供商：${effectiveLabel}）（点击切换为启用）`
+      }
+    } else if (inheritedFrom === 'global') {
+      return `继承全局设置（当前全局：${effectiveLabel}）（点击切换为启用）`
+    } else {
+      // 兜底
+      return `继承父级设置（当前：${effectiveLabel}）（点击切换为启用）`
+    }
   }
 }
 

--- a/frontend/src/features/providers/components/ProviderDetailDrawer.vue
+++ b/frontend/src/features/providers/components/ProviderDetailDrawer.vue
@@ -58,11 +58,19 @@
                   <Button
                     variant="ghost"
                     size="icon"
-                    :title="provider.enable_format_conversion ? '已启用格式转换（点击关闭）' : '启用格式转换'"
-                    :class="provider.enable_format_conversion ? 'text-primary' : ''"
+                    :title="getProviderFormatConversionTitle()"
+                    :class="getProviderFormatConversionClass()"
                     @click="toggleFormatConversion"
                   >
-                    <Shuffle class="w-4 h-4" />
+                    <!-- 继承状态用 Link2 图标，其他状态用 Shuffle -->
+                    <Link2
+                      v-if="provider.enable_format_conversion === null || provider.enable_format_conversion === undefined"
+                      class="w-4 h-4"
+                    />
+                    <Shuffle
+                      v-else
+                      class="w-4 h-4"
+                    />
                   </Button>
                   <Button
                     variant="ghost"
@@ -512,7 +520,8 @@ import {
   GripVertical,
   Copy,
   Shield,
-  Shuffle
+  Shuffle,
+  Link2
 } from 'lucide-vue-next'
 import { useEscapeKey } from '@/composables/useEscapeKey'
 import Button from '@/components/ui/button.vue'
@@ -712,14 +721,63 @@ function handleClose() {
   }
 }
 
-// 切换格式转换开关
+// 获取提供商格式转换按钮的 title
+function getProviderFormatConversionTitle(): string {
+  const current = provider.value?.enable_format_conversion
+  if (current === true) {
+    return '已启用格式转换（点击切换为禁用）'
+  } else if (current === false) {
+    return '已禁用格式转换（点击切换为继承全局）'
+  } else {
+    // null/undefined = 继承全局
+    const effective = provider.value?.format_conversion_effective
+    return `继承全局设置（当前全局：${effective ? '启用' : '禁用'}）（点击切换为启用）`
+  }
+}
+
+// 获取提供商格式转换按钮的样式类
+function getProviderFormatConversionClass(): string {
+  const current = provider.value?.enable_format_conversion
+  if (current === true) {
+    // 明确启用 - 橘黄色
+    return 'text-orange-500'
+  } else if (current === false) {
+    // 明确禁用 - 默认色
+    return ''
+  } else {
+    // 继承 - 蓝色
+    return 'text-blue-500'
+  }
+}
+
+// 切换格式转换开关（三态循环：null → true → false → null）
 async function toggleFormatConversion() {
   if (!provider.value) return
-  const newValue = !provider.value.enable_format_conversion
+
+  const current = provider.value.enable_format_conversion
+  let newValue: boolean | null
+  let message: string
+
+  if (current === null || current === undefined) {
+    // null → true
+    newValue = true
+    message = '已启用格式转换'
+  } else if (current === true) {
+    // true → false
+    newValue = false
+    message = '已禁用格式转换'
+  } else {
+    // false → null
+    newValue = null
+    message = '已切换为继承全局设置'
+  }
+
   try {
-    await updateProvider(provider.value.id, { enable_format_conversion: newValue })
+    const result = await updateProvider(provider.value.id, { enable_format_conversion: newValue })
     provider.value.enable_format_conversion = newValue
-    showSuccess(newValue ? '已启用格式转换' : '已禁用格式转换')
+    provider.value.format_conversion_effective = result.format_conversion_effective
+    provider.value.format_conversion_inherited_from = result.format_conversion_inherited_from
+    showSuccess(message)
     emit('refresh')
   } catch {
     showError('切换格式转换失败')

--- a/src/api/admin/endpoints/routes.py
+++ b/src/api/admin/endpoints/routes.py
@@ -28,6 +28,7 @@ from src.models.endpoint_models import (
     ProviderEndpointResponse,
     ProviderEndpointUpdate,
 )
+from src.services.system.config import SystemConfigService
 
 router = APIRouter(tags=["Endpoint Management"])
 pipeline = ApiRequestPipeline()
@@ -41,6 +42,32 @@ def mask_proxy_password(proxy_config: dict | None) -> dict | None:
     if masked.get("password"):
         masked["password"] = "***"
     return masked
+
+
+def _compute_endpoint_format_conversion(
+    endpoint: ProviderEndpoint, provider: Provider, db: Session
+) -> tuple[bool, str | None]:
+    """计算端点格式转换的有效值和继承来源
+
+    继承链：端点 > 提供商 > 全局
+    Returns:
+        (effective_value, inherited_from)
+        inherited_from: None=自身设置, 'provider'=继承提供商, 'global'=继承全局
+    """
+    # 端点自身配置
+    endpoint_config = endpoint.format_acceptance_config
+    if endpoint_config is not None and endpoint_config.get("enabled") is not None:
+        enabled = endpoint_config.get("enabled")
+        if enabled is True or enabled is False:
+            return bool(enabled), None
+
+    # 继承提供商设置
+    if provider.enable_format_conversion is not None:
+        return bool(provider.enable_format_conversion), "provider"
+
+    # 继承全局设置
+    global_value = SystemConfigService.get_config(db, "enable_format_conversion", False)
+    return bool(global_value), "global"
 
 
 @router.get("/providers/{provider_id}/endpoints", response_model=list[ProviderEndpointResponse])
@@ -256,6 +283,10 @@ class AdminListProviderEndpointsAdapter(AdminApiAdapter):
                 if isinstance(endpoint.api_format, str)
                 else endpoint.api_format.value
             )
+            # 计算格式转换的有效值和继承来源
+            effective, inherited_from = _compute_endpoint_format_conversion(
+                endpoint, provider, db
+            )
             endpoint_dict = {
                 **endpoint.__dict__,
                 "provider_name": provider.name,
@@ -263,6 +294,8 @@ class AdminListProviderEndpointsAdapter(AdminApiAdapter):
                 "total_keys": total_keys_map.get(endpoint_format, 0),
                 "active_keys": active_keys_map.get(endpoint_format, 0),
                 "proxy": mask_proxy_password(endpoint.proxy),
+                "format_conversion_effective": effective,
+                "format_conversion_inherited_from": inherited_from,
             }
             endpoint_dict.pop("_sa_instance_state", None)
             result.append(ProviderEndpointResponse(**endpoint_dict))
@@ -340,6 +373,9 @@ class AdminCreateProviderEndpointAdapter(AdminApiAdapter):
             for k, v in new_endpoint.__dict__.items()
             if k not in {"api_format", "_sa_instance_state", "proxy"}
         }
+        effective, inherited_from = _compute_endpoint_format_conversion(
+            new_endpoint, provider, db
+        )
         return ProviderEndpointResponse(
             **endpoint_dict,
             provider_name=provider.name,
@@ -347,6 +383,8 @@ class AdminCreateProviderEndpointAdapter(AdminApiAdapter):
             proxy=mask_proxy_password(new_endpoint.proxy),
             total_keys=0,
             active_keys=0,
+            format_conversion_effective=effective,
+            format_conversion_inherited_from=inherited_from,
         )
 
 
@@ -389,6 +427,9 @@ class AdminGetProviderEndpointAdapter(AdminApiAdapter):
             for k, v in endpoint_obj.__dict__.items()
             if k not in {"api_format", "_sa_instance_state", "proxy"}
         }
+        effective, inherited_from = _compute_endpoint_format_conversion(
+            endpoint_obj, provider, db
+        )
         return ProviderEndpointResponse(
             **endpoint_dict,
             provider_name=provider.name,
@@ -396,6 +437,8 @@ class AdminGetProviderEndpointAdapter(AdminApiAdapter):
             proxy=mask_proxy_password(endpoint_obj.proxy),
             total_keys=total_keys,
             active_keys=active_keys,
+            format_conversion_effective=effective,
+            format_conversion_inherited_from=inherited_from,
         )
 
 
@@ -468,6 +511,9 @@ class AdminUpdateProviderEndpointAdapter(AdminApiAdapter):
             for k, v in endpoint.__dict__.items()
             if k not in {"api_format", "_sa_instance_state", "proxy"}
         }
+        effective, inherited_from = _compute_endpoint_format_conversion(
+            endpoint, provider, db
+        ) if provider else (False, None)
         return ProviderEndpointResponse(
             **endpoint_dict,
             provider_name=provider.name if provider else "Unknown",
@@ -475,6 +521,8 @@ class AdminUpdateProviderEndpointAdapter(AdminApiAdapter):
             proxy=mask_proxy_password(endpoint.proxy),
             total_keys=total_keys,
             active_keys=active_keys,
+            format_conversion_effective=effective,
+            format_conversion_inherited_from=inherited_from,
         )
 
 

--- a/src/api/admin/providers/summary.py
+++ b/src/api/admin/providers/summary.py
@@ -31,6 +31,7 @@ from src.models.endpoint_models import (
     ProviderUpdateRequest,
     ProviderWithEndpointsSummary,
 )
+from src.services.system.config import SystemConfigService
 
 router = APIRouter(tags=["Provider Summary"])
 pipeline = ApiRequestPipeline()
@@ -302,6 +303,17 @@ def _build_provider_summary(db: Session, provider: Provider) -> ProviderWithEndp
         provider_ops_config.get("architecture_id") if provider_ops_config else None
     )
 
+    # 计算格式转换的有效值和继承来源
+    if provider.enable_format_conversion is not None:
+        # 提供商自身有明确设置
+        format_conversion_effective = provider.enable_format_conversion
+        format_conversion_inherited_from = None
+    else:
+        # 继承全局设置
+        global_value = SystemConfigService.get_config(db, "enable_format_conversion", False)
+        format_conversion_effective = bool(global_value)
+        format_conversion_inherited_from = "global"
+
     return ProviderWithEndpointsSummary(
         id=provider.id,
         name=provider.name,
@@ -310,6 +322,8 @@ def _build_provider_summary(db: Session, provider: Provider) -> ProviderWithEndp
         provider_priority=provider.provider_priority,
         keep_priority_on_conversion=provider.keep_priority_on_conversion,
         enable_format_conversion=provider.enable_format_conversion,
+        format_conversion_effective=format_conversion_effective,
+        format_conversion_inherited_from=format_conversion_inherited_from,
         is_active=provider.is_active,
         billing_type=provider.billing_type.value if provider.billing_type else None,
         monthly_quota_usd=provider.monthly_quota_usd,

--- a/src/models/database.py
+++ b/src/models/database.py
@@ -669,13 +669,12 @@ class Provider(Base):
     # 注意：如果全局配置 KEEP_PRIORITY_ON_CONVERSION=true，此字段被忽略（所有提供商都保持优先级）
     keep_priority_on_conversion = Column(Boolean, default=False, nullable=False)
 
-    # 是否允许格式转换（默认 True）
-    # - True: 该提供商可以作为格式转换的目标（如 OpenAI 客户端请求可以路由到此 Gemini 提供商）
-    # - False: 该提供商不接受需要格式转换的请求
-    # 优先级逻辑：
-    # - 全局开关 ON → 强制允许所有提供商的格式转换（忽略此字段）
-    # - 全局开关 OFF → 由此字段决定是否允许该提供商的格式转换
-    enable_format_conversion = Column(Boolean, default=False, nullable=False)
+    # 是否允许格式转换（三态逻辑）
+    # - True: 明确启用格式转换
+    # - False: 明确禁用格式转换
+    # - None/NULL: 继承全局设置（SystemConfig.enable_format_conversion）
+    # 继承链：端点 > 提供商 > 全局
+    enable_format_conversion = Column(Boolean, default=None, nullable=True)
 
     # 状态
     is_active = Column(Boolean, default=True, nullable=False)

--- a/src/models/endpoint_models.py
+++ b/src/models/endpoint_models.py
@@ -143,10 +143,19 @@ class ProviderEndpointResponse(BaseModel):
     # 代理配置（响应中密码已脱敏）
     proxy: dict[str, Any] | None = Field(default=None, description="代理配置（密码已脱敏）")
 
-    # 格式转换配置
+    # 格式转换配置（三态）
     format_acceptance_config: dict[str, Any] | None = Field(
         default=None,
         description="格式接受策略配置（跨格式转换开关/白黑名单等）",
+    )
+    # 格式转换有效值和继承信息
+    format_conversion_effective: bool = Field(
+        default=False,
+        description="格式转换的有效值（计算继承后的实际生效值）",
+    )
+    format_conversion_inherited_from: str | None = Field(
+        default=None,
+        description="格式转换继承来源：'provider' / 'global'，None 表示使用自身设置",
     )
 
     # 统计（从 Keys 聚合）
@@ -637,7 +646,7 @@ class ProviderUpdateRequest(BaseModel):
     )
     enable_format_conversion: bool | None = Field(
         None,
-        description="是否允许格式转换（提供商级别开关）",
+        description="是否允许格式转换（提供商级别开关，None=继承全局）",
     )
     is_active: bool | None = None
     billing_type: str | None = Field(
@@ -671,9 +680,19 @@ class ProviderWithEndpointsSummary(BaseModel):
         default=False,
         description="格式转换时是否保持优先级（True=保持原优先级，False=需要转换时降级）",
     )
-    enable_format_conversion: bool = Field(
-        default=True,
-        description="是否允许格式转换（提供商级别开关）",
+    # 三态格式转换配置
+    enable_format_conversion: bool | None = Field(
+        default=None,
+        description="是否允许格式转换（True=启用，False=禁用，None=继承全局）",
+    )
+    # 格式转换有效值和继承信息
+    format_conversion_effective: bool = Field(
+        default=False,
+        description="格式转换的有效值（计算继承后的实际生效值）",
+    )
+    format_conversion_inherited_from: str | None = Field(
+        default=None,
+        description="格式转换继承来源：'global' 表示继承全局，None 表示使用自身设置",
     )
     is_active: bool
 

--- a/src/services/cache/aware_scheduler.py
+++ b/src/services/cache/aware_scheduler.py
@@ -1170,16 +1170,23 @@ class CacheAwareScheduler:
                     str(getattr(endpoint, "endpoint_kind", "")).strip().lower(),
                 )
 
-                # 计算格式转换的有效开关状态（三层优先级）
-                # 全局 ON → 强制允许（跳过端点检查）
-                # 全局 OFF → 提供商 ON → 强制允许（跳过端点检查）
-                # 全局 OFF → 提供商 OFF → 看端点配置
-                provider_allows_conversion = getattr(provider, "enable_format_conversion", True)
-                effective_conversion_enabled = (
-                    global_conversion_enabled or provider_allows_conversion
-                )
-                # 如果全局或提供商开关为 ON，跳过端点配置检查
-                skip_endpoint_check = global_conversion_enabled or provider_allows_conversion
+                # 计算格式转换的有效开关状态（三态继承：端点 > 提供商 > 全局）
+                # provider.enable_format_conversion:
+                #   - True: 明确启用
+                #   - False: 明确禁用
+                #   - None: 继承全局设置
+                provider_conversion_setting = getattr(provider, "enable_format_conversion", None)
+                if provider_conversion_setting is not None:
+                    # 提供商有明确设置，使用提供商设置
+                    provider_allows_conversion = bool(provider_conversion_setting)
+                else:
+                    # 提供商未设置（None），继承全局设置
+                    provider_allows_conversion = global_conversion_enabled
+
+                # 有效值：如果全局或提供商（经过继承计算后）为 True，则启用
+                effective_conversion_enabled = provider_allows_conversion
+                # 如果提供商级别已明确允许，跳过端点配置检查
+                skip_endpoint_check = provider_allows_conversion
 
                 is_compatible, needs_conversion, _compat_reason = is_format_compatible(
                     client_format_str,

--- a/src/services/candidate/service.py
+++ b/src/services/candidate/service.py
@@ -235,13 +235,23 @@ class CandidateService:
                             )
                         continue
 
-                    # 2. Check global + provider switches
-                    # 全局 ON → 允许；全局 OFF → 看提供商
+                    # 2. Check global + provider switches (三态继承：提供商 > 全局)
+                    # provider.enable_format_conversion:
+                    #   - True: 明确启用
+                    #   - False: 明确禁用
+                    #   - None: 继承全局设置
                     from src.services.system.config import SystemConfigService
 
                     global_enabled = SystemConfigService.is_format_conversion_enabled(self.db)
-                    provider_enabled = getattr(cand.provider, "enable_format_conversion", True)
-                    effective_enabled = global_enabled or provider_enabled
+                    provider_conversion_setting = getattr(
+                        cand.provider, "enable_format_conversion", None
+                    )
+                    if provider_conversion_setting is not None:
+                        # 提供商有明确设置，使用提供商设置
+                        effective_enabled = bool(provider_conversion_setting)
+                    else:
+                        # 提供商未设置（None），继承全局设置
+                        effective_enabled = global_enabled
 
                     if not effective_enabled:
                         skip_reason = "format_conversion_disabled"
@@ -250,7 +260,8 @@ class CandidateService:
                                 "skipped": True,
                                 "skip_reason": skip_reason,
                                 "global_conversion_enabled": global_enabled,
-                                "provider_conversion_enabled": provider_enabled,
+                                "provider_conversion_setting": provider_conversion_setting,
+                                "effective_enabled": effective_enabled,
                             }
                         )
                         if record_id:


### PR DESCRIPTION
将 Provider 和 Endpoint 的 enable_format_conversion 从布尔值改为三态：
- true: 明确启用格式转换
- false: 明确禁用格式转换
- null: 继承父级设置

主要改动：
- 添加迁移脚本使 providers.enable_format_conversion 字段可空
- 后端 API 返回 format_conversion_effective 和 format_conversion_inherited_from 字段
- 前端按钮支持三态循环切换，继承状态显示蓝色 Link2 图标
- 更新候选服务和缓存调度器的继承计算逻辑