### PR TITLE
feat: Codex 提供商批量刷新限额功能

### DIFF
--- a/frontend/src/api/endpoints/keys.ts
+++ b/frontend/src/api/endpoints/keys.ts
@@ -144,3 +144,31 @@ export async function updateProviderKey(
   const response = await client.put(`/api/admin/endpoints/keys/${keyId}`, data)
   return response.data
 }
+
+/**
+ * 刷新 Provider 的所有 Key 限额信息（Codex）
+ */
+export interface RefreshQuotaResult {
+  success: number
+  failed: number
+  total: number
+  results: Array<{
+    key_id: string
+    key_name: string
+    status: 'success' | 'no_metadata' | 'error'
+    metadata?: {
+      plan_type?: string
+      primary_used_percent?: number
+      primary_reset_seconds?: number
+      secondary_used_percent?: number
+      secondary_reset_seconds?: number
+    }
+    message?: string
+    status_code?: number
+  }>
+}
+
+export async function refreshProviderQuota(providerId: string): Promise<RefreshQuotaResult> {
+  const response = await client.post(`/api/admin/endpoints/providers/${providerId}/refresh-quota`)
+  return response.data
+}

--- a/frontend/src/api/endpoints/providers.ts
+++ b/frontend/src/api/endpoints/providers.ts
@@ -25,7 +25,7 @@ export async function updateProvider(
   data: Partial<{
     name: string
     provider_type: 'custom' | 'claude_code' | 'codex' | 'gemini_cli' | 'antigravity'
-    description: string
+    description: string | null
     website: string
     provider_priority: number
     billing_type: 'monthly_quota' | 'pay_as_you_go' | 'free_tier'

--- a/src/services/provider/metadata_collectors/__init__.py
+++ b/src/services/provider/metadata_collectors/__init__.py
@@ -84,6 +84,11 @@ def _ensure_collectors_registered() -> None:
     MetadataCollectorRegistry.register(CodexMetadataCollector())
 
 
+def ensure_collectors_registered() -> None:
+    """Ensure metadata collectors are registered (idempotent)."""
+    _ensure_collectors_registered()
+
+
 def collect_and_save_upstream_metadata(
     db: Session,
     *,
@@ -147,4 +152,5 @@ __all__ = [
     "MetadataCollector",
     "MetadataCollectorRegistry",
     "collect_and_save_upstream_metadata",
+    "ensure_collectors_registered",
 ]


### PR DESCRIPTION
- 后端 (keys.py)：新增 POST /providers/{provider_id}/refresh-quota API，向 Codex 提供商的所有活跃 Key 发送测试请求，从响应头解析限额信息并更新数据库
- 前端 (ProviderDetailDrawer.vue)：在 Codex 类型提供商的密钥管理区域添加"刷新限额"按钮，带加载动画和结果提示
- 前端 API (keys.ts)：新增 refreshProviderQuota 接口调用及 RefreshQuotaResult 类型定义
- 其他：description 字段允许 null，公开 ensure_collectors_registered 函数