### PR TITLE
refactor(frontend): 优化模型/提供商组件的数据刷新逻辑

### DIFF
--- a/frontend/src/features/models/components/ModelDetailDrawer.vue
+++ b/frontend/src/features/models/components/ModelDetailDrawer.vue
@@ -560,9 +560,7 @@ function refreshRoutingData() {
 // 处理模型映射更新
 function handleMappingsUpdate(_mappings: string[]) {
   // 映射已在 ModelMappingsTab 内部保存到服务器
-  // 刷新路由数据以反映可能的候选变化
-  refreshRoutingData()
-  // 通知父组件刷新模型数据
+  // 路由数据刷新由 @refresh 事件处理，这里只需通知父组件刷新模型数据
   emit('refreshModel')
 }
 

--- a/frontend/src/features/models/components/ModelMappingsTab.vue
+++ b/frontend/src/features/models/components/ModelMappingsTab.vue
@@ -531,12 +531,14 @@ async function saveMappings() {
     // 自动关联未关联的提供商
     if (unlinkedProviderIds.length > 0) {
       toastSuccess(`映射规则已保存，正在关联 ${unlinkedProviderIds.length} 个提供商...`)
-      // linkProviders 处理完成后会由父组件统一刷新数据，无需再 emit update
       emit('linkProviders', unlinkedProviderIds)
     } else {
       toastSuccess('映射规则已保存')
-      emit('update', cleanedMappings)
     }
+
+    // 保存成功后刷新数据
+    emit('update', cleanedMappings)
+    emit('refresh')
   } catch (err) {
     log.error('保存映射规则失败:', err)
     toastError('保存失败，请重试')


### PR DESCRIPTION
- ModelDetailDrawer: 移除 handleMappingsUpdate 中冗余的 refreshRoutingData 调用，路由刷新改由 @refresh 事件统一处理
- ModelMappingsTab: saveMappings 成功后始终 emit update 和 refresh 事件，确保数据一致性
- BatchAssignModelsDialog: 为批量添加/导入操作增加 try-catch 错误处理，部分操作失败时仍通知父组件刷新
- ProviderDetailDrawer: 移除 modelsTabRef 直接调用子组件 reload 的模式，统一通过 emit('refresh') 由父组件协调刷新