### PR TITLE
fix(conversion): 修复 openai cli tool 调用空 call_id 导致上游失败

### DIFF
--- a/src/core/api_format/conversion/normalizers/openai_cli.py
+++ b/src/core/api_format/conversion/normalizers/openai_cli.py
@@ -1054,7 +1054,7 @@ class OpenAICliNormalizer(FormatNormalizer):
             content_text=content_text,
             extra={"openai_cli": self._extract_extra(item, {"type", "call_id", "id", "output"})},
         )
-        return InternalMessage(role=Role.TOOL, content=[result_block])
+        return InternalMessage(role=Role.USER, content=[result_block])
 
     def _parse_reasoning_item(self, item: dict[str, Any]) -> InternalMessage:
         summary_parts: list[str] = []


### PR DESCRIPTION
- 在 FormatConversionRegistry.convert_request 前统一修复 InternalRequest 中空的 tool_id/tool_use_id

- 为空 ID 自动生成 call_auto_N，并将 tool_result 关联到最近待匹配的 tool_call

- 修正 OpenAICliNormalizer 中 function_call_output 的内部角色为 USER，确保输出 openai:chat 时保留 tool_call_id

- 新增 openai:cli <-> openai:chat 空 call_id 回归测试，覆盖工具调用关联场景