### PR TITLE
feat(provider): 增加 Claude Code 适配器与高级配置能力

### DIFF
--- a/frontend/src/api/endpoints/providers.ts
+++ b/frontend/src/api/endpoints/providers.ts
@@ -1,5 +1,9 @@
 import client from '../client'
-import type { ProviderWithEndpointsSummary, ProxyConfig } from './types'
+import type {
+  ClaudeCodeAdvancedConfig,
+  ProviderWithEndpointsSummary,
+  ProxyConfig,
+} from './types'
 
 /**
  * 获取 Providers 摘要（包含 Endpoints 统计）
@@ -41,6 +45,7 @@ export async function updateProvider(
     max_probe_interval_minutes: number
     enable_format_conversion: boolean  // 是否允许格式转换（提供商级别开关）
     is_active: boolean
+    claude_code_advanced: ClaudeCodeAdvancedConfig | null
   }>
 ): Promise<ProviderWithEndpointsSummary> {
   const response = await client.patch(`/api/admin/providers/${providerId}`, data)
@@ -68,6 +73,7 @@ export async function createProvider(
     stream_first_byte_timeout?: number | null
     request_timeout?: number | null
     proxy?: ProxyConfig | null
+    claude_code_advanced?: ClaudeCodeAdvancedConfig | null
   }
 ): Promise<{ id: string; name: string; message?: string }> {
   const response = await client.post('/api/admin/providers/', data)

--- a/frontend/src/api/endpoints/types/provider.ts
+++ b/frontend/src/api/endpoints/types/provider.ts
@@ -442,6 +442,16 @@ export interface PublicEndpointStatusMonitorResponse {
 
 export type ProviderType = 'custom' | 'claude_code' | 'codex' | 'gemini_cli' | 'antigravity' | 'kiro'
 
+export interface ClaudeCodeAdvancedConfig {
+  // 会话数量控制：null/undefined 表示不限制
+  max_sessions?: number | null
+  session_idle_timeout_minutes?: number | null
+  // TLS 指纹模拟（模拟 Node.js/Claude Code 客户端指纹）
+  enable_tls_fingerprint?: boolean
+  // 会话 ID 伪装（固定 metadata.user_id 中 session 片段）
+  session_id_masking_enabled?: boolean
+}
+
 export interface ProviderWithEndpointsSummary {
   id: string
   name: string
@@ -475,6 +485,7 @@ export interface ProviderWithEndpointsSummary {
   unhealthy_endpoints: number
   api_formats: string[]
   endpoint_health_details: EndpointHealthDetail[]
+  claude_code_advanced?: ClaudeCodeAdvancedConfig | null
   ops_configured: boolean  // 是否配置了扩展操作（余额监控等）
   ops_architecture_id?: string  // 扩展操作使用的架构 ID（如 cubence, anyrouter）
   created_at: string

--- a/frontend/src/features/providers/components/ProviderFormDialog.vue
+++ b/frontend/src/features/providers/components/ProviderFormDialog.vue
@@ -37,10 +37,13 @@
                 <SelectValue placeholder="请选择" />
               </SelectTrigger>
               <SelectContent>
-                <!-- 新建模式：允许自定义、Codex、Kiro 和 Antigravity -->
+                <!-- 新建模式：允许自定义及各反代类型 -->
                 <template v-if="!isEditMode">
                   <SelectItem value="custom">
                     自定义
+                  </SelectItem>
+                  <SelectItem value="claude_code">
+                    ClaudeCode
                   </SelectItem>
                   <SelectItem value="codex">
                     Codex
@@ -260,6 +263,97 @@
           />
         </div>
       </div>
+
+      <!-- Claude Code 高级配置 -->
+      <Collapsible
+        v-if="form.provider_type === 'claude_code'"
+        v-model:open="claudeAdvancedOpen"
+        class="space-y-3"
+      >
+        <CollapsibleTrigger as-child>
+          <button
+            type="button"
+            class="w-full flex items-center justify-between py-1.5 px-2 -mx-2 rounded-md hover:bg-muted/50 transition-colors border-b"
+          >
+            <span class="text-sm font-medium">高级配置</span>
+            <ChevronDown
+              class="w-4 h-4 text-muted-foreground transition-transform"
+              :class="{ '-rotate-90': !claudeAdvancedOpen }"
+            />
+          </button>
+        </CollapsibleTrigger>
+
+        <CollapsibleContent class="space-y-3">
+          <div class="space-y-3 p-3 border rounded-lg bg-muted/50">
+            <div class="flex items-center justify-between">
+              <div class="space-y-0.5">
+                <span class="text-sm font-medium">会话数量控制</span>
+                <p class="text-xs text-muted-foreground">
+                  限制同时活跃的会话数量
+                </p>
+              </div>
+              <Switch
+                :model-value="form.claude_session_control_enabled"
+                @update:model-value="(v: boolean) => form.claude_session_control_enabled = v"
+              />
+            </div>
+
+            <div
+              v-if="form.claude_session_control_enabled"
+              class="grid grid-cols-2 gap-4"
+            >
+              <div class="space-y-1.5">
+                <Label class="text-xs">最大会话数</Label>
+                <Input
+                  :model-value="form.claude_max_sessions ?? ''"
+                  type="number"
+                  min="1"
+                  max="1000"
+                  placeholder="例如 20"
+                  @update:model-value="(v) => form.claude_max_sessions = parseNumberInput(v)"
+                />
+              </div>
+              <div class="space-y-1.5">
+                <Label class="text-xs">会话空闲超时 (分钟)</Label>
+                <Input
+                  :model-value="form.claude_session_idle_timeout_minutes ?? ''"
+                  type="number"
+                  min="1"
+                  max="1440"
+                  placeholder="默认 5"
+                  @update:model-value="(v) => form.claude_session_idle_timeout_minutes = parseNumberInput(v) ?? 5"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div class="flex items-center justify-between p-3 border rounded-lg bg-muted/50">
+            <div class="space-y-0.5">
+              <span class="text-sm font-medium">TLS 指纹模拟</span>
+              <p class="text-xs text-muted-foreground">
+                模拟 Node.js / Claude Code 客户端的 TLS 指纹
+              </p>
+            </div>
+            <Switch
+              :model-value="form.claude_enable_tls_fingerprint"
+              @update:model-value="(v: boolean) => form.claude_enable_tls_fingerprint = v"
+            />
+          </div>
+
+          <div class="flex items-center justify-between p-3 border rounded-lg bg-muted/50">
+            <div class="space-y-0.5">
+              <span class="text-sm font-medium">会话 ID 伪装</span>
+              <p class="text-xs text-muted-foreground">
+                启用后在 15 分钟内固定 metadata.user_id 中的 session ID
+              </p>
+            </div>
+            <Switch
+              :model-value="form.claude_session_id_masking_enabled"
+              @update:model-value="(v: boolean) => form.claude_session_id_masking_enabled = v"
+            />
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
     </form>
 
     <template #footer>
@@ -294,8 +388,11 @@ import {
   SelectContent,
   SelectItem,
   Switch,
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
 } from '@/components/ui'
-import { Server, SquarePen } from 'lucide-vue-next'
+import { Server, SquarePen, ChevronDown } from 'lucide-vue-next'
 import { useToast } from '@/composables/useToast'
 import { useFormDialog } from '@/composables/useFormDialog'
 import { createProvider, updateProvider, type ProviderWithEndpointsSummary } from '@/api/endpoints'
@@ -318,6 +415,7 @@ const emit = defineEmits<{
 
 const { success, error: showError } = useToast()
 const loading = ref(false)
+const claudeAdvancedOpen = ref(true)
 const proxyNodeSelectRef = ref<InstanceType<typeof ProxyNodeSelect> | null>(null)
 const proxyNodesStore = useProxyNodesStore()
 
@@ -366,10 +464,17 @@ const form = ref({
   // 代理配置
   proxy_enabled: false,
   proxy_node_id: '',
+  // Claude Code 高级配置
+  claude_session_control_enabled: false,
+  claude_max_sessions: undefined as number | undefined,
+  claude_session_idle_timeout_minutes: 5,
+  claude_enable_tls_fingerprint: false,
+  claude_session_id_masking_enabled: false,
 })
 
 // 重置表单
 function resetForm() {
+  claudeAdvancedOpen.value = true
   form.value = {
     name: '',
     provider_type: 'custom',
@@ -393,6 +498,12 @@ function resetForm() {
     // 代理配置
     proxy_enabled: false,
     proxy_node_id: '',
+    // Claude Code 高级配置
+    claude_session_control_enabled: false,
+    claude_max_sessions: undefined,
+    claude_session_idle_timeout_minutes: 5,
+    claude_enable_tls_fingerprint: false,
+    claude_session_id_masking_enabled: false,
   }
 }
 
@@ -400,7 +511,11 @@ function resetForm() {
 function loadProviderData() {
   if (!props.provider) return
 
+  claudeAdvancedOpen.value = true
   const proxy = props.provider.proxy
+  const claudeAdvanced = props.provider.claude_code_advanced || null
+  const claudeMaxSessions = claudeAdvanced?.max_sessions
+  const claudeSessionControlEnabled = typeof claudeMaxSessions === 'number' && claudeMaxSessions > 0
   form.value = {
     name: props.provider.name,
     provider_type: props.provider.provider_type || 'custom',
@@ -426,6 +541,12 @@ function loadProviderData() {
     // 代理配置
     proxy_enabled: proxy?.enabled ?? false,
     proxy_node_id: proxy?.node_id || '',
+    // Claude Code 高级配置
+    claude_session_control_enabled: claudeSessionControlEnabled,
+    claude_max_sessions: claudeSessionControlEnabled ? claudeMaxSessions : undefined,
+    claude_session_idle_timeout_minutes: claudeAdvanced?.session_idle_timeout_minutes ?? 5,
+    claude_enable_tls_fingerprint: claudeAdvanced?.enable_tls_fingerprint ?? false,
+    claude_session_id_masking_enabled: claudeAdvanced?.session_id_masking_enabled ?? false,
   }
 
   // 如果有代理配置，确保加载节点列表（直接调用 store，避免 ref 未挂载时静默失败）
@@ -458,6 +579,14 @@ const handleSubmit = async () => {
     return
   }
 
+  // Claude Code 高级配置验证
+  if (form.value.provider_type === 'claude_code' && form.value.claude_session_control_enabled) {
+    if (!form.value.claude_max_sessions || form.value.claude_max_sessions < 1) {
+      showError('请填写有效的最大会话数（>=1）', '验证失败')
+      return
+    }
+  }
+
   loading.value = true
   try {
     // 构建代理配置
@@ -465,6 +594,18 @@ const handleSubmit = async () => {
       node_id: form.value.proxy_node_id,
       enabled: true,
     } : null
+    const claudeCodeAdvanced = form.value.provider_type === 'claude_code'
+      ? {
+          max_sessions: form.value.claude_session_control_enabled
+            ? (form.value.claude_max_sessions ?? undefined)
+            : null,
+          session_idle_timeout_minutes: form.value.claude_session_control_enabled
+            ? (form.value.claude_session_idle_timeout_minutes ?? 5)
+            : null,
+          enable_tls_fingerprint: form.value.claude_enable_tls_fingerprint,
+          session_id_masking_enabled: form.value.claude_session_id_masking_enabled,
+        }
+      : undefined
 
     const payload = {
       name: form.value.name,
@@ -485,6 +626,7 @@ const handleSubmit = async () => {
       stream_first_byte_timeout: form.value.stream_first_byte_timeout ?? null,
       request_timeout: form.value.request_timeout ?? null,
       proxy,
+      claude_code_advanced: claudeCodeAdvanced,
     }
 
     if (isEditMode.value && props.provider) {

--- a/src/api/admin/providers/routes.py
+++ b/src/api/admin/providers/routes.py
@@ -37,6 +37,60 @@ MAPPING_PREVIEW_MAX_MODELS = 500
 MAPPING_PREVIEW_TIMEOUT_SECONDS = 10.0
 
 
+def _should_enable_format_conversion_by_default(provider_type: str | None) -> bool:
+    """固定类型 Provider 默认是否开启格式转换。"""
+    pt = (provider_type or "custom").strip().lower()
+    envelope_provider_types = {
+        ProviderType.ANTIGRAVITY.value,
+        ProviderType.CLAUDE_CODE.value,
+        ProviderType.CODEX.value,
+        ProviderType.KIRO.value,
+    }
+    return pt in envelope_provider_types
+
+
+def _normalize_provider_type(provider_type: str | None) -> str:
+    return (provider_type or "custom").strip().lower()
+
+
+def _merge_claude_code_advanced_config(
+    *,
+    provider_type: str | None,
+    provider_config: dict[str, Any] | None,
+    claude_code_advanced: dict[str, Any] | None,
+    claude_advanced_in_payload: bool,
+) -> tuple[dict[str, Any] | None, bool]:
+    """合并并规范 claude_code_advanced，确保仅在 claude_code 下保留。"""
+    normalized_provider_type = _normalize_provider_type(provider_type)
+    merged_config = dict(provider_config or {})
+    config_changed = False
+
+    if normalized_provider_type != ProviderType.CLAUDE_CODE.value:
+        if claude_advanced_in_payload and claude_code_advanced is not None:
+            raise InvalidRequestException(
+                "claude_code_advanced 仅适用于 provider_type=claude_code"
+            )
+        if "claude_code_advanced" in merged_config:
+            merged_config.pop("claude_code_advanced", None)
+            config_changed = True
+        return merged_config or None, config_changed
+
+    if not claude_advanced_in_payload:
+        return merged_config or None, config_changed
+
+    if claude_code_advanced is None:
+        if "claude_code_advanced" in merged_config:
+            merged_config.pop("claude_code_advanced", None)
+            config_changed = True
+    else:
+        next_value = dict(claude_code_advanced)
+        if merged_config.get("claude_code_advanced") != next_value:
+            merged_config["claude_code_advanced"] = next_value
+            config_changed = True
+
+    return merged_config or None, config_changed
+
+
 # ========== Response Models ==========
 
 
@@ -290,15 +344,20 @@ class AdminCreateProviderAdapter(AdminApiAdapter):
                 else ProviderBillingType.PAY_AS_YOU_GO
             )
 
-            # 有 envelope 包装的 Provider 类型（如 Antigravity、Codex）需要格式转换来正确
-            # 解包上游响应，创建时默认开启 enable_format_conversion。
-            pt = (validated_data.provider_type or "custom").strip()
-            envelope_provider_types = {
-                ProviderType.ANTIGRAVITY,
-                ProviderType.CODEX,
-                ProviderType.KIRO,
-            }
-            default_enable_format_conversion = pt in envelope_provider_types
+            # 有 envelope 包装的 Provider 类型（如 ClaudeCode、Antigravity、Codex）需要
+            # 格式转换来正确解包上游响应，创建时默认开启 enable_format_conversion。
+            pt = _normalize_provider_type(validated_data.provider_type)
+            default_enable_format_conversion = _should_enable_format_conversion_by_default(pt)
+            provider_config, _ = _merge_claude_code_advanced_config(
+                provider_type=pt,
+                provider_config=validated_data.config,
+                claude_code_advanced=(
+                    validated_data.claude_code_advanced.model_dump(exclude_none=True)
+                    if validated_data.claude_code_advanced is not None
+                    else None
+                ),
+                claude_advanced_in_payload=validated_data.claude_code_advanced is not None,
+            )
 
             # 创建 Provider 对象
             provider = Provider(
@@ -319,7 +378,7 @@ class AdminCreateProviderAdapter(AdminApiAdapter):
                 # 超时配置
                 stream_first_byte_timeout=validated_data.stream_first_byte_timeout,
                 request_timeout=validated_data.request_timeout,
-                config=validated_data.config,
+                config=provider_config or None,
                 # 有 envelope 的反代类型默认开启格式转换
                 enable_format_conversion=default_enable_format_conversion,
             )
@@ -411,6 +470,31 @@ class AdminUpdateProviderAdapter(AdminApiAdapter):
         try:
             # 更新字段（只更新非 None 的字段）
             update_data = validated_data.model_dump(exclude_unset=True)
+            config_in_payload = "config" in update_data
+            claude_advanced_in_payload = "claude_code_advanced" in update_data
+            provider_config = (
+                dict(update_data.pop("config") or {})
+                if config_in_payload
+                else dict(provider.config or {})
+            )
+            claude_advanced = (
+                update_data.pop("claude_code_advanced") if claude_advanced_in_payload else None
+            )
+            target_provider_type = (
+                update_data.get("provider_type")
+                or getattr(provider, "provider_type", None)
+                or "custom"
+            )
+
+            provider_config, config_changed_by_claude = _merge_claude_code_advanced_config(
+                provider_type=target_provider_type,
+                provider_config=provider_config,
+                claude_code_advanced=claude_advanced,
+                claude_advanced_in_payload=claude_advanced_in_payload,
+            )
+
+            if config_in_payload or claude_advanced_in_payload or config_changed_by_claude:
+                update_data["config"] = provider_config
 
             for field, value in update_data.items():
                 if field == "billing_type" and value is not None:

--- a/src/api/admin/providers/summary.py
+++ b/src/api/admin/providers/summary.py
@@ -15,9 +15,10 @@ from src.api.base.context import ApiRequestContext
 from src.api.base.models_service import invalidate_models_list_cache
 from src.api.base.pipeline import ApiRequestPipeline
 from src.core.enums import ProviderBillingType
-from src.core.exceptions import NotFoundException
+from src.core.exceptions import InvalidRequestException, NotFoundException
 from src.core.logger import logger
 from src.database import get_db
+from src.models.admin_requests import ClaudeCodeAdvancedConfig
 from src.models.database import (
     Model,
     Provider,
@@ -213,6 +214,38 @@ async def update_provider_settings(
     return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
 
 
+def _extract_claude_code_advanced_from_config(
+    provider_config: dict[str, Any] | None,
+    *,
+    provider_id: str,
+) -> ClaudeCodeAdvancedConfig | None:
+    """从 Provider.config 中安全提取 Claude Code 高级配置。"""
+    raw_config = (provider_config or {}).get("claude_code_advanced")
+    if raw_config is None:
+        return None
+
+    if isinstance(raw_config, ClaudeCodeAdvancedConfig):
+        return raw_config
+
+    if not isinstance(raw_config, dict):
+        logger.warning(
+            "Provider {} 的 claude_code_advanced 类型无效: {}，已忽略",
+            provider_id,
+            type(raw_config).__name__,
+        )
+        return None
+
+    try:
+        return ClaudeCodeAdvancedConfig.model_validate(raw_config)
+    except Exception as exc:
+        logger.warning(
+            "Provider {} 的 claude_code_advanced 配置无效，已忽略: {}",
+            provider_id,
+            str(exc),
+        )
+        return None
+
+
 def _build_provider_summary(db: Session, provider: Provider) -> ProviderWithEndpointsSummary:
     endpoints = db.query(ProviderEndpoint).filter(ProviderEndpoint.provider_id == provider.id).all()
 
@@ -311,11 +344,24 @@ def _build_provider_summary(db: Session, provider: Provider) -> ProviderWithEndp
         for e in endpoints
     ]
 
+    provider_config_raw = provider.config
+    provider_config = provider_config_raw if isinstance(provider_config_raw, dict) else {}
+    if provider_config_raw is not None and not isinstance(provider_config_raw, dict):
+        logger.warning(
+            "Provider {} 的 config 类型无效: {}，按空配置处理",
+            provider.id,
+            type(provider_config_raw).__name__,
+        )
+
     # 检查是否配置了 Provider Ops（余额监控等）
-    provider_ops_config = (provider.config or {}).get("provider_ops")
+    provider_ops_config = provider_config.get("provider_ops")
     ops_configured = bool(provider_ops_config)
     ops_architecture_id = (
         provider_ops_config.get("architecture_id") if provider_ops_config else None
+    )
+    claude_code_advanced = _extract_claude_code_advanced_from_config(
+        provider_config,
+        provider_id=str(provider.id),
     )
 
     return ProviderWithEndpointsSummary(
@@ -338,6 +384,7 @@ def _build_provider_summary(db: Session, provider: Provider) -> ProviderWithEndp
         proxy=provider.proxy,
         stream_first_byte_timeout=provider.stream_first_byte_timeout,
         request_timeout=provider.request_timeout,
+        claude_code_advanced=claude_code_advanced,
         total_endpoints=total_endpoints,
         active_endpoints=active_endpoints,
         total_keys=total_keys,
@@ -496,6 +543,21 @@ class AdminUpdateProviderSettingsAdapter(AdminApiAdapter):
             raise NotFoundException("Provider not found", "provider")
 
         update_dict = self.update_data.model_dump(exclude_unset=True)
+        if "claude_code_advanced" in update_dict:
+            claude_advanced = update_dict.pop("claude_code_advanced")
+            provider_type = str(getattr(provider, "provider_type", "") or "").strip().lower()
+            if claude_advanced is not None and provider_type != "claude_code":
+                raise InvalidRequestException(
+                    "claude_code_advanced 仅适用于 provider_type=claude_code"
+                )
+
+            provider_config = dict(provider.config or {})
+            if claude_advanced is None:
+                provider_config.pop("claude_code_advanced", None)
+            else:
+                provider_config["claude_code_advanced"] = dict(claude_advanced)
+            update_dict["config"] = provider_config or None
+
         if "billing_type" in update_dict and update_dict["billing_type"] is not None:
             update_dict["billing_type"] = ProviderBillingType(update_dict["billing_type"])
 

--- a/src/api/handlers/base/chat_handler_base.py
+++ b/src/api/handlers/base/chat_handler_base.py
@@ -102,6 +102,7 @@ class ProviderRequestResult:
     provider_api_format: str = ""
     client_api_format: str = ""
     auth_info: Any = None
+    tls_profile: str | None = None
 
 
 class ChatHandlerBase(BaseMessageHandler, ABC):
@@ -695,6 +696,7 @@ class ChatHandlerBase(BaseMessageHandler, ABC):
             request_body = dict(original_request_body)
 
         provider_type = str(getattr(provider, "provider_type", "") or "").lower()
+        claude_tls_profile: str | None = None
         behavior = get_provider_behavior(
             provider_type=provider_type,
             endpoint_sig=provider_api_format,
@@ -713,6 +715,16 @@ class ChatHandlerBase(BaseMessageHandler, ABC):
             client_is_stream=client_is_stream,
             policy=upstream_policy,
         )
+        if provider_type == "claude_code":
+            from src.services.provider.adapters.claude_code.context import (
+                build_and_set_claude_code_request_context,
+            )
+
+            _claude_ctx, claude_tls_profile = build_and_set_claude_code_request_context(
+                provider_config=getattr(provider, "config", None),
+                key_id=str(getattr(key, "id", "") or ""),
+                is_stream=upstream_is_stream,
+            )
 
         # 跨格式：先做请求体转换（失败触发 failover）
         registry = get_format_converter_registry()
@@ -776,6 +788,18 @@ class ChatHandlerBase(BaseMessageHandler, ABC):
                 url_model=url_model,
                 decrypted_auth_config=auth_info.decrypted_auth_config if auth_info else None,
             )
+            if provider_type == "claude_code":
+                from src.services.provider.adapters.claude_code.context import (
+                    get_claude_code_request_context,
+                )
+                from src.services.provider.adapters.claude_code.envelope import (
+                    enforce_distributed_session_controls,
+                )
+
+                await enforce_distributed_session_controls(
+                    request_body,
+                    get_claude_code_request_context(),
+                )
 
         # Provider envelope: extra upstream headers (e.g. dedicated User-Agent).
         extra_headers: dict[str, str] = {}
@@ -793,6 +817,7 @@ class ChatHandlerBase(BaseMessageHandler, ABC):
             provider_api_format=provider_api_format,
             client_api_format=client_api_format,
             auth_info=auth_info,
+            tls_profile=claude_tls_profile,
         )
 
     async def _execute_stream_request(
@@ -853,6 +878,7 @@ class ChatHandlerBase(BaseMessageHandler, ABC):
         envelope = prep.envelope
         upstream_is_stream = prep.upstream_is_stream
         auth_info = prep.auth_info
+        tls_profile = prep.tls_profile
 
         # 构建请求（上游始终使用 header 认证，不跟随客户端的 query 方式）
         provider_payload, provider_headers = self._request_builder.build(
@@ -908,7 +934,9 @@ class ChatHandlerBase(BaseMessageHandler, ABC):
             request_timeout_sync = provider.request_timeout or config.http_request_timeout
             delegate_cfg = resolve_delegate_config(effective_proxy)
             http_client = await HTTPClientPool.get_upstream_client(
-                delegate_cfg, proxy_config=effective_proxy
+                delegate_cfg,
+                proxy_config=effective_proxy,
+                tls_profile=tls_profile,
             )
 
             try:
@@ -1104,7 +1132,9 @@ class ChatHandlerBase(BaseMessageHandler, ABC):
 
         delegate_cfg = resolve_delegate_config(effective_proxy)
         http_client = await HTTPClientPool.get_upstream_client(
-            delegate_cfg, proxy_config=effective_proxy
+            delegate_cfg,
+            proxy_config=effective_proxy,
+            tls_profile=tls_profile,
         )
 
         # 用于存储内部函数的结果（必须在函数定义前声明，供 nonlocal 使用）

--- a/src/api/handlers/base/chat_sync_executor.py
+++ b/src/api/handlers/base/chat_sync_executor.py
@@ -425,6 +425,7 @@ class ChatSyncExecutor:
         envelope = prep.envelope
         upstream_is_stream = prep.upstream_is_stream
         auth_info = prep.auth_info
+        tls_profile = prep.tls_profile
 
         # 构建请求（上游始终使用 header 认证，不跟随客户端的 query 方式）
         provider_payload, provider_hdrs = handler._request_builder.build(
@@ -496,7 +497,9 @@ class ChatSyncExecutor:
 
         delegate_cfg = resolve_delegate_config(_effective_proxy)
         http_client = await HTTPClientPool.get_upstream_client(
-            delegate_cfg, proxy_config=_effective_proxy
+            delegate_cfg,
+            proxy_config=_effective_proxy,
+            tls_profile=tls_profile,
         )
 
         # 注意：不使用 async with，因为复用的客户端不应该被关闭

--- a/src/api/handlers/base/cli_stream_mixin.py
+++ b/src/api/handlers/base/cli_stream_mixin.py
@@ -319,6 +319,17 @@ class CliStreamMixin:
             client_is_stream=True,
             policy=upstream_policy,
         )
+        claude_tls_profile: str | None = None
+        if provider_type == "claude_code":
+            from src.services.provider.adapters.claude_code.context import (
+                build_and_set_claude_code_request_context,
+            )
+
+            _claude_ctx, claude_tls_profile = build_and_set_claude_code_request_context(
+                provider_config=getattr(provider, "config", None),
+                key_id=str(getattr(key, "id", "") or ""),
+                is_stream=upstream_is_stream,
+            )
 
         # 跨格式：先做请求体转换（失败触发 failover）
         if needs_conversion and provider_api_format:
@@ -374,6 +385,18 @@ class CliStreamMixin:
                 url_model=url_model,
                 decrypted_auth_config=auth_info.decrypted_auth_config if auth_info else None,
             )
+            if provider_type == "claude_code":
+                from src.services.provider.adapters.claude_code.context import (
+                    get_claude_code_request_context,
+                )
+                from src.services.provider.adapters.claude_code.envelope import (
+                    enforce_distributed_session_controls,
+                )
+
+                await enforce_distributed_session_controls(
+                    request_body,
+                    get_claude_code_request_context(),
+                )
 
         # Provider envelope: extra upstream headers (e.g. dedicated User-Agent).
         extra_headers: dict[str, str] = {}
@@ -429,7 +452,9 @@ class CliStreamMixin:
             request_timeout_sync = provider.request_timeout or config.http_request_timeout
             delegate_cfg = resolve_delegate_config(effective_proxy)
             http_client = await HTTPClientPool.get_upstream_client(
-                delegate_cfg, proxy_config=effective_proxy
+                delegate_cfg,
+                proxy_config=effective_proxy,
+                tls_profile=claude_tls_profile,
             )
 
             try:
@@ -622,8 +647,20 @@ class CliStreamMixin:
         from src.services.proxy_node.resolver import build_stream_kwargs, resolve_delegate_config
 
         delegate_cfg = resolve_delegate_config(effective_proxy)
+        claude_tls_profile: str | None = None
+        if str(ctx.provider_type or "").strip().lower() == "claude_code":
+            from src.services.provider.adapters.claude_code.context import (
+                get_claude_code_request_context,
+                resolve_claude_code_tls_profile,
+            )
+
+            claude_ctx = get_claude_code_request_context()
+            claude_tls_profile = resolve_claude_code_tls_profile(claude_ctx)
+
         http_client = await HTTPClientPool.get_upstream_client(
-            delegate_cfg, proxy_config=effective_proxy
+            delegate_cfg,
+            proxy_config=effective_proxy,
+            tls_profile=claude_tls_profile,
         )
 
         # 用于存储内部函数的结果（必须在函数定义前声明，供 nonlocal 使用）

--- a/src/api/handlers/base/cli_sync_mixin.py
+++ b/src/api/handlers/base/cli_sync_mixin.py
@@ -147,6 +147,17 @@ class CliSyncMixin:
                 client_is_stream=False,
                 policy=upstream_policy,
             )
+            claude_tls_profile: str | None = None
+            if provider_type == "claude_code":
+                from src.services.provider.adapters.claude_code.context import (
+                    build_and_set_claude_code_request_context,
+                )
+
+                _claude_ctx, claude_tls_profile = build_and_set_claude_code_request_context(
+                    provider_config=getattr(provider, "config", None),
+                    key_id=str(getattr(key, "id", "") or ""),
+                    is_stream=upstream_is_stream,
+                )
 
             # 跨格式：先做请求体转换（失败触发 failover）
             if needs_conversion and provider_api_format:
@@ -202,6 +213,18 @@ class CliSyncMixin:
                     url_model=url_model,
                     decrypted_auth_config=auth_info.decrypted_auth_config if auth_info else None,
                 )
+                if provider_type == "claude_code":
+                    from src.services.provider.adapters.claude_code.context import (
+                        get_claude_code_request_context,
+                    )
+                    from src.services.provider.adapters.claude_code.envelope import (
+                        enforce_distributed_session_controls,
+                    )
+
+                    await enforce_distributed_session_controls(
+                        request_body,
+                        get_claude_code_request_context(),
+                    )
 
             # Provider envelope: extra upstream headers (e.g. dedicated User-Agent).
             extra_headers: dict[str, str] = {}
@@ -274,7 +297,9 @@ class CliSyncMixin:
 
             delegate_cfg = resolve_delegate_config(_effective_proxy)
             http_client = await HTTPClientPool.get_upstream_client(
-                delegate_cfg, proxy_config=_effective_proxy
+                delegate_cfg,
+                proxy_config=_effective_proxy,
+                tls_profile=claude_tls_profile,
             )
 
             # 注意：不使用 async with，因为复用的客户端不应该被关闭

--- a/src/api/handlers/base/request_builder.py
+++ b/src/api/handlers/base/request_builder.py
@@ -26,9 +26,13 @@ from src.core.api_format import (
     make_signature_key,
 )
 from src.core.crypto import crypto_service
-from src.core.provider_auth_types import ProviderAuthInfo
 from src.models.endpoint_models import _CONDITION_OPS, _TYPE_IS_VALUES, parse_re_flags
-from src.services.provider.auth import get_provider_auth
+from src.services.provider.adapters.claude_code.constants import (
+    BETA_CLAUDE_CODE,
+    BETA_CONTEXT_1M,
+    BETA_OAUTH,
+)
+from src.services.provider.auth import get_provider_auth  # noqa: F401
 
 # ==============================================================================
 # 统一的头部配置常量
@@ -1114,6 +1118,93 @@ class PassthroughRequestBuilder(RequestBuilder):
         """
         return dict(original_body)
 
+    @staticmethod
+    def _merge_comma_header_values(primary: str, secondary: str) -> str:
+        """合并逗号分隔 header 值并去重，保持 primary 在前。"""
+        seen: set[str] = set()
+        merged: list[str] = []
+
+        def _append(raw: str) -> None:
+            for token in str(raw or "").split(","):
+                token = token.strip()
+                if not token or token in seen:
+                    continue
+                seen.add(token)
+                merged.append(token)
+
+        _append(primary)
+        _append(secondary)
+        return ",".join(merged)
+
+    @classmethod
+    def _drop_beta_token(cls, value: str, token: str) -> str:
+        """从逗号分隔 header 中移除指定 token。"""
+        if not value or token not in value:
+            return value
+        return cls._merge_comma_header_values(
+            ",".join(
+                p.strip()
+                for p in str(value).split(",")
+                if p.strip() and p.strip() != token
+            ),
+            "",
+        )
+
+    @staticmethod
+    def _is_claude_code_oauth_beta(value: str) -> bool:
+        """检查 anthropic-beta 是否处于 Claude Code OAuth 场景。"""
+        tokens = {p.strip() for p in str(value).split(",") if p.strip()}
+        return BETA_CLAUDE_CODE in tokens and BETA_OAUTH in tokens
+
+    @classmethod
+    def _merge_extra_headers_with_original(
+        cls,
+        original_headers: dict[str, str],
+        extra_headers: dict[str, str] | None,
+        *,
+        provider_type: str | None = None,
+    ) -> dict[str, str] | None:
+        """合并 extra_headers 与原始头部中的特定字段。"""
+        if not extra_headers:
+            return None
+
+        merged_extra = dict(extra_headers)
+        beta_extra_key = next((k for k in merged_extra if k.lower() == "anthropic-beta"), None)
+        if beta_extra_key is None:
+            return merged_extra
+
+        incoming_beta = next(
+            (v for k, v in original_headers.items() if k.lower() == "anthropic-beta"),
+            "",
+        )
+        merged_beta = str(merged_extra.get(beta_extra_key) or "")
+        if incoming_beta:
+            merged_beta = cls._merge_comma_header_values(
+                merged_beta,
+                str(incoming_beta),
+            )
+
+        normalized_provider_type = str(provider_type or "").strip().lower()
+        # Claude Code OAuth 不允许 context-1m beta，需在合并后移除。
+        if (
+            normalized_provider_type == "claude_code"
+            and cls._is_claude_code_oauth_beta(merged_beta)
+        ):
+            merged_beta = cls._drop_beta_token(merged_beta, BETA_CONTEXT_1M)
+
+        merged_extra[beta_extra_key] = merged_beta
+        return merged_extra
+
+    @staticmethod
+    def _resolve_provider_type(endpoint: Any, key: Any) -> str | None:
+        for obj in (getattr(endpoint, "provider", None), getattr(key, "provider", None)):
+            if obj is None:
+                continue
+            pt = getattr(obj, "provider_type", None)
+            if pt:
+                return str(pt).strip().lower()
+        return None
+
     def build_headers(
         self,
         original_headers: dict[str, str],
@@ -1177,8 +1268,14 @@ class PassthroughRequestBuilder(RequestBuilder):
             builder.apply_rules(header_rules, protected_keys)
 
         # 4. 添加额外头部
-        if extra_headers:
-            builder.add_many(extra_headers)
+        provider_type = self._resolve_provider_type(endpoint, key)
+        effective_extra_headers = self._merge_extra_headers_with_original(
+            original_headers,
+            extra_headers,
+            provider_type=provider_type,
+        )
+        if effective_extra_headers:
+            builder.add_many(effective_extra_headers)
 
         # 5. 设置认证头（最高优先级，上游始终使用 header 认证）
         builder.add(auth_header, auth_value)

--- a/src/clients/http_client.py
+++ b/src/clients/http_client.py
@@ -25,7 +25,7 @@ from src.services.proxy_node.resolver import (
     get_system_proxy_config,
     make_proxy_param,
 )
-from src.utils.ssl_utils import get_ssl_context
+from src.utils.ssl_utils import get_ssl_context, get_ssl_context_for_profile
 
 # 模块级锁，避免类属性延迟初始化的竞态条件
 _proxy_clients_lock = asyncio.Lock()
@@ -186,6 +186,7 @@ class HTTPClientPool:
     async def get_proxy_client(
         cls,
         proxy_config: dict[str, Any] | None = None,
+        tls_profile: str | None = None,
     ) -> httpx.AsyncClient:
         """
         获取代理客户端（带缓存复用）
@@ -205,6 +206,9 @@ class HTTPClientPool:
             proxy_config = get_system_proxy_config()
 
         cache_key = compute_proxy_cache_key(proxy_config)
+        tls_profile_key = str(tls_profile or "").strip().lower()
+        if tls_profile_key:
+            cache_key = f"{cache_key}::tls:{tls_profile_key}"
 
         # 无代理时返回默认客户端
         if cache_key == "__no_proxy__":
@@ -222,6 +226,8 @@ class HTTPClientPool:
                 else:
                     # 更新最后使用时间
                     cls._proxy_clients[cache_key] = (client, time.time())
+                    if tls_profile_key:
+                        logger.debug("复用代理客户端 TLS profile={} key={}", tls_profile_key, cache_key)
                     return client
 
             # 淘汰旧客户端（如果超过上限）
@@ -230,7 +236,7 @@ class HTTPClientPool:
             # 创建新客户端（使用默认超时，请求时可覆盖）
             client_config: dict[str, Any] = {
                 "http2": False,
-                "verify": get_ssl_context(),
+                "verify": get_ssl_context_for_profile(tls_profile),
                 "follow_redirects": True,
                 "limits": httpx.Limits(
                     max_connections=config.http_max_connections,
@@ -262,6 +268,8 @@ class HTTPClientPool:
             logger.debug(
                 "创建代理客户端(缓存): {}, 缓存数量: {}", proxy_label, len(cls._proxy_clients)
             )
+            if tls_profile_key:
+                logger.debug("创建代理客户端 TLS profile={} key={}", tls_profile_key, cache_key)
 
             return client
 
@@ -335,6 +343,7 @@ class HTTPClientPool:
         cls,
         proxy_config: dict[str, Any] | None = None,
         timeout: httpx.Timeout | None = None,
+        tls_profile: str | None = None,
         **kwargs: Any,
     ) -> httpx.AsyncClient:
         """
@@ -352,7 +361,7 @@ class HTTPClientPool:
         """
         client_config: dict[str, Any] = {
             "http2": False,
-            "verify": get_ssl_context(),
+            "verify": get_ssl_context_for_profile(tls_profile),
             "follow_redirects": True,
         }
 
@@ -385,6 +394,7 @@ class HTTPClientPool:
         cls,
         delegate_cfg: dict[str, Any] | None,
         proxy_config: dict[str, Any] | None = None,
+        tls_profile: str | None = None,
     ) -> httpx.AsyncClient:
         """
         获取可复用的上游请求客户端（自动选择 tunnel/代理模式）
@@ -394,7 +404,7 @@ class HTTPClientPool:
         """
         if delegate_cfg and delegate_cfg.get("tunnel"):
             return await cls._get_tunnel_client(delegate_cfg["node_id"])
-        return await cls.get_proxy_client(proxy_config=proxy_config)
+        return await cls.get_proxy_client(proxy_config=proxy_config, tls_profile=tls_profile)
 
     @classmethod
     async def create_upstream_stream_client(
@@ -402,6 +412,7 @@ class HTTPClientPool:
         delegate_cfg: dict[str, Any] | None,
         proxy_config: dict[str, Any] | None = None,
         timeout: httpx.Timeout | None = None,
+        tls_profile: str | None = None,
     ) -> httpx.AsyncClient:
         """
         创建上游流式请求客户端（自动选择 tunnel/代理模式）
@@ -410,7 +421,11 @@ class HTTPClientPool:
         """
         if delegate_cfg and delegate_cfg.get("tunnel"):
             return await cls._get_tunnel_client(delegate_cfg["node_id"], timeout=timeout)
-        return cls.create_client_with_proxy(proxy_config=proxy_config, timeout=timeout)
+        return cls.create_client_with_proxy(
+            proxy_config=proxy_config,
+            timeout=timeout,
+            tls_profile=tls_profile,
+        )
 
     @classmethod
     async def _get_tunnel_client(

--- a/src/core/api_format/conversion/normalizers/claude.py
+++ b/src/core/api_format/conversion/normalizers/claude.py
@@ -520,6 +520,7 @@ class ClaudeNormalizer(FormatNormalizer):
             message_raw = chunk.get("message")
             message: dict[str, Any] = message_raw if isinstance(message_raw, dict) else {}
             msg_id = str(message.get("id") or "")
+            usage_info = self._claude_usage_to_internal(message.get("usage"))
             # 保留初始化时设置的 model（客户端请求的模型），仅在空时用上游值
             model = state.model or str(message.get("model") or "")
             state.message_id = msg_id or state.message_id
@@ -527,7 +528,9 @@ class ClaudeNormalizer(FormatNormalizer):
                 state.model = model
             ss["message_started"] = True
             ss.setdefault("block_index_to_tool_id", {})
-            events.append(MessageStartEvent(message_id=msg_id, model=model))
+            if usage_info is not None:
+                ss["usage"] = message.get("usage")
+            events.append(MessageStartEvent(message_id=msg_id, model=model, usage=usage_info))
             return events
 
         if event_type == "content_block_start":

--- a/src/models/admin_requests.py
+++ b/src/models/admin_requests.py
@@ -80,6 +80,35 @@ class ProxyConfig(BaseModel):
         return self
 
 
+class ClaudeCodeAdvancedConfig(BaseModel):
+    """Claude Code 高级配置。"""
+
+    max_sessions: int | None = Field(
+        None, ge=1, le=1000, description="最大活跃会话数（为空表示不限制）"
+    )
+    session_idle_timeout_minutes: int | None = Field(
+        None, ge=1, le=1440, description="会话空闲超时（分钟）"
+    )
+    enable_tls_fingerprint: bool = Field(
+        False, description="是否启用 TLS 指纹模拟（模拟 Node.js/Claude Code 客户端）"
+    )
+    session_id_masking_enabled: bool = Field(
+        False, description="是否启用会话 ID 伪装（固定 metadata.user_id 中 session 片段）"
+    )
+
+    @model_validator(mode="after")
+    def normalize_session_control(self) -> "ClaudeCodeAdvancedConfig":
+        # 未启用会话限制时，不保留超时配置，避免产生误导。
+        if self.max_sessions is None:
+            self.session_idle_timeout_minutes = None
+            return self
+
+        # 启用会话限制但未设置超时时，回落到 5 分钟默认值。
+        if self.session_idle_timeout_minutes is None:
+            self.session_idle_timeout_minutes = 5
+        return self
+
+
 class CreateProviderRequest(BaseModel):
     """创建 Provider 请求"""
 
@@ -148,6 +177,9 @@ class CreateProviderRequest(BaseModel):
     request_timeout: float | None = Field(
         None, ge=1, le=600, description="非流式请求整体超时（秒）"
     )
+    claude_code_advanced: ClaudeCodeAdvancedConfig | None = Field(
+        None, description="Claude Code 高级配置"
+    )
     config: dict[str, Any] | None = Field(None, description="其他配置")
 
     @field_validator("provider_type")
@@ -214,6 +246,13 @@ class CreateProviderRequest(BaseModel):
             valid_types = [t.value for t in ProviderBillingType]
             raise ValueError(f"无效的计费类型，有效值为: {', '.join(valid_types)}")
 
+    @model_validator(mode="after")
+    def validate_claude_code_advanced_scope(self) -> "CreateProviderRequest":
+        provider_type = (self.provider_type or "custom").strip()
+        if self.claude_code_advanced is not None and provider_type != "claude_code":
+            raise ValueError("claude_code_advanced 仅适用于 provider_type=claude_code")
+        return self
+
 
 class UpdateProviderRequest(BaseModel):
     """更新 Provider 请求"""
@@ -244,6 +283,9 @@ class UpdateProviderRequest(BaseModel):
     request_timeout: float | None = Field(
         None, ge=1, le=600, description="非流式请求整体超时（秒）"
     )
+    claude_code_advanced: ClaudeCodeAdvancedConfig | None = Field(
+        None, description="Claude Code 高级配置"
+    )
     config: dict[str, Any] | None = None
 
     # 复用相同的验证器
@@ -257,6 +299,15 @@ class UpdateProviderRequest(BaseModel):
     _validate_provider_type = field_validator("provider_type")(
         CreateProviderRequest.validate_provider_type.__func__
     )
+
+    @model_validator(mode="after")
+    def validate_claude_code_advanced_scope(self) -> "UpdateProviderRequest":
+        # 更新场景下 provider_type 可能不在 payload 中，最终校验由路由层结合数据库值完成。
+        if self.claude_code_advanced is not None and self.provider_type is not None:
+            provider_type = (self.provider_type or "custom").strip()
+            if provider_type != "claude_code":
+                raise ValueError("claude_code_advanced 仅适用于 provider_type=claude_code")
+        return self
 
 
 class CreateEndpointRequest(BaseModel):

--- a/src/models/endpoint_models.py
+++ b/src/models/endpoint_models.py
@@ -10,7 +10,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from src.models.admin_requests import ProxyConfig
+from src.models.admin_requests import ClaudeCodeAdvancedConfig, ProxyConfig
 
 # ========== Header Rule 类型定义 ==========
 # 请求头规则支持三种操作：
@@ -934,6 +934,9 @@ class ProviderUpdateRequest(BaseModel):
     request_timeout: float | None = Field(
         None, ge=1, le=600, description="非流式请求整体超时（秒）"
     )
+    claude_code_advanced: ClaudeCodeAdvancedConfig | None = Field(
+        None, description="Claude Code 高级配置"
+    )
 
 
 class ProviderWithEndpointsSummary(BaseModel):
@@ -974,6 +977,9 @@ class ProviderWithEndpointsSummary(BaseModel):
         default=None, description="流式请求首字节超时（秒）"
     )
     request_timeout: float | None = Field(default=None, description="非流式请求整体超时（秒）")
+    claude_code_advanced: ClaudeCodeAdvancedConfig | None = Field(
+        default=None, description="Claude Code 高级配置"
+    )
 
     # Endpoint 统计
     total_endpoints: int = Field(default=0, description="总 Endpoint 数量")

--- a/src/services/provider/adapters/claude_code/__init__.py
+++ b/src/services/provider/adapters/claude_code/__init__.py
@@ -1,0 +1,3 @@
+"""Claude Code provider adapter."""
+
+__all__ = []

--- a/src/services/provider/adapters/claude_code/constants.py
+++ b/src/services/provider/adapters/claude_code/constants.py
@@ -1,0 +1,52 @@
+"""Claude Code adapter constants."""
+
+from __future__ import annotations
+
+CLAUDE_MESSAGES_PATH = "/v1/messages"
+DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
+DEFAULT_ACCEPT = "application/json"
+STREAM_HELPER_METHOD = "stream"
+SESSION_ID_MASKING_TTL_SECONDS = 15 * 60
+# 仅代表“启用 Claude Code TLS 配置”的客户端 profile 标识（best-effort）。
+TLS_PROFILE_CLAUDE_CODE = "claude_code_nodejs"
+
+# Claude Code OAuth required betas.
+BETA_CLAUDE_CODE = "claude-code-20250219"
+BETA_OAUTH = "oauth-2025-04-20"
+BETA_INTERLEAVED_THINKING = "interleaved-thinking-2025-05-14"
+BETA_CONTEXT_1M = "context-1m-2025-08-07"
+
+CLAUDE_CODE_REQUIRED_BETA_TOKENS: tuple[str, ...] = (
+    BETA_CLAUDE_CODE,
+    BETA_OAUTH,
+    BETA_INTERLEAVED_THINKING,
+)
+
+# Mimic headers observed from Claude Code traffic.
+CLAUDE_CODE_DEFAULT_HEADERS: dict[str, str] = {
+    "X-Stainless-Lang": "js",
+    "X-Stainless-Package-Version": "0.70.0",
+    "X-Stainless-OS": "Linux",
+    "X-Stainless-Arch": "arm64",
+    "X-Stainless-Runtime": "node",
+    "X-Stainless-Runtime-Version": "v24.13.0",
+    "X-Stainless-Retry-Count": "0",
+    "X-Stainless-Timeout": "600",
+    "X-App": "cli",
+    "Anthropic-Dangerous-Direct-Browser-Access": "true",
+}
+
+__all__ = [
+    "BETA_CLAUDE_CODE",
+    "BETA_CONTEXT_1M",
+    "BETA_INTERLEAVED_THINKING",
+    "BETA_OAUTH",
+    "CLAUDE_CODE_DEFAULT_HEADERS",
+    "CLAUDE_CODE_REQUIRED_BETA_TOKENS",
+    "CLAUDE_MESSAGES_PATH",
+    "DEFAULT_ACCEPT",
+    "DEFAULT_ANTHROPIC_VERSION",
+    "SESSION_ID_MASKING_TTL_SECONDS",
+    "STREAM_HELPER_METHOD",
+    "TLS_PROFILE_CLAUDE_CODE",
+]

--- a/src/services/provider/adapters/claude_code/context.py
+++ b/src/services/provider/adapters/claude_code/context.py
@@ -1,0 +1,122 @@
+"""Claude Code request context using contextvars."""
+
+from __future__ import annotations
+
+import contextvars
+from dataclasses import dataclass
+from typing import Any
+
+from src.core.logger import logger
+from src.models.admin_requests import ClaudeCodeAdvancedConfig
+from src.services.provider.adapters.claude_code.constants import TLS_PROFILE_CLAUDE_CODE
+
+
+@dataclass(frozen=True, slots=True)
+class ClaudeCodeRequestContext:
+    is_stream: bool = False
+    # 使用 Key 级别作用域，确保会话限制按 OAuth 账号隔离。
+    scope_key: str | None = None
+    key_id: str | None = None
+    max_sessions: int | None = None
+    session_idle_timeout_minutes: int = 5
+    enable_tls_fingerprint: bool = False
+    session_id_masking_enabled: bool = False
+
+
+_claude_code_request_context: contextvars.ContextVar[ClaudeCodeRequestContext | None] = (
+    contextvars.ContextVar(
+        "claude_code_request_context",
+        default=None,
+    )
+)
+
+
+def set_claude_code_request_context(ctx: ClaudeCodeRequestContext | None) -> None:
+    _claude_code_request_context.set(ctx)
+
+
+def get_claude_code_request_context() -> ClaudeCodeRequestContext | None:
+    return _claude_code_request_context.get()
+
+
+def build_claude_code_request_context(
+    *,
+    provider_config: Any,
+    key_id: str | None,
+    is_stream: bool,
+) -> ClaudeCodeRequestContext:
+    """根据 Provider.config 构建 Claude Code 请求上下文。"""
+    normalized_key_id = str(key_id or "").strip() or None
+
+    advanced_config: ClaudeCodeAdvancedConfig | None = None
+    provider_config_dict = provider_config if isinstance(provider_config, dict) else {}
+    raw_advanced = provider_config_dict.get("claude_code_advanced")
+
+    if raw_advanced is not None:
+        try:
+            if isinstance(raw_advanced, ClaudeCodeAdvancedConfig):
+                advanced_config = raw_advanced
+            elif isinstance(raw_advanced, dict):
+                advanced_config = ClaudeCodeAdvancedConfig.model_validate(raw_advanced)
+            else:
+                logger.warning(
+                    "Claude Code advanced config 类型无效: {}，已忽略",
+                    type(raw_advanced).__name__,
+                )
+        except Exception as exc:
+            logger.warning("Claude Code advanced config 解析失败，已忽略: {}", str(exc))
+
+    max_sessions = advanced_config.max_sessions if advanced_config else None
+    idle_timeout_minutes = (
+        advanced_config.session_idle_timeout_minutes
+        if advanced_config and advanced_config.session_idle_timeout_minutes is not None
+        else 5
+    )
+    enable_tls_fingerprint = bool(advanced_config.enable_tls_fingerprint) if advanced_config else False
+    session_id_masking_enabled = (
+        bool(advanced_config.session_id_masking_enabled) if advanced_config else False
+    )
+
+    return ClaudeCodeRequestContext(
+        is_stream=bool(is_stream),
+        scope_key=f"key:{normalized_key_id}" if normalized_key_id else None,
+        key_id=normalized_key_id,
+        max_sessions=max_sessions,
+        session_idle_timeout_minutes=idle_timeout_minutes,
+        enable_tls_fingerprint=enable_tls_fingerprint,
+        session_id_masking_enabled=session_id_masking_enabled,
+    )
+
+
+def resolve_claude_code_tls_profile(
+    ctx: ClaudeCodeRequestContext | None,
+) -> str | None:
+    if ctx and ctx.enable_tls_fingerprint:
+        return TLS_PROFILE_CLAUDE_CODE
+    return None
+
+
+def build_and_set_claude_code_request_context(
+    *,
+    provider_config: Any,
+    key_id: str | None,
+    is_stream: bool,
+) -> tuple[ClaudeCodeRequestContext, str | None]:
+    """构建并写入 Claude Code 上下文，同时返回对应 TLS profile。"""
+    ctx = build_claude_code_request_context(
+        provider_config=provider_config,
+        key_id=key_id,
+        is_stream=is_stream,
+    )
+    set_claude_code_request_context(ctx)
+    return ctx, resolve_claude_code_tls_profile(ctx)
+
+
+__all__ = [
+    "build_and_set_claude_code_request_context",
+    "build_claude_code_request_context",
+    "ClaudeCodeRequestContext",
+    "get_claude_code_request_context",
+    "resolve_claude_code_tls_profile",
+    "set_claude_code_request_context",
+]

--- a/src/services/provider/adapters/claude_code/envelope.py
+++ b/src/services/provider/adapters/claude_code/envelope.py
@@ -1,0 +1,475 @@
+"""Claude Code upstream envelope hooks."""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from dataclasses import replace
+from typing import Any
+
+from src.clients.redis_client import get_redis_client, get_redis_client_sync
+from src.config.settings import config
+from src.core.exceptions import ConcurrencyLimitError
+from src.core.logger import logger
+from src.services.provider.adapters.claude_code.constants import (
+    CLAUDE_CODE_DEFAULT_HEADERS,
+    CLAUDE_CODE_REQUIRED_BETA_TOKENS,
+    DEFAULT_ACCEPT,
+    DEFAULT_ANTHROPIC_VERSION,
+    SESSION_ID_MASKING_TTL_SECONDS,
+    STREAM_HELPER_METHOD,
+)
+from src.services.provider.adapters.claude_code.context import (
+    ClaudeCodeRequestContext,
+    get_claude_code_request_context,
+    set_claude_code_request_context,
+)
+
+
+_SESSION_MARKER = "_session_"
+_DUMMY_THINKING_SIGNATURE = "skip_thought_signature_validator"
+_session_runtime_lock = threading.Lock()
+# key: scope_key -> {session_id -> last_seen_monotonic}
+_active_sessions: dict[str, dict[str, float]] = {}
+# key: scope_key -> (masked_session_uuid, expire_at_monotonic)
+_masked_sessions: dict[str, tuple[str, float]] = {}
+_REDIS_SESSION_KEY_PREFIX = "claude_code:sessions"
+_REDIS_SESSION_RESERVE_LUA = """
+local key = KEYS[1]
+local sid = ARGV[1]
+local now = tonumber(ARGV[2])
+local expire_before = tonumber(ARGV[3])
+local max_sessions = tonumber(ARGV[4])
+local ttl_seconds = tonumber(ARGV[5])
+
+redis.call("ZREMRANGEBYSCORE", key, "-inf", expire_before)
+
+local exists = redis.call("ZSCORE", key, sid)
+if exists then
+    redis.call("ZADD", key, now, sid)
+    redis.call("EXPIRE", key, ttl_seconds)
+    return {1, redis.call("ZCARD", key)}
+end
+
+local active = redis.call("ZCARD", key)
+if active >= max_sessions then
+    return {0, active}
+end
+
+redis.call("ZADD", key, now, sid)
+redis.call("EXPIRE", key, ttl_seconds)
+return {1, active + 1}
+"""
+
+
+def merge_anthropic_beta_tokens(
+    incoming: str | None,
+    *,
+    required: tuple[str, ...] = CLAUDE_CODE_REQUIRED_BETA_TOKENS,
+) -> str:
+    """Merge required beta tokens and incoming anthropic-beta with deduplication."""
+    seen: set[str] = set()
+    merged: list[str] = []
+
+    def _append(token: str) -> None:
+        token = token.strip()
+        if not token or token in seen:
+            return
+        seen.add(token)
+        merged.append(token)
+
+    for token in required:
+        _append(token)
+    for token in str(incoming or "").split(","):
+        _append(token)
+
+    return ",".join(merged)
+
+
+def _parse_stream_flag(raw_stream: Any) -> bool:
+    if isinstance(raw_stream, bool):
+        return raw_stream
+    return str(raw_stream).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _get_metadata_user_id(request_body: dict[str, Any]) -> str | None:
+    metadata = request_body.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    user_id = metadata.get("user_id")
+    if not isinstance(user_id, str):
+        return None
+    text = user_id.strip()
+    return text or None
+
+
+def _set_metadata_user_id(request_body: dict[str, Any], user_id: str) -> None:
+    metadata = request_body.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        request_body["metadata"] = metadata
+    metadata["user_id"] = user_id
+
+
+def _extract_session_id(user_id: str) -> str | None:
+    idx = user_id.rfind(_SESSION_MARKER)
+    if idx == -1:
+        return None
+    session_id = user_id[idx + len(_SESSION_MARKER) :].strip()
+    return session_id or None
+
+
+def _is_thinking_enabled(request_body: dict[str, Any]) -> bool:
+    thinking = request_body.get("thinking")
+    if not isinstance(thinking, dict):
+        return False
+    thinking_type = str(thinking.get("type") or "").strip().lower()
+    return thinking_type in {"enabled", "adaptive"}
+
+
+def _sanitize_thinking_blocks(request_body: dict[str, Any]) -> None:
+    """过滤可能导致 Claude Code 400 的无效 thinking 块。"""
+    messages = request_body.get("messages")
+    if not isinstance(messages, list) or not messages:
+        return
+
+    thinking_enabled = _is_thinking_enabled(request_body)
+    filtered_messages = 0
+    filtered_blocks = 0
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+
+        role = str(message.get("role") or "")
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+
+        new_content: list[Any] = []
+        modified = False
+        for block in content:
+            if not isinstance(block, dict):
+                new_content.append(block)
+                continue
+
+            block_type = str(block.get("type") or "")
+            if block_type in {"thinking", "redacted_thinking"}:
+                keep = False
+                # 仅保留 assistant 且带真实 signature 的 thinking 块。
+                if thinking_enabled and role == "assistant":
+                    signature = str(block.get("signature") or "").strip()
+                    keep = bool(signature and signature != _DUMMY_THINKING_SIGNATURE)
+                if keep:
+                    new_content.append(block)
+                else:
+                    modified = True
+                    filtered_blocks += 1
+                continue
+
+            # 兼容无 type 但带 thinking 字段的历史块，直接移除。
+            if not block_type and "thinking" in block:
+                modified = True
+                filtered_blocks += 1
+                continue
+
+            new_content.append(block)
+
+        if modified:
+            message["content"] = new_content
+            filtered_messages += 1
+
+    if filtered_blocks:
+        logger.info(
+            "Claude Code thinking 预过滤: messages={}, blocks={}, thinking_enabled={}",
+            filtered_messages,
+            filtered_blocks,
+            thinking_enabled,
+        )
+
+
+def _get_or_create_masked_session(scope_key: str) -> str:
+    now = time.monotonic()
+    with _session_runtime_lock:
+        existing = _masked_sessions.get(scope_key)
+        if existing and existing[1] > now:
+            masked_session_id = existing[0]
+        else:
+            masked_session_id = str(uuid.uuid4())
+        _masked_sessions[scope_key] = (
+            masked_session_id,
+            now + SESSION_ID_MASKING_TTL_SECONDS,
+        )
+        return masked_session_id
+
+
+def _apply_session_id_masking(request_body: dict[str, Any], *, scope_key: str) -> None:
+    user_id = _get_metadata_user_id(request_body)
+    if not user_id:
+        return
+    idx = user_id.rfind(_SESSION_MARKER)
+    if idx == -1:
+        return
+    masked_session_id = _get_or_create_masked_session(scope_key)
+    _set_metadata_user_id(
+        request_body,
+        user_id[: idx + len(_SESSION_MARKER)] + masked_session_id,
+    )
+
+
+def _register_or_reject_session(
+    *,
+    scope_key: str,
+    session_id: str,
+    max_sessions: int,
+    idle_timeout_minutes: int,
+) -> tuple[bool, int]:
+    now = time.monotonic()
+    idle_seconds = max(60, int(idle_timeout_minutes * 60))
+
+    with _session_runtime_lock:
+        bucket = _active_sessions.setdefault(scope_key, {})
+
+        # 先清理过期会话，避免误判占用。
+        expired = [sid for sid, last_seen in bucket.items() if now - last_seen > idle_seconds]
+        for sid in expired:
+            bucket.pop(sid, None)
+
+        if session_id in bucket:
+            bucket[session_id] = now
+            return True, len(bucket)
+
+        if len(bucket) >= max_sessions:
+            return False, len(bucket)
+
+        bucket[session_id] = now
+        return True, len(bucket)
+
+
+def _build_session_limit_error(
+    *,
+    max_sessions: int,
+    active_count: int,
+    key_id: str | None,
+) -> ConcurrencyLimitError:
+    return ConcurrencyLimitError(
+        message=(
+            f"Claude Code 活跃会话数已达上限（{max_sessions}）。"
+            f"当前活跃会话: {active_count}"
+        ),
+        key_id=key_id,
+    )
+
+
+def _redis_session_key(scope_key: str) -> str:
+    return f"{_REDIS_SESSION_KEY_PREFIX}:{scope_key}"
+
+
+def _parse_redis_session_result(raw: Any) -> tuple[bool, int] | None:
+    if not isinstance(raw, (list, tuple)) or len(raw) < 2:
+        return None
+    try:
+        allowed = int(raw[0]) == 1
+        active_count = int(raw[1])
+    except Exception:
+        return None
+    return allowed, active_count
+
+
+def _enforce_session_controls(
+    request_body: dict[str, Any],
+    ctx: ClaudeCodeRequestContext,
+    *,
+    enforce_max_sessions: bool = True,
+) -> None:
+    scope_key = str(ctx.scope_key or "").strip()
+    if not scope_key:
+        return
+
+    if ctx.session_id_masking_enabled:
+        _apply_session_id_masking(request_body, scope_key=scope_key)
+
+    if not enforce_max_sessions:
+        return
+
+    if not ctx.max_sessions or ctx.max_sessions <= 0:
+        return
+
+    user_id = _get_metadata_user_id(request_body)
+    if not user_id:
+        return
+    session_id = _extract_session_id(user_id) or user_id
+
+    allowed, active_count = _register_or_reject_session(
+        scope_key=scope_key,
+        session_id=session_id,
+        max_sessions=ctx.max_sessions,
+        idle_timeout_minutes=ctx.session_idle_timeout_minutes,
+    )
+    if allowed:
+        return
+
+    raise _build_session_limit_error(
+        max_sessions=ctx.max_sessions,
+        active_count=active_count,
+        key_id=ctx.key_id,
+    )
+
+
+def _is_distributed_session_control_available() -> bool:
+    try:
+        return get_redis_client_sync() is not None
+    except Exception:
+        return False
+
+
+async def enforce_distributed_session_controls(
+    request_body: dict[str, Any],
+    ctx: ClaudeCodeRequestContext | None,
+) -> None:
+    """异步执行会话限制。
+
+    优先使用 Redis（多实例共享）；Redis 不可用时回退到进程内计数。
+    """
+    if ctx is None:
+        return
+
+    scope_key = str(ctx.scope_key or "").strip()
+    if not scope_key:
+        return
+    if not ctx.max_sessions or ctx.max_sessions <= 0:
+        return
+
+    user_id = _get_metadata_user_id(request_body)
+    if not user_id:
+        return
+    session_id = _extract_session_id(user_id) or user_id
+
+    idle_seconds = max(60, int(ctx.session_idle_timeout_minutes * 60))
+    redis_ttl = idle_seconds + 300
+    now = int(time.time())
+    expire_before = now - idle_seconds
+
+    redis_client = await get_redis_client(require_redis=False)
+    if redis_client is not None:
+        try:
+            raw_result = await redis_client.eval(
+                _REDIS_SESSION_RESERVE_LUA,
+                1,
+                _redis_session_key(scope_key),
+                session_id,
+                str(now),
+                str(expire_before),
+                str(ctx.max_sessions),
+                str(redis_ttl),
+            )
+            parsed = _parse_redis_session_result(raw_result)
+            if parsed is None:
+                raise ValueError(f"invalid redis eval result: {raw_result!r}")
+
+            allowed, active_count = parsed
+            if allowed:
+                return
+
+            raise _build_session_limit_error(
+                max_sessions=ctx.max_sessions,
+                active_count=active_count,
+                key_id=ctx.key_id,
+            )
+        except ConcurrencyLimitError:
+            raise
+        except Exception as exc:
+            logger.warning("Claude Code 分布式会话控制失败，回退本地计数: {}", str(exc))
+
+    allowed, active_count = _register_or_reject_session(
+        scope_key=scope_key,
+        session_id=session_id,
+        max_sessions=ctx.max_sessions,
+        idle_timeout_minutes=ctx.session_idle_timeout_minutes,
+    )
+    if allowed:
+        return
+    raise _build_session_limit_error(
+        max_sessions=ctx.max_sessions,
+        active_count=active_count,
+        key_id=ctx.key_id,
+    )
+
+
+class ClaudeCodeEnvelope:
+    """Provider envelope hooks for Claude Code OAuth upstream."""
+
+    name = "claude:cli"
+
+    def extra_headers(self) -> dict[str, str] | None:
+        ctx = get_claude_code_request_context()
+        is_stream = bool(ctx.is_stream) if ctx else False
+
+        headers = dict(CLAUDE_CODE_DEFAULT_HEADERS)
+        headers["Accept"] = DEFAULT_ACCEPT
+        headers["anthropic-version"] = DEFAULT_ANTHROPIC_VERSION
+        headers["anthropic-beta"] = merge_anthropic_beta_tokens(None)
+        if is_stream:
+            headers["x-stainless-helper-method"] = STREAM_HELPER_METHOD
+
+        ua = str(getattr(config, "internal_user_agent_claude_cli", "") or "").strip()
+        if ua:
+            headers["User-Agent"] = ua
+
+        return headers
+
+    def wrap_request(
+        self,
+        request_body: dict[str, Any],
+        *,
+        model: str,  # noqa: ARG002
+        url_model: str | None,
+        decrypted_auth_config: dict[str, Any] | None,  # noqa: ARG002
+    ) -> tuple[dict[str, Any], str | None]:
+        raw_stream = request_body.get("stream", False)
+        is_stream = _parse_stream_flag(raw_stream)
+
+        ctx = get_claude_code_request_context()
+        if ctx is None:
+            ctx = ClaudeCodeRequestContext()
+        ctx = replace(ctx, is_stream=is_stream)
+        set_claude_code_request_context(ctx)
+
+        _sanitize_thinking_blocks(request_body)
+
+        _enforce_session_controls(
+            request_body,
+            ctx,
+            enforce_max_sessions=not _is_distributed_session_control_available(),
+        )
+        return request_body, url_model
+
+    def unwrap_response(self, data: Any) -> Any:
+        return data
+
+    def postprocess_unwrapped_response(self, *, model: str, data: Any) -> None:  # noqa: ARG002
+        return
+
+    def capture_selected_base_url(self) -> str | None:
+        return None
+
+    def on_http_status(self, *, base_url: str | None, status_code: int) -> None:  # noqa: ARG002
+        return
+
+    def on_connection_error(self, *, base_url: str | None, exc: Exception) -> None:  # noqa: ARG002
+        return
+
+    def force_stream_rewrite(self) -> bool:
+        return False
+
+
+claude_code_envelope = ClaudeCodeEnvelope()
+
+
+__all__ = [
+    "ClaudeCodeEnvelope",
+    "claude_code_envelope",
+    "enforce_distributed_session_controls",
+    "merge_anthropic_beta_tokens",
+]

--- a/src/services/provider/adapters/claude_code/plugin.py
+++ b/src/services/provider/adapters/claude_code/plugin.py
@@ -1,0 +1,57 @@
+"""Claude Code provider plugin."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlencode
+
+from src.services.provider.adapters.claude_code.constants import CLAUDE_MESSAGES_PATH
+from src.services.provider.preset_models import create_preset_models_fetcher
+
+fetch_models_claude_code = create_preset_models_fetcher("claude_code")
+
+
+def build_claude_code_url(
+    endpoint: Any,
+    *,
+    is_stream: bool,
+    effective_query_params: dict[str, Any],
+) -> str:
+    """Build Claude Code upstream URL and avoid duplicate /v1/messages suffix."""
+    _ = is_stream
+
+    base = str(getattr(endpoint, "base_url", "") or "").rstrip("/")
+    if base.endswith(CLAUDE_MESSAGES_PATH) or base.endswith("/messages"):
+        url = base
+    elif base.endswith("/v1"):
+        url = f"{base}/messages"
+    else:
+        url = f"{base}{CLAUDE_MESSAGES_PATH}"
+
+    if effective_query_params:
+        query_string = urlencode(effective_query_params, doseq=True)
+        if query_string:
+            url = f"{url}?{query_string}"
+
+    return url
+
+
+def register_all() -> None:
+    """Register Claude Code hooks into shared registries."""
+    from src.services.model.upstream_fetcher import UpstreamModelsFetcherRegistry
+    from src.services.provider.adapters.claude_code.envelope import claude_code_envelope
+    from src.services.provider.envelope import register_envelope
+    from src.services.provider.transport import register_transport_hook
+
+    register_envelope("claude_code", "claude:cli", claude_code_envelope)
+    register_envelope("claude_code", "", claude_code_envelope)
+
+    register_transport_hook("claude_code", "claude:cli", build_claude_code_url)
+
+    UpstreamModelsFetcherRegistry.register(
+        provider_types=["claude_code"],
+        fetcher=fetch_models_claude_code,
+    )
+
+
+__all__ = ["build_claude_code_url", "fetch_models_claude_code", "register_all"]

--- a/src/services/provider/envelope.py
+++ b/src/services/provider/envelope.py
@@ -119,10 +119,14 @@ def ensure_providers_bootstrapped() -> None:
         from src.services.provider.adapters.antigravity.plugin import (
             register_all as _reg_antigravity,
         )
+        from src.services.provider.adapters.claude_code.plugin import (
+            register_all as _reg_claude_code,
+        )
         from src.services.provider.adapters.codex.plugin import register_all as _reg_codex
         from src.services.provider.adapters.kiro.plugin import register_all as _reg_kiro
 
         _reg_antigravity()
+        _reg_claude_code()
         _reg_codex()
         _reg_kiro()
 

--- a/src/services/provider/preset_models.py
+++ b/src/services/provider/preset_models.py
@@ -60,6 +60,39 @@ PRESET_MODELS: dict[str, list[dict[str, Any]]] = {
             "display_name": "Claude Haiku 4.5",
         },
     ],
+    # Claude Code (Claude CLI OAuth 反代)
+    "claude_code": [
+        {
+            "id": "claude-opus-4-5-20251101",
+            "object": "model",
+            "owned_by": "anthropic",
+            "display_name": "Claude Opus 4.5",
+        },
+        {
+            "id": "claude-opus-4-6",
+            "object": "model",
+            "owned_by": "anthropic",
+            "display_name": "Claude Opus 4.6",
+        },
+        {
+            "id": "claude-sonnet-4-6",
+            "object": "model",
+            "owned_by": "anthropic",
+            "display_name": "Claude Sonnet 4.6",
+        },
+        {
+            "id": "claude-sonnet-4-5-20250929",
+            "object": "model",
+            "owned_by": "anthropic",
+            "display_name": "Claude Sonnet 4.5",
+        },
+        {
+            "id": "claude-haiku-4-5-20251001",
+            "object": "model",
+            "owned_by": "anthropic",
+            "display_name": "Claude Haiku 4.5",
+        },
+    ],
     # Codex (OpenAI CLI 反代)
     "codex": [
         {

--- a/src/utils/ssl_utils.py
+++ b/src/utils/ssl_utils.py
@@ -7,14 +7,23 @@ import ssl
 
 from loguru import logger
 
-try:
-    import certifi
 
-    _SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
-except ImportError:
+def _create_default_ssl_context() -> ssl.SSLContext:
+    try:
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        return ssl.create_default_context()
+
+
+try:
+    _SSL_CONTEXT = _create_default_ssl_context()
+except Exception:
     _SSL_CONTEXT = ssl.create_default_context()
 
 _PROXY_SSL_CONTEXT: ssl.SSLContext | None = None
+_PROFILE_SSL_CONTEXTS: dict[str, ssl.SSLContext] = {}
 
 
 def get_ssl_context() -> ssl.SSLContext:
@@ -55,3 +64,54 @@ def get_proxy_ssl_context(expected_fingerprint: str | None = None) -> ssl.SSLCon
         _PROXY_SSL_CONTEXT = ctx
     # TODO: 实现基于 expected_fingerprint 的证书指纹校验
     return _PROXY_SSL_CONTEXT
+
+
+def _build_claude_code_ssl_context() -> ssl.SSLContext:
+    """构建 Claude Code best-effort TLS 配置。
+
+    说明：Python/OpenSSL 无法完整模拟 Node.js ClientHello。
+    这里仅做可控项的尽力对齐（ALPN/TLS 版本/常见 cipher 偏好）。
+    """
+    ctx = _create_default_ssl_context()
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    try:
+        ctx.maximum_version = ssl.TLSVersion.TLSv1_3
+    except Exception:
+        pass
+    try:
+        ctx.set_alpn_protocols(["h2", "http/1.1"])
+    except Exception:
+        pass
+    try:
+        ctx.set_ciphers(
+            "ECDHE-ECDSA-AES128-GCM-SHA256:"
+            "ECDHE-RSA-AES128-GCM-SHA256:"
+            "ECDHE-ECDSA-AES256-GCM-SHA384:"
+            "ECDHE-RSA-AES256-GCM-SHA384:"
+            "ECDHE-ECDSA-CHACHA20-POLY1305:"
+            "ECDHE-RSA-CHACHA20-POLY1305"
+        )
+    except Exception:
+        pass
+    return ctx
+
+
+def get_ssl_context_for_profile(tls_profile: str | None = None) -> ssl.SSLContext:
+    """按 profile 返回 SSL 上下文。"""
+    profile = str(tls_profile or "").strip().lower()
+    if not profile:
+        return get_ssl_context()
+
+    if profile in _PROFILE_SSL_CONTEXTS:
+        logger.debug("复用 TLS profile SSL context: {}", profile)
+        return _PROFILE_SSL_CONTEXTS[profile]
+
+    if profile == "claude_code_nodejs":
+        logger.info("启用 TLS profile: {}（best-effort）", profile)
+        ctx = _build_claude_code_ssl_context()
+    else:
+        logger.warning("未知 TLS profile: {}，回退默认 SSL context", profile)
+        ctx = get_ssl_context()
+
+    _PROFILE_SSL_CONTEXTS[profile] = ctx
+    return ctx

--- a/tests/api/handlers/base/test_upstream_stream_bridge.py
+++ b/tests/api/handlers/base/test_upstream_stream_bridge.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import pytest
+
+from src.api.handlers.base.upstream_stream_bridge import aggregate_upstream_stream_to_internal_response
+from src.core.api_format.conversion import register_default_normalizers
+from src.core.api_format.conversion.internal import TextBlock
+
+
+async def _iter_stream_lines(lines: list[str]) -> AsyncIterator[bytes]:
+    for line in lines:
+        yield line.encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_aggregate_claude_stream_uses_message_start_usage_when_message_delta_absent() -> None:
+    register_default_normalizers()
+
+    lines = [
+        "data: "
+        + json.dumps(
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_bridge_usage",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-sonnet-4-5",
+                    "content": [],
+                    "usage": {
+                        "input_tokens": 120,
+                        "output_tokens": 0,
+                        "cache_read_input_tokens": 11,
+                    },
+                },
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        "data: "
+        + json.dumps(
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            ensure_ascii=False,
+        )
+        + "\n",
+        "data: "
+        + json.dumps(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "hello"},
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        "data: " + json.dumps({"type": "content_block_stop", "index": 0}, ensure_ascii=False) + "\n",
+    ]
+
+    internal = await aggregate_upstream_stream_to_internal_response(
+        _iter_stream_lines(lines),
+        provider_api_format="claude:cli",
+        provider_name="claude_code",
+        model="claude-sonnet-4-5",
+        request_id="req_bridge_usage",
+    )
+
+    assert internal.usage is not None
+    assert internal.usage.input_tokens == 120
+    assert internal.usage.output_tokens == 0
+    assert internal.usage.cache_read_tokens == 11
+    assert len(internal.content) == 1
+    assert isinstance(internal.content[0], TextBlock)
+    assert internal.content[0].text == "hello"

--- a/tests/services/test_admin_provider_defaults.py
+++ b/tests/services/test_admin_provider_defaults.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from src.api.admin.providers.routes import (
+    _merge_claude_code_advanced_config,
+    _should_enable_format_conversion_by_default,
+)
+from src.core.exceptions import InvalidRequestException
+
+
+def test_claude_code_defaults_format_conversion_enabled() -> None:
+    assert _should_enable_format_conversion_by_default("claude_code") is True
+
+
+def test_custom_defaults_format_conversion_disabled() -> None:
+    assert _should_enable_format_conversion_by_default("custom") is False
+
+
+def test_merge_claude_code_advanced_clears_stale_config_for_non_claude_provider() -> None:
+    merged, changed = _merge_claude_code_advanced_config(
+        provider_type="custom",
+        provider_config={"foo": "bar", "claude_code_advanced": {"max_sessions": 9}},
+        claude_code_advanced=None,
+        claude_advanced_in_payload=False,
+    )
+
+    assert merged == {"foo": "bar"}
+    assert changed is True
+
+
+def test_merge_claude_code_advanced_rejects_non_claude_payload() -> None:
+    with pytest.raises(InvalidRequestException):
+        _merge_claude_code_advanced_config(
+            provider_type="custom",
+            provider_config={},
+            claude_code_advanced={"max_sessions": 9},
+            claude_advanced_in_payload=True,
+        )

--- a/tests/services/test_claude_code_distributed_sessions.py
+++ b/tests/services/test_claude_code_distributed_sessions.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from src.core.exceptions import ConcurrencyLimitError
+from src.services.provider.adapters.claude_code.context import (
+    ClaudeCodeRequestContext,
+    set_claude_code_request_context,
+)
+from src.services.provider.adapters.claude_code.envelope import (
+    claude_code_envelope,
+    enforce_distributed_session_controls,
+)
+
+
+class _StubRedis:
+    def __init__(self, *, result=None, exc: Exception | None = None) -> None:
+        self._result = result
+        self._exc = exc
+        self.calls: list[tuple] = []
+
+    async def eval(self, *args):
+        self.calls.append(args)
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+@pytest.fixture(autouse=True)
+def _reset_claude_code_context():
+    set_claude_code_request_context(None)
+    yield
+    set_claude_code_request_context(None)
+
+
+@pytest.mark.asyncio
+async def test_distributed_session_controls_accept_when_redis_allows(monkeypatch: pytest.MonkeyPatch):
+    stub = _StubRedis(result=[1, 1])
+
+    async def _fake_get_redis_client(*, require_redis: bool = False):
+        _ = require_redis
+        return stub
+
+    monkeypatch.setattr(
+        "src.services.provider.adapters.claude_code.envelope.get_redis_client",
+        _fake_get_redis_client,
+    )
+
+    ctx = ClaudeCodeRequestContext(
+        scope_key=f"key:test-dist-ok-{uuid.uuid4()}",
+        key_id="key-ok",
+        max_sessions=1,
+        session_idle_timeout_minutes=5,
+    )
+    request_body = {
+        "metadata": {"user_id": "user_a_account_b_session_11111111-1111-1111-1111-111111111111"}
+    }
+
+    await enforce_distributed_session_controls(request_body, ctx)
+    assert len(stub.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_distributed_session_controls_reject_when_redis_denies(monkeypatch: pytest.MonkeyPatch):
+    stub = _StubRedis(result=[0, 1])
+
+    async def _fake_get_redis_client(*, require_redis: bool = False):
+        _ = require_redis
+        return stub
+
+    monkeypatch.setattr(
+        "src.services.provider.adapters.claude_code.envelope.get_redis_client",
+        _fake_get_redis_client,
+    )
+
+    ctx = ClaudeCodeRequestContext(
+        scope_key=f"key:test-dist-deny-{uuid.uuid4()}",
+        key_id="key-deny",
+        max_sessions=1,
+        session_idle_timeout_minutes=5,
+    )
+    request_body = {
+        "metadata": {"user_id": "user_a_account_b_session_22222222-2222-2222-2222-222222222222"}
+    }
+
+    with pytest.raises(ConcurrencyLimitError):
+        await enforce_distributed_session_controls(request_body, ctx)
+
+
+@pytest.mark.asyncio
+async def test_distributed_session_controls_fallback_to_local_when_redis_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    stub = _StubRedis(exc=RuntimeError("redis unavailable"))
+
+    async def _fake_get_redis_client(*, require_redis: bool = False):
+        _ = require_redis
+        return stub
+
+    monkeypatch.setattr(
+        "src.services.provider.adapters.claude_code.envelope.get_redis_client",
+        _fake_get_redis_client,
+    )
+
+    ctx = ClaudeCodeRequestContext(
+        scope_key=f"key:test-dist-fallback-{uuid.uuid4()}",
+        key_id="key-fallback",
+        max_sessions=1,
+        session_idle_timeout_minutes=5,
+    )
+
+    first = {
+        "metadata": {"user_id": "user_a_account_b_session_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}
+    }
+    second = {
+        "metadata": {"user_id": "user_a_account_b_session_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}
+    }
+
+    await enforce_distributed_session_controls(first, ctx)
+    with pytest.raises(ConcurrencyLimitError):
+        await enforce_distributed_session_controls(second, ctx)
+
+
+def test_wrap_request_skips_local_limit_when_distributed_store_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "src.services.provider.adapters.claude_code.envelope.get_redis_client_sync",
+        lambda: object(),
+    )
+    scope_key = f"key:test-wrap-skip-{uuid.uuid4()}"
+    set_claude_code_request_context(
+        ClaudeCodeRequestContext(
+            is_stream=False,
+            scope_key=scope_key,
+            key_id="key-wrap",
+            max_sessions=1,
+            session_idle_timeout_minutes=5,
+        )
+    )
+
+    first = {
+        "metadata": {"user_id": "user_a_account_b_session_11111111-1111-1111-1111-111111111111"}
+    }
+    second = {
+        "metadata": {"user_id": "user_a_account_b_session_22222222-2222-2222-2222-222222222222"}
+    }
+
+    claude_code_envelope.wrap_request(
+        first,
+        model="claude-sonnet-4-5-20250929",
+        url_model=None,
+        decrypted_auth_config=None,
+    )
+    claude_code_envelope.wrap_request(
+        second,
+        model="claude-sonnet-4-5-20250929",
+        url_model=None,
+        decrypted_auth_config=None,
+    )

--- a/tests/services/test_claude_code_envelope.py
+++ b/tests/services/test_claude_code_envelope.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.api.handlers.base.request_builder import PassthroughRequestBuilder
+from src.config.settings import config
+from src.services.provider.adapters.claude_code.constants import (
+    BETA_CLAUDE_CODE,
+    BETA_CONTEXT_1M,
+    BETA_INTERLEAVED_THINKING,
+    BETA_OAUTH,
+    CLAUDE_CODE_REQUIRED_BETA_TOKENS,
+    DEFAULT_ACCEPT,
+    DEFAULT_ANTHROPIC_VERSION,
+    STREAM_HELPER_METHOD,
+)
+from src.services.provider.adapters.claude_code.context import set_claude_code_request_context
+from src.services.provider.adapters.claude_code.envelope import (
+    claude_code_envelope,
+    merge_anthropic_beta_tokens,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_claude_code_context():
+    set_claude_code_request_context(None)
+    yield
+    set_claude_code_request_context(None)
+
+
+def test_merge_anthropic_beta_tokens_adds_required_and_deduplicates() -> None:
+    merged = merge_anthropic_beta_tokens(
+        "context-1m-2025-08-07,oauth-2025-04-20,custom-beta,claude-code-20250219"
+    )
+
+    assert merged.split(",") == [
+        BETA_CLAUDE_CODE,
+        BETA_OAUTH,
+        BETA_INTERLEAVED_THINKING,
+        "context-1m-2025-08-07",
+        "custom-beta",
+    ]
+
+
+def test_claude_code_envelope_extra_headers_include_required_defaults(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(config, "internal_user_agent_claude_cli", "claude-code/test")
+
+    headers = claude_code_envelope.extra_headers() or {}
+
+    assert headers.get("anthropic-version") == DEFAULT_ANTHROPIC_VERSION
+    assert headers.get("anthropic-beta") == ",".join(CLAUDE_CODE_REQUIRED_BETA_TOKENS)
+    assert headers.get("Accept") == DEFAULT_ACCEPT
+    assert headers.get("X-App") == "cli"
+    assert headers.get("X-Stainless-Lang") == "js"
+    assert headers.get("Anthropic-Dangerous-Direct-Browser-Access") == "true"
+    assert headers.get("User-Agent") == "claude-code/test"
+    assert "x-stainless-helper-method" not in headers
+
+
+def test_claude_code_envelope_adds_stream_helper_header_for_stream_request() -> None:
+    _, _ = claude_code_envelope.wrap_request(
+        {"stream": True},
+        model="claude-sonnet-4-5-20250929",
+        url_model=None,
+        decrypted_auth_config=None,
+    )
+    headers = claude_code_envelope.extra_headers() or {}
+    assert headers.get("Accept") == DEFAULT_ACCEPT
+    assert headers.get("x-stainless-helper-method") == STREAM_HELPER_METHOD
+
+
+def test_passthrough_request_builder_drops_context_1m_for_claude_code_oauth() -> None:
+    builder = PassthroughRequestBuilder()
+    endpoint = SimpleNamespace(
+        header_rules=None,
+        provider=SimpleNamespace(provider_type="claude_code"),
+    )
+    key = SimpleNamespace(api_key="unused")
+
+    headers = builder.build_headers(
+        original_headers={"anthropic-beta": BETA_CONTEXT_1M},
+        endpoint=endpoint,
+        key=key,
+        extra_headers={"anthropic-beta": ",".join(CLAUDE_CODE_REQUIRED_BETA_TOKENS)},
+        pre_computed_auth=("Authorization", "Bearer test-token"),
+    )
+
+    assert headers.get("anthropic-beta") == ",".join(CLAUDE_CODE_REQUIRED_BETA_TOKENS)
+
+
+def test_passthrough_request_builder_keeps_context_1m_for_non_claude_code_provider() -> None:
+    builder = PassthroughRequestBuilder()
+    endpoint = SimpleNamespace(
+        header_rules=None,
+        provider=SimpleNamespace(provider_type="custom"),
+    )
+    key = SimpleNamespace(api_key="unused")
+
+    headers = builder.build_headers(
+        original_headers={"anthropic-beta": BETA_CONTEXT_1M},
+        endpoint=endpoint,
+        key=key,
+        extra_headers={"anthropic-beta": ",".join(CLAUDE_CODE_REQUIRED_BETA_TOKENS)},
+        pre_computed_auth=("Authorization", "Bearer test-token"),
+    )
+
+    assert BETA_CONTEXT_1M in str(headers.get("anthropic-beta") or "")
+
+
+def test_claude_code_envelope_filters_invalid_thinking_blocks_when_enabled() -> None:
+    body = {
+        "thinking": {"type": "enabled"},
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "keep", "signature": "sig_valid"},
+                    {"type": "thinking", "thinking": "drop-empty-signature", "signature": ""},
+                    {
+                        "type": "thinking",
+                        "thinking": "drop-dummy-signature",
+                        "signature": "skip_thought_signature_validator",
+                    },
+                    {"type": "redacted_thinking", "data": "keep", "signature": "sig_redacted"},
+                    {"type": "redacted_thinking", "data": "drop-no-signature"},
+                    {"thinking": "drop-no-type"},
+                    {"type": "text", "text": "ok"},
+                ],
+            }
+        ],
+    }
+
+    wrapped, _ = claude_code_envelope.wrap_request(
+        body,
+        model="claude-sonnet-4-5-20250929",
+        url_model=None,
+        decrypted_auth_config=None,
+    )
+
+    content = wrapped["messages"][0]["content"]
+    assert content == [
+        {"type": "thinking", "thinking": "keep", "signature": "sig_valid"},
+        {"type": "redacted_thinking", "data": "keep", "signature": "sig_redacted"},
+        {"type": "text", "text": "ok"},
+    ]
+
+
+def test_claude_code_envelope_drops_all_thinking_blocks_when_disabled() -> None:
+    body = {
+        "thinking": {"type": "disabled"},
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "remove", "signature": "sig_valid"},
+                    {"type": "redacted_thinking", "data": "remove", "signature": "sig_redacted"},
+                    {"type": "text", "text": "keep"},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "thinking", "thinking": "remove-user", "signature": "sig_user"},
+                    {"type": "text", "text": "keep-user"},
+                ],
+            },
+        ],
+    }
+
+    wrapped, _ = claude_code_envelope.wrap_request(
+        body,
+        model="claude-sonnet-4-5-20250929",
+        url_model=None,
+        decrypted_auth_config=None,
+    )
+
+    assert wrapped["messages"][0]["content"] == [{"type": "text", "text": "keep"}]
+    assert wrapped["messages"][1]["content"] == [{"type": "text", "text": "keep-user"}]

--- a/tests/services/test_claude_code_runtime_controls.py
+++ b/tests/services/test_claude_code_runtime_controls.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from src.core.exceptions import ConcurrencyLimitError
+from src.services.provider.adapters.claude_code.context import (
+    ClaudeCodeRequestContext,
+    build_and_set_claude_code_request_context,
+    build_claude_code_request_context,
+    get_claude_code_request_context,
+    resolve_claude_code_tls_profile,
+    set_claude_code_request_context,
+)
+from src.services.provider.adapters.claude_code.constants import TLS_PROFILE_CLAUDE_CODE
+from src.services.provider.adapters.claude_code.envelope import claude_code_envelope
+from src.utils.ssl_utils import get_ssl_context, get_ssl_context_for_profile
+
+
+@pytest.fixture(autouse=True)
+def _reset_claude_code_context():
+    set_claude_code_request_context(None)
+    yield
+    set_claude_code_request_context(None)
+
+
+def _session_tail(user_id: str) -> str:
+    return user_id.split("_session_")[-1]
+
+
+def test_build_context_reads_claude_code_advanced_from_provider_config() -> None:
+    ctx = build_claude_code_request_context(
+        provider_config={
+            "claude_code_advanced": {
+                "max_sessions": 3,
+                "session_idle_timeout_minutes": 7,
+                "enable_tls_fingerprint": True,
+                "session_id_masking_enabled": True,
+            }
+        },
+        key_id="key-123",
+        is_stream=False,
+    )
+
+    assert ctx.scope_key == "key:key-123"
+    assert ctx.key_id == "key-123"
+    assert ctx.max_sessions == 3
+    assert ctx.session_idle_timeout_minutes == 7
+    assert ctx.enable_tls_fingerprint is True
+    assert ctx.session_id_masking_enabled is True
+
+
+def test_build_and_set_context_returns_tls_profile_when_enabled() -> None:
+    ctx, tls_profile = build_and_set_claude_code_request_context(
+        provider_config={"claude_code_advanced": {"enable_tls_fingerprint": True}},
+        key_id="key-tls",
+        is_stream=True,
+    )
+
+    assert ctx.key_id == "key-tls"
+    assert get_claude_code_request_context() == ctx
+    assert tls_profile == TLS_PROFILE_CLAUDE_CODE
+    assert resolve_claude_code_tls_profile(ctx) == TLS_PROFILE_CLAUDE_CODE
+
+
+def test_get_ssl_context_for_claude_code_profile_is_cached() -> None:
+    first = get_ssl_context_for_profile(TLS_PROFILE_CLAUDE_CODE)
+    second = get_ssl_context_for_profile(TLS_PROFILE_CLAUDE_CODE)
+
+    assert first is second
+
+
+def test_get_ssl_context_for_unknown_profile_falls_back_to_default() -> None:
+    assert get_ssl_context_for_profile("unknown_profile") is get_ssl_context()
+
+
+def test_wrap_request_masks_session_id_when_enabled() -> None:
+    scope_key = f"key:test-mask-{uuid.uuid4()}"
+    set_claude_code_request_context(
+        ClaudeCodeRequestContext(
+            is_stream=False,
+            scope_key=scope_key,
+            key_id="key-mask",
+            session_id_masking_enabled=True,
+        )
+    )
+
+    body1 = {
+        "metadata": {
+            "user_id": "user_client_account_main_session_11111111-1111-1111-1111-111111111111"
+        }
+    }
+    body2 = {
+        "metadata": {
+            "user_id": "user_client_account_main_session_22222222-2222-2222-2222-222222222222"
+        }
+    }
+
+    wrapped1, _ = claude_code_envelope.wrap_request(
+        body1,
+        model="claude-sonnet-4-5-20250929",
+        url_model=None,
+        decrypted_auth_config=None,
+    )
+    wrapped2, _ = claude_code_envelope.wrap_request(
+        body2,
+        model="claude-sonnet-4-5-20250929",
+        url_model=None,
+        decrypted_auth_config=None,
+    )
+
+    tail1 = _session_tail(wrapped1["metadata"]["user_id"])
+    tail2 = _session_tail(wrapped2["metadata"]["user_id"])
+
+    assert tail1 != "11111111-1111-1111-1111-111111111111"
+    assert tail1 == tail2
+
+
+def test_wrap_request_enforces_max_sessions() -> None:
+    scope_key = f"key:test-limit-{uuid.uuid4()}"
+    set_claude_code_request_context(
+        ClaudeCodeRequestContext(
+            is_stream=False,
+            scope_key=scope_key,
+            key_id="key-limit",
+            max_sessions=1,
+            session_idle_timeout_minutes=5,
+        )
+    )
+
+    first = {"metadata": {"user_id": "user_a_account_b_session_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}}
+    second = {"metadata": {"user_id": "user_a_account_b_session_bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}}
+
+    claude_code_envelope.wrap_request(
+        first,
+        model="claude-sonnet-4-5-20250929",
+        url_model=None,
+        decrypted_auth_config=None,
+    )
+
+    with pytest.raises(ConcurrencyLimitError):
+        claude_code_envelope.wrap_request(
+            second,
+            model="claude-sonnet-4-5-20250929",
+            url_model=None,
+            decrypted_auth_config=None,
+        )
+
+
+def test_wrap_request_releases_expired_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
+    scope_key = f"key:test-expire-{uuid.uuid4()}"
+    set_claude_code_request_context(
+        ClaudeCodeRequestContext(
+            is_stream=False,
+            scope_key=scope_key,
+            key_id="key-expire",
+            max_sessions=1,
+            session_idle_timeout_minutes=1,
+        )
+    )
+
+    ticks = iter([0.0, 61.0])
+    monkeypatch.setattr(
+        "src.services.provider.adapters.claude_code.envelope.time.monotonic",
+        lambda: next(ticks),
+    )
+
+    first = {"metadata": {"user_id": "user_a_account_b_session_11111111-1111-1111-1111-111111111111"}}
+    second = {"metadata": {"user_id": "user_a_account_b_session_22222222-2222-2222-2222-222222222222"}}
+
+    claude_code_envelope.wrap_request(
+        first,
+        model="claude-sonnet-4-5-20250929",
+        url_model=None,
+        decrypted_auth_config=None,
+    )
+    # 61s > 1min idle timeout，旧会话应过期，第二个会话可进入。
+    claude_code_envelope.wrap_request(
+        second,
+        model="claude-sonnet-4-5-20250929",
+        url_model=None,
+        decrypted_auth_config=None,
+    )

--- a/tests/services/test_provider_summary_claude_code_advanced.py
+++ b/tests/services/test_provider_summary_claude_code_advanced.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from src.api.admin.providers.summary import _extract_claude_code_advanced_from_config
+from src.models.admin_requests import ClaudeCodeAdvancedConfig
+
+
+def test_extract_claude_code_advanced_valid_dict() -> None:
+    config = {"claude_code_advanced": {"max_sessions": 12}}
+
+    parsed = _extract_claude_code_advanced_from_config(config, provider_id="provider-1")
+
+    assert isinstance(parsed, ClaudeCodeAdvancedConfig)
+    assert parsed.max_sessions == 12
+    assert parsed.session_idle_timeout_minutes == 5
+
+
+def test_extract_claude_code_advanced_invalid_type_returns_none() -> None:
+    config = {"claude_code_advanced": "not-a-dict"}
+
+    parsed = _extract_claude_code_advanced_from_config(config, provider_id="provider-1")
+
+    assert parsed is None
+
+
+def test_extract_claude_code_advanced_invalid_payload_returns_none() -> None:
+    config = {"claude_code_advanced": {"max_sessions": 0}}
+
+    parsed = _extract_claude_code_advanced_from_config(config, provider_id="provider-1")
+
+    assert parsed is None

--- a/tests/services/test_provider_transport_claude_code.py
+++ b/tests/services/test_provider_transport_claude_code.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from src.services.model.upstream_fetcher import UpstreamModelsFetcherRegistry
+from src.services.provider.adapters.claude_code.plugin import register_all
+from src.services.provider.transport import build_provider_url
+
+
+@dataclass
+class _DummyEndpoint:
+    base_url: str
+    api_format: str
+    custom_path: str | None = None
+    provider: object | None = None
+
+
+def test_claude_code_claude_cli_uses_messages_path() -> None:
+    endpoint = _DummyEndpoint(
+        base_url="https://api.anthropic.com",
+        api_format="claude:cli",
+        provider=SimpleNamespace(provider_type="claude_code"),
+    )
+
+    url = build_provider_url(
+        endpoint,  # type: ignore[arg-type]
+        path_params={"model": "ignored"},
+        is_stream=True,
+    )
+
+    assert url == "https://api.anthropic.com/v1/messages"
+
+
+def test_claude_code_claude_cli_does_not_duplicate_messages_suffix() -> None:
+    endpoint = _DummyEndpoint(
+        base_url="https://api.anthropic.com/v1/messages",
+        api_format="claude:cli",
+        provider=SimpleNamespace(provider_type="claude_code"),
+    )
+
+    url = build_provider_url(
+        endpoint,  # type: ignore[arg-type]
+        path_params={"model": "ignored"},
+        is_stream=False,
+    )
+
+    assert url == "https://api.anthropic.com/v1/messages"
+
+
+def test_claude_code_claude_cli_appends_query_params() -> None:
+    endpoint = _DummyEndpoint(
+        base_url="https://api.anthropic.com/v1",
+        api_format="claude:cli",
+        provider=SimpleNamespace(provider_type="claude_code"),
+    )
+
+    url = build_provider_url(
+        endpoint,  # type: ignore[arg-type]
+        query_params={"beta": "true"},
+        path_params={"model": "ignored"},
+        is_stream=False,
+    )
+
+    assert url == "https://api.anthropic.com/v1/messages?beta=true"
+
+
+@pytest.mark.asyncio
+async def test_claude_code_registers_preset_model_fetcher() -> None:
+    register_all()
+
+    fetcher = UpstreamModelsFetcherRegistry.get("claude_code")
+    assert fetcher is not None
+
+    models, errors, has_success, upstream_metadata = await fetcher(SimpleNamespace(), 1.0)
+    model_ids = {m["id"] for m in models}
+
+    assert "claude-sonnet-4-5-20250929" in model_ids
+    assert "claude-opus-4-6" in model_ids
+    assert errors == []
+    assert has_success is True
+    assert upstream_metadata is None


### PR DESCRIPTION
- 新增 claude_code provider 适配器（transport/envelope/context/constants）及预置模型注册
- 打通前后端 claude_code_advanced 配置：会话并发限制、空闲超时、TLS 指纹模拟、session_id 伪装
- 请求链路支持 Claude Code 上下文、分布式会话控制、thinking 块预过滤与 anthropic-beta 合并处理
- HTTP 客户端新增 TLS profile 复用；补充 stream usage 兼容修复与 Codex OAuth 跨套餐判重优化
- 新增/更新 Claude Code 相关单测（transport、runtime controls、envelope、summary、stream bridge）