### PR TITLE
feat(admin,frontend): 统一 OAuth 账号类型解析

### DIFF
--- a/frontend/src/features/providers/components/ProviderDetailDrawer.vue
+++ b/frontend/src/features/providers/components/ProviderDetailDrawer.vue
@@ -1107,6 +1107,12 @@ import {
 } from '@/api/endpoints'
 import type { UpstreamMetadata, AntigravityModelQuota } from '@/api/endpoints/types'
 import { formatApiFormat } from '@/api/endpoints/types/api-format'
+import {
+  formatOAuthPlanType,
+  getOAuthPlanTypeClass,
+  isNonFreeOAuthPlan,
+  normalizeOAuthPlanType,
+} from '@/utils/oauthPlanType'
 
 // 扩展端点类型,包含密钥列表
 interface ProviderEndpointWithKeys extends ProviderEndpoint {
@@ -2242,20 +2248,6 @@ function getKeyRateMultiplier(key: EndpointAPIKey, format: string): number {
   return 1.0
 }
 
-// OAuth 订阅类型格式化
-function formatOAuthPlanType(planType: string): string {
-  const labels: Record<string, string> = {
-    plus: 'Plus',
-    pro: 'Pro',
-    free: 'Free',
-    paid: 'Paid',
-    team: 'Team',
-    enterprise: 'Enterprise',
-    ultra: 'Ultra',
-  }
-  return labels[planType.toLowerCase()] || planType
-}
-
 // Codex 剩余额度样式（基于已用百分比计算剩余）
 function getQuotaRemainingClass(usedPercent: number): string {
   const remaining = 100 - usedPercent
@@ -2274,9 +2266,11 @@ function getQuotaRemainingBarColor(usedPercent: number): string {
 
 // 判断是否为 Codex Team/Plus/Enterprise 账号（有 5H 限额，显示 3 列）
 function isCodexTeamPlan(key: EndpointAPIKey): boolean {
-  const planType = key.oauth_plan_type?.toLowerCase() || key.upstream_metadata?.codex?.plan_type?.toLowerCase()
+  const planType =
+    normalizeOAuthPlanType(key.oauth_plan_type)
+    ?? normalizeOAuthPlanType(key.upstream_metadata?.codex?.plan_type)
   // Free 账号返回 false（2 列），其他所有账号返回 true（3 列）
-  return planType !== undefined && planType !== 'free'
+  return isNonFreeOAuthPlan(planType)
 }
 
 interface AntigravityQuotaItem {
@@ -2442,22 +2436,6 @@ function formatResetTime(seconds: number): string {
     return `${hours}小时 ${minutes}分钟`
   }
   return `${minutes}分钟`
-}
-
-// OAuth 订阅类型样式
-function getOAuthPlanTypeClass(planType: string): string {
-  const classes: Record<string, string> = {
-    plus: 'border-green-500/50 text-green-600 dark:text-green-400',
-    pro: 'border-blue-500/50 text-blue-600 dark:text-blue-400',
-    free: 'border-primary/50 text-primary',
-    paid: 'border-blue-500/50 text-blue-600 dark:text-blue-400',
-    team: 'border-purple-500/50 text-purple-600 dark:text-purple-400',
-    enterprise: 'border-amber-500/50 text-amber-600 dark:text-amber-400',
-    ultra: 'border-amber-500/50 text-amber-600 dark:text-amber-400',
-    'pro+': 'border-purple-500/50 text-purple-600 dark:text-purple-400',
-    power: 'border-amber-500/50 text-amber-600 dark:text-amber-400',
-  }
-  return classes[planType.toLowerCase()] || ''
 }
 
 // OAuth 状态信息（包括失效和过期）

--- a/frontend/src/features/usage/components/HorizontalRequestTimeline.vue
+++ b/frontend/src/features/usage/components/HorizontalRequestTimeline.vue
@@ -372,6 +372,7 @@ import { ChevronLeft, ChevronRight, ExternalLink } from 'lucide-vue-next'
 import { requestTraceApi, type RequestTrace, type CandidateRecord } from '@/api/requestTrace'
 import { log } from '@/utils/logger'
 import { parseApiError } from '@/utils/errorParser'
+import { formatOAuthPlanType } from '@/utils/oauthPlanType'
 import { formatApiFormat } from '@/api/endpoints/types/api-format'
 
 // 节点组类型
@@ -744,8 +745,9 @@ const formatAuthTypeWithPlan = (authType: string, planType?: string): string => 
     'gemini_cli': 'Gemini CLI',
   }
   const typeName = labels[authType] || authType
-  if (planType) {
-    return `${typeName} ${planType}`
+  const planLabel = formatOAuthPlanType(planType)
+  if (planLabel) {
+    return `${typeName} ${planLabel}`
   }
   return typeName
 }

--- a/frontend/src/features/usage/components/UsageRecordsTable.vue
+++ b/frontend/src/features/usage/components/UsageRecordsTable.vue
@@ -414,11 +414,20 @@
           </TableCell>
           <TableCell
             v-if="isAdmin"
-            class="py-4 w-[60px]"
+            class="py-4 w-[100px]"
           >
             <div class="flex items-center gap-1">
               <div class="flex flex-col text-xs gap-0.5">
-                <span>{{ record.provider }}</span>
+                <div class="flex items-center gap-1 min-w-0">
+                  <span class="truncate">{{ record.provider }}</span>
+                  <span
+                    v-if="record.oauth_plan_type"
+                    class="text-[10px] px-1 py-0.5 rounded border border-border/60 text-muted-foreground whitespace-nowrap"
+                    :title="`账号类型: ${formatOAuthPlanType(record.oauth_plan_type)}`"
+                  >
+                    {{ formatOAuthPlanType(record.oauth_plan_type) }}
+                  </span>
+                </div>
                 <span
                   v-if="record.api_key_name"
                   class="text-muted-foreground truncate"
@@ -666,6 +675,7 @@ import {
 } from '@/components/ui'
 import { RefreshCcw, Search } from 'lucide-vue-next'
 import { formatTokens, formatCurrency } from '@/utils/format'
+import { formatOAuthPlanType } from '@/utils/oauthPlanType'
 import { formatDateTime } from '../composables'
 import { useRowClick } from '@/composables/useRowClick'
 import { formatApiFormat } from '@/api/endpoints/types/api-format'

--- a/frontend/src/features/usage/types.ts
+++ b/frontend/src/features/usage/types.ts
@@ -68,6 +68,7 @@ export interface UsageRecord {
   } | null
   provider?: string  // 仅管理员可见
   api_key_name?: string
+  oauth_plan_type?: string  // OAuth 账号类型（如 free/plus/team/enterprise）
   rate_multiplier?: number
   model: string
   target_model?: string | null  // 映射后的目标模型名（若无映射则为空）

--- a/frontend/src/utils/oauthPlanType.ts
+++ b/frontend/src/utils/oauthPlanType.ts
@@ -1,0 +1,70 @@
+const PLAN_TYPE_LABELS: Record<string, string> = {
+  free: 'Free',
+  plus: 'Plus',
+  team: 'Team',
+  enterprise: 'Enterprise',
+  paid: 'Paid',
+  pro: 'Pro',
+  'pro+': 'Pro+',
+  power: 'Power',
+  ultra: 'Ultra',
+}
+
+const PLAN_TYPE_CLASS_NAMES: Record<string, string> = {
+  plus: 'border-green-500/50 text-green-600 dark:text-green-400',
+  pro: 'border-blue-500/50 text-blue-600 dark:text-blue-400',
+  free: 'border-primary/50 text-primary',
+  paid: 'border-blue-500/50 text-blue-600 dark:text-blue-400',
+  team: 'border-purple-500/50 text-purple-600 dark:text-purple-400',
+  enterprise: 'border-amber-500/50 text-amber-600 dark:text-amber-400',
+  ultra: 'border-amber-500/50 text-amber-600 dark:text-amber-400',
+  'pro+': 'border-purple-500/50 text-purple-600 dark:text-purple-400',
+  power: 'border-amber-500/50 text-amber-600 dark:text-amber-400',
+}
+
+export function normalizeOAuthPlanType(planType?: string | null): string | null {
+  if (typeof planType !== 'string') {
+    return null
+  }
+
+  const normalized = planType.trim().toLowerCase()
+  if (!normalized) {
+    return null
+  }
+  return normalized
+}
+
+export function formatOAuthPlanType(planType?: string | null): string {
+  const normalized = normalizeOAuthPlanType(planType)
+  if (!normalized) {
+    return ''
+  }
+
+  const knownLabel = PLAN_TYPE_LABELS[normalized]
+  if (knownLabel) {
+    return knownLabel
+  }
+
+  return normalized
+    .replace(/[_-]+/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(part => part[0].toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export function getOAuthPlanTypeClass(planType?: string | null): string {
+  const normalized = normalizeOAuthPlanType(planType)
+  if (!normalized) {
+    return ''
+  }
+  return PLAN_TYPE_CLASS_NAMES[normalized] || ''
+}
+
+export function isNonFreeOAuthPlan(planType?: string | null): boolean {
+  const normalized = normalizeOAuthPlanType(planType)
+  if (!normalized) {
+    return false
+  }
+  return normalized !== 'free'
+}

--- a/src/api/admin/endpoints/keys.py
+++ b/src/api/admin/endpoints/keys.py
@@ -22,6 +22,7 @@ from src.core.crypto import crypto_service
 from src.core.exceptions import InvalidRequestException, NotFoundException
 from src.core.key_capabilities import get_capability
 from src.core.logger import logger
+from src.core.oauth_plan import extract_oauth_plan_type_from_auth_config_data
 from src.core.provider_types import ProviderType
 from src.database import get_db
 from src.models.database import Provider, ProviderAPIKey, ProviderEndpoint, User
@@ -869,12 +870,7 @@ def _build_key_response(
             auth_config = json.loads(decrypted_config)
             oauth_expires_at = auth_config.get("expires_at")
             oauth_email = auth_config.get("email")
-            oauth_plan_type = auth_config.get("plan_type")  # Codex: plus/free/team/enterprise
-            # Antigravity 使用 "tier" 字段（如 "PAID"/"FREE"），做小写化 fallback
-            if not oauth_plan_type:
-                ag_tier = auth_config.get("tier")
-                if ag_tier and isinstance(ag_tier, str):
-                    oauth_plan_type = ag_tier.lower()
+            oauth_plan_type = extract_oauth_plan_type_from_auth_config_data(auth_config)
             oauth_account_id = auth_config.get("account_id")  # Codex: chatgpt_account_id
         except Exception as e:
             logger.error("Failed to decrypt auth_config for key {}: {}", key.id, e)
@@ -1347,7 +1343,9 @@ class AdminRefreshProviderQuotaAdapter(AdminApiAdapter):
                         try:
                             decrypted_config = crypto_service.decrypt(key.auth_config)
                             auth_config_data = json.loads(decrypted_config)
-                            oauth_plan_type = auth_config_data.get("plan_type")
+                            oauth_plan_type = extract_oauth_plan_type_from_auth_config_data(
+                                auth_config_data
+                            )
                             oauth_account_id = auth_config_data.get("account_id")
                         except Exception:
                             pass

--- a/src/api/admin/monitoring/trace.py
+++ b/src/api/admin/monitoring/trace.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -17,6 +16,7 @@ from src.api.base.admin_adapter import AdminApiAdapter
 from src.api.base.context import ApiRequestContext
 from src.api.base.pipeline import ApiRequestPipeline
 from src.core.crypto import crypto_service
+from src.core.oauth_plan import extract_oauth_plan_type
 from src.database import get_db
 from src.models.database import Provider, ProviderAPIKey, ProviderEndpoint
 from src.services.request.candidate import RequestCandidateService
@@ -255,35 +255,12 @@ class AdminGetRequestTraceAdapter(AdminApiAdapter):
                     key_auth_type_map[k.id] = (
                         provider_type_map.get(pid, "oauth") if pid else "oauth"
                     )
-                    # 提取 plan_type（不同 provider 存储位置不同）
-                    oauth_plan_type = None
-                    # 1. Codex: auth_config.plan_type
-                    # 2. Antigravity: auth_config.tier
-                    if k.auth_config:
-                        try:
-                            decrypted_config = crypto_service.decrypt(k.auth_config)
-                            auth_config = json.loads(decrypted_config)
-                            oauth_plan_type = auth_config.get("plan_type")
-                            if not oauth_plan_type:
-                                ag_tier = auth_config.get("tier")
-                                if ag_tier and isinstance(ag_tier, str):
-                                    oauth_plan_type = ag_tier.lower()
-                        except Exception:
-                            pass
-                    # 3. Kiro: upstream_metadata.kiro.subscription_title
-                    #    subscription_title 通常为 "KIRO FREE" / "KIRO PRO+" 等，
-                    #    去掉 provider 名称前缀，只保留等级部分
-                    if not oauth_plan_type:
-                        um = getattr(k, "upstream_metadata", None) or {}
-                        kiro_meta = um.get("kiro") if isinstance(um, dict) else None
-                        if isinstance(kiro_meta, dict):
-                            sub_title = kiro_meta.get("subscription_title")
-                            if sub_title and isinstance(sub_title, str):
-                                # "KIRO FREE" -> "Free", "KIRO PRO+" -> "Pro+"
-                                ptype = provider_type_map.get(pid, "") if pid else ""
-                                if ptype and sub_title.upper().startswith(ptype.upper()):
-                                    sub_title = sub_title[len(ptype) :].strip()
-                                oauth_plan_type = sub_title
+                    oauth_plan_type = extract_oauth_plan_type(
+                        getattr(k, "auth_config", None),
+                        upstream_metadata=getattr(k, "upstream_metadata", None),
+                        provider_type=provider_type_map.get(pid, None) if pid else None,
+                        silent=True,
+                    )
                     key_oauth_plan_map[k.id] = oauth_plan_type
                     continue
                 else:

--- a/src/api/admin/provider_oauth.py
+++ b/src/api/admin/provider_oauth.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse
 
-import httpx
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, Field
 from redis.asyncio import Redis
@@ -31,6 +30,7 @@ from src.clients.redis_client import get_redis_client
 from src.core.crypto import crypto_service
 from src.core.exceptions import InvalidRequestException, NotFoundException
 from src.core.logger import logger
+from src.core.oauth_plan import decrypt_auth_config_to_dict, normalize_oauth_plan_type
 from src.core.provider_oauth_utils import enrich_auth_config, post_oauth_token
 from src.core.provider_templates.fixed_providers import FIXED_PROVIDERS
 from src.core.provider_templates.types import ProviderType
@@ -357,6 +357,41 @@ def _build_kiro_key_name(
     return f"{base} ({method})"
 
 
+def _normalize_codex_plan_group(plan_type: Any) -> str | None:
+    """将 Codex plan_type 归一化到判重分组。
+
+    分组规则：
+    - free
+    - team/plus/enterprise（同组）
+    """
+    normalized = normalize_oauth_plan_type(plan_type)
+    if not normalized:
+        return None
+    if normalized == "free":
+        return "free"
+    if normalized in {"team", "plus", "enterprise"}:
+        return "team_plus_enterprise"
+    return None
+
+
+def _is_codex_cross_plan_group_non_duplicate(
+    *,
+    new_provider_type: Any,
+    existing_provider_type: Any,
+    new_plan_type: Any,
+    existing_plan_type: Any,
+) -> bool:
+    """Codex 账号在 free 与 Team/Plus/Enterprise 之间不判重。"""
+    new_pt = str(new_provider_type or "").strip().lower()
+    existing_pt = str(existing_provider_type or "").strip().lower()
+    if new_pt != ProviderType.CODEX.value and existing_pt != ProviderType.CODEX.value:
+        return False
+
+    new_group = _normalize_codex_plan_group(new_plan_type)
+    existing_group = _normalize_codex_plan_group(existing_plan_type)
+    return bool(new_group and existing_group and new_group != existing_group)
+
+
 def _check_duplicate_oauth_account(
     db: Session,
     provider_id: str,
@@ -402,9 +437,9 @@ def _check_duplicate_oauth_account(
         if not existing_key.auth_config:
             continue
         try:
-            decrypted_config = json.loads(
-                crypto_service.decrypt(existing_key.auth_config, silent=True)
-            )
+            decrypted_config = decrypt_auth_config_to_dict(existing_key.auth_config, silent=True)
+            if not decrypted_config:
+                continue
             existing_email = decrypted_config.get("email")
             existing_user_id = decrypted_config.get("user_id")
             existing_auth_method = decrypted_config.get("auth_method")
@@ -422,8 +457,8 @@ def _check_duplicate_oauth_account(
                 if is_kiro:
                     # Kiro: 只有 email + auth_method 都相同才视为重复
                     if (
-                        new_auth_method
-                        and existing_auth_method
+                        isinstance(new_auth_method, str)
+                        and isinstance(existing_auth_method, str)
                         and new_auth_method.lower() == existing_auth_method.lower()
                     ):
                         is_duplicate = True

--- a/src/api/admin/provider_query.py
+++ b/src/api/admin/provider_query.py
@@ -9,7 +9,6 @@ import asyncio
 import json
 from typing import Any
 
-import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session, joinedload
@@ -19,6 +18,7 @@ from src.core.api_format import get_extra_headers_from_endpoint
 from src.core.cache_service import CacheService
 from src.core.crypto import crypto_service
 from src.core.logger import logger
+from src.core.oauth_plan import decrypt_auth_config_to_dict, normalize_antigravity_tier
 from src.core.provider_types import ProviderType
 from src.database.database import get_db
 from src.models.database import Provider, ProviderEndpoint, User
@@ -79,15 +79,13 @@ def _antigravity_sort_keys(api_keys: list[Any]) -> list[Any]:
     for api_key in api_keys:
         availability = 0 if getattr(api_key, "oauth_invalid_at", None) else 1
         tier_weight = 0
-        encrypted_auth_config = getattr(api_key, "auth_config", None)
-        if encrypted_auth_config:
-            try:
-                decrypted = crypto_service.decrypt(encrypted_auth_config)
-                auth_config = json.loads(decrypted)
-                tier = (auth_config.get("tier") or "").lower()
+        auth_config = decrypt_auth_config_to_dict(
+            getattr(api_key, "auth_config", None), silent=True
+        )
+        if auth_config:
+            tier = normalize_antigravity_tier(auth_config.get("tier"))
+            if tier:
                 tier_weight = _ANTIGRAVITY_TIER_PRIORITY.get(tier, 0)
-            except Exception:
-                pass
         sort_keys.append(((availability, tier_weight), api_key))
 
     sort_keys.sort(key=lambda x: x[0], reverse=True)

--- a/src/api/admin/usage/routes.py
+++ b/src/api/admin/usage/routes.py
@@ -17,6 +17,7 @@ from src.api.base.pipeline import ApiRequestPipeline
 from src.config.constants import CacheTTL
 from src.config.settings import config
 from src.core.logger import logger
+from src.core.oauth_plan import extract_oauth_plan_type
 from src.database import get_db
 from src.models.database import (
     ApiKey,
@@ -227,7 +228,8 @@ async def get_usage_records(
       input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens, total_tokens,
       cost, actual_cost, rate_multiplier, response_time_ms, first_byte_time_ms, created_at, is_stream,
       input_price_per_1m, output_price_per_1m, cache_creation_price_per_1m, cache_read_price_per_1m,
-      status_code, error_message, status, has_fallback, has_retry, has_rectified, api_format, api_key_name, request_metadata
+      status_code, error_message, status, has_fallback, has_retry, has_rectified, api_format,
+      api_key_name, oauth_plan_type, request_metadata
     - `total`: 符合条件的总记录数
     - `limit`: 当前分页限制
     - `offset`: 当前分页偏移量
@@ -1008,7 +1010,11 @@ class AdminUsageRecordsAdapter(AdminApiAdapter):
             ),
             load_only(User.id, User.email, User.username),
             load_only(ProviderEndpoint.id, ProviderEndpoint.api_format),
-            load_only(ProviderAPIKey.id, ProviderAPIKey.name),
+            load_only(
+                ProviderAPIKey.id,
+                ProviderAPIKey.name,
+                ProviderAPIKey.auth_type,
+            ),
             load_only(ApiKey.id, ApiKey.name, ApiKey.key_encrypted),
         )
         records = (
@@ -1089,6 +1095,32 @@ class AdminUsageRecordsAdapter(AdminApiAdapter):
 
         data = []
         api_key_display_cache: dict[str, str] = {}
+        oauth_key_ids = {
+            str(provider_api_key.id)
+            for _, _, _, provider_api_key, _ in records
+            if provider_api_key
+            and str(getattr(provider_api_key, "auth_type", "") or "").strip().lower() == "oauth"
+        }
+        oauth_plan_type_cache: dict[str, str | None] = {}
+        if oauth_key_ids:
+            oauth_key_rows = (
+                db.query(
+                    ProviderAPIKey.id,
+                    ProviderAPIKey.auth_config,
+                    ProviderAPIKey.upstream_metadata,
+                )
+                .filter(ProviderAPIKey.id.in_(oauth_key_ids))
+                .all()
+            )
+            oauth_plan_type_cache = {
+                str(key_id): extract_oauth_plan_type(
+                    auth_config,
+                    upstream_metadata=upstream_metadata,
+                    silent=True,
+                )
+                for key_id, auth_config, upstream_metadata in oauth_key_rows
+            }
+
         for usage, user, endpoint, provider_api_key, user_api_key in records:
             actual_cost = (
                 float(usage.actual_total_cost_usd)
@@ -1119,6 +1151,14 @@ class AdminUsageRecordsAdapter(AdminApiAdapter):
                 has_format_conversion = bool(
                     client_fmt and endpoint_fmt and client_fmt != endpoint_fmt
                 )
+
+            oauth_plan_type: str | None = None
+            if (
+                provider_api_key
+                and str(getattr(provider_api_key, "auth_type", "") or "").strip().lower() == "oauth"
+            ):
+                provider_key_id = str(provider_api_key.id)
+                oauth_plan_type = oauth_plan_type_cache.get(provider_key_id)
 
             data.append(
                 {
@@ -1166,6 +1206,7 @@ class AdminUsageRecordsAdapter(AdminApiAdapter):
                     "endpoint_api_format": endpoint_api_format,
                     "has_format_conversion": bool(has_format_conversion),
                     "api_key_name": provider_api_key.name if provider_api_key else None,
+                    "oauth_plan_type": oauth_plan_type,
                     "request_metadata": usage.request_metadata,  # Provider 响应元数据
                 }
             )

--- a/src/core/oauth_plan.py
+++ b/src/core/oauth_plan.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from src.core.crypto import crypto_service
+
+
+def normalize_oauth_plan_type(plan_type: Any) -> str | None:
+    if not isinstance(plan_type, str):
+        return None
+    normalized = plan_type.strip().lower()
+    if not normalized:
+        return None
+    return normalized
+
+
+def extract_oauth_plan_type_from_auth_config_data(auth_config: Any) -> str | None:
+    if not isinstance(auth_config, dict):
+        return None
+
+    # Codex: plan_type (free/plus/team/enterprise)
+    plan_type = normalize_oauth_plan_type(auth_config.get("plan_type"))
+    if plan_type:
+        return plan_type
+
+    # Antigravity: tier (PAID/FREE/...)
+    tier = normalize_oauth_plan_type(auth_config.get("tier"))
+    if tier:
+        return tier
+
+    return None
+
+
+def decrypt_auth_config_to_dict(
+    encrypted_auth_config: str | None,
+    *,
+    silent: bool = True,
+) -> dict[str, Any] | None:
+    if not encrypted_auth_config:
+        return None
+    try:
+        decrypted = crypto_service.decrypt(encrypted_auth_config, silent=silent)
+        parsed = json.loads(decrypted)
+        if isinstance(parsed, dict):
+            return parsed
+    except Exception:
+        return None
+    return None
+
+
+def _strip_provider_prefix(value: str, provider_type: str | None = None) -> str:
+    normalized = value.strip()
+    if not normalized:
+        return ""
+
+    prefixes: list[str] = []
+    if isinstance(provider_type, str) and provider_type.strip():
+        prefixes.append(provider_type.strip())
+    # Kiro 目前将套餐信息记录为 "KIRO FREE" / "KIRO PRO+"。
+    if "kiro" not in {p.lower() for p in prefixes}:
+        prefixes.append("kiro")
+
+    upper = normalized.upper()
+    for prefix in prefixes:
+        prefix_upper = prefix.upper()
+        if upper == prefix_upper:
+            return ""
+        if upper.startswith(f"{prefix_upper} "):
+            return normalized[len(prefix) :].strip()
+
+    return normalized
+
+
+def extract_oauth_plan_type_from_upstream_metadata(
+    upstream_metadata: Any,
+    *,
+    provider_type: str | None = None,
+) -> str | None:
+    if not isinstance(upstream_metadata, dict):
+        return None
+
+    kiro_meta = upstream_metadata.get("kiro")
+    if isinstance(kiro_meta, dict):
+        subscription_title = kiro_meta.get("subscription_title")
+        if isinstance(subscription_title, str):
+            normalized = _strip_provider_prefix(subscription_title, provider_type=provider_type)
+            return normalize_oauth_plan_type(normalized)
+
+    return None
+
+
+def extract_oauth_plan_type(
+    encrypted_auth_config: str | None,
+    *,
+    upstream_metadata: Any = None,
+    provider_type: str | None = None,
+    silent: bool = True,
+) -> str | None:
+    auth_config = decrypt_auth_config_to_dict(encrypted_auth_config, silent=silent)
+    plan_type = extract_oauth_plan_type_from_auth_config_data(auth_config)
+    if plan_type:
+        return plan_type
+    return extract_oauth_plan_type_from_upstream_metadata(
+        upstream_metadata, provider_type=provider_type
+    )
+
+
+def normalize_antigravity_tier(raw_tier: Any) -> str | None:
+    normalized = normalize_oauth_plan_type(raw_tier)
+    if not normalized:
+        return None
+    if "ultra" in normalized:
+        return "ultra"
+    if "pro" in normalized or "paid" in normalized:
+        return "pro"
+    if "free" in normalized or "legacy" in normalized:
+        return "free"
+    return normalized
+
+
+def _extract_antigravity_tier_raw(tier_obj: Any) -> str | None:
+    if isinstance(tier_obj, str):
+        stripped = tier_obj.strip()
+        return stripped or None
+    if isinstance(tier_obj, dict):
+        for key in ("id", "tierType"):
+            value = tier_obj.get(key)
+            if isinstance(value, str):
+                stripped = value.strip()
+                if stripped:
+                    return stripped
+    return None
+
+
+def _format_antigravity_tier_label(
+    normalized_tier: str,
+    *,
+    fallback_raw: str | None = None,
+) -> str:
+    if normalized_tier == "ultra":
+        return "Ultra"
+    if normalized_tier == "pro":
+        return "Pro"
+    if normalized_tier == "free":
+        return "Free"
+    if fallback_raw:
+        return fallback_raw
+    return normalized_tier
+
+
+def extract_antigravity_tier_from_code_assist(code_assist: Any) -> str:
+    if not isinstance(code_assist, dict):
+        return "Free"
+
+    paid_tier_raw = _extract_antigravity_tier_raw(code_assist.get("paidTier"))
+    paid_tier = normalize_antigravity_tier(paid_tier_raw)
+    if paid_tier:
+        return _format_antigravity_tier_label(paid_tier, fallback_raw=paid_tier_raw)
+
+    current_tier_raw = _extract_antigravity_tier_raw(code_assist.get("currentTier"))
+    current_tier = normalize_antigravity_tier(current_tier_raw)
+    if current_tier:
+        return _format_antigravity_tier_label(current_tier, fallback_raw=current_tier_raw)
+
+    return "Free"

--- a/src/services/provider/adapters/antigravity/plugin.py
+++ b/src/services/provider/adapters/antigravity/plugin.py
@@ -17,6 +17,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 from src.core.logger import logger
+from src.core.oauth_plan import extract_antigravity_tier_from_code_assist
 from src.services.provider.adapters.antigravity.constants import V1INTERNAL_PATH_TEMPLATE
 from src.services.provider.adapters.antigravity.url_availability import url_availability
 from src.services.provider.request_context import set_selected_base_url
@@ -112,7 +113,7 @@ async def enrich_antigravity(
             code_assist = await load_code_assist(access_token, proxy_config=proxy_config)
 
             # 提取 tier 信息（对齐 sub2api：优先 paidTier，fallback currentTier）
-            tier_str = _extract_tier_from_code_assist(code_assist)
+            tier_str = extract_antigravity_tier_from_code_assist(code_assist)
             if tier_str:
                 auth_config["tier"] = tier_str
                 logger.info("[enrich] Antigravity tier: {}", tier_str)
@@ -142,58 +143,6 @@ async def enrich_antigravity(
                 logger.info("[enrich] Antigravity 随机 project_id fallback: {}", fallback)
 
     return auth_config
-
-
-def _extract_tier_from_code_assist(code_assist: dict[str, Any]) -> str:
-    """从 loadCodeAssist 响应中提取用户层级，返回 Free/Pro/Ultra。
-
-    对齐 sub2api/CLIProxyAPI：优先 paidTier，fallback currentTier。
-    兼容 tier 为字符串或 {"id": "...", "tierType": "..."} 两种格式。
-    """
-    # 优先 paidTier（付费订阅级别）
-    paid_tier = code_assist.get("paidTier")
-    tier = _normalize_tier(_extract_tier_raw(paid_tier))
-    if tier:
-        return tier
-
-    # fallback currentTier
-    current_tier = code_assist.get("currentTier")
-    tier = _normalize_tier(_extract_tier_raw(current_tier))
-    if tier:
-        return tier
-
-    return "Free"
-
-
-def _extract_tier_raw(tier_obj: Any) -> str:
-    """从 tier 对象中提取原始标识，兼容字符串和字典两种格式。"""
-    if isinstance(tier_obj, str) and tier_obj.strip():
-        return tier_obj.strip()
-    if isinstance(tier_obj, dict):
-        for key in ("id", "tierType"):
-            val = tier_obj.get(key)
-            if isinstance(val, str) and val.strip():
-                return val.strip()
-    return ""
-
-
-def _normalize_tier(raw: str) -> str:
-    """将上游 tier 标识归一化为 Free/Pro/Ultra。
-
-    上游格式示例：
-    - id: "free-tier", "g1-pro-tier", "g1-ultra-tier"
-    - tierType: "FREE", "PAID"
-    """
-    if not raw:
-        return ""
-    lower = raw.lower()
-    if "ultra" in lower:
-        return "Ultra"
-    if "pro" in lower or "paid" in lower:
-        return "Pro"
-    if "free" in lower or "legacy" in lower:
-        return "Free"
-    return raw
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- 新增后端 `src/core/oauth_plan.py`，集中处理 plan_type/tier 解析、归一化与解密读取
- 新增前端 `frontend/src/utils/oauthPlanType.ts`，统一套餐文案/样式/非 free 判定
- 管理端 keys/trace/provider_query/usage 改为复用公共解析逻辑，减少重复实现
- usage records 返回 `oauth_plan_type`，前端用量表与时间线展示套餐标签