### PR TITLE
fix(frontend): 修复 Provider Key 列表只显示 100 条的问题

### DIFF
--- a/frontend/src/api/endpoints/keys.ts
+++ b/frontend/src/api/endpoints/keys.ts
@@ -91,8 +91,24 @@ export async function deleteEndpointKey(keyId: string): Promise<{ message: strin
  * 获取 Provider 的所有 Keys
  */
 export async function getProviderKeys(providerId: string): Promise<EndpointAPIKey[]> {
-  const response = await client.get(`/api/admin/endpoints/providers/${providerId}/keys`)
-  return response.data
+  // 后端默认 limit=100，这里主动分页拉取，避免账号数 >100 时前端被截断
+  const pageSize = 1000
+  let skip = 0
+  const allKeys: EndpointAPIKey[] = []
+
+  while (true) {
+    const response = await client.get(`/api/admin/endpoints/providers/${providerId}/keys`, {
+      params: { skip, limit: pageSize },
+    })
+
+    const batch = Array.isArray(response.data) ? (response.data as EndpointAPIKey[]) : []
+    allKeys.push(...batch)
+
+    if (batch.length < pageSize) break
+    skip += pageSize
+  }
+
+  return allKeys
 }
 
 /**


### PR DESCRIPTION
  - 在 getProviderKeys 中增加 skip/limit 自动分页拉取
  - 默认每页 1000，循环获取直到无更多数据
  - 避免后端默认 limit=100 导致账号展示被截断