### PR TITLE
feat(pool): 新增账号配额展示并清理 Codex 旧限额字段

### DIFF
--- a/frontend/src/api/endpoints/pool.ts
+++ b/frontend/src/api/endpoints/pool.ts
@@ -78,6 +78,7 @@ export interface PoolKeyDetail {
   key_name: string
   is_active: boolean
   auth_type: string
+  account_quota: string | null
   cooldown_reason: string | null
   cooldown_ttl_seconds: number | null
   cost_window_usage: number

--- a/frontend/src/api/endpoints/types/provider.ts
+++ b/frontend/src/api/endpoints/types/provider.ts
@@ -284,10 +284,6 @@ export interface CodexUpstreamMetadata {
   secondary_reset_seconds?: number  // 5H限额重置剩余秒数
   secondary_reset_at?: number  // 5H限额重置时间（Unix 时间戳）
   secondary_window_minutes?: number  // 5H限额窗口大小（分钟）
-  code_review_used_percent?: number  // 代码审查限额使用百分比
-  code_review_reset_seconds?: number  // 代码审查限额重置剩余秒数
-  code_review_reset_at?: number  // 代码审查限额重置时间（Unix 时间戳）
-  code_review_window_minutes?: number  // 代码审查限额窗口大小（分钟）
   has_credits?: boolean  // 是否有积分
   credits_balance?: number  // 积分余额
 }

--- a/frontend/src/features/providers/components/ProviderDetailDrawer.vue
+++ b/frontend/src/features/providers/components/ProviderDetailDrawer.vue
@@ -534,10 +534,10 @@
                           </span>
                         </div>
                       </div>
-                      <!-- 限额并排显示：Team/Plus/Enterprise 账号 3列, Free 账号 2列 -->
+                      <!-- 限额并排显示：Team/Plus/Enterprise 账号 2列, Free 账号 1列 -->
                       <div
                         class="grid gap-3"
-                        :class="isCodexTeamPlan(key) ? 'grid-cols-3' : 'grid-cols-2'"
+                        :class="isCodexTeamPlan(key) ? 'grid-cols-2' : 'grid-cols-1'"
                       >
                         <!-- 周限额 -->
                         <div v-if="key.upstream_metadata.codex?.primary_used_percent !== undefined">
@@ -583,28 +583,6 @@
                             <template v-else>
                               已重置
                             </template>
-                          </div>
-                        </div>
-                        <!-- 代码审查限额 -->
-                        <div v-if="key.upstream_metadata.codex?.code_review_used_percent !== undefined">
-                          <div class="flex items-center justify-between text-[10px] mb-0.5">
-                            <span class="text-muted-foreground">审查限额</span>
-                            <span :class="getQuotaRemainingClass(key.upstream_metadata.codex.code_review_used_percent)">
-                              {{ (100 - key.upstream_metadata.codex.code_review_used_percent).toFixed(1) }}%
-                            </span>
-                          </div>
-                          <div class="relative w-full h-1.5 bg-border rounded-full overflow-hidden">
-                            <div
-                              class="absolute left-0 top-0 h-full transition-all duration-300"
-                              :class="getQuotaRemainingBarColor(key.upstream_metadata.codex.code_review_used_percent)"
-                              :style="{ width: `${Math.max(100 - key.upstream_metadata.codex.code_review_used_percent, 0)}%` }"
-                            />
-                          </div>
-                          <div
-                            v-if="key.upstream_metadata.codex.code_review_reset_seconds"
-                            class="text-[9px] text-muted-foreground/70 mt-0.5"
-                          >
-                            {{ formatResetTime(key.upstream_metadata.codex.code_review_reset_seconds) }}后重置
                           </div>
                         </div>
                       </div>

--- a/src/api/admin/pool/schemas.py
+++ b/src/api/admin/pool/schemas.py
@@ -39,6 +39,7 @@ class PoolKeyDetail(BaseModel):
     key_name: str
     is_active: bool
     auth_type: str = "api_key"
+    account_quota: str | None = None
     cooldown_reason: str | None = None
     cooldown_ttl_seconds: int | None = None
     cost_window_usage: int = 0

--- a/src/services/provider_keys/codex_realtime_quota.py
+++ b/src/services/provider_keys/codex_realtime_quota.py
@@ -25,7 +25,6 @@ _COMPARE_IGNORE_FIELDS = frozenset(
         "updated_at",
         "primary_reset_seconds",
         "secondary_reset_seconds",
-        "code_review_reset_seconds",
     }
 )
 _CACHE_TTL_SECONDS = 30.0

--- a/src/services/scheduling/quota_skipper.py
+++ b/src/services/scheduling/quota_skipper.py
@@ -33,7 +33,7 @@ def is_key_quota_exhausted(
 
     Requirements:
     - Kiro: account-level quota. When remaining == 0, skip this key; allow again when remaining > 0.
-    - Codex: only consider weekly quota + 5H quota (ignore code review quota).
+    - Codex: only consider weekly quota + 5H quota.
              If either remaining is 0%, skip this key.
     - Antigravity: quota is per-model; do not disable the account.
                    When the requested model's quota is 0%, skip this key.

--- a/tests/services/test_aware_scheduler_quota_skipping.py
+++ b/tests/services/test_aware_scheduler_quota_skipping.py
@@ -68,7 +68,6 @@ def test_codex_weekly_quota_exhausted_skips(_mock_cb: MagicMock) -> None:
             "codex": {
                 "primary_used_percent": 100.0,
                 "secondary_used_percent": 10.0,
-                "code_review_used_percent": 100.0,
             }
         }
     )
@@ -114,14 +113,14 @@ def test_codex_5h_quota_exhausted_skips(_mock_cb: MagicMock) -> None:
     "src.services.scheduling.candidate_builder.health_monitor.get_circuit_breaker_status",
     return_value=(True, None),
 )
-def test_codex_ignores_code_review_quota(_mock_cb: MagicMock) -> None:
+def test_codex_ignores_unrelated_metadata_fields(_mock_cb: MagicMock) -> None:
     scheduler = CacheAwareScheduler()
     key = _make_key(
         upstream_metadata={
             "codex": {
                 "primary_used_percent": 10.0,
                 "secondary_used_percent": 20.0,
-                "code_review_used_percent": 100.0,
+                "legacy_marker": "ignore-me",
             }
         }
     )

--- a/tests/services/test_provider_keys_codex_realtime_quota.py
+++ b/tests/services/test_provider_keys_codex_realtime_quota.py
@@ -114,7 +114,7 @@ def test_sync_codex_quota_from_headers_updates_and_preserves_existing_fields() -
         upstream_metadata={
             "codex": {
                 "primary_used_percent": 50.0,
-                "code_review_used_percent": 12.0,
+                "legacy_marker": "keep-me",
             }
         },
     )
@@ -131,8 +131,8 @@ def test_sync_codex_quota_from_headers_updates_and_preserves_existing_fields() -
     codex_meta = key.upstream_metadata["codex"]
     assert codex_meta["primary_used_percent"] == 64.0
     assert codex_meta["secondary_used_percent"] == 3.0
-    # 旧的 code_review 字段应被保留（wham/usage 补充信息）
-    assert codex_meta["code_review_used_percent"] == 12.0
+    # 旧字段应被保留（解析器只覆盖已知配额字段）
+    assert codex_meta["legacy_marker"] == "keep-me"
 
 
 def test_sync_codex_quota_from_headers_skips_when_only_reset_seconds_changed() -> None:


### PR DESCRIPTION
- 后端池子 Key 列表新增 account_quota 字段，按 provider_type 生成配额摘要（codex/kiro/antigravity）
- 前端 PoolManagement 新增“配额”列与进度条展示，桌面端与移动端同步支持
- Provider 详情页移除 Codex code_review 限额展示，仅保留周限额与 5H 限额
- 清理 codex usage parser/realtime quota 中 code_review 相关解析与比较逻辑
- 同步更新调度与配额相关测试，改为忽略无关历史字段