### PR TITLE
feat(pool): 记录并展示 Provider Key 累计 Token 与费用

### DIFF
--- a/alembic/versions/20260310_0200_9b7c6d5e4f3a_add_provider_key_usage_totals.py
+++ b/alembic/versions/20260310_0200_9b7c6d5e4f3a_add_provider_key_usage_totals.py
@@ -1,0 +1,59 @@
+"""add provider_api_keys usage total columns
+
+Revision ID: 9b7c6d5e4f3a
+Revises: d7649c1f8e21
+Create Date: 2026-03-10 02:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9b7c6d5e4f3a"
+down_revision: str | None = "d7649c1f8e21"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def column_exists(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [c["name"] for c in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+def upgrade() -> None:
+    if not column_exists("provider_api_keys", "total_tokens"):
+        op.add_column(
+            "provider_api_keys",
+            sa.Column("total_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+        )
+    if column_exists("provider_api_keys", "total_tokens"):
+        op.alter_column("provider_api_keys", "total_tokens", server_default=None)
+
+    if not column_exists("provider_api_keys", "total_cost_usd"):
+        op.add_column(
+            "provider_api_keys",
+            sa.Column(
+                "total_cost_usd",
+                sa.Numeric(20, 8),
+                nullable=False,
+                server_default="0.0",
+            ),
+        )
+    if column_exists("provider_api_keys", "total_cost_usd"):
+        op.alter_column("provider_api_keys", "total_cost_usd", server_default=None)
+
+
+def downgrade() -> None:
+    if column_exists("provider_api_keys", "total_cost_usd"):
+        op.drop_column("provider_api_keys", "total_cost_usd")
+
+    if column_exists("provider_api_keys", "total_tokens"):
+        op.drop_column("provider_api_keys", "total_tokens")

--- a/frontend/src/api/endpoints/pool.ts
+++ b/frontend/src/api/endpoints/pool.ts
@@ -29,7 +29,7 @@ export interface PoolStatusResponse {
  * 获取 Provider 的号池状态
  */
 export async function getPoolStatus(providerId: string): Promise<PoolStatusResponse> {
-  const response = await client.get(`/api/admin/providers/${providerId}/pool-status`)
+  const response = await client.get<PoolStatusResponse>(`/api/admin/providers/${providerId}/pool-status`)
   return response.data
 }
 
@@ -40,7 +40,7 @@ export async function clearPoolCooldown(
   providerId: string,
   keyId: string,
 ): Promise<{ message: string }> {
-  const response = await client.post(
+  const response = await client.post<{ message: string }>(
     `/api/admin/providers/${providerId}/pool/clear-cooldown/${keyId}`,
   )
   return response.data
@@ -53,7 +53,7 @@ export async function resetPoolCost(
   providerId: string,
   keyId: string,
 ): Promise<{ message: string }> {
-  const response = await client.post(
+  const response = await client.post<{ message: string }>(
     `/api/admin/providers/${providerId}/pool/reset-cost/${keyId}`,
   )
   return response.data
@@ -125,6 +125,8 @@ export interface PoolKeyDetail {
   cost_window_usage: number
   cost_limit: number | null
   request_count: number
+  total_tokens: number
+  total_cost_usd: string
   sticky_sessions: number
   lru_score: number | null
   created_at: string | null

--- a/frontend/src/views/admin/PoolManagement.vue
+++ b/frontend/src/views/admin/PoolManagement.vue
@@ -543,11 +543,23 @@
                   >-</span>
                 </TableCell>
                 <TableCell class="py-3 px-2 align-middle">
-                  <div class="w-[136px] mx-auto text-[10px] leading-4">
+                  <div class="grid grid-rows-3 gap-0.5 w-[136px] mx-auto text-[10px] leading-4">
                     <div class="flex items-center justify-between gap-2">
                       <span class="text-muted-foreground">请求</span>
                       <span class="tabular-nums text-foreground/90">
                         {{ formatStatInteger(key.request_count) }}
+                      </span>
+                    </div>
+                    <div class="flex items-center justify-between gap-2">
+                      <span class="text-muted-foreground">Token</span>
+                      <span class="tabular-nums text-foreground/90">
+                        {{ formatTokenCount(key.total_tokens) }}
+                      </span>
+                    </div>
+                    <div class="flex items-center justify-between gap-2">
+                      <span class="text-muted-foreground">费用</span>
+                      <span class="tabular-nums text-foreground/90">
+                        {{ formatStatUsd(key.total_cost_usd) }}
                       </span>
                     </div>
                   </div>
@@ -912,10 +924,18 @@
                 <div class="text-muted-foreground mb-0.5">
                   统计
                 </div>
-                <div class="text-[10px]">
+                <div class="space-y-0.5 text-[10px]">
                   <div class="flex items-center justify-between gap-2">
                     <span class="text-muted-foreground">请求</span>
                     <span class="tabular-nums">{{ formatStatInteger(key.request_count) }}</span>
+                  </div>
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-muted-foreground">Token</span>
+                    <span class="tabular-nums">{{ formatTokenCount(key.total_tokens) }}</span>
+                  </div>
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-muted-foreground">费用</span>
+                    <span class="tabular-nums">{{ formatStatUsd(key.total_cost_usd) }}</span>
                   </div>
                 </div>
               </div>
@@ -1195,6 +1215,7 @@ async function loadOverview() {
         selectedProviderData.value = null
         showAccountBatchDialog.value = false
         closeProviderProxyPopovers()
+        resetKeyPage()
       }
     }
   } catch (err) {
@@ -1381,6 +1402,7 @@ const desktopColumnWidths = computed(() => {
 async function selectProvider(id: string) {
   const requestId = ++selectProviderRequestId
   selectedProviderId.value = id
+  selectedProviderData.value = null
   editingKeyDetail.value = null
   showAccountBatchDialog.value = false
   keyPermissionsDialogOpen.value = false
@@ -1398,6 +1420,7 @@ async function selectProvider(id: string) {
     clearTimeout(keysSearchDebounceTimer)
     keysSearchDebounceTimer = null
   }
+  resetKeyPage(1, pageSize.value)
   const keysTask = loadKeys()
   // Provider summary is non-blocking for key list rendering.
   void loadProviderData(id)
@@ -1422,7 +1445,11 @@ async function refresh() {
 }
 
 // --- Keys ---
-const keyPage = ref<PoolKeysPageResponse>({ total: 0, page: 1, page_size: 50, keys: [] })
+function createEmptyKeyPage(page = 1, pageSizeValue = 50): PoolKeysPageResponse {
+  return { total: 0, page, page_size: pageSizeValue, keys: [] }
+}
+
+const keyPage = ref<PoolKeysPageResponse>(createEmptyKeyPage())
 const keysLoading = ref(false)
 const refreshingCurrentPageQuota = ref(false)
 const searchQuery = ref('')
@@ -1431,7 +1458,6 @@ const currentPage = ref(1)
 const pageSize = ref(50)
 const MANUAL_QUOTA_REFRESH_COOLDOWN_SECONDS = 5 * 60
 const refreshingOAuthKeyId = ref<string | null>(null)
-const revealedKeys = ref<Map<string, string>>(new Map())
 const recoveringHealthKeyId = ref<string | null>(null)
 const savingProxyKeyId = ref<string | null>(null)
 const proxyDesktopPopoverOpenKeyId = ref<string | null>(null)
@@ -1471,6 +1497,14 @@ const quotaRefreshSupported = computed(() => {
 const refreshCurrentPageLoading = computed(() => {
   return keysLoading.value || refreshingCurrentPageQuota.value
 })
+
+function resetKeyPage(page = currentPage.value, pageSizeValue = pageSize.value): void {
+  keyPage.value = createEmptyKeyPage(page, pageSizeValue)
+}
+
+function refreshOverviewInBackground(): void {
+  void loadOverview()
+}
 
 function normalizeQuotaUpdatedAt(raw: number | null | undefined): number | null {
   const value = Number(raw ?? 0)
@@ -1607,6 +1641,7 @@ async function loadKeys() {
     keyPage.value = nextPage
   } catch (err) {
     if (requestId !== keysRequestId || selectedProviderId.value !== providerId) return
+    resetKeyPage(page, pageSizeValue)
     showError(parseApiError(err))
   } finally {
     if (requestId === keysRequestId) {
@@ -1878,6 +1913,7 @@ async function handleDeleteKey(key: PoolKeyDetail) {
     if (keyPage.value.keys.length === 0 && currentPage.value > 1) {
       currentPage.value--
     }
+    refreshOverviewInBackground()
   } catch (err) {
     showError(parseApiError(err, '删除账号失败'))
   } finally {
@@ -1886,12 +1922,6 @@ async function handleDeleteKey(key: PoolKeyDetail) {
 }
 
 async function copyFullKey(key: PoolKeyDetail) {
-  const cached = revealedKeys.value.get(key.key_id)
-  if (cached) {
-    await copyToClipboard(cached)
-    return
-  }
-
   try {
     const result = await revealEndpointKey(key.key_id)
     let textToCopy = ''
@@ -1911,7 +1941,6 @@ async function copyFullKey(key: PoolKeyDetail) {
       return
     }
 
-    revealedKeys.value.set(key.key_id, textToCopy)
     await copyToClipboard(textToCopy)
   } catch (err) {
     showError(parseApiError(err, '获取密钥失败'))
@@ -1968,6 +1997,7 @@ async function clearCooldown(keyId: string) {
     const res = await clearPoolCooldown(selectedProviderId.value, keyId)
     success(res.message)
     await loadKeys()
+    refreshOverviewInBackground()
   } catch (err) {
     showError(parseApiError(err))
   }
@@ -1993,6 +2023,7 @@ async function toggleKeyActive(key: PoolKeyDetail) {
     }
     success(nextStatus ? '账号已启用' : '账号已停用')
     await loadKeys()
+    refreshOverviewInBackground()
   } catch (err) {
     showError(parseApiError(err))
   } finally {
@@ -2493,6 +2524,23 @@ function formatStatInteger(value: number | null | undefined): string {
   const n = Number(value ?? 0)
   if (!Number.isFinite(n) || n <= 0) return '0'
   return Math.round(n).toLocaleString('en-US')
+}
+
+function formatTokenCount(value: number | null | undefined): string {
+  const n = Number(value ?? 0)
+  if (!Number.isFinite(n) || n <= 0) return '0'
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(Math.round(n))
+}
+
+function formatStatUsd(value: number | string | null | undefined): string {
+  const n = Number(value ?? 0)
+  if (!Number.isFinite(n) || n <= 0) return '$0.00'
+  if (n < 0.01) return `$${n.toFixed(4)}`
+  if (n < 1) return `$${n.toFixed(3)}`
+  if (n < 1000) return `$${n.toFixed(2)}`
+  return `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
 }
 
 function formatRelativeTime(isoStr: string): string {

--- a/src/api/admin/pool/routes.py
+++ b/src/api/admin/pool/routes.py
@@ -30,6 +30,7 @@ from src.core.exceptions import NotFoundException
 from src.core.logger import logger
 from src.database import get_db
 from src.models.database import Provider, ProviderAPIKey
+from src.services.billing.precision import to_money_decimal
 from src.services.provider.fingerprint import generate_fingerprint
 from src.services.provider.pool import redis_ops as pool_redis
 from src.services.provider.pool.account_state import resolve_pool_account_state
@@ -214,6 +215,10 @@ def _to_float(value: Any) -> float | None:
         except ValueError:
             return None
     return None
+
+
+def _serialize_money(value: Any) -> str:
+    return format(to_money_decimal(value), "f")
 
 
 def _is_known_banned_key(key: ProviderAPIKey, provider_type: str) -> bool:
@@ -677,6 +682,8 @@ class AdminListPoolKeysAdapter(AdminApiAdapter):
                     ProviderAPIKey.health_by_format,
                     ProviderAPIKey.circuit_breaker_by_format,
                     ProviderAPIKey.request_count,
+                    ProviderAPIKey.total_tokens,
+                    ProviderAPIKey.total_cost_usd,
                     ProviderAPIKey.last_used_at,
                     ProviderAPIKey.created_at,
                     ProviderAPIKey.upstream_metadata,
@@ -864,6 +871,8 @@ class AdminListPoolKeysAdapter(AdminApiAdapter):
                 else []
             )
             key_request_count = int(getattr(k, "request_count", 0) or 0)
+            key_total_tokens = int(getattr(k, "total_tokens", 0) or 0)
+            key_total_cost_usd = _serialize_money(getattr(k, "total_cost_usd", 0.0))
             key_last_used_at = getattr(k, "last_used_at", None)
             oauth_auth_config = _extract_oauth_auth_config(k)
 
@@ -923,6 +932,8 @@ class AdminListPoolKeysAdapter(AdminApiAdapter):
                     cost_window_usage=cost_usage,
                     cost_limit=cost_limit,
                     request_count=key_request_count,
+                    total_tokens=key_total_tokens,
+                    total_cost_usd=key_total_cost_usd,
                     sticky_sessions=sticky_counts.get(kid, 0),
                     lru_score=lru_scores.get(kid),
                     created_at=(

--- a/src/api/admin/pool/schemas.py
+++ b/src/api/admin/pool/schemas.py
@@ -103,6 +103,8 @@ class PoolKeyDetail(BaseModel):
     cost_window_usage: int = 0
     cost_limit: int | None = None
     request_count: int = 0
+    total_tokens: int = 0
+    total_cost_usd: str = "0.00000000"
     sticky_sessions: int = 0
     lru_score: float | None = None
     created_at: str | None = None

--- a/src/api/admin/system.py
+++ b/src/api/admin/system.py
@@ -2858,6 +2858,8 @@ def _purge_stats_and_reset_counters(db: Session) -> None:
     db.query(ProviderAPIKey).update(
         {
             ProviderAPIKey.request_count: 0,
+            ProviderAPIKey.total_tokens: 0,
+            ProviderAPIKey.total_cost_usd: 0.0,
             ProviderAPIKey.success_count: 0,
             ProviderAPIKey.error_count: 0,
             ProviderAPIKey.total_response_time_ms: 0,

--- a/src/models/database.py
+++ b/src/models/database.py
@@ -1760,6 +1760,8 @@ class ProviderAPIKey(ExportMixin, Base):
             "health_by_format",
             "circuit_breaker_by_format",
             "request_count",
+            "total_tokens",
+            "total_cost_usd",
             "success_count",
             "error_count",
             "total_response_time_ms",
@@ -1865,6 +1867,8 @@ class ProviderAPIKey(ExportMixin, Base):
 
     # 使用统计
     request_count = Column(Integer, default=0)  # 请求次数
+    total_tokens = Column(BigInteger, default=0, nullable=False)  # 累计 Token 数
+    total_cost_usd = Column(Numeric(20, 8), default=0.0, nullable=False)  # 累计成本
     success_count = Column(Integer, default=0)  # 成功次数
     error_count = Column(Integer, default=0)  # 错误次数
     total_response_time_ms = Column(Integer, default=0)  # 总响应时间（用于计算平均值）

--- a/src/services/usage/recording.py
+++ b/src/services/usage/recording.py
@@ -9,7 +9,15 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from src.core.logger import logger
-from src.models.database import ApiKey, Provider, ProxyNode, Usage, User, UserModelUsageCount
+from src.models.database import (
+    ApiKey,
+    Provider,
+    ProviderAPIKey,
+    ProxyNode,
+    Usage,
+    User,
+    UserModelUsageCount,
+)
 from src.services.billing.precision import to_money_decimal
 from src.services.provider_keys.codex_quota_sync_dispatcher import (
     dispatch_codex_quota_sync_from_response_headers,
@@ -24,6 +32,7 @@ from src.services.usage._recording_helpers import (
 )
 from src.services.usage._types import UsageCostInfo, UsageRecordParams
 from src.services.wallet import WalletService
+from src.utils.perf import PerfRecorder
 
 
 def _extract_manual_proxy_node_id(metadata: dict[str, Any] | None) -> str | None:
@@ -68,6 +77,57 @@ def _increment_proxy_node_requests(
                 .where(ProxyNode.id == node_id, ProxyNode.is_manual == True)  # noqa: E712
                 .values(**values)
             )
+
+
+def _increment_provider_api_key_totals(
+    db: Session,
+    provider_api_key_id: str | None,
+    *,
+    total_tokens: int = 0,
+    total_cost: float = 0.0,
+    source: str = "unknown",
+) -> None:
+    """原子递增 ProviderAPIKey 的累计 Token/成本，并刷新最后使用时间。"""
+    if not provider_api_key_id:
+        return
+
+    from sqlalchemy import func as sql_func
+    from sqlalchemy import update
+
+    values: dict[str, Any] = {
+        "last_used_at": sql_func.now(),
+        "updated_at": sql_func.now(),
+    }
+
+    token_increment = int(total_tokens or 0)
+    if token_increment > 0:
+        values["total_tokens"] = ProviderAPIKey.total_tokens + token_increment
+
+    cost_increment = to_money_decimal(total_cost)
+    if cost_increment > 0:
+        values["total_cost_usd"] = ProviderAPIKey.total_cost_usd + Decimal(str(cost_increment))
+
+    perf_labels = {
+        "source": source,
+        "has_tokens": "true" if token_increment > 0 else "false",
+        "has_cost": "true" if cost_increment > 0 else "false",
+    }
+    PerfRecorder.record_counter("provider_key_totals_update_total", labels=perf_labels)
+    perf_start = PerfRecorder.start()
+
+    db.execute(
+        update(ProviderAPIKey).where(ProviderAPIKey.id == provider_api_key_id).values(**values)
+    )
+    PerfRecorder.stop(
+        perf_start,
+        "provider_key_totals_update",
+        labels=perf_labels,
+        log_hint=f"source={source}",
+    )
+
+
+def _get_actual_total_cost_usd(usage_params: dict[str, Any]) -> float:
+    return float(to_money_decimal(usage_params.get("actual_total_cost_usd") or 0.0))
 
 
 class UsageRecordingMixin(UsageBillingIntegrationMixin):
@@ -305,12 +365,21 @@ class UsageRecordingMixin(UsageBillingIntegrationMixin):
                 .values(monthly_used_usd=Provider.monthly_used_usd + actual_total_cost)
             )
 
-        cls._finalize_usage_billing(
+        accounted, _charge_applied = cls._finalize_usage_billing(
             db,
             usage=usage,
             total_cost=total_cost,
             status=status,
         )
+
+        if accounted:
+            _increment_provider_api_key_totals(
+                db,
+                provider_api_key_id,
+                total_tokens=int(usage_params.get("total_tokens") or 0),
+                total_cost=_get_actual_total_cost_usd(usage_params),
+                source="record_usage_async",
+            )
 
         dispatch_codex_quota_sync_from_response_headers(
             provider_api_key_id=provider_api_key_id,
@@ -481,6 +550,14 @@ class UsageRecordingMixin(UsageBillingIntegrationMixin):
                     db.execute(
                         sa_update(ApiKeyModel).where(ApiKeyModel.id == api_key.id).values(**values)
                     )
+
+                _increment_provider_api_key_totals(
+                    db,
+                    provider_api_key_id,
+                    total_tokens=int(usage_params.get("total_tokens") or 0),
+                    total_cost=_get_actual_total_cost_usd(usage_params),
+                    source="record_usage",
+                )
 
                 # 更新 GlobalModel 使用计数
                 db.execute(
@@ -706,6 +783,14 @@ class UsageRecordingMixin(UsageBillingIntegrationMixin):
                     )
                 db.execute(update(ApiKeyModel).where(ApiKeyModel.id == api_key.id).values(**values))
 
+            _increment_provider_api_key_totals(
+                db,
+                provider_api_key_id,
+                total_tokens=int(usage_params.get("total_tokens") or 0),
+                total_cost=_get_actual_total_cost_usd(usage_params),
+                source="record_usage_with_custom_cost",
+            )
+
             # 更新 GlobalModel 使用计数
             db.execute(
                 update(GlobalModel)
@@ -841,6 +926,9 @@ class UsageRecordingMixin(UsageBillingIntegrationMixin):
         usages: list[Usage] = []
         apikey_stats: dict[str, dict[str, Any]] = defaultdict(
             lambda: {"requests": 0, "cost": 0.0, "is_standalone": False}
+        )
+        provider_key_stats: dict[str, dict[str, Any]] = defaultdict(
+            lambda: {"tokens": 0, "actual_cost": 0.0}
         )
         model_counts: dict[str, int] = defaultdict(int)  # model -> count
         user_model_counts: dict[tuple[str, str], int] = defaultdict(
@@ -1006,6 +1094,15 @@ class UsageRecordingMixin(UsageBillingIntegrationMixin):
                             apikey_stats[key_id]["cost"] += total_cost
                         apikey_stats[key_id]["is_standalone"] = api_key.is_standalone
 
+                    provider_api_key_id = record.get("provider_api_key_id")
+                    if isinstance(provider_api_key_id, str) and provider_api_key_id:
+                        provider_key_stats[provider_api_key_id]["tokens"] += int(
+                            usage_params.get("total_tokens") or 0
+                        )
+                        provider_key_stats[provider_api_key_id][
+                            "actual_cost"
+                        ] += _get_actual_total_cost_usd(usage_params)
+
                     manual_nid = _extract_manual_proxy_node_id(record.get("metadata"))
                     if manual_nid:
                         proxy_node_counts[manual_nid] += 1
@@ -1067,6 +1164,15 @@ class UsageRecordingMixin(UsageBillingIntegrationMixin):
                         if charge_applied:
                             apikey_stats[key_id]["cost"] += total_cost
                         apikey_stats[key_id]["is_standalone"] = api_key.is_standalone
+
+                    provider_api_key_id = record.get("provider_api_key_id")
+                    if isinstance(provider_api_key_id, str) and provider_api_key_id:
+                        provider_key_stats[provider_api_key_id]["tokens"] += int(
+                            usage_params.get("total_tokens") or 0
+                        )
+                        provider_key_stats[provider_api_key_id][
+                            "actual_cost"
+                        ] += _get_actual_total_cost_usd(usage_params)
 
                     manual_nid = _extract_manual_proxy_node_id(record.get("metadata"))
                     if manual_nid:
@@ -1155,6 +1261,27 @@ class UsageRecordingMixin(UsageBillingIntegrationMixin):
                     updated_at=sql_func.now(),
                 )
             )
+
+        provider_key_perf_start = PerfRecorder.start()
+        for provider_key_id, stats in provider_key_stats.items():
+            _increment_provider_api_key_totals(
+                db,
+                provider_key_id,
+                total_tokens=int(stats["tokens"]),
+                total_cost=float(stats["actual_cost"]),
+                source="record_usage_batch",
+            )
+        PerfRecorder.stop(
+            provider_key_perf_start,
+            "provider_key_totals_batch_apply",
+            labels={"source": "record_usage_batch"},
+            log_hint=f"rows={len(provider_key_stats)}",
+        )
+        PerfRecorder.record_counter(
+            "provider_key_totals_batch_rows_total",
+            value=len(provider_key_stats),
+            labels={"source": "record_usage_batch"},
+        )
 
         # 批量更新手动代理节点请求计数
         _increment_proxy_node_requests(db, proxy_node_counts, proxy_node_failed)

--- a/tests/services/test_usage_recording_provider_key_totals.py
+++ b/tests/services/test_usage_recording_provider_key_totals.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import src.services.usage.recording as recording_module
+from src.services.usage.service import UsageService
+
+
+class DummyQuery:
+    def __init__(self, result: list[Any]) -> None:
+        self._result = result
+
+    def options(self, *args: Any, **kwargs: Any) -> "DummyQuery":
+        return self
+
+    def filter(self, *args: Any, **kwargs: Any) -> "DummyQuery":
+        return self
+
+    def with_for_update(self) -> "DummyQuery":
+        return self
+
+    def all(self) -> list[Any]:
+        return self._result
+
+    def first(self) -> Any | None:
+        return self._result[0] if self._result else None
+
+
+@pytest.mark.asyncio
+async def test_record_usage_updates_provider_key_totals(monkeypatch: Any) -> None:
+    db = MagicMock()
+    db.query.side_effect = lambda _model: DummyQuery([])
+
+    usage_params = {
+        "request_id": "req-provider-key-1",
+        "provider_name": "openai",
+        "model": "gpt-4o",
+        "status": "completed",
+        "total_tokens": 123,
+        "actual_total_cost_usd": 1.75,
+    }
+
+    monkeypatch.setattr(
+        UsageService,
+        "_prepare_usage_record",
+        AsyncMock(return_value=(usage_params, 1.25)),
+    )
+    monkeypatch.setattr(
+        UsageService,
+        "_finalize_usage_billing",
+        MagicMock(return_value=(True, True)),
+    )
+    helper = MagicMock()
+    monkeypatch.setattr(recording_module, "_increment_provider_api_key_totals", helper)
+    monkeypatch.setattr(
+        recording_module,
+        "dispatch_codex_quota_sync_from_response_headers",
+        MagicMock(),
+    )
+
+    await UsageService.record_usage(
+        db=db,
+        user=None,
+        api_key=None,
+        provider="openai",
+        model="gpt-4o",
+        input_tokens=100,
+        output_tokens=23,
+        provider_api_key_id="provider-key-1",
+        request_id="req-provider-key-1",
+        status="completed",
+    )
+
+    helper.assert_called_once()
+    _, provider_key_id = helper.call_args.args
+    assert provider_key_id == "provider-key-1"
+    assert helper.call_args.kwargs["total_tokens"] == 123
+    assert float(helper.call_args.kwargs["total_cost"]) == 1.75
+
+
+@pytest.mark.asyncio
+async def test_record_usage_async_updates_provider_key_totals(monkeypatch: Any) -> None:
+    db = MagicMock()
+
+    usage_params = {
+        "request_id": "req-provider-key-async",
+        "provider_name": "openai",
+        "model": "gpt-4o-mini",
+        "status": "completed",
+        "total_tokens": 77,
+        "actual_total_cost_usd": 0.75,
+    }
+
+    monkeypatch.setattr(
+        UsageService,
+        "_prepare_usage_record",
+        AsyncMock(return_value=(usage_params, 0.5)),
+    )
+    monkeypatch.setattr(
+        UsageService,
+        "_finalize_usage_billing",
+        MagicMock(return_value=(True, False)),
+    )
+    helper = MagicMock()
+    monkeypatch.setattr(recording_module, "_increment_provider_api_key_totals", helper)
+    monkeypatch.setattr(
+        recording_module,
+        "dispatch_codex_quota_sync_from_response_headers",
+        MagicMock(),
+    )
+
+    await UsageService.record_usage_async(
+        db=db,
+        user=None,
+        api_key=None,
+        provider="openai",
+        model="gpt-4o-mini",
+        input_tokens=50,
+        output_tokens=27,
+        provider_api_key_id="provider-key-async",
+        request_id="req-provider-key-async",
+        status="completed",
+    )
+
+    helper.assert_called_once()
+    _, provider_key_id = helper.call_args.args
+    assert provider_key_id == "provider-key-async"
+    assert helper.call_args.kwargs["total_tokens"] == 77
+    assert helper.call_args.kwargs["total_cost"] == 0.75
+
+
+@pytest.mark.asyncio
+async def test_record_usage_batch_aggregates_provider_key_totals(monkeypatch: Any) -> None:
+    db = MagicMock()
+    db.query.side_effect = lambda _model: DummyQuery([])
+
+    usage_params_1 = {
+        "request_id": "req-provider-key-batch-1",
+        "provider_name": "anthropic",
+        "model": "claude-sonnet",
+        "status": "completed",
+        "total_tokens": 321,
+        "actual_total_cost_usd": 2.5,
+    }
+    usage_params_2 = {
+        "request_id": "req-provider-key-batch-2",
+        "provider_name": "anthropic",
+        "model": "claude-sonnet",
+        "status": "completed",
+        "total_tokens": 79,
+        "actual_total_cost_usd": 0.75,
+    }
+
+    monkeypatch.setattr(
+        UsageService,
+        "_prepare_usage_records_batch",
+        AsyncMock(
+            return_value=[
+                (usage_params_1, 2.0, None),
+                (usage_params_2, 0.5, None),
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        UsageService,
+        "_finalize_usage_billing",
+        MagicMock(return_value=(True, True)),
+    )
+    helper = MagicMock()
+    monkeypatch.setattr(recording_module, "_increment_provider_api_key_totals", helper)
+    monkeypatch.setattr(
+        recording_module,
+        "dispatch_codex_quota_sync_from_response_headers",
+        MagicMock(),
+    )
+
+    await UsageService.record_usage_batch(
+        db,
+        [
+            {
+                "request_id": "req-provider-key-batch-1",
+                "provider": "anthropic",
+                "model": "claude-sonnet",
+                "status": "completed",
+                "provider_api_key_id": "provider-key-batch",
+            },
+            {
+                "request_id": "req-provider-key-batch-2",
+                "provider": "anthropic",
+                "model": "claude-sonnet",
+                "status": "completed",
+                "provider_api_key_id": "provider-key-batch",
+            },
+        ],
+    )
+
+    helper.assert_called_once()
+    _, provider_key_id = helper.call_args.args
+    assert provider_key_id == "provider-key-batch"
+    assert helper.call_args.kwargs["total_tokens"] == 400
+    assert helper.call_args.kwargs["total_cost"] == 3.25

--- a/tests/unit/test_admin_pool_money_serialization.py
+++ b/tests/unit/test_admin_pool_money_serialization.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from src.api.admin.pool.routes import _serialize_money
+
+
+def test_serialize_money_preserves_storage_precision() -> None:
+    assert _serialize_money(Decimal("12.34")) == "12.34000000"
+    assert _serialize_money("0.00000001") == "0.00000001"
+    assert _serialize_money(None) == "0.00000000"


### PR DESCRIPTION
- 为 provider_api_keys 新增 total_tokens 与 total_cost_usd 字段，并补充 Alembic 迁移，兼容列已存在场景
- 在 usage 记录链路中同步累计 provider key 维度统计，覆盖 record_usage、record_usage_async 与 record_usage_batch
- 批量记录时按 provider_api_key_id 聚合 token 与实际成本后统一更新，减少重复写入并保证统计口径一致
- 使用金额精度工具统一处理 total_cost_usd，避免浮点误差，并在管理接口中按 8 位小数返回
- 扩展后台号池接口与前端类型定义，向管理页透出请求数、累计 Token、累计费用等统计字段
- 在号池管理页新增 Token/费用展示与格式化逻辑，同时优化分页重置、概览刷新与密钥复制行为
- 系统清理统计时一并重置 provider key 的累计请求、Token 和费用数据
- 补充测试，覆盖 provider key 统计累加、批量聚合更新以及金额序列化精度