### PR TITLE
fix(usage,pool): 修复号池最后使用时间不更新

### DIFF
--- a/src/services/usage/recording.py
+++ b/src/services/usage/recording.py
@@ -97,19 +97,20 @@ def _increment_provider_api_key_totals(
     total_tokens: int = 0,
     total_cost: float = 0.0,
 ) -> None:
-    """原子递增 ProviderAPIKey 的累计 Token/成本。"""
+    """原子更新 ProviderAPIKey 统计并刷新最后使用时间。"""
     if not provider_api_key_id:
         return
 
+    from sqlalchemy import func as sql_func
     token_increment = int(total_tokens or 0)
     cost_increment = to_money_decimal(total_cost)
 
-    if token_increment <= 0 and cost_increment <= 0:
-        return
-
     from sqlalchemy import update
 
-    values: dict[str, Any] = {}
+    values: dict[str, Any] = {
+        "last_used_at": sql_func.now(),
+        "updated_at": sql_func.now(),
+    }
     if token_increment > 0:
         values["total_tokens"] = ProviderAPIKey.total_tokens + token_increment
     if cost_increment > 0:

--- a/tests/services/test_usage_recording_provider_key_totals.py
+++ b/tests/services/test_usage_recording_provider_key_totals.py
@@ -29,6 +29,36 @@ class DummyQuery:
         return self._result[0] if self._result else None
 
 
+def test_increment_provider_api_key_totals_refreshes_last_used_at_on_zero_delta() -> None:
+    db = MagicMock()
+
+    recording_module._increment_provider_api_key_totals(
+        db,
+        "provider-key-zero-delta",
+        total_tokens=0,
+        total_cost=0.0,
+    )
+
+    db.execute.assert_called_once()
+    stmt = db.execute.call_args.args[0]
+    sql = str(stmt)
+    assert "last_used_at" in sql
+    assert "updated_at" in sql
+
+
+def test_increment_provider_api_key_totals_skips_when_key_id_missing() -> None:
+    db = MagicMock()
+
+    recording_module._increment_provider_api_key_totals(
+        db,
+        None,
+        total_tokens=100,
+        total_cost=1.0,
+    )
+
+    db.execute.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_record_usage_updates_provider_key_totals(monkeypatch: Any) -> None:
     db = MagicMock()


### PR DESCRIPTION
统一在 ProviderAPIKey 累计更新时刷新 last_used_at/updated_at，即使 token/cost 增量为 0。

补充回归测试：覆盖 zero delta 场景和 provider_api_key_id 为空时跳过更新。