### PR TITLE
会话级认证体系重构，修复密码输入与策略校验问题

### DIFF
--- a/alembic/versions/20260315_1200_f6e7d8c9b0a1_add_user_sessions_table.py
+++ b/alembic/versions/20260315_1200_f6e7d8c9b0a1_add_user_sessions_table.py
@@ -1,0 +1,76 @@
+"""add user sessions table for device-level auth
+
+Revision ID: f6e7d8c9b0a1
+Revises: c1d2e3f4a5b6
+Create Date: 2026-03-15 12:00:00.000000+00:00
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f6e7d8c9b0a1"
+down_revision = "c1d2e3f4a5b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_sessions",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("user_id", sa.String(length=36), nullable=False),
+        sa.Column("client_device_id", sa.String(length=128), nullable=False),
+        sa.Column("device_label", sa.String(length=120), nullable=True),
+        sa.Column("device_type", sa.String(length=20), nullable=False, server_default="unknown"),
+        sa.Column("browser_name", sa.String(length=50), nullable=True),
+        sa.Column("browser_version", sa.String(length=50), nullable=True),
+        sa.Column("os_name", sa.String(length=50), nullable=True),
+        sa.Column("os_version", sa.String(length=50), nullable=True),
+        sa.Column("device_model", sa.String(length=100), nullable=True),
+        sa.Column("ip_address", sa.String(length=45), nullable=True),
+        sa.Column("user_agent", sa.String(length=1000), nullable=True),
+        sa.Column("client_hints", sa.JSON(), nullable=True),
+        sa.Column("refresh_token_hash", sa.String(length=64), nullable=False),
+        sa.Column("prev_refresh_token_hash", sa.String(length=64), nullable=True),
+        sa.Column("rotated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoke_reason", sa.String(length=100), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_user_sessions_user_id", "user_sessions", ["user_id"], unique=False)
+    op.create_index(
+        "ix_user_sessions_client_device_id",
+        "user_sessions",
+        ["client_device_id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_user_sessions_user_active",
+        "user_sessions",
+        ["user_id", "revoked_at", "expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_user_sessions_user_device",
+        "user_sessions",
+        ["user_id", "client_device_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_user_sessions_user_device", table_name="user_sessions")
+    op.drop_index("idx_user_sessions_user_active", table_name="user_sessions")
+    op.drop_index("ix_user_sessions_client_device_id", table_name="user_sessions")
+    op.drop_index("ix_user_sessions_user_id", table_name="user_sessions")
+    op.drop_table("user_sessions")

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,12 +5,14 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onErrorCaptured } from 'vue'
+import { onMounted, onErrorCaptured, onUnmounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import ToastContainer from '@/components/ToastContainer.vue'
 import ConfirmContainer from '@/components/ConfirmContainer.vue'
-import apiClient from '@/api/client'
+import apiClient, { AUTH_STATE_CHANGE_EVENT } from '@/api/client'
 import { NETWORK_CONFIG, AUTH_CONFIG } from '@/config/constants'
+import router from '@/router'
+import { hasAuthIdentityChanged } from '@/utils/authToken'
 import { log } from '@/utils/logger'
 
 const authStore = useAuthStore()
@@ -86,7 +88,59 @@ if (typeof window !== 'undefined') {
   })
 }
 
+async function syncExternalAuthState(nextToken: string | null): Promise<void> {
+  const previousToken = authStore.token
+  const previousUser = authStore.user
+    ? {
+        id: authStore.user.id,
+        role: authStore.user.role,
+      }
+    : null
+
+  authStore.syncToken()
+
+  if (!nextToken) {
+    if (previousToken || previousUser) {
+      authStore.applyExternalLogout()
+      await router.replace('/')
+    }
+    return
+  }
+
+  const identityChanged = hasAuthIdentityChanged(previousToken, nextToken, previousUser)
+  if (!identityChanged && previousUser) {
+    return
+  }
+
+  const user = await authStore.fetchCurrentUser()
+  if (!user) {
+    return
+  }
+
+  if (router.currentRoute.value.path.startsWith('/admin') && user.role !== 'admin') {
+    await router.replace('/dashboard')
+  }
+}
+
+function handleAuthStorageChange(event: StorageEvent): void {
+  if (event.key !== 'access_token') {
+    return
+  }
+
+  void syncExternalAuthState(event.newValue)
+}
+
+function handleLocalAuthStateChange(event: Event): void {
+  const authEvent = event as CustomEvent<{ token: string | null }>
+  void syncExternalAuthState(authEvent.detail?.token ?? apiClient.getToken())
+}
+
 onMounted(async () => {
+  if (typeof window !== 'undefined') {
+    window.addEventListener('storage', handleAuthStorageChange)
+    window.addEventListener(AUTH_STATE_CHANGE_EVENT, handleLocalAuthStateChange as EventListener)
+  }
+
   // 延迟检查认证状态,让页面先加载
   setTimeout(async () => {
     try {
@@ -96,5 +150,15 @@ onMounted(async () => {
       log.warn('Auth check failed, but keeping session', error)
     }
   }, AUTH_CONFIG.TOKEN_REFRESH_INTERVAL)
+})
+
+onUnmounted(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('storage', handleAuthStorageChange)
+    window.removeEventListener(
+      AUTH_STATE_CHANGE_EVENT,
+      handleLocalAuthStateChange as EventListener,
+    )
+  }
 })
 </script>

--- a/frontend/src/api/__tests__/client.spec.ts
+++ b/frontend/src/api/__tests__/client.spec.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import apiClient, { AUTH_STATE_CHANGE_EVENT } from '@/api/client'
+
+describe('apiClient auth state change event', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    apiClient.clearAuth()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    apiClient.clearAuth()
+  })
+
+  it('dispatches a same-tab auth change event when clearing auth', () => {
+    const handler = vi.fn()
+    window.addEventListener(AUTH_STATE_CHANGE_EVENT, handler as EventListener)
+
+    apiClient.setToken('access-token')
+    apiClient.clearAuth()
+
+    expect(localStorage.getItem('access_token')).toBeNull()
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    const event = handler.mock.calls[0][0] as CustomEvent<{ token: string | null }>
+    expect(event.detail).toEqual({ token: null })
+
+    window.removeEventListener(AUTH_STATE_CHANGE_EVENT, handler as EventListener)
+  })
+})

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -9,7 +9,6 @@ export interface LoginRequest {
 
 export interface LoginResponse {
   access_token: string
-  refresh_token?: string
   token_type?: string
   expires_in?: number
   user_id?: string // UUID
@@ -127,10 +126,6 @@ export const authApi = {
   async login(credentials: LoginRequest): Promise<LoginResponse> {
     const response = await apiClient.post<LoginResponse>('/api/auth/login', credentials)
     apiClient.setToken(response.data.access_token)
-    // 后端暂时没有返回 refresh_token
-    if (response.data.refresh_token) {
-      localStorage.setItem('refresh_token', response.data.refresh_token)
-    }
     return response.data
   },
 
@@ -152,14 +147,9 @@ export const authApi = {
     return response.data
   },
 
-  async refreshToken(refreshToken: string): Promise<LoginResponse> {
-    const response = await apiClient.post<LoginResponse>('/api/auth/refresh', {
-      refresh_token: refreshToken
-    })
+  async refreshToken(): Promise<LoginResponse> {
+    const response = await apiClient.post<LoginResponse>('/api/auth/refresh', {})
     apiClient.setToken(response.data.access_token)
-    if (response.data.refresh_token) {
-      localStorage.setItem('refresh_token', response.data.refresh_token)
-    }
     return response.data
   },
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,10 +3,13 @@ import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosReq
 import { NETWORK_CONFIG, AUTH_CONFIG } from '@/config/constants'
 import { isDemoMode } from '@/config/demo'
 import { handleMockRequest, setMockUserToken } from '@/mocks'
+import { getClientDeviceId } from '@/utils/deviceId'
+import { CrossTabRefreshCoordinator } from '@/utils/crossTabRefresh'
 import { log } from '@/utils/logger'
 
 // 在开发环境下使用代理,生产环境使用环境变量
 const API_BASE_URL = import.meta.env.VITE_API_URL || ''
+export const AUTH_STATE_CHANGE_EVENT = 'aether-auth-state-change'
 
 /**
  * 判断请求是否为公共端点
@@ -83,12 +86,21 @@ class ApiClient {
   private client: AxiosInstance
   private token: string | null = null
   private isRefreshing = false
-  private refreshPromise: Promise<AxiosResponse> | null = null
+  private refreshPromise: Promise<string> | null = null
+  private readonly refreshCoordinator = new CrossTabRefreshCoordinator()
+
+  private readonly onStorageSync = (event: StorageEvent): void => {
+    if (event.key !== 'access_token') {
+      return
+    }
+    this.syncTokenState(event.newValue)
+  }
 
   constructor() {
     this.client = axios.create({
       baseURL: API_BASE_URL,
       timeout: NETWORK_CONFIG.API_TIMEOUT,
+      withCredentials: true,
       headers: {
         'Content-Type': 'application/json',
       },
@@ -99,6 +111,7 @@ class ApiClient {
     this.client.defaults.adapter = createDemoAdapter(defaultAdapter)
 
     this.setupInterceptors()
+    this.setupCrossTabAuthSync()
   }
 
   /**
@@ -108,6 +121,10 @@ class ApiClient {
     // 请求拦截器 - 仅处理认证
     this.client.interceptors.request.use(
       (config) => {
+        if (config.url?.includes('/api/')) {
+          config.headers['X-Client-Device-Id'] = getClientDeviceId()
+        }
+
         const requiresAuth = !isPublicEndpoint(config.url, config.method) &&
                            config.url?.includes('/api/')
 
@@ -126,6 +143,23 @@ class ApiClient {
     this.client.interceptors.response.use(
       (response) => response,
       async (error) => this.handleResponseError(error)
+    )
+  }
+
+  private setupCrossTabAuthSync(): void {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', this.onStorageSync)
+    }
+  }
+
+  private emitAuthStateChange(token: string | null): void {
+    if (typeof window === 'undefined') {
+      return
+    }
+    window.dispatchEvent(
+      new CustomEvent<{ token: string | null }>(AUTH_STATE_CHANGE_EVENT, {
+        detail: { token },
+      })
     )
   }
 
@@ -189,14 +223,6 @@ class ApiClient {
       return Promise.reject(error)
     }
 
-    // 获取refresh token
-    const refreshToken = localStorage.getItem('refresh_token')
-    if (!refreshToken) {
-      log.info('No refresh token available, clearing invalid token')
-      this.clearAuth()
-      return Promise.reject(error)
-    }
-
     // 标记为已重试
     originalRequest._retry = true
     originalRequest._retryCount = (originalRequest._retryCount || 0) + 1
@@ -210,8 +236,8 @@ class ApiClient {
     // 如果正在刷新,等待刷新完成
     if (this.isRefreshing) {
       try {
-        await this.refreshPromise
-        originalRequest.headers.Authorization = `Bearer ${this.getToken()}`
+        const accessToken = await this.refreshPromise
+        originalRequest.headers.Authorization = `Bearer ${accessToken}`
         return this.client.request(originalRequest)
       } catch {
         return Promise.reject(error)
@@ -219,29 +245,27 @@ class ApiClient {
     }
 
     // 开始刷新token
-    return this.refreshTokenAndRetry(refreshToken, originalRequest, error)
+    return this.refreshTokenAndRetry(originalRequest, error)
   }
 
   /**
    * 刷新token并重试原始请求
    */
   private async refreshTokenAndRetry(
-    refreshToken: string,
     originalRequest: InternalAxiosRequestConfig,
     originalError: import('axios').AxiosError
   ): Promise<AxiosResponse> {
     this.isRefreshing = true
-    this.refreshPromise = this.refreshToken(refreshToken)
+    this.refreshPromise = this.coordinatedRefresh()
 
     try {
-      const response = await this.refreshPromise
-      this.setToken(response.data.access_token)
-      localStorage.setItem('refresh_token', response.data.refresh_token)
+      const accessToken = await this.refreshPromise
+      this.setToken(accessToken)
       this.isRefreshing = false
       this.refreshPromise = null
 
       // 重试原始请求
-      originalRequest.headers.Authorization = `Bearer ${response.data.access_token}`
+      originalRequest.headers.Authorization = `Bearer ${accessToken}`
       return this.client.request(originalRequest)
     } catch (refreshError: unknown) {
       log.error('Token refresh failed', refreshError instanceof Error ? refreshError.message : String(refreshError))
@@ -252,13 +276,33 @@ class ApiClient {
     }
   }
 
-  setToken(token: string): void {
+  private async coordinatedRefresh(): Promise<string> {
+    const latestStoredToken = localStorage.getItem('access_token')
+    if (latestStoredToken && latestStoredToken !== this.token) {
+      this.syncTokenState(latestStoredToken)
+      return latestStoredToken
+    }
+
+    return this.refreshCoordinator.run(async () => {
+      const response = await this.refreshToken()
+      const accessToken = response.data.access_token
+      if (!accessToken) {
+        throw new Error('Refresh response missing access token')
+      }
+      return accessToken
+    })
+  }
+
+  private syncTokenState(token: string | null): void {
     this.token = token
-    localStorage.setItem('access_token', token)
-    // 同步到 mock handler
     if (isDemoMode()) {
       setMockUserToken(token)
     }
+  }
+
+  setToken(token: string): void {
+    this.syncTokenState(token)
+    localStorage.setItem('access_token', token)
   }
 
   getToken(): string | null {
@@ -273,18 +317,17 @@ class ApiClient {
   }
 
   clearAuth(): void {
-    this.token = null
+    const hadAuth = this.token !== null || localStorage.getItem('access_token') !== null
+    this.syncTokenState(null)
     localStorage.removeItem('access_token')
-    localStorage.removeItem('refresh_token')
-    // 同步清除 mock token
-    if (isDemoMode()) {
-      setMockUserToken(null)
+    // 同标签页内清理认证状态时不会触发 storage 事件，这里主动广播一次。
+    if (hadAuth) {
+      this.emitAuthStateChange(null)
     }
   }
 
-  async refreshToken(refreshToken: string): Promise<AxiosResponse> {
-    // refreshToken 会通过 adapter 处理 Demo 模式
-    return this.client.post('/api/auth/refresh', { refresh_token: refreshToken })
+  async refreshToken(): Promise<AxiosResponse> {
+    return this.client.post('/api/auth/refresh', {})
   }
 
   // 以下方法直接委托给 axios client，Demo 模式由 adapter 统一处理

--- a/frontend/src/api/me.ts
+++ b/frontend/src/api/me.ts
@@ -137,6 +137,23 @@ export interface ChangePasswordRequest {
   new_password: string
 }
 
+export interface UserSession {
+  id: string
+  device_label: string
+  device_type: string
+  browser_name?: string | null
+  browser_version?: string | null
+  os_name?: string | null
+  os_version?: string | null
+  device_model?: string | null
+  ip_address?: string | null
+  last_seen_at?: string | null
+  created_at: string
+  is_current: boolean
+  revoked_at?: string | null
+  revoke_reason?: string | null
+}
+
 export const meApi = {
   // 获取个人信息
   async getProfile(): Promise<Profile> {
@@ -156,6 +173,28 @@ export const meApi = {
   // 修改密码
   async changePassword(data: ChangePasswordRequest): Promise<{ message: string }> {
     const response = await apiClient.patch('/api/users/me/password', data)
+    return response.data
+  },
+
+  async listSessions(): Promise<UserSession[]> {
+    const response = await apiClient.get<UserSession[]>('/api/users/me/sessions')
+    return response.data
+  },
+
+  async updateSessionLabel(sessionId: string, deviceLabel: string): Promise<UserSession> {
+    const response = await apiClient.patch<UserSession>(`/api/users/me/sessions/${sessionId}`, {
+      device_label: deviceLabel,
+    })
+    return response.data
+  },
+
+  async revokeSession(sessionId: string): Promise<{ message: string }> {
+    const response = await apiClient.delete(`/api/users/me/sessions/${sessionId}`)
+    return response.data
+  },
+
+  async revokeOtherSessions(): Promise<{ message: string; revoked_count: number }> {
+    const response = await apiClient.delete('/api/users/me/sessions/others')
     return response.data
   },
 

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -54,6 +54,23 @@ export interface ApiKey {
   total_cost_usd?: number  // 总费用
 }
 
+export interface UserSession {
+  id: string
+  device_label: string
+  device_type: string
+  browser_name?: string | null
+  browser_version?: string | null
+  os_name?: string | null
+  os_version?: string | null
+  device_model?: string | null
+  ip_address?: string | null
+  last_seen_at?: string | null
+  created_at: string
+  is_current: boolean
+  revoked_at?: string | null
+  revoke_reason?: string | null
+}
+
 export const usersApi = {
   async getAllUsers(): Promise<User[]> {
     const response = await apiClient.get<User[]>('/api/admin/users')
@@ -82,6 +99,21 @@ export const usersApi = {
   async getUserApiKeys(userId: string): Promise<ApiKey[]> {
     const response = await apiClient.get<{ api_keys: ApiKey[] }>(`/api/admin/users/${userId}/api-keys`)
     return response.data.api_keys
+  },
+
+  async getUserSessions(userId: string): Promise<UserSession[]> {
+    const response = await apiClient.get<UserSession[]>(`/api/admin/users/${userId}/sessions`)
+    return response.data
+  },
+
+  async revokeUserSession(userId: string, sessionId: string): Promise<{ message: string }> {
+    const response = await apiClient.delete(`/api/admin/users/${userId}/sessions/${sessionId}`)
+    return response.data
+  },
+
+  async revokeAllUserSessions(userId: string): Promise<{ message: string; revoked_count: number }> {
+    const response = await apiClient.delete(`/api/admin/users/${userId}/sessions`)
+    return response.data
   },
 
   async createApiKey(userId: string, name?: string): Promise<ApiKey & { key: string }> {

--- a/frontend/src/components/ui/input.vue
+++ b/frontend/src/components/ui/input.vue
@@ -69,24 +69,6 @@ const emit = defineEmits<{
   'update:modelValue': [value: string]
 }>()
 
-// 开发环境警告：type="password" 已被弃用
-const warnPasswordType = import.meta.env.DEV
-  ? (() => {
-      let warned = false
-      return () => {
-        if (!warned) {
-          warned = true
-          // eslint-disable-next-line no-console
-          console.warn(
-            '[Input] type="password" 已被弃用，请使用 masked 属性代替。\n' +
-              '示例：<Input v-model="apiKey" masked />\n' +
-              'masked 属性使用 CSS 遮蔽而非 password 类型，不会触发浏览器密码管理器。'
-          )
-        }
-      }
-    })()
-  : () => {}
-
 interface Props {
   modelValue?: string | number
   class?: string
@@ -99,9 +81,8 @@ interface Props {
   size?: 'default' | 'sm'
   /**
    * 遮蔽显示内容（用于 API Key 等敏感信息）
-   * 使用 CSS -webkit-text-security 实现，不会触发浏览器密码管理器
+   * 隐藏态使用真正的 password 输入框，显示态切换为 text
    * 同时会显示一个小眼睛按钮用于切换显示/隐藏
-   * 注意：Firefox 不支持 -webkit-text-security，会显示明文（但仍可通过按钮切换）
    */
   masked?: boolean
   /**
@@ -134,13 +115,10 @@ const shouldDisableAutofill = computed(() => {
   return props.disableAutofill ?? false
 })
 
-// 始终使用 text 类型，永远不用 password
 const effectiveType = computed(() => {
-  const attrType = attrs.type as string | undefined
-  // 如果传入 password，强制转为 text（配合 masked 使用）
-  if (attrType === 'password') {
-    warnPasswordType()
-    return 'text'
+  const attrType = (attrs.type as string | undefined) ?? 'text'
+  if (props.masked) {
+    return isVisible.value ? 'text' : 'password'
   }
   return attrType
 })
@@ -182,13 +160,7 @@ const inputClass = computed(() =>
   )
 )
 
-// 当 masked 为 true 且未显示时，用 CSS 遮蔽文字
 const inputStyle = computed(() => {
-  if (props.masked && !isVisible.value) {
-    // 使用 -webkit-text-security（Chrome, Safari, Edge 支持）
-    // Firefox 不支持此属性，会显示明文，但仍可通过小眼睛按钮切换
-    return { '-webkit-text-security': 'disc' }
-  }
   return undefined
 })
 

--- a/frontend/src/features/auth/components/LoginDialog.vue
+++ b/frontend/src/features/auth/components/LoginDialog.vue
@@ -247,6 +247,7 @@ import { isDemoMode, DEMO_ACCOUNTS } from '@/config/demo'
 import RegisterDialog from './RegisterDialog.vue'
 import { authApi } from '@/api/auth'
 import { oauthApi, type OAuthProviderInfo } from '@/api/oauth'
+import { getClientDeviceId } from '@/utils/deviceId'
 import { getApiUrl } from '@/utils/url'
 import { getOAuthIcon } from '@/utils/oauth-icons'
 
@@ -350,7 +351,12 @@ async function handleLogin() {
 function handleOAuthLogin(providerType: string) {
   // 如果 sessionStorage 中没有 redirectPath（用户直接点击登录而非被守卫拦截），
   // 则不设置，让 AuthCallback 使用默认跳转逻辑
-  window.location.href = getApiUrl(`/api/oauth/${providerType}/authorize`)
+  const authorizeUrl = new URL(
+    getApiUrl(`/api/oauth/${providerType}/authorize`),
+    window.location.origin,
+  )
+  authorizeUrl.searchParams.set('client_device_id', getClientDeviceId())
+  window.location.href = authorizeUrl.toString()
 }
 
 function handleSwitchToRegister() {

--- a/frontend/src/features/auth/components/RegisterDialog.vue
+++ b/frontend/src/features/auth/components/RegisterDialog.vue
@@ -151,15 +151,12 @@
           <Input
             :id="`pwd-${formNonce}`"
             v-model="formData.password"
-            type="text"
-            autocomplete="one-time-code"
-            data-form-type="other"
-            data-lpignore="true"
-            data-1p-ignore="true"
+            masked
+            autocomplete="new-password"
+            disable-autofill
             :name="`pwd-${formNonce}`"
             :placeholder="getPasswordPolicyPlaceholder(props.passwordPolicyLevel)"
             required
-            class="-webkit-text-security-disc"
             :disabled="isLoading"
           />
           <p
@@ -182,17 +179,20 @@
           <Input
             :id="`pwd-confirm-${formNonce}`"
             v-model="formData.confirmPassword"
-            type="text"
-            autocomplete="one-time-code"
-            data-form-type="other"
-            data-lpignore="true"
-            data-1p-ignore="true"
+            masked
+            autocomplete="new-password"
+            disable-autofill
             :name="`pwd-confirm-${formNonce}`"
             placeholder="再次输入密码"
             required
-            class="-webkit-text-security-disc"
             :disabled="isLoading"
           />
+          <p
+            v-if="formData.confirmPassword && formData.password !== formData.confirmPassword"
+            class="text-xs text-destructive"
+          >
+            两次输入的密码不一致
+          </p>
         </div>
       </form>
 

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -483,16 +483,15 @@ onUnmounted(() => {
   document.removeEventListener('visibilitychange', handleVisibilityChange)
 })
 
-function handleRelogin() {
+async function handleRelogin() {
   showAuthError.value = false
-  router.push('/').then(() => {
-    authStore.logout()
-  })
+  await authStore.logout()
+  await router.push('/')
 }
 
-function handleLogout() {
-  authStore.logout()
-  router.push('/')
+async function handleLogout() {
+  await authStore.logout()
+  await router.push('/')
 }
 
 function isNavActive(href: string) {

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -76,7 +76,6 @@ export const MOCK_NORMAL_USER: User = {
 
 export const MOCK_LOGIN_RESPONSE_ADMIN: LoginResponse = {
   access_token: 'demo-access-token-admin',
-  refresh_token: 'demo-refresh-token-admin',
   token_type: 'bearer',
   expires_in: 3600,
   user_id: MOCK_ADMIN_USER.id,
@@ -87,7 +86,6 @@ export const MOCK_LOGIN_RESPONSE_ADMIN: LoginResponse = {
 
 export const MOCK_LOGIN_RESPONSE_USER: LoginResponse = {
   access_token: 'demo-access-token-user',
-  refresh_token: 'demo-refresh-token-user',
   token_type: 'bearer',
   expires_in: 3600,
   user_id: MOCK_NORMAL_USER.id,

--- a/frontend/src/mocks/handler.ts
+++ b/frontend/src/mocks/handler.ts
@@ -531,6 +531,76 @@ const mockHandlers: Record<string, (config: AxiosRequestConfig) => Promise<Axios
     return createMockResponse({ message: '密码修改成功（演示模式）' })
   },
 
+  'GET /api/users/me/sessions': async () => {
+    await delay()
+    return createMockResponse([
+      {
+        id: 'session-current',
+        device_label: 'Chrome / macOS',
+        device_type: 'desktop',
+        browser_name: 'Chrome',
+        browser_version: '134.0',
+        os_name: 'macOS',
+        os_version: '15.3',
+        device_model: null,
+        ip_address: '192.168.1.100',
+        last_seen_at: new Date().toISOString(),
+        created_at: new Date(Date.now() - 2 * 24 * 3600 * 1000).toISOString(),
+        is_current: true,
+        revoked_at: null,
+        revoke_reason: null
+      },
+      {
+        id: 'session-other',
+        device_label: 'Safari / iPhone',
+        device_type: 'mobile',
+        browser_name: 'Safari',
+        browser_version: '18.0',
+        os_name: 'iOS',
+        os_version: '18.3',
+        device_model: 'iPhone',
+        ip_address: '10.0.0.12',
+        last_seen_at: new Date(Date.now() - 3 * 3600 * 1000).toISOString(),
+        created_at: new Date(Date.now() - 5 * 24 * 3600 * 1000).toISOString(),
+        is_current: false,
+        revoked_at: null,
+        revoke_reason: null
+      }
+    ])
+  },
+
+  'DELETE /api/users/me/sessions/others': async () => {
+    await delay()
+    return createMockResponse({ message: '其他设备已退出登录（演示模式）', revoked_count: 1 })
+  },
+
+  'PATCH /api/users/me/sessions/:sessionId': async (config) => {
+    await delay()
+    const sessionId = config.url?.split('/').pop() || 'session'
+    const body = JSON.parse(config.data || '{}')
+    return createMockResponse({
+      id: sessionId,
+      device_label: body.device_label || '已重命名设备',
+      device_type: 'desktop',
+      browser_name: 'Chrome',
+      browser_version: '134.0',
+      os_name: 'macOS',
+      os_version: '15.3',
+      device_model: null,
+      ip_address: '192.168.1.100',
+      last_seen_at: new Date().toISOString(),
+      created_at: new Date(Date.now() - 2 * 24 * 3600 * 1000).toISOString(),
+      is_current: sessionId === 'session-current',
+      revoked_at: null,
+      revoke_reason: null
+    })
+  },
+
+  'DELETE /api/users/me/sessions/:sessionId': async () => {
+    await delay()
+    return createMockResponse({ message: '设备已退出登录（演示模式）' })
+  },
+
   'GET /api/users/me/api-keys': async () => {
     await delay()
     return createMockResponse(MOCK_USER_API_KEYS)
@@ -2084,6 +2154,44 @@ registerDynamicRoute('GET', '/api/admin/users/:userId/api-keys', async (_config,
   await delay()
   requireAdmin()
   return createMockResponse(MOCK_USER_API_KEYS)
+})
+
+// 管理员 - 用户会话列表
+registerDynamicRoute('GET', '/api/admin/users/:userId/sessions', async (_config, _params) => {
+  await delay()
+  requireAdmin()
+  return createMockResponse([
+    {
+      id: 'admin-session-1',
+      device_label: 'Chrome / macOS',
+      device_type: 'desktop',
+      browser_name: 'Chrome',
+      browser_version: '134.0',
+      os_name: 'macOS',
+      os_version: '15.3',
+      device_model: null,
+      ip_address: '192.168.1.100',
+      last_seen_at: new Date().toISOString(),
+      created_at: new Date(Date.now() - 2 * 24 * 3600 * 1000).toISOString(),
+      is_current: false,
+      revoked_at: null,
+      revoke_reason: null
+    }
+  ])
+})
+
+// 管理员 - 撤销用户单个会话
+registerDynamicRoute('DELETE', '/api/admin/users/:userId/sessions/:sessionId', async (_config, _params) => {
+  await delay()
+  requireAdmin()
+  return createMockResponse({ message: '会话已撤销（演示模式）' })
+})
+
+// 管理员 - 撤销用户全部会话
+registerDynamicRoute('DELETE', '/api/admin/users/:userId/sessions', async (_config, _params) => {
+  await delay()
+  requireAdmin()
+  return createMockResponse({ message: '全部会话已撤销（演示模式）', revoked_count: 1 })
 })
 
 // API Key 详情

--- a/frontend/src/router/guards/authGuard.ts
+++ b/frontend/src/router/guards/authGuard.ts
@@ -28,7 +28,7 @@ export async function ensureUserLoaded(
         })
       } else if (err.response?.status === 401) {
         log.info('Authentication failed, clearing session')
-        authStore.logout()
+        await authStore.logout()
       } else {
         log.warn('Failed to fetch user info, but keeping session', { error: err?.message })
       }

--- a/frontend/src/stores/__tests__/auth.spec.ts
+++ b/frontend/src/stores/__tests__/auth.spec.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+const { logoutMock, getTokenMock, getCurrentUserMock } = vi.hoisted(() => ({
+  logoutMock: vi.fn(),
+  getTokenMock: vi.fn(() => null),
+  getCurrentUserMock: vi.fn(),
+}))
+
+vi.mock('@/api/auth', () => ({
+  authApi: {
+    logout: logoutMock,
+    getCurrentUser: getCurrentUserMock,
+  },
+}))
+
+vi.mock('@/api/client', () => ({
+  default: {
+    getToken: getTokenMock,
+  },
+}))
+
+import { useAuthStore } from '@/stores/auth'
+
+describe('auth store logout', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    logoutMock.mockReset()
+    getTokenMock.mockReset()
+    getCurrentUserMock.mockReset()
+    getTokenMock.mockReturnValue(null)
+  })
+
+  it('waits for backend logout before resolving', async () => {
+    let resolveLogout: (() => void) | null = null
+    logoutMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLogout = resolve
+        })
+    )
+
+    const store = useAuthStore()
+    store.user = {
+      id: 'user-1',
+      username: 'tester',
+      role: 'user',
+      is_active: true,
+      created_at: '2026-03-16T00:00:00Z',
+    }
+    store.token = 'access-token'
+
+    let settled = false
+    const logoutPromise = store.logout().then(() => {
+      settled = true
+    })
+
+    await Promise.resolve()
+
+    expect(logoutMock).toHaveBeenCalledTimes(1)
+    expect(store.user).toBeNull()
+    expect(store.token).toBeNull()
+    expect(settled).toBe(false)
+
+    resolveLogout?.()
+    await logoutPromise
+
+    expect(settled).toBe(true)
+  })
+
+  it('clears local auth state for external logout without calling backend', () => {
+    const store = useAuthStore()
+    store.user = {
+      id: 'user-1',
+      username: 'tester',
+      role: 'user',
+      is_active: true,
+      created_at: '2026-03-16T00:00:00Z',
+    }
+    store.token = 'access-token'
+
+    store.applyExternalLogout()
+
+    expect(store.user).toBeNull()
+    expect(store.token).toBeNull()
+    expect(logoutMock).not.toHaveBeenCalled()
+  })
+
+  it('clears stale store auth when fetchCurrentUser fails after token was removed', async () => {
+    const store = useAuthStore()
+    store.user = {
+      id: 'user-1',
+      username: 'tester',
+      role: 'user',
+      is_active: true,
+      created_at: '2026-03-16T00:00:00Z',
+    }
+    store.token = 'access-token'
+    getCurrentUserMock.mockRejectedValue(new Error('unauthorized'))
+    getTokenMock.mockReturnValue(null)
+
+    const result = await store.fetchCurrentUser()
+
+    expect(result).toBeNull()
+    expect(store.user).toBeNull()
+    expect(store.token).toBeNull()
+  })
+})

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -70,7 +70,13 @@ export const useAuthStore = defineStore('auth', () => {
   async function logout() {
     user.value = null
     token.value = null
-    authApi.logout()
+    await authApi.logout()
+  }
+
+  function applyExternalLogout() {
+    user.value = null
+    token.value = null
+    error.value = null
   }
 
   async function fetchCurrentUser() {
@@ -80,6 +86,10 @@ export const useAuthStore = defineStore('auth', () => {
       return userInfo
     } catch (err: unknown) {
       log.error('Failed to fetch user info', err)
+      syncToken()
+      if (!token.value) {
+        user.value = null
+      }
       // 根据用户要求,不管什么错误都不清除状态
       // 保持登录状态,除非用户手动退出
       log.info('Keeping session despite error, as per user requirement')
@@ -106,6 +116,7 @@ export const useAuthStore = defineStore('auth', () => {
     isAdmin,
     login,
     logout,
+    applyExternalLogout,
     fetchCurrentUser,
     checkAuth,
     syncToken

--- a/frontend/src/stores/users.ts
+++ b/frontend/src/stores/users.ts
@@ -1,6 +1,13 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { usersApi, type User, type CreateUserRequest, type UpdateUserRequest, type ApiKey } from '@/api/users'
+import {
+  usersApi,
+  type User,
+  type CreateUserRequest,
+  type UpdateUserRequest,
+  type ApiKey,
+  type UserSession,
+} from '@/api/users'
 import { parseApiError } from '@/utils/errorParser'
 
 export const useUsersStore = defineStore('users', () => {
@@ -111,6 +118,35 @@ export const useUsersStore = defineStore('users', () => {
     }
   }
 
+  async function getUserSessions(userId: string): Promise<UserSession[]> {
+    try {
+      return await usersApi.getUserSessions(userId)
+    } catch (err: unknown) {
+      error.value = parseApiError(err, '获取用户设备会话失败')
+      throw err
+    }
+  }
+
+  async function revokeUserSession(userId: string, sessionId: string): Promise<{ message: string }> {
+    try {
+      return await usersApi.revokeUserSession(userId, sessionId)
+    } catch (err: unknown) {
+      error.value = parseApiError(err, '强制下线设备失败')
+      throw err
+    }
+  }
+
+  async function revokeAllUserSessions(
+    userId: string,
+  ): Promise<{ message: string; revoked_count: number }> {
+    try {
+      return await usersApi.revokeAllUserSessions(userId)
+    } catch (err: unknown) {
+      error.value = parseApiError(err, '强制下线全部设备失败')
+      throw err
+    }
+  }
+
   return {
     users,
     loading,
@@ -122,6 +158,9 @@ export const useUsersStore = defineStore('users', () => {
     getUserApiKeys,
     createApiKey,
     deleteApiKey,
-    getFullApiKey
+    getFullApiKey,
+    getUserSessions,
+    revokeUserSession,
+    revokeAllUserSessions,
   }
 })

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1236,10 +1236,4 @@ body[theme-mode='dark'] .literary-annotation {
     background-color: rgb(var(--color-primary-rgb) / 0.1) !important;
   }
 
-  /* Password masking without type="password" to prevent browser autofill */
-  .-webkit-text-security-disc {
-    -webkit-text-security: disc;
-    -moz-text-security: disc;
-    text-security: disc;
-  }
 }

--- a/frontend/src/utils/__tests__/authToken.spec.ts
+++ b/frontend/src/utils/__tests__/authToken.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasAuthIdentityChanged, parseAccessTokenIdentity } from '@/utils/authToken'
+
+function buildToken(payload: Record<string, unknown>): string {
+  const encoded = btoa(JSON.stringify(payload))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+  return `header.${encoded}.signature`
+}
+
+describe('authToken helpers', () => {
+  it('parses user identity from JWT payload', () => {
+    const token = buildToken({ user_id: 'user-1', role: 'admin' })
+
+    expect(parseAccessTokenIdentity(token)).toEqual({
+      userId: 'user-1',
+      role: 'admin',
+    })
+  })
+
+  it('returns null for non-jwt tokens', () => {
+    expect(parseAccessTokenIdentity('demo-access-token')).toBeNull()
+  })
+
+  it('detects unchanged identity when only token value rotates', () => {
+    const previous = buildToken({ user_id: 'user-1', role: 'user', exp: 1 })
+    const next = buildToken({ user_id: 'user-1', role: 'user', exp: 2 })
+
+    expect(
+      hasAuthIdentityChanged(previous, next, { id: 'user-1', role: 'user' }),
+    ).toBe(false)
+  })
+
+  it('detects account switch when user identity changes', () => {
+    const previous = buildToken({ user_id: 'user-1', role: 'user' })
+    const next = buildToken({ user_id: 'user-2', role: 'admin' })
+
+    expect(
+      hasAuthIdentityChanged(previous, next, { id: 'user-1', role: 'user' }),
+    ).toBe(true)
+  })
+})

--- a/frontend/src/utils/__tests__/crossTabRefresh.spec.ts
+++ b/frontend/src/utils/__tests__/crossTabRefresh.spec.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { BroadcastChannelLike } from '@/utils/crossTabRefresh'
+import { CrossTabRefreshCoordinator } from '@/utils/crossTabRefresh'
+
+type Listener = (event: { data: unknown }) => void
+
+const channelRegistry = new Map<string, Set<FakeBroadcastChannel>>()
+
+class FakeBroadcastChannel implements BroadcastChannelLike {
+  private readonly listeners = new Set<Listener>()
+
+  constructor(private readonly name: string) {
+    const channels = channelRegistry.get(name) ?? new Set<FakeBroadcastChannel>()
+    channels.add(this)
+    channelRegistry.set(name, channels)
+  }
+
+  postMessage(data: unknown): void {
+    const channels = channelRegistry.get(this.name) ?? new Set<FakeBroadcastChannel>()
+    for (const channel of channels) {
+      if (channel === this) continue
+      for (const listener of channel.listeners) {
+        listener({ data })
+      }
+    }
+  }
+
+  addEventListener(_type: 'message', listener: Listener): void {
+    this.listeners.add(listener)
+  }
+
+  removeEventListener(_type: 'message', listener: Listener): void {
+    this.listeners.delete(listener)
+  }
+
+  close(): void {
+    channelRegistry.get(this.name)?.delete(this)
+  }
+}
+
+function createChannel(name: string): BroadcastChannelLike {
+  return new FakeBroadcastChannel(name)
+}
+
+describe('CrossTabRefreshCoordinator', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    channelRegistry.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    channelRegistry.clear()
+  })
+
+  it('deduplicates refresh requests across tabs', async () => {
+    let resolveRefresh: ((token: string) => void) | null = null
+    const firstExecutor = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRefresh = resolve
+        }),
+    )
+    const secondExecutor = vi.fn(() => Promise.resolve('should-not-run'))
+
+    const first = new CrossTabRefreshCoordinator({
+      storage: localStorage,
+      channelFactory: createChannel,
+    })
+    const second = new CrossTabRefreshCoordinator({
+      storage: localStorage,
+      channelFactory: createChannel,
+    })
+
+    const firstRun = first.run(firstExecutor)
+    await Promise.resolve()
+    const secondRun = second.run(secondExecutor)
+
+    expect(firstExecutor).toHaveBeenCalledTimes(1)
+    expect(secondExecutor).not.toHaveBeenCalled()
+
+    resolveRefresh?.('access-from-first-tab')
+
+    await expect(firstRun).resolves.toBe('access-from-first-tab')
+    await expect(secondRun).resolves.toBe('access-from-first-tab')
+
+    first.destroy()
+    second.destroy()
+  })
+
+  it('propagates refresh failure to waiting tabs without second refresh call', async () => {
+    const refreshError = new Error('refresh failed')
+    let rejectRefresh: ((error: Error) => void) | null = null
+    const firstExecutor = vi.fn(
+      () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectRefresh = reject
+        }),
+    )
+    const secondExecutor = vi.fn(() => Promise.resolve('should-not-run'))
+
+    const first = new CrossTabRefreshCoordinator({
+      storage: localStorage,
+      channelFactory: createChannel,
+    })
+    const second = new CrossTabRefreshCoordinator({
+      storage: localStorage,
+      channelFactory: createChannel,
+    })
+
+    const firstRun = first.run(firstExecutor)
+    await Promise.resolve()
+    const secondRun = second.run(secondExecutor)
+
+    rejectRefresh?.(refreshError)
+
+    await expect(firstRun).rejects.toThrow('refresh failed')
+    await expect(secondRun).rejects.toThrow('failed in another tab')
+    expect(secondExecutor).not.toHaveBeenCalled()
+
+    first.destroy()
+    second.destroy()
+  })
+})

--- a/frontend/src/utils/__tests__/passwordPolicy.spec.ts
+++ b/frontend/src/utils/__tests__/passwordPolicy.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { getPasswordPolicyErrors, validatePasswordByPolicy } from '../passwordPolicy'
+
+describe('passwordPolicy utils', () => {
+  it('rejects passwords longer than 72 bytes', () => {
+    expect(getPasswordPolicyErrors('a'.repeat(80), 'weak')).toContain('长度不能超过72字节')
+  })
+
+  it('rejects multibyte passwords longer than 72 bytes', () => {
+    expect(getPasswordPolicyErrors('中'.repeat(25), 'weak')).toContain('长度不能超过72字节')
+  })
+
+  it('formats validation errors into a single message', () => {
+    expect(validatePasswordByPolicy('abc', 'strong')).toBe(
+      '密码需要：至少 8 个字符、包含大写字母、包含数字、包含特殊字符',
+    )
+  })
+})

--- a/frontend/src/utils/authToken.ts
+++ b/frontend/src/utils/authToken.ts
@@ -1,0 +1,61 @@
+export type AccessTokenIdentity = {
+  userId: string | null
+  role: string | null
+}
+
+function decodeBase64Url(value: string): string | null {
+  try {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=')
+    return atob(padded)
+  } catch {
+    return null
+  }
+}
+
+export function parseAccessTokenIdentity(token: string | null): AccessTokenIdentity | null {
+  if (!token) {
+    return null
+  }
+
+  const parts = token.split('.')
+  if (parts.length < 2) {
+    return null
+  }
+
+  const decodedPayload = decodeBase64Url(parts[1])
+  if (!decodedPayload) {
+    return null
+  }
+
+  try {
+    const payload = JSON.parse(decodedPayload) as Record<string, unknown>
+    return {
+      userId: typeof payload.user_id === 'string' ? payload.user_id : null,
+      role: typeof payload.role === 'string' ? payload.role : null,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function hasAuthIdentityChanged(
+  previousToken: string | null,
+  nextToken: string | null,
+  currentUser: { id?: string | null; role?: string | null } | null,
+): boolean {
+  const nextIdentity = parseAccessTokenIdentity(nextToken)
+  if (!nextIdentity) {
+    return true
+  }
+
+  const previousIdentity = parseAccessTokenIdentity(previousToken)
+  const previousUserId = previousIdentity?.userId ?? currentUser?.id ?? null
+  const previousRole = previousIdentity?.role ?? currentUser?.role ?? null
+
+  if (!previousUserId && !previousRole) {
+    return true
+  }
+
+  return nextIdentity.userId !== previousUserId || nextIdentity.role !== previousRole
+}

--- a/frontend/src/utils/crossTabRefresh.ts
+++ b/frontend/src/utils/crossTabRefresh.ts
@@ -1,0 +1,296 @@
+import { NETWORK_CONFIG } from '@/config/constants'
+
+const REFRESH_LOCK_KEY = 'aether_auth_refresh_lock'
+const REFRESH_RESULT_KEY = 'aether_auth_refresh_result'
+const REFRESH_CHANNEL_NAME = 'aether-auth-refresh'
+const DEFAULT_WAIT_TIMEOUT_MS = NETWORK_CONFIG.API_TIMEOUT + 5000
+
+type RefreshStatus = 'success' | 'failure'
+
+type RefreshLock = {
+  owner: string
+  requestId: string
+  expiresAt: number
+}
+
+type RefreshResult = {
+  requestId: string
+  status: RefreshStatus
+  accessToken?: string
+  emittedAt: number
+}
+
+type RefreshEventMessage = {
+  type: 'refresh-result'
+  payload: RefreshResult
+}
+
+type Waiter = {
+  resolve: (result: RefreshResult) => void
+  reject: (error: Error) => void
+  timeoutId: ReturnType<typeof setTimeout>
+}
+
+type BroadcastMessageEvent = {
+  data: unknown
+}
+
+export type BroadcastChannelLike = {
+  postMessage(data: unknown): void
+  addEventListener(type: 'message', listener: (event: BroadcastMessageEvent) => void): void
+  removeEventListener(
+    type: 'message',
+    listener: (event: BroadcastMessageEvent) => void,
+  ): void
+  close?(): void
+}
+
+type CoordinatorOptions = {
+  storage?: Storage | null
+  waitTimeoutMs?: number
+  channelFactory?: (name: string) => BroadcastChannelLike | null
+}
+
+class CrossTabRefreshTimeoutError extends Error {
+  constructor(requestId: string) {
+    super(`Timed out while waiting for refresh request ${requestId}`)
+    this.name = 'CrossTabRefreshTimeoutError'
+  }
+}
+
+function createId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `refresh-${Math.random().toString(36).slice(2, 10)}-${Date.now()}`
+}
+
+function parseJson<T>(raw: string | null): T | null {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}
+
+function defaultChannelFactory(name: string): BroadcastChannelLike | null {
+  if (typeof BroadcastChannel === 'undefined') {
+    return null
+  }
+  return new BroadcastChannel(name)
+}
+
+export class CrossTabRefreshCoordinator {
+  private readonly storage: Storage | null
+  private readonly waitTimeoutMs: number
+  private readonly tabId = createId()
+  private readonly channel: BroadcastChannelLike | null
+  private readonly waiters = new Map<string, Waiter>()
+
+  private readonly onStorage = (event: StorageEvent): void => {
+    if (event.key !== REFRESH_RESULT_KEY || !event.newValue) {
+      return
+    }
+    const result = parseJson<RefreshResult>(event.newValue)
+    if (result) {
+      this.resolveWaiter(result)
+    }
+  }
+
+  private readonly onBroadcastMessage = (event: BroadcastMessageEvent): void => {
+    const message = event.data as RefreshEventMessage | null
+    if (!message || message.type !== 'refresh-result') {
+      return
+    }
+    this.resolveWaiter(message.payload)
+  }
+
+  constructor(options: CoordinatorOptions = {}) {
+    this.storage = options.storage ?? (typeof window !== 'undefined' ? window.localStorage : null)
+    this.waitTimeoutMs = options.waitTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS
+    this.channel = (options.channelFactory ?? defaultChannelFactory)(REFRESH_CHANNEL_NAME)
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', this.onStorage)
+    }
+    this.channel?.addEventListener('message', this.onBroadcastMessage)
+  }
+
+  destroy(): void {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('storage', this.onStorage)
+    }
+    this.channel?.removeEventListener('message', this.onBroadcastMessage)
+    this.channel?.close?.()
+    for (const waiter of this.waiters.values()) {
+      clearTimeout(waiter.timeoutId)
+    }
+    this.waiters.clear()
+  }
+
+  async run(executor: () => Promise<string>): Promise<string> {
+    const activeLock = this.readActiveLock()
+    if (activeLock && activeLock.owner !== this.tabId) {
+      return this.waitForRefreshResult(activeLock.requestId, executor)
+    }
+
+    const lock = this.tryAcquireLock()
+    if (!lock) {
+      const currentLock = this.readActiveLock()
+      if (currentLock && currentLock.owner !== this.tabId) {
+        return this.waitForRefreshResult(currentLock.requestId, executor)
+      }
+      return executor()
+    }
+
+    try {
+      const accessToken = await executor()
+      this.publishRefreshResult({
+        requestId: lock.requestId,
+        status: 'success',
+        accessToken,
+        emittedAt: Date.now(),
+      })
+      return accessToken
+    } catch (error) {
+      this.publishRefreshResult({
+        requestId: lock.requestId,
+        status: 'failure',
+        emittedAt: Date.now(),
+      })
+      throw error
+    } finally {
+      this.releaseLock(lock)
+    }
+  }
+
+  private waitForRefreshResult(requestId: string, executor: () => Promise<string>): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        this.waiters.delete(requestId)
+        reject(new CrossTabRefreshTimeoutError(requestId))
+      }, this.waitTimeoutMs)
+
+      this.waiters.set(requestId, {
+        resolve: (result) => {
+          if (result.status === 'success' && result.accessToken) {
+            resolve(result.accessToken)
+            return
+          }
+          reject(new Error(`Refresh request ${requestId} failed in another tab`))
+        },
+        reject,
+        timeoutId,
+      })
+    }).catch((error: unknown) => {
+      if (error instanceof CrossTabRefreshTimeoutError) {
+        return this.run(executor)
+      }
+      throw error
+    })
+  }
+
+  private tryAcquireLock(): RefreshLock | null {
+    if (!this.storage) {
+      return {
+        owner: this.tabId,
+        requestId: createId(),
+        expiresAt: Date.now() + this.waitTimeoutMs,
+      }
+    }
+
+    const existing = this.readActiveLock()
+    if (existing && existing.owner !== this.tabId) {
+      return null
+    }
+
+    const lock: RefreshLock = {
+      owner: this.tabId,
+      requestId: createId(),
+      expiresAt: Date.now() + this.waitTimeoutMs,
+    }
+
+    try {
+      // 这是一个 best-effort 跨标签页锁；写入后立刻回读，只认最终赢得竞态的 owner。
+      this.storage.setItem(REFRESH_LOCK_KEY, JSON.stringify(lock))
+      const current = this.readLock()
+      if (current && current.owner === lock.owner && current.requestId === lock.requestId) {
+        return current
+      }
+    } catch {
+      return lock
+    }
+
+    return null
+  }
+
+  private releaseLock(lock: RefreshLock): void {
+    if (!this.storage) {
+      return
+    }
+    try {
+      const current = this.readLock()
+      if (current && current.owner === lock.owner && current.requestId === lock.requestId) {
+        this.storage.removeItem(REFRESH_LOCK_KEY)
+      }
+    } catch {
+      // ignore storage release failures and allow lock TTL to expire naturally
+    }
+  }
+
+  private publishRefreshResult(result: RefreshResult): void {
+    const message: RefreshEventMessage = {
+      type: 'refresh-result',
+      payload: result,
+    }
+    this.channel?.postMessage(message)
+    if (!this.storage) {
+      return
+    }
+    try {
+      this.storage.setItem(REFRESH_RESULT_KEY, JSON.stringify(result))
+    } catch {
+      // ignore storage publish failures; BroadcastChannel already covers most browsers
+    }
+  }
+
+  private resolveWaiter(result: RefreshResult): void {
+    const waiter = this.waiters.get(result.requestId)
+    if (!waiter) {
+      return
+    }
+    clearTimeout(waiter.timeoutId)
+    this.waiters.delete(result.requestId)
+    waiter.resolve(result)
+  }
+
+  private readActiveLock(): RefreshLock | null {
+    const lock = this.readLock()
+    if (!lock) {
+      return null
+    }
+    if (lock.expiresAt > Date.now()) {
+      return lock
+    }
+    if (this.storage) {
+      try {
+        this.storage.removeItem(REFRESH_LOCK_KEY)
+      } catch {
+        // ignore storage cleanup failures; stale lock will age out on next write
+      }
+    }
+    return null
+  }
+
+  private readLock(): RefreshLock | null {
+    if (!this.storage) {
+      return null
+    }
+    try {
+      return parseJson<RefreshLock>(this.storage.getItem(REFRESH_LOCK_KEY))
+    } catch {
+      return null
+    }
+  }
+}

--- a/frontend/src/utils/deviceId.ts
+++ b/frontend/src/utils/deviceId.ts
@@ -1,0 +1,19 @@
+const DEVICE_ID_KEY = 'aether_client_device_id'
+
+function generateDeviceId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `device-${Math.random().toString(36).slice(2, 10)}-${Date.now()}`
+}
+
+export function getClientDeviceId(): string {
+  const existing = localStorage.getItem(DEVICE_ID_KEY)
+  if (existing) {
+    return existing
+  }
+
+  const created = generateDeviceId()
+  localStorage.setItem(DEVICE_ID_KEY, created)
+  return created
+}

--- a/frontend/src/utils/passwordPolicy.ts
+++ b/frontend/src/utils/passwordPolicy.ts
@@ -1,4 +1,11 @@
 export type PasswordPolicyLevel = 'weak' | 'medium' | 'strong'
+export const PASSWORD_MAX_BYTES = 72
+
+const textEncoder = new TextEncoder()
+
+function getPasswordByteLength(password: string): number {
+  return textEncoder.encode(password).length
+}
 
 export const PASSWORD_POLICY_OPTIONS: Array<{
   value: PasswordPolicyLevel
@@ -53,46 +60,51 @@ export function getPasswordPolicyPlaceholder(level: unknown): string {
   }
 }
 
-export function validatePasswordByPolicy(password: string, level: unknown): string {
-  if (!password) {
-    return ''
-  }
+/**
+ * 返回所有未满足的密码策略条件。
+ * 空数组 = 密码合规。
+ */
+export function getPasswordPolicyErrors(password: string, level: unknown): string[] {
+  if (!password) return []
 
   const normalized = normalizePasswordPolicyLevel(level)
+  const errors: string[] = []
 
-  if (password.length < 6) {
-    return '密码长度至少为6个字符'
+  const byteLength = getPasswordByteLength(password)
+  if (byteLength > PASSWORD_MAX_BYTES) {
+    errors.push(`长度不能超过${PASSWORD_MAX_BYTES}字节`)
+  }
+
+  // 根据策略确定最小长度，不做两段式报错
+  const minLen = normalized === 'weak' ? 6 : 8
+  if (password.length < minLen) {
+    errors.push(`至少 ${minLen} 个字符`)
   }
 
   if (normalized === 'medium') {
-    if (password.length < 8) {
-      return '密码长度至少为8个字符'
-    }
-    if (!/[A-Za-z]/.test(password)) {
-      return '密码必须包含至少一个字母'
-    }
-    if (!/[0-9]/.test(password)) {
-      return '密码必须包含至少一个数字'
-    }
+    if (!/[A-Za-z]/.test(password)) errors.push('包含字母')
+    if (!/[0-9]/.test(password)) errors.push('包含数字')
   }
 
   if (normalized === 'strong') {
-    if (password.length < 8) {
-      return '密码长度至少为8个字符'
-    }
-    if (!/[A-Z]/.test(password)) {
-      return '密码必须包含至少一个大写字母'
-    }
-    if (!/[a-z]/.test(password)) {
-      return '密码必须包含至少一个小写字母'
-    }
-    if (!/[0-9]/.test(password)) {
-      return '密码必须包含至少一个数字'
-    }
-    if (!/[!@#$%^&*()_+\-=[\]{};:'",.<>?/\\|`~]/.test(password)) {
-      return '密码必须包含至少一个特殊字符'
-    }
+    if (!/[A-Z]/.test(password)) errors.push('包含大写字母')
+    if (!/[a-z]/.test(password)) errors.push('包含小写字母')
+    if (!/[0-9]/.test(password)) errors.push('包含数字')
+    if (!/[!@#$%^&*()_+\-=[\]{};:'",.<>?/\\|`~]/.test(password)) errors.push('包含特殊字符')
   }
 
-  return ''
+  return errors
+}
+
+/**
+ * 兼容旧接口：返回单条错误字符串，空字符串表示通过。
+ * 多条未满足条件时用顿号连接。
+ */
+export function validatePasswordByPolicy(password: string, level: unknown): string {
+  const errors = getPasswordPolicyErrors(password, level)
+  if (errors.length === 0) return ''
+  if (errors.length === 1 && errors[0].startsWith('长度不能超过')) {
+    return '密码' + errors[0]
+  }
+  return '密码需要：' + errors.join('、')
 }

--- a/frontend/src/views/admin/Users.vue
+++ b/frontend/src/views/admin/Users.vue
@@ -332,6 +332,15 @@
                     variant="ghost"
                     size="icon"
                     class="h-8 w-8"
+                    title="登录设备"
+                    @click="manageUserSessions(user)"
+                  >
+                    <MonitorSmartphone class="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="h-8 w-8"
                     :title="user.is_active ? '禁用用户' : '启用用户'"
                     @click="toggleUserStatus(user)"
                   >
@@ -523,6 +532,15 @@
                 >
                   <Key class="mr-1.5 h-3.5 w-3.5" />
                   API Keys
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  class="h-8 text-xs"
+                  @click="manageUserSessions(user)"
+                >
+                  <MonitorSmartphone class="mr-1.5 h-3.5 w-3.5" />
+                  设备
                 </Button>
                 <Button
                   variant="outline"
@@ -725,6 +743,94 @@
       </template>
     </Dialog>
 
+    <Dialog
+      v-model="showUserSessionsDialog"
+      size="xl"
+    >
+      <template #header>
+        <div class="border-b border-border px-6 py-4">
+          <div class="flex items-center gap-3">
+            <div class="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 flex-shrink-0">
+              <MonitorSmartphone class="h-5 w-5 text-primary" />
+            </div>
+            <div class="flex-1 min-w-0">
+              <h3 class="text-lg font-semibold text-foreground leading-tight">
+                登录设备
+              </h3>
+              <p class="text-xs text-muted-foreground">
+                查看并强制下线该用户的设备会话
+              </p>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <div class="max-h-[60vh] overflow-y-auto space-y-3">
+        <div
+          v-if="loadingUserSessions"
+          class="rounded-lg border border-dashed border-border/60 bg-muted/20 px-4 py-10 text-center text-sm text-muted-foreground"
+        >
+          正在加载设备会话...
+        </div>
+        <div
+          v-else-if="userSessions.length === 0"
+          class="rounded-lg border border-dashed border-border/60 bg-muted/20 px-4 py-10 text-center text-sm text-muted-foreground"
+        >
+          暂无在线设备
+        </div>
+        <div
+          v-else
+          class="space-y-3"
+        >
+          <div
+            v-for="session in userSessions"
+            :key="session.id"
+            class="rounded-lg border border-border bg-card p-4 hover:border-primary/30 transition-colors"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <div class="min-w-0 flex-1">
+                <div class="font-semibold text-foreground">
+                  {{ session.device_label }}
+                </div>
+                <div class="mt-1 text-xs text-muted-foreground">
+                  {{ formatAdminSessionMeta(session) }}
+                </div>
+                <div class="mt-1 text-xs text-muted-foreground">
+                  最近活跃 {{ formatDate(session.last_seen_at || session.created_at) }}
+                  <span v-if="session.ip_address"> · IP {{ session.ip_address }}</span>
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                :disabled="sessionDialogActionLoading === session.id"
+                @click="revokeSelectedUserSession(session.id)"
+              >
+                {{ sessionDialogActionLoading === session.id ? '处理中...' : '强制下线' }}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <template #footer>
+        <Button
+          variant="outline"
+          class="h-10 px-5"
+          @click="showUserSessionsDialog = false"
+        >
+          关闭
+        </Button>
+        <Button
+          class="h-10 px-5"
+          :disabled="loadingUserSessions || userSessions.length === 0 || sessionDialogActionLoading === 'all'"
+          @click="revokeAllSelectedUserSessions"
+        >
+          {{ sessionDialogActionLoading === 'all' ? '处理中...' : '全部下线' }}
+        </Button>
+      </template>
+    </Dialog>
+
     <WalletOpsDrawer
       :open="showWalletActionDialogState"
       :wallet="walletActionTarget?.wallet || null"
@@ -796,7 +902,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { useUsersStore } from '@/stores/users'
-import type { User, ApiKey } from '@/api/users'
+import type { User, ApiKey, UserSession } from '@/api/users'
 import { adminWalletApi, type AdminWallet } from '@/api/admin-wallets'
 import { useToast } from '@/composables/useToast'
 import { useConfirm } from '@/composables/useConfirm'
@@ -842,7 +948,8 @@ import {
   Search,
   CheckCircle,
   Lock,
-  LockOpen
+  LockOpen,
+  MonitorSmartphone
 } from 'lucide-vue-next'
 
 // 功能组件
@@ -863,11 +970,15 @@ const userFormDialogRef = ref<InstanceType<typeof UserFormDialog>>()
 
 // API Keys 对话框状态
 const showApiKeysDialog = ref(false)
+const showUserSessionsDialog = ref(false)
 const showNewApiKeyDialog = ref(false)
 const selectedUser = ref<User | null>(null)
 const userApiKeys = ref<ApiKey[]>([])
+const userSessions = ref<UserSession[]>([])
 const newApiKey = ref('')
 const creatingApiKey = ref(false)
+const loadingUserSessions = ref(false)
+const sessionDialogActionLoading = ref<string | null>(null)
 const apiKeyInput = ref<HTMLInputElement>()
 
 // 用户统计
@@ -1136,6 +1247,19 @@ async function manageApiKeys(user: User) {
   await loadUserApiKeys(user.id)
 }
 
+async function manageUserSessions(user: User) {
+  selectedUser.value = user
+  showUserSessionsDialog.value = true
+  loadingUserSessions.value = true
+  try {
+    userSessions.value = await usersStore.getUserSessions(user.id)
+  } catch (err) {
+    error(parseApiError(err, '加载用户设备会话失败'))
+  } finally {
+    loadingUserSessions.value = false
+  }
+}
+
 async function loadUserApiKeys(userId: string) {
   try {
     userApiKeys.value = await usersStore.getUserApiKeys(userId)
@@ -1161,6 +1285,47 @@ async function createApiKey() {
     error(parseApiError(err, '未知错误'), '创建 API Key 失败')
   } finally {
     creatingApiKey.value = false
+  }
+}
+
+function formatAdminSessionMeta(session: UserSession): string {
+  const parts = [
+    session.browser_name && session.browser_version
+      ? `${session.browser_name} ${session.browser_version}`
+      : session.browser_name || null,
+    session.os_name && session.os_version
+      ? `${session.os_name} ${session.os_version}`
+      : session.os_name || null,
+    session.device_model || null,
+  ].filter(Boolean)
+  return parts.length > 0 ? parts.join(' · ') : '设备信息未知'
+}
+
+async function revokeSelectedUserSession(sessionId: string) {
+  if (!selectedUser.value) return
+  sessionDialogActionLoading.value = sessionId
+  try {
+    await usersStore.revokeUserSession(selectedUser.value.id, sessionId)
+    userSessions.value = userSessions.value.filter((session) => session.id !== sessionId)
+    success('设备已强制下线')
+  } catch (err) {
+    error(parseApiError(err, '强制下线失败'))
+  } finally {
+    sessionDialogActionLoading.value = null
+  }
+}
+
+async function revokeAllSelectedUserSessions() {
+  if (!selectedUser.value) return
+  sessionDialogActionLoading.value = 'all'
+  try {
+    const result = await usersStore.revokeAllUserSessions(selectedUser.value.id)
+    userSessions.value = []
+    success(result.revoked_count > 0 ? `已强制下线 ${result.revoked_count} 个设备` : '没有可下线的设备')
+  } catch (err) {
+    error(parseApiError(err, '强制下线全部设备失败'))
+  } finally {
+    sessionDialogActionLoading.value = null
   }
 }
 

--- a/frontend/src/views/public/AuthCallback.vue
+++ b/frontend/src/views/public/AuthCallback.vue
@@ -89,7 +89,6 @@ onMounted(async () => {
   const hash = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : window.location.hash
   const params = new URLSearchParams(hash)
   const accessToken = params.get('access_token')
-  const refreshToken = params.get('refresh_token')
 
   clearUrlState()
 
@@ -101,9 +100,6 @@ onMounted(async () => {
 
   hint.value = '正在写入登录态...'
   apiClient.setToken(accessToken)
-  if (refreshToken) {
-    localStorage.setItem('refresh_token', refreshToken)
-  }
 
   authStore.syncToken()
 

--- a/frontend/src/views/user/Settings.vue
+++ b/frontend/src/views/user/Settings.vue
@@ -152,6 +152,118 @@
           </form>
         </Card>
 
+        <Card class="p-6">
+          <div class="flex items-center justify-between mb-4">
+            <div>
+              <h3 class="text-lg font-medium text-foreground">
+                登录设备
+              </h3>
+              <p class="text-sm text-muted-foreground mt-1">
+                管理当前账号在各设备上的登录状态
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              :disabled="sessionsLoading || otherSessionCount === 0 || sessionActionLoading === 'others'"
+              @click="handleRevokeOtherSessions"
+            >
+              {{ sessionActionLoading === 'others' ? '处理中...' : '退出其他设备' }}
+            </Button>
+          </div>
+
+          <div
+            v-if="sessionsLoading"
+            class="text-sm text-muted-foreground"
+          >
+            正在加载设备列表...
+          </div>
+          <div
+            v-else-if="userSessions.length === 0"
+            class="text-sm text-muted-foreground"
+          >
+            暂无登录设备记录
+          </div>
+          <div
+            v-else
+            class="space-y-3"
+          >
+            <div
+              v-for="session in userSessions"
+              :key="session.id"
+              class="flex items-start justify-between gap-4 rounded-lg border border-border/60 bg-muted/20 p-4"
+            >
+              <div class="min-w-0">
+                <div class="flex items-center gap-2 flex-wrap">
+                  <template v-if="editingSessionId === session.id">
+                    <Input
+                      v-model="sessionLabelDraft"
+                      size="sm"
+                      class="h-8 w-56"
+                      maxlength="120"
+                      @keyup.enter="saveSessionLabel(session.id)"
+                    />
+                  </template>
+                  <span
+                    v-else
+                    class="font-medium text-foreground"
+                  >{{ session.device_label }}</span>
+                  <Badge
+                    v-if="session.is_current"
+                    variant="secondary"
+                  >
+                    当前设备
+                  </Badge>
+                </div>
+                <p class="mt-1 text-xs text-muted-foreground">
+                  {{ formatSessionMeta(session) }}
+                </p>
+                <p class="mt-1 text-xs text-muted-foreground">
+                  最近活跃 {{ formatDate(session.last_seen_at || session.created_at) }}
+                  <span v-if="session.ip_address"> · IP {{ session.ip_address }}</span>
+                </p>
+              </div>
+              <div class="flex items-center gap-2">
+                <template v-if="editingSessionId === session.id">
+                  <Button
+                    size="sm"
+                    :disabled="sessionActionLoading === session.id || !sessionLabelDraft.trim()"
+                    @click="saveSessionLabel(session.id)"
+                  >
+                    {{ sessionActionLoading === session.id ? '保存中...' : '保存' }}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    :disabled="sessionActionLoading === session.id"
+                    @click="cancelSessionLabelEdit"
+                  >
+                    取消
+                  </Button>
+                </template>
+                <template v-else>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    :disabled="sessionActionLoading !== null"
+                    @click="startSessionLabelEdit(session)"
+                  >
+                    重命名
+                  </Button>
+                  <Button
+                    v-if="!session.is_current"
+                    variant="outline"
+                    size="sm"
+                    :disabled="sessionActionLoading === session.id"
+                    @click="handleRevokeSession(session.id)"
+                  >
+                    {{ sessionActionLoading === session.id ? '处理中...' : '退出' }}
+                  </Button>
+                </template>
+              </div>
+            </div>
+          </div>
+        </Card>
+
         <!-- OAuth 绑定 -->
         <Card class="p-6">
           <h3 class="text-lg font-medium text-foreground mb-4">
@@ -478,11 +590,12 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
-import { meApi, type Profile } from '@/api/me'
+import { meApi, type Profile, type UserSession } from '@/api/me'
 import { authApi } from '@/api/auth'
 import { oauthApi, type OAuthLinkInfo, type OAuthProviderInfo } from '@/api/oauth'
+import { getClientDeviceId } from '@/utils/deviceId'
 import { getOAuthIcon } from '@/utils/oauth-icons'
 import { useDarkMode, type ThemeMode } from '@/composables/useDarkMode'
 import {
@@ -512,10 +625,12 @@ import { getErrorMessage, getErrorStatus } from '@/types/api-error'
 
 const authStore = useAuthStore()
 const route = useRoute()
+const router = useRouter()
 const { success, error: showError } = useToast()
 const { setThemeMode } = useDarkMode()
 
 const profile = ref<Profile | null>(null)
+const userSessions = ref<UserSession[]>([])
 
 const profileForm = ref({
   email: '',
@@ -543,6 +658,10 @@ const preferencesForm = ref({
 
 const savingProfile = ref(false)
 const changingPassword = ref(false)
+const sessionsLoading = ref(false)
+const sessionActionLoading = ref<string | null>(null)
+const editingSessionId = ref<string | null>(null)
+const sessionLabelDraft = ref('')
 const passwordPolicyLevel = ref<PasswordPolicyLevel>('weak')
 const themeSelectOpen = ref(false)
 const languageSelectOpen = ref(false)
@@ -584,6 +703,8 @@ const hasPasswordChanges = computed(() => {
   }
 })
 
+const otherSessionCount = computed(() => userSessions.value.filter((session) => !session.is_current).length)
+
 function handleThemeChange(value: string) {
   preferencesForm.value.theme = value
   themeSelectOpen.value = false
@@ -602,6 +723,7 @@ function handleLanguageChange(value: string) {
 onMounted(async () => {
   await loadProfile()
   await loadPreferences()
+  await loadSessions()
   await loadOAuthBindings()
   await loadEmailConfigured()
 })
@@ -629,6 +751,23 @@ async function loadProfile() {
   } catch (error) {
     log.error('加载个人信息失败:', error)
     showError('加载个人信息失败')
+  }
+}
+
+async function loadSessions() {
+  sessionsLoading.value = true
+  try {
+    userSessions.value = await meApi.listSessions()
+    if (editingSessionId.value) {
+      const currentEditing = userSessions.value.find((session) => session.id === editingSessionId.value)
+      if (!currentEditing) {
+        cancelSessionLabelEdit()
+      }
+    }
+  } catch (error) {
+    log.error('加载登录设备失败:', error)
+  } finally {
+    sessionsLoading.value = false
   }
 }
 
@@ -679,6 +818,7 @@ function handleBind(providerType: string) {
         ? new URL(basePath)
         : new URL(basePath, window.location.origin)
       bindUrl.searchParams.set('bind_token', bindToken)
+      bindUrl.searchParams.set('client_device_id', getClientDeviceId())
 
       // 新标签页打开 OAuth 流程
       const newTab = window.open(bindUrl.toString(), '_blank')
@@ -813,16 +953,9 @@ async function changePassword() {
       old_password: isSettingPassword ? undefined : passwordForm.value.old_password,
       new_password: passwordForm.value.new_password
     })
-    success(isSettingPassword ? '密码设置成功' : '密码修改成功')
-    passwordForm.value = {
-      old_password: '',
-      new_password: '',
-      confirm_password: ''
-    }
-    // 刷新 profile 以更新 has_password 状态
-    if (isSettingPassword) {
-      await loadProfile()
-    }
+    success(isSettingPassword ? '密码设置成功，请重新登录' : '密码修改成功，请重新登录')
+    await authStore.logout()
+    await router.replace('/')
   } catch (err) {
     log.error('修改密码失败:', err)
     const title = isSettingPassword ? '密码设置失败' : '密码修改失败'
@@ -830,6 +963,83 @@ async function changePassword() {
     showError(getErrorMessage(err, defaultMsg), title)
   } finally {
     changingPassword.value = false
+  }
+}
+
+function formatSessionMeta(session: UserSession): string {
+  const parts = [
+    session.browser_name && session.browser_version
+      ? `${session.browser_name} ${session.browser_version}`
+      : session.browser_name || null,
+    session.os_name && session.os_version
+      ? `${session.os_name} ${session.os_version}`
+      : session.os_name || null,
+    session.device_model || null,
+  ].filter(Boolean)
+  return parts.length > 0 ? parts.join(' · ') : '设备信息未知'
+}
+
+function startSessionLabelEdit(session: UserSession) {
+  editingSessionId.value = session.id
+  sessionLabelDraft.value = session.device_label
+}
+
+function cancelSessionLabelEdit() {
+  editingSessionId.value = null
+  sessionLabelDraft.value = ''
+}
+
+async function saveSessionLabel(sessionId: string) {
+  const nextLabel = sessionLabelDraft.value.trim()
+  if (!nextLabel) {
+    showError('设备名称不能为空')
+    return
+  }
+
+  sessionActionLoading.value = sessionId
+  try {
+    const updated = await meApi.updateSessionLabel(sessionId, nextLabel)
+    userSessions.value = userSessions.value.map((session) =>
+      session.id === sessionId ? updated : session
+    )
+    cancelSessionLabelEdit()
+    success('设备名称已更新')
+  } catch (error) {
+    log.error('更新设备名称失败:', error)
+    showError(getErrorMessage(error, '更新设备名称失败'))
+  } finally {
+    sessionActionLoading.value = null
+  }
+}
+
+async function handleRevokeSession(sessionId: string) {
+  sessionActionLoading.value = sessionId
+  try {
+    await meApi.revokeSession(sessionId)
+    if (editingSessionId.value === sessionId) {
+      cancelSessionLabelEdit()
+    }
+    success('设备已退出登录')
+    await loadSessions()
+  } catch (error) {
+    log.error('退出设备失败:', error)
+    showError(getErrorMessage(error, '退出设备失败'))
+  } finally {
+    sessionActionLoading.value = null
+  }
+}
+
+async function handleRevokeOtherSessions() {
+  sessionActionLoading.value = 'others'
+  try {
+    const result = await meApi.revokeOtherSessions()
+    success(result.revoked_count > 0 ? `已退出 ${result.revoked_count} 个其他设备` : '没有其他在线设备')
+    await loadSessions()
+  } catch (error) {
+    log.error('退出其他设备失败:', error)
+    showError(getErrorMessage(error, '退出其他设备失败'))
+  } finally {
+    sessionActionLoading.value = null
   }
 }
 

--- a/frontend/src/views/user/Settings.vue
+++ b/frontend/src/views/user/Settings.vue
@@ -117,6 +117,7 @@
                 id="new-password"
                 v-model="passwordForm.new_password"
                 type="password"
+                :placeholder="getPasswordPolicyPlaceholder(passwordPolicyLevel)"
                 class="mt-1"
               />
               <p
@@ -138,8 +139,15 @@
                 id="confirm-password"
                 v-model="passwordForm.confirm_password"
                 type="password"
+                placeholder="再次输入密码"
                 class="mt-1"
               />
+              <p
+                v-if="passwordForm.confirm_password && passwordForm.new_password !== passwordForm.confirm_password"
+                class="mt-1 text-xs text-destructive"
+              >
+                两次输入的密码不一致
+              </p>
             </div>
           </form>
         </Card>
@@ -479,6 +487,7 @@ import { getOAuthIcon } from '@/utils/oauth-icons'
 import { useDarkMode, type ThemeMode } from '@/composables/useDarkMode'
 import {
   getPasswordPolicyHint,
+  getPasswordPolicyPlaceholder,
   normalizePasswordPolicyLevel,
   validatePasswordByPolicy,
   type PasswordPolicyLevel,

--- a/src/api/admin/users/routes.py
+++ b/src/api/admin/users/routes.py
@@ -18,8 +18,9 @@ from src.core.exceptions import InvalidRequestException, NotFoundException, tran
 from src.core.logger import logger
 from src.database import get_db, get_db_context
 from src.models.admin_requests import UpdateUserRequest
-from src.models.api import CreateApiKeyRequest, CreateUserRequest
+from src.models.api import CreateApiKeyRequest, CreateUserRequest, UserSessionResponse
 from src.models.database import ApiKey, User, UserRole, Wallet
+from src.services.auth.session_service import SessionService
 from src.services.cache.user_cache import UserCacheService
 from src.services.system.config import SystemConfigService
 from src.services.user.apikey import ApiKeyService
@@ -190,6 +191,88 @@ def _delete_user_sync(user_id: str) -> tuple[dict[str, Any], dict[str, Any], str
         )
 
 
+def _serialize_user_session(session: Any) -> dict[str, Any]:
+    return UserSessionResponse(
+        id=session.id,
+        device_label=session.device_label or "未知设备",
+        device_type=session.device_type or "unknown",
+        browser_name=session.browser_name,
+        browser_version=session.browser_version,
+        os_name=session.os_name,
+        os_version=session.os_version,
+        device_model=session.device_model,
+        ip_address=session.ip_address,
+        last_seen_at=session.last_seen_at.isoformat() if session.last_seen_at else None,
+        created_at=session.created_at.isoformat(),
+        is_current=False,
+        revoked_at=session.revoked_at.isoformat() if session.revoked_at else None,
+        revoke_reason=session.revoke_reason,
+    ).model_dump()
+
+
+def _list_user_sessions_sync(user_id: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    with get_db_context() as db:
+        user = UserService.get_user(db, user_id)
+        if not user:
+            raise NotFoundException("用户不存在", "user")
+        sessions = SessionService.list_user_sessions(db, user_id=user_id)
+        return (
+            [_serialize_user_session(session) for session in sessions],
+            {
+                "action": "list_user_sessions",
+                "target_user_id": user_id,
+                "session_count": len(sessions),
+            },
+        )
+
+
+def _revoke_user_session_sync(
+    user_id: str,
+    session_id: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    with get_db_context() as db:
+        user = UserService.get_user(db, user_id)
+        if not user:
+            raise NotFoundException("用户不存在", "user")
+        session = SessionService.get_session_for_user(db, user_id=user_id, session_id=session_id)
+        if not session:
+            raise NotFoundException("会话不存在", "session")
+        SessionService.revoke_session(
+            db,
+            session=session,
+            reason="admin_session_revoked",
+            audit_user_id=user_id,
+        )
+        return (
+            {"message": "用户设备已强制下线"},
+            {
+                "action": "revoke_user_session",
+                "target_user_id": user_id,
+                "session_id": session_id,
+            },
+        )
+
+
+def _revoke_all_user_sessions_sync(user_id: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    with get_db_context() as db:
+        user = UserService.get_user(db, user_id)
+        if not user:
+            raise NotFoundException("用户不存在", "user")
+        revoked_count = SessionService.revoke_all_user_sessions(
+            db,
+            user_id=user_id,
+            reason="admin_revoke_all_sessions",
+        )
+        return (
+            {"message": "已强制下线该用户所有设备", "revoked_count": revoked_count},
+            {
+                "action": "revoke_all_user_sessions",
+                "target_user_id": user_id,
+                "revoked_count": revoked_count,
+            },
+        )
+
+
 def _create_user_key_sync(
     user_id: str,
     key_data: CreateApiKeyRequest,
@@ -342,6 +425,36 @@ async def get_user(user_id: str, request: Request, db: Session = Depends(get_db)
     - `user_id`: 用户 ID (UUID)
     """
     adapter = AdminGetUserAdapter(user_id=user_id)
+    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+
+
+@router.get("/{user_id}/sessions")
+async def list_user_sessions(user_id: str, request: Request, db: Session = Depends(get_db)) -> Any:
+    """获取用户登录设备列表。"""
+    adapter = AdminListUserSessionsAdapter(user_id=user_id)
+    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+
+
+@router.delete("/{user_id}/sessions/{session_id}")
+async def revoke_user_session(
+    user_id: str,
+    session_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> Any:
+    """强制下线用户的单个设备会话。"""
+    adapter = AdminRevokeUserSessionAdapter(user_id=user_id, session_id=session_id)
+    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+
+
+@router.delete("/{user_id}/sessions")
+async def revoke_all_user_sessions(
+    user_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> Any:
+    """强制下线用户的全部设备会话。"""
+    adapter = AdminRevokeAllUserSessionsAdapter(user_id=user_id)
     return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
 
 
@@ -562,6 +675,39 @@ class AdminGetUserAdapter(AdminApiAdapter):
         )
 
         return _serialize_user(db, user)
+
+
+class AdminListUserSessionsAdapter(AdminApiAdapter):
+    def __init__(self, user_id: str):
+        self.user_id = user_id
+
+    async def handle(self, context: ApiRequestContext) -> Any:  # type: ignore[override]
+        response, audit_meta = await run_in_threadpool(_list_user_sessions_sync, self.user_id)
+        context.add_audit_metadata(**audit_meta)
+        return response
+
+
+class AdminRevokeUserSessionAdapter(AdminApiAdapter):
+    def __init__(self, user_id: str, session_id: str):
+        self.user_id = user_id
+        self.session_id = session_id
+
+    async def handle(self, context: ApiRequestContext) -> Any:  # type: ignore[override]
+        response, audit_meta = await run_in_threadpool(
+            _revoke_user_session_sync, self.user_id, self.session_id
+        )
+        context.add_audit_metadata(**audit_meta)
+        return response
+
+
+class AdminRevokeAllUserSessionsAdapter(AdminApiAdapter):
+    def __init__(self, user_id: str):
+        self.user_id = user_id
+
+    async def handle(self, context: ApiRequestContext) -> Any:  # type: ignore[override]
+        response, audit_meta = await run_in_threadpool(_revoke_all_user_sessions_sync, self.user_id)
+        context.add_audit_metadata(**audit_meta)
+        return response
 
 
 class AdminUpdateUserAdapter(AdminApiAdapter):

--- a/src/api/auth/routes.py
+++ b/src/api/auth/routes.py
@@ -17,7 +17,6 @@ from src.api.base.context import ApiRequestContext
 from src.api.base.pipeline import ApiRequestPipeline
 from src.core.exceptions import InvalidRequestException
 from src.core.logger import logger
-from src.core.validators import PasswordValidator
 from src.database import get_db
 from src.models.api import (
     LoginRequest,
@@ -172,18 +171,6 @@ async def get_current_user_info(request: Request, db: Session = Depends(get_db))
     需要 Bearer Token 认证。
     """
     adapter = AuthCurrentUserAdapter()
-    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
-
-
-@router.patch("/password")
-async def change_password(request: Request, db: Session = Depends(get_db)) -> Any:
-    """
-    修改密码
-
-    修改当前用户的登录密码，需提供旧密码验证。
-    密码长度至少 6 位。
-    """
-    adapter = AuthChangePasswordAdapter()
     return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
 
 
@@ -609,27 +596,6 @@ class AuthCurrentUserAdapter(AuthenticatedApiAdapter):
             "last_login_at": user.last_login_at.isoformat() if user.last_login_at else None,
             "auth_source": user.auth_source.value,
         }
-
-
-class AuthChangePasswordAdapter(AuthenticatedApiAdapter):
-    async def handle(self, context: ApiRequestContext) -> Any:  # type: ignore[override]
-        payload = context.ensure_json_body()
-        old_password = payload.get("old_password")
-        new_password = payload.get("new_password")
-        if not old_password or not new_password:
-            raise HTTPException(status_code=400, detail="必须提供旧密码和新密码")
-        user = context.user
-        if not user.verify_password(old_password):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="旧密码错误")
-        policy_level = SystemConfigService.get_password_policy_level(context.db)
-        valid, error_msg = PasswordValidator.validate(new_password, policy=policy_level)
-        if not valid:
-            raise InvalidRequestException(error_msg or "密码格式无效")
-        user.set_password(new_password)
-        context.db.commit()
-        context.request.state.tx_committed_by_route = True
-        logger.info(f"用户修改密码: {user.email}")
-        return {"message": "密码修改成功"}
 
 
 class AuthLogoutAdapter(AuthenticatedApiAdapter):

--- a/src/api/auth/routes.py
+++ b/src/api/auth/routes.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
+import uuid
+from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.security import HTTPBearer
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
@@ -15,14 +17,14 @@ from src.api.base.adapter import ApiAdapter, ApiMode
 from src.api.base.authenticated_adapter import AuthenticatedApiAdapter
 from src.api.base.context import ApiRequestContext
 from src.api.base.pipeline import ApiRequestPipeline
-from src.core.exceptions import InvalidRequestException
+from src.core.exceptions import ErrorResponse, InvalidRequestException
 from src.core.logger import logger
 from src.database import get_db
+from src.config import config
 from src.models.api import (
     LoginRequest,
     LoginResponse,
     LogoutResponse,
-    RefreshTokenRequest,
     RefreshTokenResponse,
     RegisterRequest,
     RegisterResponse,
@@ -35,11 +37,13 @@ from src.models.api import (
     VerifyEmailResponse,
 )
 from src.models.database import AuditEventType, User, UserRole
-from src.services.auth.service import AuthService
+from src.services.auth.session_service import SessionService
+from src.services.auth.service import AuthService, REFRESH_TOKEN_EXPIRATION_DAYS
 from src.services.email import EmailSenderService, EmailVerificationService
 from src.services.rate_limit.ip_limiter import IPRateLimiter
 from src.services.system.audit import AuditService
 from src.services.system.config import SystemConfigService
+from src.services.cache.user_cache import UserCacheService
 from src.services.user.service import UserService
 from src.services.wallet import WalletService
 from src.utils.request_utils import get_client_ip, get_user_agent
@@ -90,6 +94,143 @@ def validate_email_suffix(db: Session, email: str) -> tuple[bool, str | None]:
     return True, None
 
 
+def _issue_session_bound_tokens(
+    *,
+    db: Session,
+    user_id: str,
+    user_role: UserRole,
+    user_created_at: Any,
+    user: User | None,
+    request: Request,
+) -> tuple[str, str, str]:
+    session_id = str(uuid.uuid4())
+    access_token = AuthService.create_access_token(
+        data={
+            "user_id": user_id,
+            "role": user_role.value,
+            "created_at": user_created_at.isoformat() if user_created_at else None,
+            "session_id": session_id,
+        }
+    )
+    refresh_token = AuthService.create_refresh_token(
+        data={
+            "user_id": user_id,
+            "created_at": user_created_at.isoformat() if user_created_at else None,
+            "session_id": session_id,
+            "jti": str(uuid.uuid4()),
+        }
+    )
+
+    if user is None:
+        user = db.query(User).filter(User.id == user_id).first()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="用户不存在")
+
+    client_device_id = SessionService.extract_client_device_id(request)
+    client_context = SessionService.build_client_context(
+        client_device_id=client_device_id,
+        client_ip=get_client_ip(request),
+        user_agent=get_user_agent(request),
+        headers=dict(request.headers),
+    )
+    SessionService.create_session(
+        db,
+        user=user,
+        session_id=session_id,
+        refresh_token=refresh_token,
+        expires_at=AuthService.get_refresh_token_expiry(),
+        client=client_context,
+    )
+    return session_id, access_token, refresh_token
+
+
+def _set_refresh_token_cookie(response: Response, refresh_token: str) -> None:
+    max_age_seconds = REFRESH_TOKEN_EXPIRATION_DAYS * 24 * 60 * 60
+    response.set_cookie(
+        key=config.auth_refresh_cookie_name,
+        value=refresh_token,
+        httponly=True,
+        secure=config.auth_refresh_cookie_secure,
+        samesite=config.auth_refresh_cookie_samesite,
+        path="/api/auth",
+        max_age=max_age_seconds,
+    )
+
+
+def _clear_refresh_token_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=config.auth_refresh_cookie_name,
+        path="/api/auth",
+        secure=config.auth_refresh_cookie_secure,
+        samesite=config.auth_refresh_cookie_samesite,
+    )
+
+
+def _error_response_with_cleared_refresh_cookie(exc: Exception) -> Response:
+    response = ErrorResponse.from_exception(exc)
+    _clear_refresh_token_cookie(response)
+    return response
+
+
+async def _logout_with_refresh_cookie_fallback(
+    request: Request,
+    db: Session,
+) -> dict[str, Any] | None:
+    refresh_token_value = request.cookies.get(config.auth_refresh_cookie_name)
+    if not refresh_token_value:
+        return None
+
+    try:
+        token_payload = await AuthService.verify_token(refresh_token_value, token_type="refresh")
+        user_id = token_payload.get("user_id")
+        session_id = token_payload.get("session_id")
+        if not user_id or not session_id:
+            return None
+
+        client_device_id = SessionService.extract_client_device_id(request)
+        session = SessionService.get_session_for_user(
+            db,
+            user_id=str(user_id),
+            session_id=str(session_id),
+        )
+        user = db.query(User).filter(User.id == user_id).first()
+
+        if session and not session.is_revoked and not session.is_expired:
+            SessionService.assert_session_device_matches(session, client_device_id)
+            SessionService.revoke_session(
+                db,
+                session=session,
+                reason="user_logout",
+                audit_user_id=str(user_id),
+                ip_address=get_client_ip(request),
+                user_agent=get_user_agent(request),
+            )
+
+        AuditService.log_event(
+            db=db,
+            event_type=AuditEventType.LOGOUT,
+            description=f"User logged out via refresh cookie: {user.email if user else user_id}",
+            user_id=str(user_id),
+            ip_address=get_client_ip(request),
+            user_agent=get_user_agent(request),
+            metadata={
+                "user_id": str(user_id),
+                "email": user.email if user else None,
+                "logout_via": "refresh_cookie",
+            },
+        )
+        db.commit()
+        request.state.tx_committed_by_route = True
+        logger.info("用户通过 refresh cookie 登出成功: {}", user.email if user else user_id)
+        return LogoutResponse(message="登出成功", success=True).model_dump()
+    except HTTPException as exc:
+        logger.info("Refresh cookie logout fallback skipped: {}", exc.detail)
+        return None
+    except Exception as exc:
+        logger.warning("Refresh cookie logout fallback failed: {}", exc)
+        return None
+
+
 router = APIRouter(prefix="/api/auth", tags=["Authentication"])
 security = HTTPBearer()
 pipeline = ApiRequestPipeline()
@@ -120,32 +261,43 @@ async def auth_settings(request: Request, db: Session = Depends(get_db)) -> Any:
     return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
 
 
-@router.post("/login", response_model=LoginResponse)
-async def login(request: Request, db: Session = Depends(get_db)) -> Any:
+@router.post("/login", response_model=LoginResponse, response_model_exclude_none=True)
+async def login(request: Request, response: Response, db: Session = Depends(get_db)) -> Any:
     """
     用户登录
 
-    使用邮箱和密码登录，成功后返回 JWT access_token 和 refresh_token。
+    使用邮箱和密码登录，成功后返回 JWT access_token。
 
     - **access_token**: 用于后续 API 调用，有效期 24 小时
-    - **refresh_token**: 用于刷新 access_token
+    - **refresh_token**: 通过 HttpOnly Cookie 下发，不出现在响应体
 
     速率限制: 20次/分钟/IP
     """
     adapter = AuthLoginAdapter()
-    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+    result = await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+    refresh_token = result.pop("_refresh_token", None) if isinstance(result, dict) else None
+    if refresh_token:
+        _set_refresh_token_cookie(response, refresh_token)
+    return result
 
 
-@router.post("/refresh", response_model=RefreshTokenResponse)
-async def refresh_token(request: Request, db: Session = Depends(get_db)) -> None:
+@router.post("/refresh", response_model=RefreshTokenResponse, response_model_exclude_none=True)
+async def refresh_token(request: Request, response: Response, db: Session = Depends(get_db)) -> Any:
     """
     刷新访问令牌
 
-    使用 refresh_token 获取新的 access_token 和 refresh_token。
-    原 refresh_token 刷新后失效。
+    使用 HttpOnly Cookie 中的 refresh_token 获取新的 access_token。
+    原 refresh_token 刷新后失效并轮换 Cookie。
     """
     adapter = AuthRefreshAdapter()
-    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+    try:
+        result = await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+    except HTTPException as exc:
+        return _error_response_with_cleared_refresh_cookie(exc)
+    refresh_token_value = result.pop("_refresh_token", None) if isinstance(result, dict) else None
+    if refresh_token_value:
+        _set_refresh_token_cookie(response, refresh_token_value)
+    return result
 
 
 @router.post("/register", response_model=RegisterResponse)
@@ -175,14 +327,25 @@ async def get_current_user_info(request: Request, db: Session = Depends(get_db))
 
 
 @router.post("/logout", response_model=LogoutResponse)
-async def logout(request: Request, db: Session = Depends(get_db)) -> Any:
+async def logout(request: Request, response: Response, db: Session = Depends(get_db)) -> Any:
     """
     用户登出
 
     将当前 Token 加入黑名单，使其失效。
+    即使 access_token 过期，也始终清除 refresh_token cookie。
     """
-    adapter = AuthLogoutAdapter()
-    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+    try:
+        adapter = AuthLogoutAdapter()
+        result = await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+    except HTTPException as exc:
+        fallback_result = await _logout_with_refresh_cookie_fallback(request, db)
+        if fallback_result is not None:
+            _clear_refresh_token_cookie(response)
+            return fallback_result
+        # 即使认证失败（如 access_token 过期），也要清除 cookie 防止会话残留
+        return _error_response_with_cleared_refresh_cookie(exc)
+    _clear_refresh_token_cookie(response)
+    return result
 
 
 @router.post("/send-verification-code", response_model=SendVerificationCodeResponse)
@@ -278,6 +441,18 @@ class AuthLoginAdapter(AuthPublicAdapter):
             context.request.state.tx_committed_by_route = True
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="邮箱或密码错误")
 
+        db_user = db.query(User).filter(User.id == authenticated_user.user_id).first()
+        if db_user is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="用户不存在")
+
+        _, access_token, refresh_token = _issue_session_bound_tokens(
+            db=db,
+            user_id=authenticated_user.user_id,
+            user_role=authenticated_user.role,
+            user_created_at=authenticated_user.created_at,
+            user=db_user,
+            request=context.request,
+        )
         AuditService.log_login_attempt(
             db=db,
             email=login_request.email,
@@ -286,54 +461,49 @@ class AuthLoginAdapter(AuthPublicAdapter):
             user_agent=user_agent,
             user_id=authenticated_user.user_id,
         )
+        db_user.last_login_at = datetime.now(timezone.utc)
         db.commit()
         context.request.state.tx_committed_by_route = True
+        await UserCacheService.invalidate_user_cache(
+            authenticated_user.user_id,
+            authenticated_user.email or "",
+        )
+        logger.info("用户登录成功: {} (ID: {})", login_request.email, authenticated_user.user_id)
 
-        access_token = AuthService.create_access_token(
-            data={
-                "user_id": authenticated_user.user_id,
-                "role": authenticated_user.role.value,
-                "created_at": (
-                    authenticated_user.created_at.isoformat()
-                    if authenticated_user.created_at
-                    else None
-                ),
-            }
-        )
-        refresh_token = AuthService.create_refresh_token(
-            data={
-                "user_id": authenticated_user.user_id,
-                "created_at": (
-                    authenticated_user.created_at.isoformat()
-                    if authenticated_user.created_at
-                    else None
-                ),
-            }
-        )
         response = LoginResponse(
             access_token=access_token,
-            refresh_token=refresh_token,
             token_type="bearer",
             expires_in=86400,
             user_id=authenticated_user.user_id,
             email=authenticated_user.email,
             username=authenticated_user.username,
             role=authenticated_user.role.value,
-        )
-        return response.model_dump()
+        ).model_dump()
+        response["_refresh_token"] = refresh_token
+        return response
 
 
 class AuthRefreshAdapter(AuthPublicAdapter):
     async def handle(self, context: ApiRequestContext) -> Any:  # type: ignore[override]
         db = context.db
-        payload = context.ensure_json_body()
-        refresh_request = RefreshTokenRequest.model_validate(payload)
+        if context.request.headers.get("content-length") not in (None, "0"):
+            payload = context.ensure_json_body()
+            if payload:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="刷新接口不接受请求体，请使用 Cookie",
+                )
+
+        refresh_token_value = context.request.cookies.get(config.auth_refresh_cookie_name)
+        if not refresh_token_value:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="缺少刷新令牌")
         try:
             token_payload = await AuthService.verify_token(
-                refresh_request.refresh_token, token_type="refresh"
+                refresh_token_value, token_type="refresh"
             )
             user_id = token_payload.get("user_id")
-            if not user_id:
+            session_id = token_payload.get("session_id")
+            if not user_id or not session_id:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED, detail="无效的刷新令牌"
                 )
@@ -355,26 +525,60 @@ class AuthRefreshAdapter(AuthPublicAdapter):
                     status_code=status.HTTP_401_UNAUTHORIZED, detail="无效的刷新令牌"
                 )
 
+            client_device_id = SessionService.extract_client_device_id(context.request)
+            session, is_prev = SessionService.validate_refresh_session(
+                db,
+                user_id=str(user_id),
+                session_id=str(session_id),
+                refresh_token=refresh_token_value,
+                ip_address=get_client_ip(context.request),
+                user_agent=get_user_agent(context.request),
+            )
+            if session:
+                SessionService.assert_session_device_matches(session, client_device_id)
+            if not session:
+                db.commit()
+                context.request.state.tx_committed_by_route = True
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED, detail="登录会话已失效，请重新登录"
+                )
+
             new_access_token = AuthService.create_access_token(
                 data={
                     "user_id": user.id,
                     "role": user.role.value,
                     "created_at": user.created_at.isoformat() if user.created_at else None,
+                    "session_id": session.id,
                 }
             )
-            new_refresh_token = AuthService.create_refresh_token(
-                data={
-                    "user_id": user.id,
-                    "created_at": user.created_at.isoformat() if user.created_at else None,
-                }
-            )
+            new_refresh_token: str | None = None
+            if not is_prev:
+                new_refresh_token = AuthService.create_refresh_token(
+                    data={
+                        "user_id": user.id,
+                        "created_at": user.created_at.isoformat() if user.created_at else None,
+                        "session_id": session.id,
+                        "jti": str(uuid.uuid4()),
+                    }
+                )
+                SessionService.rotate_refresh_token(
+                    session,
+                    refresh_token=new_refresh_token,
+                    expires_at=AuthService.get_refresh_token_expiry(),
+                    client_ip=get_client_ip(context.request),
+                    user_agent=get_user_agent(context.request),
+                )
+            db.commit()
+            context.request.state.tx_committed_by_route = True
             logger.info(f"令牌刷新成功: user_id={user.id}")
-            return RefreshTokenResponse(
+            response = RefreshTokenResponse(
                 access_token=new_access_token,
-                refresh_token=new_refresh_token,
                 token_type="bearer",
                 expires_in=86400,
             ).model_dump()
+            if new_refresh_token:
+                response["_refresh_token"] = new_refresh_token
+            return response
         except HTTPException:
             raise
         except Exception as exc:
@@ -603,18 +807,33 @@ class AuthLogoutAdapter(AuthenticatedApiAdapter):
         """用户登出，将 Token 加入黑名单"""
         user = context.user
         client_ip = get_client_ip(context.request)
+        current_session_id = getattr(context.request.state, "user_session_id", None)
 
-        # 从 Authorization header 获取 Token
-        auth_header = context.request.headers.get("Authorization")
-        if not auth_header or not auth_header.startswith("Bearer "):
+        # 从 Authorization header 获取 Token（与 pipeline 保持一致的大小写无关匹配）
+        auth_header = context.request.headers.get("Authorization") or ""
+        if not auth_header.lower().startswith("bearer "):
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="缺少认证令牌")
 
-        token = auth_header.replace("Bearer ", "")
+        token = auth_header[7:].strip()
 
         # 将 Token 加入黑名单
         success = await AuthService.logout(token)
 
-        if success:
+        if current_session_id:
+            session = SessionService.get_session_for_user(
+                context.db, user_id=user.id, session_id=str(current_session_id)
+            )
+            if session:
+                SessionService.revoke_session(
+                    context.db,
+                    session=session,
+                    reason="user_logout",
+                    audit_user_id=user.id,
+                    ip_address=client_ip,
+                    user_agent=get_user_agent(context.request),
+                )
+
+        if success or current_session_id:
             # 记录审计日志
             AuditService.log_event(
                 db=context.db,

--- a/src/api/base/pipeline.py
+++ b/src/api/base/pipeline.py
@@ -18,6 +18,7 @@ from src.core.exceptions import BalanceInsufficientException
 from src.core.logger import logger
 from src.database.database import create_session
 from src.models.database import ApiKey, AuditEventType, User
+from src.services.auth.session_service import SessionService
 from src.services.auth.service import AuthService
 from src.services.system.audit import AuditService
 from src.services.usage.service import UsageService
@@ -401,6 +402,7 @@ class ApiRequestPipeline:
 
             request.state.user_id = user.id
             request.state.management_token_id = management_token.id if management_token else None
+            request.state.user_session_id = None
             return user, management_token
 
         try:
@@ -412,8 +414,11 @@ class ApiRequestPipeline:
             raise HTTPException(status_code=401, detail="无效的管理员令牌")
 
         user_id = payload.get("user_id")
+        session_id = payload.get("session_id")
         if not user_id:
             raise HTTPException(status_code=401, detail="无效的管理员令牌")
+        if not session_id:
+            raise HTTPException(status_code=401, detail="登录会话已失效，请重新登录")
 
         db_user = db.query(User).filter(User.id == user_id).first()
         if not db_user or not db_user.is_active or db_user.is_deleted:
@@ -425,6 +430,20 @@ class ApiRequestPipeline:
         if db_user.role != UserRole.ADMIN:
             logger.warning("非管理员尝试通过 JWT 访问管理端点: {}", db_user.email)
             raise HTTPException(status_code=403, detail="需要管理员权限")
+
+        from src.utils.request_utils import get_client_ip
+
+        client_device_id = SessionService.extract_client_device_id(request)
+        session = SessionService.get_active_session(db, str(session_id), str(user_id))
+        if not session:
+            raise HTTPException(status_code=401, detail="登录会话已失效，请重新登录")
+        SessionService.assert_session_device_matches(session, client_device_id)
+        SessionService.touch_session(
+            session,
+            client_ip=get_client_ip(request),
+            user_agent=request.headers.get("user-agent", "unknown"),
+        )
+        request.state.user_session_id = session.id
 
         request.state.user_id = db_user.id
         return db_user, None
@@ -444,6 +463,7 @@ class ApiRequestPipeline:
             user, management_token = self._reattach_token_auth_result(db, token_auth_result)
             request.state.user_id = user.id
             request.state.management_token_id = management_token.id if management_token else None
+            request.state.user_session_id = None
             return user, management_token
 
         try:
@@ -455,8 +475,11 @@ class ApiRequestPipeline:
             raise HTTPException(status_code=401, detail="无效的用户令牌")
 
         user_id = payload.get("user_id")
+        session_id = payload.get("session_id")
         if not user_id:
             raise HTTPException(status_code=401, detail="无效的用户令牌")
+        if not session_id:
+            raise HTTPException(status_code=401, detail="登录会话已失效，请重新登录")
 
         db_user = db.query(User).filter(User.id == user_id).first()
         if not db_user or not db_user.is_active or db_user.is_deleted:
@@ -465,6 +488,19 @@ class ApiRequestPipeline:
         if not self.auth_service.token_identity_matches_user(payload, db_user):
             raise HTTPException(status_code=403, detail="无效的用户令牌")
 
+        from src.utils.request_utils import get_client_ip
+
+        client_device_id = SessionService.extract_client_device_id(request)
+        session = SessionService.get_active_session(db, str(session_id), str(user_id))
+        if not session:
+            raise HTTPException(status_code=401, detail="登录会话已失效，请重新登录")
+        SessionService.assert_session_device_matches(session, client_device_id)
+        SessionService.touch_session(
+            session,
+            client_ip=get_client_ip(request),
+            user_agent=request.headers.get("user-agent", "unknown"),
+        )
+        request.state.user_session_id = session.id
         request.state.user_id = db_user.id
         return db_user, None
 
@@ -487,6 +523,7 @@ class ApiRequestPipeline:
             # 存储到 request.state
             request.state.user_id = user.id
             request.state.management_token_id = management_token.id if management_token else None
+            request.state.user_session_id = None
 
             return user, management_token
 
@@ -538,8 +575,10 @@ class ApiRequestPipeline:
     ) -> None:
         """记录审计事件
 
-        事务策略：复用请求级 Session，不单独提交。
-        审计记录随主事务一起提交，由中间件统一管理。
+        事务策略：
+        - 默认复用请求级 Session，由中间件在请求结束时统一提交。
+        - 若路由已显式提交主事务（tx_committed_by_route=True），则审计日志会落在新的事务中，
+          这里需要立即提交，否则中间件会跳过二次提交，导致审计记录丢失。
         """
         if not getattr(adapter, "audit_log_enabled", True):
             return
@@ -564,6 +603,9 @@ class ApiRequestPipeline:
             error=error,
         )
 
+        request_state = getattr(context.request, "state", None)
+        tx_committed_by_route = getattr(request_state, "tx_committed_by_route", False) is True
+
         try:
             # 复用请求级 Session，不创建新的连接
             # 审计记录随主事务一起提交，由中间件统一管理
@@ -580,6 +622,12 @@ class ApiRequestPipeline:
                 error_message=error,
                 metadata=metadata,
             )
+            if tx_committed_by_route:
+                try:
+                    context.db.commit()
+                except Exception:
+                    context.db.rollback()
+                    raise
         except Exception as exc:
             # 审计失败不应影响主请求，仅记录警告
             logger.warning("[Audit] Failed to record event for adapter={}: {}", adapter.name, exc)

--- a/src/api/oauth/public.py
+++ b/src/api/oauth/public.py
@@ -2,14 +2,29 @@
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, Query, Request, status
 from sqlalchemy.orm import Session
 from starlette.responses import RedirectResponse
 
+from src.config import config
 from src.database import get_db
 from src.services.auth.oauth.service import OAuthService
+from src.services.auth.service import REFRESH_TOKEN_EXPIRATION_DAYS
+from src.utils.request_utils import get_client_ip, get_user_agent
 
 router = APIRouter(prefix="/api/oauth", tags=["OAuth"])
+
+
+def _set_refresh_token_cookie(response: RedirectResponse, refresh_token: str) -> None:
+    response.set_cookie(
+        key=config.auth_refresh_cookie_name,
+        value=refresh_token,
+        httponly=True,
+        secure=config.auth_refresh_cookie_secure,
+        samesite=config.auth_refresh_cookie_samesite,
+        path="/api/auth",
+        max_age=REFRESH_TOKEN_EXPIRATION_DAYS * 24 * 60 * 60,
+    )
 
 
 @router.get("/providers")
@@ -24,17 +39,24 @@ async def list_oauth_providers(db: Session = Depends(get_db)) -> dict[str, Any]:
 
 
 @router.get("/{provider_type}/authorize")
-async def oauth_authorize(provider_type: str, db: Session = Depends(get_db)) -> RedirectResponse:
+async def oauth_authorize(
+    provider_type: str,
+    client_device_id: str = Query(..., min_length=1, max_length=128),
+    db: Session = Depends(get_db),
+) -> RedirectResponse:
     """
     发起 OAuth 登录（login flow）。
     """
-    url = await OAuthService.build_login_authorize_url(db, provider_type)
+    url = await OAuthService.build_login_authorize_url(
+        db, provider_type, client_device_id=client_device_id
+    )
     return RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
 
 
 @router.get("/{provider_type}/callback")
 async def oauth_callback(
     provider_type: str,
+    request: Request,
     db: Session = Depends(get_db),
     code: str | None = Query(None),
     state: str | None = Query(None),
@@ -46,12 +68,18 @@ async def oauth_callback(
 
     成功/失败都会重定向到前端回调页。
     """
-    redirect_url = await OAuthService.handle_callback(
+    callback_result = await OAuthService.handle_callback(
         db=db,
         provider_type=provider_type,
         state=state or "",
         code=code,
         error=error,
         error_description=error_description,
+        client_ip=get_client_ip(request),
+        user_agent=get_user_agent(request),
+        headers=dict(request.headers),
     )
-    return RedirectResponse(url=redirect_url, status_code=status.HTTP_302_FOUND)
+    response = RedirectResponse(url=callback_result.redirect_url, status_code=status.HTTP_302_FOUND)
+    if callback_result.refresh_token:
+        _set_refresh_token_cookie(response, callback_result.refresh_token)
+    return response

--- a/src/api/oauth/user.py
+++ b/src/api/oauth/user.py
@@ -13,6 +13,7 @@ from src.api.base.pipeline import ApiRequestPipeline
 from src.clients.redis_client import get_redis_client
 from src.database import get_db
 from src.models.database import User
+from src.services.auth.session_service import CLIENT_DEVICE_ID_HEADER, SessionService
 from src.services.auth.oauth.service import OAuthService
 from src.services.auth.oauth.state import consume_oauth_bind_token, create_oauth_bind_token
 
@@ -156,7 +157,18 @@ class BindOAuthProviderAdapter(AuthenticatedApiAdapter):
                 raise HTTPException(status_code=403, detail="用户不存在或已禁用")
 
         assert user is not None
-        url = await OAuthService.build_bind_authorize_url(context.db, user, self.provider_type)
+        client_device_id: str | None = None
+        if (
+            context.request.headers.get(CLIENT_DEVICE_ID_HEADER)
+            or context.request.query_params.get("client_device_id")
+        ):
+            client_device_id = SessionService.extract_client_device_id(context.request)
+        url = await OAuthService.build_bind_authorize_url(
+            context.db,
+            user,
+            self.provider_type,
+            client_device_id=client_device_id,
+        )
         return RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
 
 

--- a/src/api/user_me/routes.py
+++ b/src/api/user_me/routes.py
@@ -32,9 +32,11 @@ from src.models.api import (
     CreateMyApiKeyRequest,
     PublicGlobalModelListResponse,
     PublicGlobalModelResponse,
+    UpdateSessionLabelRequest,
     UpdateApiKeyProvidersRequest,
     UpdatePreferencesRequest,
     UpdateProfileRequest,
+    UserSessionResponse,
 )
 from src.models.database import (
     ApiKey,
@@ -46,6 +48,7 @@ from src.models.database import (
     UserModelUsageCount,
 )
 from src.services.cache.user_cache import UserCacheService
+from src.services.auth.session_service import SessionService
 from src.services.system.config import SystemConfigService
 from src.services.system.time_range import TimeRangeParams
 from src.services.usage.service import UsageService
@@ -121,9 +124,84 @@ def _change_password_sync(
             raise InvalidRequestException(error_msg or "密码格式无效")
 
         user.set_password(request.new_password)
+        SessionService.revoke_all_user_sessions(
+            db,
+            user_id=user.id,
+            reason="password_changed",
+        )
         user.updated_at = datetime.now(timezone.utc)
         action = "修改" if has_password else "设置"
         return {"message": f"密码{action}成功"}, user.email, action
+
+
+def _serialize_user_session(session: Any, current_session_id: str | None) -> dict[str, Any]:
+    return UserSessionResponse(
+        id=session.id,
+        device_label=session.device_label or "未知设备",
+        device_type=session.device_type or "unknown",
+        browser_name=session.browser_name,
+        browser_version=session.browser_version,
+        os_name=session.os_name,
+        os_version=session.os_version,
+        device_model=session.device_model,
+        ip_address=session.ip_address,
+        last_seen_at=session.last_seen_at.isoformat() if session.last_seen_at else None,
+        created_at=session.created_at.isoformat(),
+        is_current=bool(current_session_id and session.id == current_session_id),
+        revoked_at=session.revoked_at.isoformat() if session.revoked_at else None,
+        revoke_reason=session.revoke_reason,
+    ).model_dump()
+
+
+def _list_user_sessions_sync(user_id: str, current_session_id: str | None) -> list[dict[str, Any]]:
+    with get_db_context() as db:
+        sessions = SessionService.list_user_sessions(db, user_id=user_id)
+        return [_serialize_user_session(session, current_session_id) for session in sessions]
+
+
+def _update_session_label_sync(
+    user_id: str,
+    session_id: str,
+    request: UpdateSessionLabelRequest,
+    current_session_id: str | None,
+) -> dict[str, Any]:
+    with get_db_context() as db:
+        session = SessionService.get_session_for_user(db, user_id=user_id, session_id=session_id)
+        if not session:
+            raise NotFoundException("会话不存在", "session")
+        SessionService.update_session_label(session, request.device_label)
+        return _serialize_user_session(session, current_session_id)
+
+
+def _revoke_session_sync(
+    user_id: str,
+    session_id: str,
+) -> dict[str, Any]:
+    with get_db_context() as db:
+        session = SessionService.get_session_for_user(db, user_id=user_id, session_id=session_id)
+        if not session:
+            raise NotFoundException("会话不存在", "session")
+        SessionService.revoke_session(
+            db,
+            session=session,
+            reason="user_session_revoked",
+            audit_user_id=user_id,
+        )
+        return {"message": "设备已退出登录"}
+
+
+def _revoke_other_sessions_sync(
+    user_id: str,
+    current_session_id: str | None,
+) -> dict[str, Any]:
+    with get_db_context() as db:
+        revoked_count = SessionService.revoke_all_user_sessions(
+            db,
+            user_id=user_id,
+            reason="logout_other_sessions",
+            exclude_session_id=current_session_id,
+        )
+        return {"message": "其他设备已退出登录", "revoked_count": revoked_count}
 
 
 def _create_my_api_key_sync(user_id: str, request: CreateMyApiKeyRequest) -> dict[str, Any]:
@@ -396,6 +474,42 @@ async def change_my_password(request: Request, db: Session = Depends(get_db)) ->
     - `new_password`: 新密码（至少 6 位）
     """
     adapter = ChangePasswordAdapter()
+    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+
+
+@router.get("/sessions")
+async def list_my_sessions(request: Request, db: Session = Depends(get_db)) -> Any:
+    """列出当前用户的登录会话。"""
+    adapter = ListMySessionsAdapter()
+    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+
+
+@router.delete("/sessions/others")
+async def revoke_other_sessions(request: Request, db: Session = Depends(get_db)) -> Any:
+    """退出当前设备之外的所有登录会话。"""
+    adapter = RevokeOtherSessionsAdapter()
+    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+
+
+@router.patch("/sessions/{session_id}")
+async def update_my_session_label(
+    session_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> Any:
+    """修改某个登录设备的显示名称。"""
+    adapter = UpdateMySessionLabelAdapter(session_id=session_id)
+    return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
+
+
+@router.delete("/sessions/{session_id}")
+async def revoke_my_session(
+    session_id: str,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> Any:
+    """退出指定登录会话。"""
+    adapter = RevokeMySessionAdapter(session_id=session_id)
     return await pipeline.run(adapter=adapter, http_request=request, db=db, mode=adapter.mode)
 
 
@@ -797,6 +911,62 @@ class ChangePasswordAdapter(AuthenticatedApiAdapter):
         )
         logger.info(f"用户{action}密码: {email}")
         return result
+
+
+class ListMySessionsAdapter(AuthenticatedApiAdapter):
+    async def handle(self, context: ApiRequestContext) -> Any:  # type: ignore[override]
+        current_session_id = getattr(context.request.state, "user_session_id", None)
+        return await run_in_threadpool(
+            _list_user_sessions_sync,
+            context.user.id,
+            current_session_id,
+        )
+
+
+class UpdateMySessionLabelAdapter(AuthenticatedApiAdapter):
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+
+    async def handle(self, context: ApiRequestContext) -> Any:  # type: ignore[override]
+        payload = context.ensure_json_body()
+        try:
+            request = UpdateSessionLabelRequest.model_validate(payload)
+        except ValidationError as e:
+            errors = e.errors()
+            if errors:
+                raise InvalidRequestException(translate_pydantic_error(errors[0]))
+            raise InvalidRequestException("请求数据验证失败")
+
+        current_session_id = getattr(context.request.state, "user_session_id", None)
+        return await run_in_threadpool(
+            _update_session_label_sync,
+            context.user.id,
+            self.session_id,
+            request,
+            current_session_id,
+        )
+
+
+class RevokeMySessionAdapter(AuthenticatedApiAdapter):
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+
+    async def handle(self, context: ApiRequestContext) -> Any:  # type: ignore[override]
+        return await run_in_threadpool(
+            _revoke_session_sync,
+            context.user.id,
+            self.session_id,
+        )
+
+
+class RevokeOtherSessionsAdapter(AuthenticatedApiAdapter):
+    async def handle(self, context: ApiRequestContext) -> Any:  # type: ignore[override]
+        current_session_id = getattr(context.request.state, "user_session_id", None)
+        return await run_in_threadpool(
+            _revoke_other_sessions_sync,
+            context.user.id,
+            current_session_id,
+        )
 
 
 class ListMyApiKeysAdapter(AuthenticatedApiAdapter):

--- a/src/api/user_me/routes.py
+++ b/src/api/user_me/routes.py
@@ -112,6 +112,8 @@ def _change_password_sync(
                 raise InvalidRequestException("请输入当前密码")
             if not user.verify_password(request.old_password):
                 raise InvalidRequestException("旧密码错误")
+            if user.verify_password(request.new_password):
+                raise InvalidRequestException("新密码不能与当前密码相同")
 
         policy_level = SystemConfigService.get_password_policy_level(db)
         valid, error_msg = PasswordValidator.validate(request.new_password, policy=policy_level)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -20,6 +20,8 @@ except ImportError:
 
 
 class Config:
+    _VALID_COOKIE_SAMESITE = {"lax", "strict", "none"}
+
     def __init__(self) -> None:
         # 服务器配置
         self.host = os.getenv("HOST", "0.0.0.0")
@@ -86,6 +88,33 @@ class Config:
         # CORS是否允许凭证(Cookie/Authorization header)
         # 注意: allow_credentials=True 时不能使用 allow_origins=["*"]
         self.cors_allow_credentials = os.getenv("CORS_ALLOW_CREDENTIALS", "true").lower() == "true"
+
+        self.auth_refresh_cookie_name = os.getenv(
+            "AUTH_REFRESH_COOKIE_NAME", "aether_refresh_token"
+        )
+        raw_refresh_cookie_samesite = os.getenv("AUTH_REFRESH_COOKIE_SAMESITE")
+        normalized_refresh_cookie_samesite = self._normalize_cookie_samesite(
+            raw_refresh_cookie_samesite
+        )
+        self._invalid_auth_refresh_cookie_samesite = (
+            raw_refresh_cookie_samesite
+            if raw_refresh_cookie_samesite is not None
+            and normalized_refresh_cookie_samesite is None
+            else None
+        )
+        # 生产默认使用 SameSite=None，兼容前后端跨站点部署下的 refresh cookie。
+        self.auth_refresh_cookie_samesite = (
+            normalized_refresh_cookie_samesite
+            if normalized_refresh_cookie_samesite is not None
+            else ("none" if self.environment == "production" else "lax")
+        )
+        self.auth_refresh_cookie_secure = (
+            os.getenv(
+                "AUTH_REFRESH_COOKIE_SECURE",
+                "true" if self.environment == "production" else "false",
+            ).lower()
+            == "true"
+        )
 
         # 管理员账户配置（用于初始化）
         self.admin_email = os.getenv("ADMIN_EMAIL", "admin@localhost")
@@ -482,6 +511,15 @@ class Config:
         """
         errors: list[str] = []
 
+        if self._invalid_auth_refresh_cookie_samesite:
+            errors.append(
+                "AUTH_REFRESH_COOKIE_SAMESITE must be one of: lax, strict, none."
+            )
+        if self.auth_refresh_cookie_samesite == "none" and not self.auth_refresh_cookie_secure:
+            errors.append(
+                "AUTH_REFRESH_COOKIE_SECURE must be true when AUTH_REFRESH_COOKIE_SAMESITE=none."
+            )
+
         if self.environment == "production":
             # 生产环境必须设置 JWT 密钥
             if not self.jwt_secret_key:
@@ -500,6 +538,15 @@ class Config:
                 )
 
         return errors
+
+    @classmethod
+    def _normalize_cookie_samesite(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        if normalized in cls._VALID_COOKIE_SAMESITE:
+            return normalized
+        return None
 
     def __repr__(self) -> None:
         """配置信息字符串表示"""

--- a/src/core/validators.py
+++ b/src/core/validators.py
@@ -23,7 +23,12 @@ class PasswordValidator:
     MIN_LENGTH = 6
     MEDIUM_MIN_LENGTH = 8
     STRONG_MIN_LENGTH = 8
-    MAX_LENGTH = 128
+    MAX_BYTES = 72
+
+    @classmethod
+    def get_byte_length(cls, password: str) -> int:
+        """返回密码的 UTF-8 字节长度。"""
+        return len(password.encode("utf-8"))
 
     @classmethod
     def normalize_policy(cls, policy: PasswordPolicyLevel | str | None) -> PasswordPolicyLevel:
@@ -39,6 +44,22 @@ class PasswordValidator:
         return PasswordPolicyLevel.WEAK
 
     @classmethod
+    def validate_basic_input(cls, password: str) -> tuple[bool, str | None]:
+        """验证密码输入的基础约束，不修改原始内容。"""
+        if password == "":
+            return False, "密码不能为空"
+
+        if cls.get_byte_length(password) > cls.MAX_BYTES:
+            return False, f"密码长度不能超过{cls.MAX_BYTES}字节"
+
+        return True, None
+
+    @classmethod
+    def validate_login_input(cls, password: str) -> tuple[bool, str | None]:
+        """验证登录时的密码输入，不修改原始内容。"""
+        return cls.validate_basic_input(password)
+
+    @classmethod
     def validate(
         cls,
         password: str,
@@ -48,24 +69,26 @@ class PasswordValidator:
         if not password:
             return False, "密码不能为空"
 
-        if len(password) < cls.MIN_LENGTH:
-            return False, f"密码长度至少为{cls.MIN_LENGTH}个字符"
-
-        if len(password) > cls.MAX_LENGTH:
-            return False, f"密码长度不能超过{cls.MAX_LENGTH}个字符"
+        if cls.get_byte_length(password) > cls.MAX_BYTES:
+            return False, f"密码长度不能超过{cls.MAX_BYTES}字节"
 
         policy_level = cls.normalize_policy(policy)
 
+        # 根据策略级别确定最小长度，避免分两次报长度错误
+        if policy_level in (PasswordPolicyLevel.MEDIUM, PasswordPolicyLevel.STRONG):
+            min_len = cls.MEDIUM_MIN_LENGTH
+        else:
+            min_len = cls.MIN_LENGTH
+
+        if len(password) < min_len:
+            return False, f"密码长度至少为{min_len}个字符"
+
         if policy_level == PasswordPolicyLevel.MEDIUM:
-            if len(password) < cls.MEDIUM_MIN_LENGTH:
-                return False, f"密码长度至少为{cls.MEDIUM_MIN_LENGTH}个字符"
             if not re.search(r"[A-Za-z]", password):
                 return False, "密码必须包含至少一个字母"
             if not re.search(r"\d", password):
                 return False, "密码必须包含至少一个数字"
         elif policy_level == PasswordPolicyLevel.STRONG:
-            if len(password) < cls.STRONG_MIN_LENGTH:
-                return False, f"密码长度至少为{cls.STRONG_MIN_LENGTH}个字符"
             if not re.search(r"[A-Z]", password):
                 return False, "密码必须包含至少一个大写字母"
             if not re.search(r"[a-z]", password):
@@ -76,53 +99,6 @@ class PasswordValidator:
                 return False, "密码必须包含至少一个特殊字符"
 
         return True, None
-
-    @classmethod
-    def get_password_strength(cls, password: str) -> str:
-        """
-        获取密码强度评级
-
-        Args:
-            password: 密码
-
-        Returns:
-            强度评级: 弱、中、强、非常强
-        """
-        if not password:
-            return "无效"
-
-        score = 0
-
-        # 长度评分
-        if len(password) >= 8:
-            score += 1
-        if len(password) >= 12:
-            score += 1
-        if len(password) >= 16:
-            score += 1
-
-        # 字符类型评分
-        if re.search(r"[a-z]", password):
-            score += 1
-        if re.search(r"[A-Z]", password):
-            score += 1
-        if re.search(r"\d", password):
-            score += 1
-        if re.search(r"[!@#$%^&*()_+\-=\[\]{};:\'\",.<>?/\\|`~]", password):
-            score += 2
-
-        # 额外复杂度评分
-        if re.search(r"[^\w\s]", password):  # 非字母数字字符
-            score += 1
-
-        if score < 3:
-            return "弱"
-        elif score < 5:
-            return "中"
-        elif score < 7:
-            return "强"
-        else:
-            return "非常强"
 
 
 class EmailValidator:

--- a/src/models/admin_requests.py
+++ b/src/models/admin_requests.py
@@ -13,6 +13,7 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from src.core.enums import ProviderBillingType
+from src.core.validators import PasswordValidator
 
 
 class ProxyConfig(BaseModel):
@@ -686,9 +687,7 @@ class UpdateUserRequest(BaseModel):
 
     username: str | None = Field(None, min_length=1, max_length=50)
     email: str | None = Field(None, max_length=100)
-    password: str | None = Field(
-        None, min_length=6, max_length=128, description="新密码（留空保持不变）"
-    )
+    password: str | None = Field(None, description="新密码（留空保持不变）")
     unlimited: bool | None = Field(None, description="是否无限制（true=无限制，false=有限制）")
     is_active: bool | None = None
     role: str | None = None
@@ -721,6 +720,19 @@ class UpdateUserRequest(BaseModel):
             raise ValueError("邮箱格式不正确")
 
         return v.lower()
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str | None) -> str | None:
+        """验证密码"""
+        if v is None:
+            return v
+
+        valid, error_msg = PasswordValidator.validate_basic_input(v)
+        if not valid:
+            raise ValueError(error_msg or "密码格式无效")
+
+        return v
 
     @field_validator("role")
     @classmethod

--- a/src/models/api.py
+++ b/src/models/api.py
@@ -19,16 +19,16 @@ class LoginRequest(BaseModel):
     """登录请求"""
 
     email: str = Field(..., min_length=1, max_length=255, description="邮箱/用户名")
-    password: str = Field(..., min_length=1, max_length=128, description="密码")
+    password: str = Field(..., description="密码")
     auth_type: Literal["local", "ldap"] = Field(default="local", description="认证类型")
 
-    @classmethod
     @field_validator("password")
+    @classmethod
     def validate_password(cls, v: Any) -> Any:
-        """验证密码不为空且去除前后空格"""
-        v = v.strip()
-        if not v:
-            raise ValueError("密码不能为空")
+        """验证密码输入合法，保留原始内容。"""
+        valid, error_msg = PasswordValidator.validate_login_input(v)
+        if not valid:
+            raise ValueError(error_msg or "密码格式无效")
         return v
 
     @model_validator(mode="after")
@@ -82,8 +82,8 @@ class RegisterRequest(BaseModel):
     """注册请求"""
 
     email: str | None = Field(None, max_length=255, description="邮箱地址（可选）")
-    username: str = Field(..., min_length=2, max_length=50, description="用户名")
-    password: str = Field(..., min_length=6, max_length=128, description="密码")
+    username: str = Field(..., min_length=3, max_length=50, description="用户名")
+    password: str = Field(..., description="密码")
 
     @field_validator("email")
     @classmethod
@@ -110,11 +110,11 @@ class RegisterRequest(BaseModel):
             raise ValueError("用户名只能包含字母、数字、下划线、连字符和点号")
         return v
 
-    @classmethod
     @field_validator("password")
+    @classmethod
     def validate_password(cls, v: Any) -> Any:
-        """基础校验（长度上下限），策略级别校验在服务层按系统配置执行。"""
-        valid, error_msg = PasswordValidator.validate(v)
+        """基础校验（非空和算法限制），策略级别校验在服务层按系统配置执行。"""
+        valid, error_msg = PasswordValidator.validate_basic_input(v)
         if not valid:
             raise ValueError(error_msg or "密码格式无效")
         return v
@@ -234,8 +234,8 @@ class RegistrationSettingsResponse(BaseModel):
 class CreateUserRequest(BaseModel):
     """创建用户请求"""
 
-    username: str = Field(..., min_length=2, max_length=50, description="用户名")
-    password: str = Field(..., min_length=6, max_length=128, description="密码")
+    username: str = Field(..., min_length=3, max_length=50, description="用户名")
+    password: str = Field(..., description="密码")
     email: str | None = Field(None, max_length=255, description="邮箱地址（可选）")
     role: UserRole | None = Field(UserRole.USER, description="用户角色")
     initial_gift_usd: float | None = Field(
@@ -314,11 +314,11 @@ class CreateUserRequest(BaseModel):
             out.append(norm)
         return out
 
-    @classmethod
     @field_validator("password")
+    @classmethod
     def validate_password(cls, v: Any) -> Any:
-        """基础校验（长度上下限），策略级别校验在服务层按系统配置执行。"""
-        valid, error_msg = PasswordValidator.validate(v)
+        """基础校验（非空和算法限制），策略级别校验在服务层按系统配置执行。"""
+        valid, error_msg = PasswordValidator.validate_basic_input(v)
         if not valid:
             raise ValueError(error_msg or "密码格式无效")
         return v
@@ -329,7 +329,7 @@ class UpdateUserRequest(BaseModel):
 
     email: str | None = None
     username: str | None = None
-    password: str | None = None
+    password: str | None = Field(None, description="新密码（留空保持不变）")
     role: UserRole | None = None
     unlimited: bool | None = None
     allowed_providers: list[str] | None = None  # 允许使用的提供商 ID 列表
@@ -342,6 +342,13 @@ class UpdateUserRequest(BaseModel):
     def validate_allowed_api_formats(cls, v: list[str] | None) -> list[str] | None:
         # 与 CreateUserRequest 保持一致
         return CreateUserRequest.validate_allowed_api_formats(v)
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return CreateUserRequest.validate_password(v)
 
 
 class CreateApiKeyRequest(BaseModel):
@@ -765,7 +772,16 @@ class ChangePasswordRequest(BaseModel):
     """修改密码请求"""
 
     old_password: str | None = None  # 可选：首次设置密码时不需要
-    new_password: str
+    new_password: str = Field(..., description="新密码")
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_new_password(cls, v: Any) -> Any:
+        """基础校验（非空和算法限制），策略级别校验在服务层按系统配置执行。"""
+        valid, error_msg = PasswordValidator.validate_basic_input(v)
+        if not valid:
+            raise ValueError(error_msg or "密码格式无效")
+        return v
 
 
 class CreateMyApiKeyRequest(BaseModel):

--- a/src/models/api.py
+++ b/src/models/api.py
@@ -54,7 +54,6 @@ class LoginResponse(BaseModel):
     """登录响应"""
 
     access_token: str
-    refresh_token: str  # 刷新令牌
     token_type: str = "bearer"
     expires_in: int = 86400  # Token有效期（秒），默认24小时
     user_id: str
@@ -63,17 +62,10 @@ class LoginResponse(BaseModel):
     role: str
 
 
-class RefreshTokenRequest(BaseModel):
-    """刷新令牌请求"""
-
-    refresh_token: str = Field(..., description="刷新令牌")
-
-
 class RefreshTokenResponse(BaseModel):
     """刷新令牌响应"""
 
     access_token: str
-    refresh_token: str  # 返回新的刷新令牌
     token_type: str = "bearer"
     expires_in: int = 86400  # Token有效期（秒），默认24小时
 
@@ -782,6 +774,39 @@ class ChangePasswordRequest(BaseModel):
         if not valid:
             raise ValueError(error_msg or "密码格式无效")
         return v
+
+
+class UserSessionResponse(BaseModel):
+    """用户会话响应"""
+
+    id: str
+    device_label: str
+    device_type: str
+    browser_name: str | None = None
+    browser_version: str | None = None
+    os_name: str | None = None
+    os_version: str | None = None
+    device_model: str | None = None
+    ip_address: str | None = None
+    last_seen_at: str | None = None
+    created_at: str
+    is_current: bool = False
+    revoked_at: str | None = None
+    revoke_reason: str | None = None
+
+
+class UpdateSessionLabelRequest(BaseModel):
+    """更新会话显示名称"""
+
+    device_label: str = Field(..., min_length=1, max_length=120, description="设备名称")
+
+    @field_validator("device_label")
+    @classmethod
+    def validate_device_label(cls, v: Any) -> Any:
+        normalized = str(v).strip()
+        if not normalized:
+            raise ValueError("设备名称不能为空")
+        return normalized
 
 
 class CreateMyApiKeyRequest(BaseModel):

--- a/src/models/database.py
+++ b/src/models/database.py
@@ -166,15 +166,21 @@ class User(Base):
 
     def set_password(self, password: str) -> None:
         """设置密码"""
-        self.password_hash = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode(
-            "utf-8"
-        )
+        try:
+            self.password_hash = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode(
+                "utf-8"
+            )
+        except ValueError as exc:
+            raise ValueError("密码长度不能超过72字节") from exc
 
     def verify_password(self, password: str) -> bool:
         """验证密码"""
         if not self.password_hash:
             return False
-        return bcrypt.checkpw(password.encode("utf-8"), self.password_hash.encode("utf-8"))
+        try:
+            return bcrypt.checkpw(password.encode("utf-8"), self.password_hash.encode("utf-8"))
+        except ValueError:
+            return False
 
 
 class ApiKey(Base):

--- a/src/models/database.py
+++ b/src/models/database.py
@@ -136,6 +136,7 @@ class User(Base):
     management_tokens = relationship(
         "ManagementToken", back_populates="user", cascade="all, delete-orphan"
     )
+    sessions = relationship("UserSession", back_populates="user", cascade="all, delete-orphan")
     preferences = relationship(
         "UserPreference", back_populates="user", cascade="all, delete-orphan", passive_deletes=True
     )
@@ -181,6 +182,113 @@ class User(Base):
             return bcrypt.checkpw(password.encode("utf-8"), self.password_hash.encode("utf-8"))
         except ValueError:
             return False
+
+
+class UserSession(Base):
+    """用户登录会话（设备级）。"""
+
+    __tablename__ = "user_sessions"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(
+        String(36), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    # 客户端标识
+    client_device_id = Column(String(128), nullable=False, index=True)
+    device_label = Column(String(120), nullable=True)
+    device_type = Column(String(20), nullable=False, default="unknown")
+    browser_name = Column(String(50), nullable=True)
+    browser_version = Column(String(50), nullable=True)
+    os_name = Column(String(50), nullable=True)
+    os_version = Column(String(50), nullable=True)
+    device_model = Column(String(100), nullable=True)
+
+    # 请求上下文
+    ip_address = Column(String(45), nullable=True)
+    user_agent = Column(String(1000), nullable=True)
+    client_hints = Column(JSON, nullable=True)
+
+    # Refresh Token 仅存储哈希，不保存明文
+    refresh_token_hash = Column(String(64), nullable=False)
+    # 上一个 refresh token 的哈希，用于并发刷新的宽限窗口
+    prev_refresh_token_hash = Column(String(64), nullable=True)
+    rotated_at = Column(DateTime(timezone=True), nullable=True)
+
+    # 状态
+    last_seen_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+    revoke_reason = Column(String(100), nullable=True)
+
+    # 时间戳
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    # 关系
+    user = relationship("User", back_populates="sessions")
+
+    __table_args__ = (
+        Index("idx_user_sessions_user_active", "user_id", "revoked_at", "expires_at"),
+        Index("idx_user_sessions_user_device", "user_id", "client_device_id"),
+    )
+
+    @staticmethod
+    def hash_refresh_token(token: str) -> str:
+        """对 refresh token 做 SHA256 哈希。"""
+        return hashlib.sha256(token.encode()).hexdigest()
+
+    def set_refresh_token(self, token: str) -> None:
+        """设置 refresh token 哈希，同时保存上一个哈希用于并发宽限。"""
+        self.prev_refresh_token_hash = self.refresh_token_hash
+        self.rotated_at = datetime.now(timezone.utc)
+        self.refresh_token_hash = self.hash_refresh_token(token)
+
+    # 并发刷新宽限窗口（秒）
+    REFRESH_GRACE_SECONDS = 10
+
+    def verify_refresh_token(self, token: str) -> tuple[bool, bool]:
+        """校验 refresh token 是否匹配（常量时间比较）。
+
+        Returns:
+            (is_valid, is_prev): is_valid 表示 token 是否通过校验，
+            is_prev 表示匹配的是上一个（宽限窗口内的旧）token。
+        """
+        import hmac
+
+        token_hash = self.hash_refresh_token(token)
+        if hmac.compare_digest(self.refresh_token_hash, token_hash):
+            return True, False
+        # 检查宽限窗口内的上一个 token
+        if self.prev_refresh_token_hash and self.rotated_at:
+            rotated_at = self.rotated_at
+            if rotated_at.tzinfo is None:
+                rotated_at = rotated_at.replace(tzinfo=timezone.utc)
+            elapsed = (datetime.now(timezone.utc) - rotated_at).total_seconds()
+            if elapsed <= self.REFRESH_GRACE_SECONDS:
+                if hmac.compare_digest(self.prev_refresh_token_hash, token_hash):
+                    return True, True
+        return False, False
+
+    @property
+    def is_revoked(self) -> bool:
+        return self.revoked_at is not None
+
+    @property
+    def is_expired(self) -> bool:
+        expires_at = self.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        return expires_at <= datetime.now(timezone.utc)
 
 
 class ApiKey(Base):

--- a/src/services/auth/oauth/service.py
+++ b/src/services/auth/oauth/service.py
@@ -1,5 +1,6 @@
 import re
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
@@ -21,6 +22,7 @@ from src.models.database import OAuthProvider, User, UserOAuthLink
 from src.services.auth.oauth.base import OAuthProviderBase
 from src.services.auth.oauth.models import OAuthFlowError, OAuthUserInfo
 from src.services.auth.oauth.registry import get_oauth_provider_registry
+from src.services.auth.session_service import SessionService
 from src.services.auth.oauth.state import consume_oauth_state, create_oauth_state
 from src.services.auth.service import AuthService
 from src.services.cache.user_cache import UserCacheService
@@ -36,6 +38,11 @@ def _build_oauth_client_kwargs(
     return build_proxy_client_kwargs(
         timeout=httpx.Timeout(timeout_seconds), follow_redirects=follow_redirects
     )
+
+@dataclass(frozen=True)
+class OAuthCallbackResult:
+    redirect_url: str
+    refresh_token: str | None = None
 
 
 class OAuthService:
@@ -406,13 +413,12 @@ class OAuthService:
 
     @staticmethod
     def _build_frontend_login_success_redirect(
-        frontend_callback_url: str, *, access_token: str, refresh_token: str
+        frontend_callback_url: str, *, access_token: str
     ) -> str:
         parsed = urlparse(frontend_callback_url)
         fragment = urlencode(
             {
                 "access_token": access_token,
-                "refresh_token": refresh_token,
                 "token_type": "bearer",
                 "expires_in": 86400,
             }
@@ -449,8 +455,15 @@ class OAuthService:
         return result
 
     @staticmethod
-    async def build_login_authorize_url(db: Session, provider_type: str) -> str:
+    async def build_login_authorize_url(
+        db: Session, provider_type: str, client_device_id: str | None = None
+    ) -> str:
         OAuthService._require_module_active(db)
+        normalized_device_id = (
+            SessionService._normalize_device_id(client_device_id) if client_device_id else None
+        )
+        if not normalized_device_id:
+            raise HTTPException(status_code=400, detail="缺少或无效的设备标识")
 
         provider = OAuthService._get_provider_impl(provider_type)
         if not provider:
@@ -468,17 +481,32 @@ class OAuthService:
             raise HTTPException(status_code=503, detail="Redis 不可用")
 
         state = await create_oauth_state(
-            redis, provider_type=provider_type, action="login", user_id=None
+            redis,
+            provider_type=provider_type,
+            action="login",
+            user_id=None,
+            client_device_id=normalized_device_id,
         )
         return provider.get_authorization_url(config, state)
 
     @staticmethod
-    async def build_bind_authorize_url(db: Session, user: User, provider_type: str) -> str:
+    async def build_bind_authorize_url(
+        db: Session,
+        user: User,
+        provider_type: str,
+        client_device_id: str | None = None,
+    ) -> str:
         OAuthService._require_module_active(db)
 
         if user.auth_source == AuthSource.LDAP:
             raise HTTPException(status_code=403, detail="LDAP 用户不允许绑定 OAuth")
 
+        normalized_device_id: str | None = None
+        if client_device_id is not None:
+            normalized_device_id = SessionService._normalize_device_id(client_device_id)
+            if not normalized_device_id:
+                raise HTTPException(status_code=400, detail="缺少或无效的设备标识")
+
         provider = OAuthService._get_provider_impl(provider_type)
         if not provider:
             raise HTTPException(status_code=404, detail="不支持的 OAuth provider")
@@ -495,7 +523,11 @@ class OAuthService:
             raise HTTPException(status_code=503, detail="Redis 不可用")
 
         state = await create_oauth_state(
-            redis, provider_type=provider_type, action="bind", user_id=user.id
+            redis,
+            provider_type=provider_type,
+            action="bind",
+            user_id=user.id,
+            client_device_id=normalized_device_id,
         )
         return provider.get_authorization_url(config, state)
 
@@ -570,7 +602,10 @@ class OAuthService:
         code: str | None,
         error: str | None,
         error_description: str | None,
-    ) -> str:
+        client_ip: str | None,
+        user_agent: str,
+        headers: dict[str, str],
+    ) -> OAuthCallbackResult:
         OAuthService._require_module_active(db)
 
         provider = OAuthService._get_provider_impl(provider_type)
@@ -589,22 +624,28 @@ class OAuthService:
 
         # provider 被禁用时仍引导回前端（给出明确提示）
         if not config.is_enabled:
-            return OAuthService._build_frontend_error_redirect(
-                frontend_callback_url, error_code="provider_disabled"
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_error_redirect(
+                    frontend_callback_url, error_code="provider_disabled"
+                )
             )
 
         # provider 侧 error
         if error:
             code_map = "authorization_denied" if error == "access_denied" else "provider_error"
-            return OAuthService._build_frontend_error_redirect(
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_error_redirect(
                 frontend_callback_url,
                 error_code=code_map,
                 error_detail=error_description or error,
+                )
             )
 
         if not code or not state:
-            return OAuthService._build_frontend_error_redirect(
-                frontend_callback_url, error_code="invalid_callback"
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_error_redirect(
+                    frontend_callback_url, error_code="invalid_callback"
+                )
             )
 
         # 一次性消费 state
@@ -618,36 +659,63 @@ class OAuthService:
             state_data = None
 
         if not state_data:
-            return OAuthService._build_frontend_error_redirect(
-                frontend_callback_url, error_code="invalid_state"
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_error_redirect(
+                    frontend_callback_url, error_code="invalid_state"
+                )
+            )
+        normalized_device_id = None
+        if state_data.client_device_id:
+            normalized_device_id = SessionService._normalize_device_id(state_data.client_device_id)
+            if not normalized_device_id:
+                return OAuthCallbackResult(
+                    redirect_url=OAuthService._build_frontend_error_redirect(
+                        frontend_callback_url, error_code="invalid_state"
+                    )
+                )
+        if state_data.action == "login" and not normalized_device_id:
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_error_redirect(
+                    frontend_callback_url, error_code="invalid_state"
+                )
             )
 
         if state_data.provider_type != provider_type:
-            return OAuthService._build_frontend_error_redirect(
-                frontend_callback_url, error_code="invalid_state"
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_error_redirect(
+                    frontend_callback_url, error_code="invalid_state"
+                )
             )
 
         if state_data.action not in ("login", "bind"):
-            return OAuthService._build_frontend_error_redirect(
-                frontend_callback_url, error_code="invalid_state"
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_error_redirect(
+                    frontend_callback_url, error_code="invalid_state"
+                )
             )
 
         if state_data.action == "bind" and not state_data.user_id:
-            return OAuthService._build_frontend_error_redirect(
-                frontend_callback_url, error_code="invalid_bind_state"
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_error_redirect(
+                    frontend_callback_url, error_code="invalid_bind_state"
+                )
             )
 
         try:
             token = await provider.exchange_code(config, code)
             oauth_user = await provider.get_user_info(config, token.access_token)
         except OAuthFlowError as exc:
-            return OAuthService._build_frontend_error_redirect(
-                frontend_callback_url, error_code=exc.error_code, error_detail=exc.detail
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_error_redirect(
+                    frontend_callback_url, error_code=exc.error_code, error_detail=exc.detail
+                )
             )
         except Exception as exc:
             logger.warning("OAuth callback 处理失败: {}", exc)
-            return OAuthService._build_frontend_error_redirect(
-                frontend_callback_url, error_code="provider_error"
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_error_redirect(
+                    frontend_callback_url, error_code="provider_error"
+                )
             )
 
         if state_data.action == "bind":
@@ -656,41 +724,69 @@ class OAuthService:
                     db, user_id=state_data.user_id or "", config=config, oauth_user=oauth_user
                 )
             except OAuthFlowError as exc:
-                return OAuthService._build_frontend_error_redirect(
-                    frontend_callback_url, error_code=exc.error_code, error_detail=exc.detail
+                return OAuthCallbackResult(
+                    redirect_url=OAuthService._build_frontend_error_redirect(
+                        frontend_callback_url, error_code=exc.error_code, error_detail=exc.detail
+                    )
                 )
 
-            return OAuthService._build_frontend_bind_success_redirect(
-                frontend_callback_url, display_name
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_bind_success_redirect(
+                    frontend_callback_url, display_name
+                )
             )
 
         # login
         try:
             user = await OAuthService._handle_login(db, config=config, oauth_user=oauth_user)
         except OAuthFlowError as exc:
-            return OAuthService._build_frontend_error_redirect(
-                frontend_callback_url, error_code=exc.error_code, error_detail=exc.detail
+            return OAuthCallbackResult(
+                redirect_url=OAuthService._build_frontend_error_redirect(
+                    frontend_callback_url, error_code=exc.error_code, error_detail=exc.detail
+                )
             )
 
         assert user.id is not None
         assert user.role is not None
 
+        session_id = str(uuid.uuid4())
         access_token = AuthService.create_access_token(
             data={
                 "user_id": user.id,
                 "role": user.role.value,
                 "created_at": user.created_at.isoformat() if user.created_at else None,
+                "session_id": session_id,
             }
         )
         refresh_token = AuthService.create_refresh_token(
             data={
                 "user_id": user.id,
                 "created_at": user.created_at.isoformat() if user.created_at else None,
+                "session_id": session_id,
+                "jti": str(uuid.uuid4()),
             }
         )
+        client_context = SessionService.build_client_context(
+            client_device_id=normalized_device_id,
+            client_ip=client_ip,
+            user_agent=user_agent,
+            headers=headers,
+        )
+        SessionService.create_session(
+            db,
+            user=user,
+            session_id=session_id,
+            refresh_token=refresh_token,
+            expires_at=AuthService.get_refresh_token_expiry(),
+            client=client_context,
+        )
+        db.commit()
 
-        return OAuthService._build_frontend_login_success_redirect(
-            frontend_callback_url, access_token=access_token, refresh_token=refresh_token
+        return OAuthCallbackResult(
+            redirect_url=OAuthService._build_frontend_login_success_redirect(
+                frontend_callback_url, access_token=access_token
+            ),
+            refresh_token=refresh_token,
         )
 
     @staticmethod

--- a/src/services/auth/oauth/state.py
+++ b/src/services/auth/oauth/state.py
@@ -33,6 +33,7 @@ class OAuthStateData:
     provider_type: str
     action: str  # "login" | "bind"
     user_id: str | None
+    client_device_id: str | None
     created_at: int
 
     @classmethod
@@ -42,6 +43,7 @@ class OAuthStateData:
             provider_type=str(data.get("provider_type") or ""),
             action=str(data.get("action") or ""),
             user_id=data.get("user_id"),
+            client_device_id=data.get("client_device_id"),
             created_at=int(data.get("created_at") or 0),
         )
 
@@ -51,7 +53,12 @@ def _state_key(nonce: str) -> str:
 
 
 async def create_oauth_state(
-    redis: Redis, *, provider_type: str, action: str, user_id: str | None = None
+    redis: Redis,
+    *,
+    provider_type: str,
+    action: str,
+    user_id: str | None = None,
+    client_device_id: str | None = None,
 ) -> str:
     nonce = secrets.token_urlsafe(24)
     data = {
@@ -59,6 +66,7 @@ async def create_oauth_state(
         "provider_type": provider_type,
         "action": action,
         "user_id": user_id,
+        "client_device_id": client_device_id,
         "created_at": int(time.time()),
     }
     await redis.setex(_state_key(nonce), OAUTH_STATE_TTL_SECONDS, json.dumps(data))

--- a/src/services/auth/service.py
+++ b/src/services/auth/service.py
@@ -117,6 +117,14 @@ class AuthService:
     """认证服务"""
 
     @staticmethod
+    def get_access_token_expiry() -> datetime:
+        return datetime.now(timezone.utc) + timedelta(hours=JWT_EXPIRATION_HOURS)
+
+    @staticmethod
+    def get_refresh_token_expiry() -> datetime:
+        return datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRATION_DAYS)
+
+    @staticmethod
     def token_identity_matches_user(payload: dict[str, Any], user: User) -> bool:
         """
         校验 token 的身份字段是否与用户一致。
@@ -157,7 +165,7 @@ class AuthService:
     def create_access_token(data: dict) -> str:
         """创建JWT访问令牌"""
         to_encode = data.copy()
-        expire = datetime.now(timezone.utc) + timedelta(hours=JWT_EXPIRATION_HOURS)
+        expire = AuthService.get_access_token_expiry()
         to_encode.update({"exp": expire, "type": "access"})
         encoded_jwt = jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
         return encoded_jwt
@@ -166,7 +174,7 @@ class AuthService:
     def create_refresh_token(data: dict) -> str:
         """创建JWT刷新令牌"""
         to_encode = data.copy()
-        expire = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRATION_DAYS)
+        expire = AuthService.get_refresh_token_expiry()
         to_encode.update({"exp": expire, "type": "refresh"})
         encoded_jwt = jwt.encode(to_encode, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
         return encoded_jwt
@@ -362,7 +370,12 @@ class AuthService:
     async def authenticate_user_threadsafe(
         db: Session, email: str, password: str, auth_type: str = "local"
     ) -> AuthenticatedUserSnapshot | None:
-        """为异步登录路由提供线程池隔离的本地认证入口。"""
+        """为异步登录路由提供线程池隔离的认证入口。
+
+        这里仅负责校验凭证并返回用户快照，不提前持久化登录成功状态。
+        登录成功相关的审计、会话创建和 last_login_at 统一由路由层在同一事务里提交，
+        避免后续会话创建失败时留下错误的成功痕迹。
+        """
         if auth_type != "local":
             user = await AuthService.authenticate_user(db, email, password, auth_type)
             if not user:
@@ -376,8 +389,6 @@ class AuthService:
                 if not user:
                     return None
 
-                user.last_login_at = datetime.now(timezone.utc)
-                thread_db.commit()
                 return AuthService._build_authenticated_snapshot(user)
             finally:
                 thread_db.close()
@@ -386,8 +397,6 @@ class AuthService:
         if not snapshot:
             return None
 
-        await UserCacheService.invalidate_user_cache(snapshot.user_id, snapshot.email or "")
-        logger.info("用户登录成功: {} (ID: {})", email, snapshot.user_id)
         return snapshot
 
     @staticmethod
@@ -497,10 +506,6 @@ class AuthService:
             if ldap_username and user.ldap_username != ldap_username:
                 user.ldap_username = ldap_username
 
-            user.last_login_at = datetime.now(timezone.utc)
-            db.commit()
-            await UserCacheService.invalidate_user_cache(user.id, user.email)
-            logger.info(f"LDAP 用户登录成功: {ldap_user['email']} (ID: {user.id})")
             return user
 
         # 检查 username 是否已被占用，使用时间戳+随机数确保唯一性
@@ -532,7 +537,7 @@ class AuthService:
                 ldap_username=ldap_username,
                 role=UserRole.USER,
                 is_active=True,
-                last_login_at=datetime.now(timezone.utc),
+                last_login_at=None,
             )
 
             try:
@@ -549,9 +554,6 @@ class AuthService:
                     description="LDAP 注册初始赠款",
                 )
 
-                db.commit()
-                db.refresh(user)
-                logger.info(f"LDAP 用户创建成功: {ldap_user['email']} (ID: {user.id})")
                 return user
             except IntegrityError as e:
                 db.rollback()

--- a/src/services/auth/session_service.py
+++ b/src/services/auth/session_service.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
+
+from fastapi import HTTPException, Request, status
+from sqlalchemy import and_, or_
+from sqlalchemy.orm import Session
+
+from src.core.logger import logger
+from src.models.database import AuditEventType, User, UserSession
+from src.services.system.audit import AuditService
+
+SESSION_TOUCH_INTERVAL_SECONDS = 300
+CLIENT_DEVICE_ID_HEADER = "X-Client-Device-Id"
+MAX_SESSIONS_PER_USER = 20
+TERMINAL_SESSION_RETENTION_DAYS = 30
+_DEVICE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9\-_]{1,128}$")
+
+
+def _strip_hint(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip().strip('"').strip()
+    return cleaned or None
+
+
+def _parse_browser(user_agent: str) -> tuple[str | None, str | None]:
+    patterns = [
+        ("Edge", r"Edg/([\d.]+)"),
+        ("Opera", r"OPR/([\d.]+)"),
+        ("Chrome", r"Chrome/([\d.]+)"),
+        ("Firefox", r"Firefox/([\d.]+)"),
+        ("Safari", r"Version/([\d.]+).*Safari"),
+    ]
+    for name, pattern in patterns:
+        match = re.search(pattern, user_agent)
+        if match:
+            return name, match.group(1)
+    return None, None
+
+
+def _parse_os(user_agent: str, client_hints: Mapping[str, str | None]) -> tuple[str | None, str | None]:
+    platform = _strip_hint(client_hints.get("sec-ch-ua-platform"))
+    platform_version = _strip_hint(client_hints.get("sec-ch-ua-platform-version"))
+    if platform:
+        return platform, platform_version
+
+    patterns = [
+        ("Windows", r"Windows NT ([\d.]+)"),
+        ("macOS", r"Mac OS X ([\d_]+)"),
+        ("iOS", r"(?:iPhone OS|CPU OS) ([\d_]+)"),
+        ("Android", r"Android ([\d.]+)"),
+        ("Linux", r"Linux"),
+    ]
+    for name, pattern in patterns:
+        match = re.search(pattern, user_agent)
+        if match:
+            version = match.group(1).replace("_", ".") if match.lastindex else None
+            return name, version
+    return None, None
+
+
+def _parse_device_type(user_agent: str, client_hints: Mapping[str, str | None]) -> str:
+    ch_mobile = _strip_hint(client_hints.get("sec-ch-ua-mobile"))
+    ua_lower = user_agent.lower()
+    if ch_mobile == "?1":
+        return "mobile"
+    if "ipad" in ua_lower or "tablet" in ua_lower:
+        return "tablet"
+    if any(marker in ua_lower for marker in ("iphone", "android", "mobile")):
+        return "mobile"
+    if any(marker in ua_lower for marker in ("macintosh", "windows", "linux", "x11")):
+        return "desktop"
+    return "unknown"
+
+
+def _build_device_label(
+    *,
+    browser_name: str | None,
+    os_name: str | None,
+    device_model: str | None,
+    device_type: str,
+) -> str:
+    if device_model:
+        return device_model
+    if browser_name and os_name:
+        return f"{browser_name} / {os_name}"
+    if browser_name:
+        return browser_name
+    if os_name:
+        return os_name
+    if device_type == "mobile":
+        return "移动设备"
+    if device_type == "tablet":
+        return "平板设备"
+    if device_type == "desktop":
+        return "桌面设备"
+    return "未知设备"
+
+
+@dataclass(frozen=True)
+class SessionClientContext:
+    client_device_id: str
+    device_label: str
+    device_type: str
+    browser_name: str | None
+    browser_version: str | None
+    os_name: str | None
+    os_version: str | None
+    device_model: str | None
+    client_hints: dict[str, str | None]
+    ip_address: str | None
+    user_agent: str
+
+
+class SessionService:
+    """用户设备会话服务。"""
+
+    @staticmethod
+    def _utcnow() -> datetime:
+        return datetime.now(timezone.utc)
+
+    @staticmethod
+    def _active_sessions_query(db: Session, *, user_id: str) -> Any:
+        return db.query(UserSession).filter(
+            UserSession.user_id == user_id,
+            UserSession.revoked_at.is_(None),
+            UserSession.expires_at > SessionService._utcnow(),
+        )
+
+    @staticmethod
+    def cleanup_user_sessions(db: Session, *, user_id: str) -> int:
+        """清理该用户已进入终态且超过保留期的会话记录。"""
+        cutoff = SessionService._utcnow() - timedelta(days=TERMINAL_SESSION_RETENTION_DAYS)
+        deleted = (
+            db.query(UserSession)
+            .filter(UserSession.user_id == user_id)
+            .filter(
+                or_(
+                    UserSession.expires_at < cutoff,
+                    and_(UserSession.revoked_at.is_not(None), UserSession.revoked_at < cutoff),
+                )
+            )
+            .delete(synchronize_session=False)
+        )
+        if deleted:
+            db.flush()
+        return int(deleted or 0)
+
+    @staticmethod
+    def _normalize_device_id(raw: str) -> str | None:
+        """校验并规范化 device id，非法值返回 None。"""
+        cleaned = raw.strip()[:128]
+        if not cleaned:
+            return None
+        if _DEVICE_ID_PATTERN.match(cleaned):
+            return cleaned
+        # 不符合格式的视为无效
+        return None
+
+    @staticmethod
+    def extract_client_device_id(request: Request) -> str:
+        header_value = request.headers.get(CLIENT_DEVICE_ID_HEADER)
+        if header_value:
+            normalized = SessionService._normalize_device_id(header_value)
+            if normalized:
+                return normalized
+
+        query_value = request.query_params.get("client_device_id")
+        if query_value:
+            normalized = SessionService._normalize_device_id(query_value)
+            if normalized:
+                return normalized
+
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="缺少或无效的设备标识",
+        )
+
+    @staticmethod
+    def build_client_context(
+        *,
+        client_device_id: str,
+        client_ip: str | None,
+        user_agent: str,
+        headers: Mapping[str, str],
+    ) -> SessionClientContext:
+        normalized_headers = {str(key).lower(): value for key, value in headers.items()}
+        client_hints = {
+            "sec-ch-ua": normalized_headers.get("sec-ch-ua"),
+            "sec-ch-ua-platform": normalized_headers.get("sec-ch-ua-platform"),
+            "sec-ch-ua-platform-version": normalized_headers.get("sec-ch-ua-platform-version"),
+            "sec-ch-ua-model": normalized_headers.get("sec-ch-ua-model"),
+            "sec-ch-ua-mobile": normalized_headers.get("sec-ch-ua-mobile"),
+        }
+        browser_name, browser_version = _parse_browser(user_agent)
+        os_name, os_version = _parse_os(user_agent, client_hints)
+        device_model = _strip_hint(client_hints.get("sec-ch-ua-model"))
+        device_type = _parse_device_type(user_agent, client_hints)
+        device_label = _build_device_label(
+            browser_name=browser_name,
+            os_name=os_name,
+            device_model=device_model,
+            device_type=device_type,
+        )
+        return SessionClientContext(
+            client_device_id=client_device_id,
+            device_label=device_label,
+            device_type=device_type,
+            browser_name=browser_name,
+            browser_version=browser_version,
+            os_name=os_name,
+            os_version=os_version,
+            device_model=device_model,
+            client_hints=client_hints,
+            ip_address=client_ip,
+            user_agent=user_agent,
+        )
+
+    @staticmethod
+    def get_active_session(db: Session, session_id: str, user_id: str) -> UserSession | None:
+        session = (
+            db.query(UserSession)
+            .filter(UserSession.id == session_id, UserSession.user_id == user_id)
+            .first()
+        )
+        if not session:
+            return None
+        if session.is_revoked or session.is_expired:
+            return None
+        return session
+
+    @staticmethod
+    def assert_session_device_matches(session: UserSession, client_device_id: str) -> None:
+        if session.client_device_id != client_device_id:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="设备标识与登录会话不匹配",
+            )
+
+    @staticmethod
+    def create_session(
+        db: Session,
+        *,
+        user: User,
+        session_id: str,
+        refresh_token: str,
+        expires_at: datetime,
+        client: SessionClientContext,
+        revoke_existing_same_device: bool = True,
+    ) -> UserSession:
+        now = SessionService._utcnow()
+        SessionService.cleanup_user_sessions(db, user_id=user.id)
+        if revoke_existing_same_device:
+            existing_sessions = (
+                SessionService._active_sessions_query(db, user_id=user.id)
+                .filter(UserSession.client_device_id == client.client_device_id)
+                .all()
+            )
+            for existing in existing_sessions:
+                existing.revoked_at = now
+                existing.revoke_reason = "replaced_by_new_login"
+                existing.updated_at = now
+
+        # 如果活跃会话数超出限制，淘汰最旧的会话
+        active_count = SessionService._active_sessions_query(db, user_id=user.id).count()
+        if active_count >= MAX_SESSIONS_PER_USER:
+            oldest_sessions = (
+                SessionService._active_sessions_query(db, user_id=user.id)
+                .order_by(UserSession.last_seen_at.asc())
+                .limit(active_count - MAX_SESSIONS_PER_USER + 1)
+                .all()
+            )
+            for old_session in oldest_sessions:
+                old_session.revoked_at = now
+                old_session.revoke_reason = "session_limit_exceeded"
+                old_session.updated_at = now
+
+        session = UserSession(
+            id=session_id,
+            user_id=user.id,
+            client_device_id=client.client_device_id,
+            device_label=client.device_label,
+            device_type=client.device_type,
+            browser_name=client.browser_name,
+            browser_version=client.browser_version,
+            os_name=client.os_name,
+            os_version=client.os_version,
+            device_model=client.device_model,
+            ip_address=client.ip_address,
+            user_agent=client.user_agent[:1000],
+            client_hints=client.client_hints,
+            last_seen_at=now,
+            expires_at=expires_at,
+            revoked_at=None,
+            revoke_reason=None,
+        )
+        session.set_refresh_token(refresh_token)
+        db.add(session)
+        db.flush()
+        return session
+
+    @staticmethod
+    def rotate_refresh_token(
+        session: UserSession,
+        *,
+        refresh_token: str,
+        expires_at: datetime,
+        client_ip: str | None,
+        user_agent: str,
+    ) -> None:
+        session.set_refresh_token(refresh_token)
+        session.expires_at = expires_at
+        session.last_seen_at = datetime.now(timezone.utc)
+        if client_ip:
+            session.ip_address = client_ip
+        if user_agent:
+            session.user_agent = user_agent[:1000]
+
+    @staticmethod
+    def touch_session(
+        session: UserSession,
+        *,
+        client_ip: str | None,
+        user_agent: str,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        last_seen_at = session.last_seen_at
+        if last_seen_at.tzinfo is None:
+            last_seen_at = last_seen_at.replace(tzinfo=timezone.utc)
+        if (now - last_seen_at).total_seconds() < SESSION_TOUCH_INTERVAL_SECONDS:
+            return
+
+        session.last_seen_at = now
+        if client_ip:
+            session.ip_address = client_ip
+        if user_agent:
+            session.user_agent = user_agent[:1000]
+
+    @staticmethod
+    def revoke_session(
+        db: Session,
+        *,
+        session: UserSession,
+        reason: str,
+        audit_user_id: str | None = None,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+    ) -> None:
+        if session.revoked_at is not None:
+            return
+
+        now = datetime.now(timezone.utc)
+        session.revoked_at = now
+        session.revoke_reason = reason[:100]
+        session.updated_at = now
+
+        if reason == "refresh_token_reused":
+            AuditService.log_event(
+                db=db,
+                event_type=AuditEventType.SUSPICIOUS_ACTIVITY,
+                description="Detected refresh token reuse; session revoked",
+                user_id=audit_user_id or session.user_id,
+                ip_address=ip_address,
+                user_agent=user_agent,
+                metadata={
+                    "session_id": session.id,
+                    "client_device_id": session.client_device_id,
+                    "reason": reason,
+                },
+            )
+
+    @staticmethod
+    def revoke_all_user_sessions(
+        db: Session,
+        *,
+        user_id: str,
+        reason: str,
+        exclude_session_id: str | None = None,
+    ) -> int:
+        now = SessionService._utcnow()
+        SessionService.cleanup_user_sessions(db, user_id=user_id)
+        sessions = SessionService._active_sessions_query(db, user_id=user_id).all()
+        count = 0
+        for session in sessions:
+            if exclude_session_id and session.id == exclude_session_id:
+                continue
+            session.revoked_at = now
+            session.revoke_reason = reason[:100]
+            session.updated_at = now
+            count += 1
+        return count
+
+    @staticmethod
+    def list_user_sessions(db: Session, *, user_id: str) -> list[UserSession]:
+        SessionService.cleanup_user_sessions(db, user_id=user_id)
+        return (
+            SessionService._active_sessions_query(db, user_id=user_id)
+            .order_by(UserSession.last_seen_at.desc(), UserSession.created_at.desc())
+            .all()
+        )
+
+    @staticmethod
+    def update_session_label(session: UserSession, device_label: str) -> None:
+        normalized = device_label.strip()
+        if not normalized:
+            raise ValueError("设备名称不能为空")
+        session.device_label = normalized[:120]
+        session.updated_at = datetime.now(timezone.utc)
+
+    @staticmethod
+    def get_session_for_user(
+        db: Session,
+        *,
+        user_id: str,
+        session_id: str,
+        lock_for_update: bool = False,
+    ) -> UserSession | None:
+        query = db.query(UserSession).filter(
+            UserSession.user_id == user_id,
+            UserSession.id == session_id,
+        )
+        if lock_for_update:
+            # 串行化 refresh token 轮换，避免并发刷新把合法会话误判为重放攻击。
+            query = query.with_for_update()
+        return query.first()
+
+    @staticmethod
+    def validate_refresh_session(
+        db: Session,
+        *,
+        user_id: str,
+        session_id: str,
+        refresh_token: str,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+    ) -> tuple[UserSession | None, bool]:
+        session = SessionService.get_session_for_user(
+            db,
+            user_id=user_id,
+            session_id=session_id,
+            lock_for_update=True,
+        )
+        if not session or session.is_revoked or session.is_expired:
+            return None, False
+        is_valid, is_prev = session.verify_refresh_token(refresh_token)
+        if not is_valid:
+            logger.warning("Refresh token mismatch for session {}", session_id)
+            SessionService.revoke_session(
+                db,
+                session=session,
+                reason="refresh_token_reused",
+                audit_user_id=user_id,
+                ip_address=ip_address,
+                user_agent=user_agent,
+            )
+            db.flush()
+            return None, False
+        if is_prev:
+            logger.info("Grace window hit for session {} (prev token used)", session_id)
+        return session, is_prev

--- a/src/services/user/service.py
+++ b/src/services/user/service.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session, contains_eager
 from src.core.logger import logger
 from src.core.validators import EmailValidator, PasswordValidator, UsernameValidator
 from src.models.database import ApiKey, GlobalModel, Model, Provider, Usage, User, UserRole
+from src.services.auth.session_service import SessionService
 from src.services.cache.user_cache import UserCacheService
 from src.services.system.config import SystemConfigService
 from src.services.user.bulk_cleanup import batch_nullify_fk, pre_clean_api_key
@@ -244,6 +245,11 @@ class UserService:
             if not valid:
                 raise ValueError(error_msg)
             user.set_password(kwargs["password"])
+            SessionService.revoke_all_user_sessions(
+                db,
+                user_id=user.id,
+                reason="admin_password_reset",
+            )
 
         user.updated_at = datetime.now(timezone.utc)
         db.commit()  # 立即提交事务,释放数据库锁

--- a/src/services/user/service.py
+++ b/src/services/user/service.py
@@ -358,52 +358,6 @@ class UserService:
         return True
 
     @staticmethod
-    @transactional()
-    def change_password(
-        db: Session, user_id: str, old_password: str, new_password: str
-    ) -> tuple[bool, str]:
-        """
-        更改用户密码
-
-        Args:
-            db: 数据库会话
-            user_id: 用户ID
-            old_password: 旧密码
-            new_password: 新密码
-
-        Returns:
-            (是否成功, 消息)
-        """
-        user = db.query(User).filter(User.id == user_id).first()
-        if not user:
-            return False, "用户不存在"
-
-        # 验证旧密码
-        if not user.verify_password(old_password):
-            logger.warning(f"密码更改失败 - 旧密码错误: 用户ID {user_id}")
-            return False, "旧密码错误"
-
-        # 验证新密码复杂度
-        policy_level = SystemConfigService.get_password_policy_level(db)
-        valid, error_msg = PasswordValidator.validate(new_password, policy=policy_level)
-        if not valid:
-            return False, error_msg
-
-        # 检查新密码不能与旧密码相同
-        if old_password == new_password:
-            return False, "新密码不能与旧密码相同"
-
-        # 设置新密码
-        user.set_password(new_password)
-        user.updated_at = datetime.now(timezone.utc)
-
-        # 清除用户缓存
-        safe_create_task(UserCacheService.invalidate_user_cache(user.id, user.email))
-
-        logger.info(f"密码更改成功: 用户ID {user_id}")
-        return True, "密码更改成功"
-
-    @staticmethod
     def get_user_usage_stats(
         db: Session,
         user_id: str,

--- a/tests/api/test_admin_user_routes.py
+++ b/tests/api/test_admin_user_routes.py
@@ -94,6 +94,69 @@ def test_list_users_uses_wallet_batch_lookup(monkeypatch: pytest.MonkeyPatch) ->
     assert batch_getter.call_args.args[1] == ["user-1", "user-2"]
 
 
+def test_list_user_sessions_route_returns_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = MagicMock()
+    client = _build_admin_users_app(db, monkeypatch)
+    sessions = [
+        {
+            "id": "session-1",
+            "device_label": "Chrome / macOS",
+            "device_type": "desktop",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "is_current": False,
+        }
+    ]
+
+    monkeypatch.setattr(
+        "src.api.admin.users.routes._list_user_sessions_sync",
+        lambda user_id: (
+            sessions,
+            {"action": "list_user_sessions", "target_user_id": user_id},
+        ),
+    )
+
+    response = client.get("/api/admin/users/user-1/sessions")
+
+    assert response.status_code == 200
+    assert response.json() == sessions
+
+
+def test_revoke_user_session_route_returns_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = MagicMock()
+    client = _build_admin_users_app(db, monkeypatch)
+
+    monkeypatch.setattr(
+        "src.api.admin.users.routes._revoke_user_session_sync",
+        lambda user_id, session_id: (
+            {"message": f"{user_id}:{session_id}:revoked"},
+            {"action": "revoke_user_session", "target_user_id": user_id, "session_id": session_id},
+        ),
+    )
+
+    response = client.delete("/api/admin/users/user-1/sessions/session-1")
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "user-1:session-1:revoked"}
+
+
+def test_revoke_all_user_sessions_route_returns_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = MagicMock()
+    client = _build_admin_users_app(db, monkeypatch)
+
+    monkeypatch.setattr(
+        "src.api.admin.users.routes._revoke_all_user_sessions_sync",
+        lambda user_id: (
+            {"message": "done", "revoked_count": 2},
+            {"action": "revoke_all_user_sessions", "target_user_id": user_id, "revoked_count": 2},
+        ),
+    )
+
+    response = client.delete("/api/admin/users/user-1/sessions")
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "done", "revoked_count": 2}
+
+
 @pytest.mark.asyncio
 async def test_create_user_adapter_preserves_empty_restriction_lists(
     monkeypatch: pytest.MonkeyPatch,
@@ -101,24 +164,12 @@ async def test_create_user_adapter_preserves_empty_restriction_lists(
     db = MagicMock()
     captured: dict[str, Any] = {}
 
-    def _create_user(**kwargs: Any) -> SimpleNamespace:
-        captured.update(kwargs)
-        return SimpleNamespace(
-            id="user-3",
-            email="u3@example.com",
-            username="user3",
-            role=SimpleNamespace(value="user"),
-            is_active=True,
-            allowed_providers=[],
-            allowed_api_formats=[],
-            allowed_models=[],
-        )
+    def _fake_create_user_sync(request: Any, role: Any) -> tuple[dict[str, Any], dict[str, Any]]:
+        captured["request"] = request
+        captured["role"] = role
+        return {"id": "user-3"}, {"action": "create_user", "target_user_id": "user-3"}
 
-    monkeypatch.setattr("src.api.admin.users.routes.UserService.create_user", _create_user)
-    monkeypatch.setattr(
-        "src.api.admin.users.routes._serialize_user",
-        lambda _db, user: {"id": user.id},
-    )
+    monkeypatch.setattr("src.api.admin.users.routes._create_user_sync", _fake_create_user_sync)
 
     context = SimpleNamespace(
         db=db,
@@ -139,6 +190,6 @@ async def test_create_user_adapter_preserves_empty_restriction_lists(
     result = await AdminCreateUserAdapter().handle(context)
 
     assert result == {"id": "user-3"}
-    assert captured["allowed_providers"] == []
-    assert captured["allowed_api_formats"] == []
-    assert captured["allowed_models"] == []
+    assert captured["request"].allowed_providers == []
+    assert captured["request"].allowed_api_formats == []
+    assert captured["request"].allowed_models == []

--- a/tests/api/test_auth_routes.py
+++ b/tests/api/test_auth_routes.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from src.api.auth.routes import _logout_with_refresh_cookie_fallback, router as auth_router
+from src.config import config
+from src.database import get_db
+
+
+def _build_auth_app(
+    db: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    pipeline_result: Any = None,
+    pipeline_exception: Exception | None = None,
+) -> TestClient:
+    app = FastAPI()
+    app.include_router(auth_router)
+    app.dependency_overrides[get_db] = lambda: db
+
+    async def _fake_pipeline_run(
+        *, adapter: Any, http_request: object, db: MagicMock, mode: object
+    ) -> Any:
+        _ = adapter, http_request, db, mode
+        if pipeline_exception is not None:
+            raise pipeline_exception
+        return pipeline_result
+
+    monkeypatch.setattr("src.api.auth.routes.pipeline.run", _fake_pipeline_run)
+    return TestClient(app)
+
+
+def test_login_route_sets_refresh_cookie_and_hides_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = MagicMock()
+    client = _build_auth_app(
+        db,
+        monkeypatch,
+        pipeline_result={
+            "access_token": "access-1",
+            "token_type": "bearer",
+            "expires_in": 86400,
+            "user_id": "user-1",
+            "username": "tester",
+            "role": "user",
+            "_refresh_token": "refresh-1",
+        },
+    )
+
+    response = client.post("/api/auth/login", json={"email": "user@example.com", "password": "pw"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "access_token": "access-1",
+        "token_type": "bearer",
+        "expires_in": 86400,
+        "user_id": "user-1",
+        "username": "tester",
+        "role": "user",
+    }
+    set_cookie = response.headers.get("set-cookie", "")
+    assert config.auth_refresh_cookie_name in set_cookie
+    assert "refresh-1" in set_cookie
+    assert "HttpOnly" in set_cookie
+
+
+def test_refresh_route_sets_cookie_and_hides_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = MagicMock()
+    client = _build_auth_app(
+        db,
+        monkeypatch,
+        pipeline_result={
+            "access_token": "access-2",
+            "token_type": "bearer",
+            "expires_in": 86400,
+            "_refresh_token": "refresh-2",
+        },
+    )
+
+    response = client.post("/api/auth/refresh")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "access_token": "access-2",
+        "token_type": "bearer",
+        "expires_in": 86400,
+    }
+    set_cookie = response.headers.get("set-cookie", "")
+    assert config.auth_refresh_cookie_name in set_cookie
+    assert "refresh-2" in set_cookie
+    assert "HttpOnly" in set_cookie
+
+
+def test_refresh_route_clears_cookie_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = MagicMock()
+    client = _build_auth_app(
+        db,
+        monkeypatch,
+        pipeline_exception=HTTPException(status_code=401, detail="登录会话已失效，请重新登录"),
+    )
+
+    response = client.post("/api/auth/refresh")
+
+    assert response.status_code == 401
+    assert response.json()["error"]["message"] == "登录会话已失效，请重新登录"
+    set_cookie = response.headers.get("set-cookie", "")
+    assert config.auth_refresh_cookie_name in set_cookie
+    assert "Max-Age=0" in set_cookie
+
+
+def test_logout_route_clears_cookie_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = MagicMock()
+    client = _build_auth_app(
+        db,
+        monkeypatch,
+        pipeline_exception=HTTPException(status_code=401, detail="缺少认证令牌"),
+    )
+
+    response = client.post("/api/auth/logout")
+
+    assert response.status_code == 401
+    assert response.json()["error"]["message"] == "缺少认证令牌"
+    set_cookie = response.headers.get("set-cookie", "")
+    assert config.auth_refresh_cookie_name in set_cookie
+    assert "Max-Age=0" in set_cookie
+
+
+def test_logout_route_uses_refresh_cookie_fallback_on_auth_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = MagicMock()
+    client = _build_auth_app(
+        db,
+        monkeypatch,
+        pipeline_exception=HTTPException(status_code=401, detail="Token已过期"),
+    )
+
+    async def _fake_fallback(_request: object, _db: MagicMock) -> dict[str, Any]:
+        return {"message": "登出成功", "success": True}
+
+    monkeypatch.setattr(
+        "src.api.auth.routes._logout_with_refresh_cookie_fallback",
+        _fake_fallback,
+    )
+
+    response = client.post(
+        "/api/auth/logout",
+        cookies={config.auth_refresh_cookie_name: "refresh-1"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "登出成功", "success": True}
+    set_cookie = response.headers.get("set-cookie", "")
+    assert config.auth_refresh_cookie_name in set_cookie
+    assert "Max-Age=0" in set_cookie
+
+
+@pytest.mark.asyncio
+async def test_logout_with_refresh_cookie_fallback_revokes_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = MagicMock()
+    user = SimpleNamespace(id="user-1", email="user@example.com")
+    session = SimpleNamespace(id="session-1", is_revoked=False, is_expired=False)
+    db.query.return_value.filter.return_value.first.return_value = user
+    request = SimpleNamespace(
+        cookies={config.auth_refresh_cookie_name: "refresh-1"},
+        headers={},
+        query_params={},
+        state=SimpleNamespace(),
+    )
+
+    monkeypatch.setattr(
+        "src.api.auth.routes.AuthService.verify_token",
+        AsyncMock(
+            return_value={
+                "user_id": "user-1",
+                "session_id": "session-1",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "src.api.auth.routes.SessionService.extract_client_device_id",
+        lambda _request: "device-1",
+    )
+    monkeypatch.setattr(
+        "src.api.auth.routes.SessionService.get_session_for_user",
+        lambda *_args, **_kwargs: session,
+    )
+    assert_session_device_matches = MagicMock()
+    revoke_session = MagicMock()
+    log_event = MagicMock()
+    monkeypatch.setattr(
+        "src.api.auth.routes.SessionService.assert_session_device_matches",
+        assert_session_device_matches,
+    )
+    monkeypatch.setattr(
+        "src.api.auth.routes.SessionService.revoke_session",
+        revoke_session,
+    )
+    monkeypatch.setattr("src.api.auth.routes.AuditService.log_event", log_event)
+    monkeypatch.setattr("src.api.auth.routes.get_client_ip", lambda _request: "127.0.0.1")
+    monkeypatch.setattr(
+        "src.api.auth.routes.get_user_agent",
+        lambda _request: "pytest-agent",
+    )
+
+    result = await _logout_with_refresh_cookie_fallback(request, db)
+
+    assert result == {"message": "登出成功", "success": True}
+    assert_session_device_matches.assert_called_once_with(session, "device-1")
+    revoke_session.assert_called_once()
+    log_event.assert_called_once()
+    db.commit.assert_called_once()
+    assert request.state.tx_committed_by_route is True

--- a/tests/api/test_pipeline.py
+++ b/tests/api/test_pipeline.py
@@ -8,6 +8,7 @@ API Pipeline 测试
 """
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -225,6 +226,35 @@ class TestPipelineAuditLogging:
             call_kwargs = mock_log.call_args[1]
             assert call_kwargs["status_code"] == 500
             assert call_kwargs["error_message"] == "Internal error"
+
+    def test_record_audit_event_commits_when_route_already_committed(
+        self, pipeline: ApiRequestPipeline
+    ) -> None:
+        mock_context = MagicMock()
+        mock_context.db = MagicMock()
+        mock_context.user = MagicMock()
+        mock_context.user.id = "user-123"
+        mock_context.api_key = None
+        mock_context.request_id = "req-123"
+        mock_context.client_ip = "127.0.0.1"
+        mock_context.user_agent = "test-agent"
+        mock_context.request = MagicMock()
+        mock_context.request.method = "POST"
+        mock_context.request.url.path = "/api/auth/refresh"
+        mock_context.request.state = SimpleNamespace(tx_committed_by_route=True)
+        mock_context.start_time = 1000.0
+
+        mock_adapter = MagicMock()
+        mock_adapter.name = "test-adapter"
+        mock_adapter.audit_log_enabled = True
+        mock_adapter.audit_success_event = None
+        mock_adapter.audit_failure_event = None
+
+        with patch.object(pipeline.audit_service, "log_event") as mock_log:
+            pipeline._record_audit_event(mock_context, mock_adapter, success=True, status_code=200)
+
+        mock_log.assert_called_once()
+        mock_context.db.commit.assert_called_once()
 
     def test_record_audit_event_no_db(self, pipeline: ApiRequestPipeline) -> None:
         """测试没有数据库会话时跳过审计"""
@@ -594,6 +624,8 @@ class TestPipelineAdminAuth:
     async def test_authenticate_admin_success(self, pipeline: ApiRequestPipeline) -> None:
         """测试管理员认证成功"""
         created_at = datetime.now(timezone.utc)
+        mock_session = MagicMock()
+        mock_session.id = "session-123"
 
         mock_user = MagicMock()
         mock_user.id = "admin-123"
@@ -604,7 +636,10 @@ class TestPipelineAdminAuth:
         mock_user.created_at = created_at
 
         mock_request = MagicMock()
-        mock_request.headers = {"authorization": "Bearer valid-token"}
+        mock_request.headers = {
+            "authorization": "Bearer valid-token",
+            "X-Client-Device-Id": "device-admin-123",
+        }
         mock_request.state = MagicMock()
 
         mock_db = MagicMock()
@@ -614,18 +649,32 @@ class TestPipelineAdminAuth:
             pipeline.auth_service,
             "verify_token",
             new_callable=AsyncMock,
-            return_value={"user_id": "admin-123", "created_at": created_at.isoformat()},
+            return_value={
+                "user_id": "admin-123",
+                "created_at": created_at.isoformat(),
+                "session_id": "session-123",
+            },
+        ), patch(
+            "src.api.base.pipeline.SessionService.get_active_session",
+            return_value=mock_session,
+        ), patch(
+            "src.api.base.pipeline.SessionService.touch_session"
+        ), patch(
+            "src.api.base.pipeline.SessionService.assert_session_device_matches"
         ):
             user, management_token = await pipeline._authenticate_admin(mock_request, mock_db)
 
         assert user == mock_user
         assert management_token is None
         assert mock_request.state.user_id == "admin-123"
+        assert mock_request.state.user_session_id == "session-123"
 
     @pytest.mark.asyncio
     async def test_authenticate_admin_lowercase_bearer(self, pipeline: ApiRequestPipeline) -> None:
         """测试 bearer (小写) 前缀也能正确解析"""
         created_at = datetime.now(timezone.utc)
+        mock_session = MagicMock()
+        mock_session.id = "session-123"
 
         mock_user = MagicMock()
         mock_user.id = "admin-123"
@@ -636,7 +685,10 @@ class TestPipelineAdminAuth:
         mock_user.created_at = created_at
 
         mock_request = MagicMock()
-        mock_request.headers = {"authorization": "bearer valid-token"}
+        mock_request.headers = {
+            "authorization": "bearer valid-token",
+            "X-Client-Device-Id": "device-admin-123",
+        }
         mock_request.state = MagicMock()
 
         mock_db = MagicMock()
@@ -646,13 +698,61 @@ class TestPipelineAdminAuth:
             pipeline.auth_service,
             "verify_token",
             new_callable=AsyncMock,
-            return_value={"user_id": "admin-123", "created_at": created_at.isoformat()},
-        ) as mock_verify:
+            return_value={
+                "user_id": "admin-123",
+                "created_at": created_at.isoformat(),
+                "session_id": "session-123",
+            },
+        ) as mock_verify, patch(
+            "src.api.base.pipeline.SessionService.get_active_session",
+            return_value=mock_session,
+        ), patch(
+            "src.api.base.pipeline.SessionService.touch_session"
+        ), patch(
+            "src.api.base.pipeline.SessionService.assert_session_device_matches"
+        ):
             user, management_token = await pipeline._authenticate_admin(mock_request, mock_db)
 
         mock_verify.assert_awaited_once_with("valid-token", token_type="access")
         assert user == mock_user
         assert management_token is None
+
+    @pytest.mark.asyncio
+    async def test_authenticate_admin_rejects_legacy_token_without_session_id(
+        self, pipeline: ApiRequestPipeline
+    ) -> None:
+        created_at = datetime.now(timezone.utc)
+
+        mock_request = MagicMock()
+        mock_request.headers = {
+            "authorization": "Bearer valid-token",
+            "X-Client-Device-Id": "device-admin-legacy",
+        }
+        mock_request.state = MagicMock()
+
+        mock_user = MagicMock()
+        mock_user.id = "admin-123"
+        mock_user.is_active = True
+        mock_user.is_deleted = False
+        mock_user.role = UserRole.ADMIN
+        mock_user.email = "admin@example.com"
+        mock_user.created_at = created_at
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        with patch.object(
+            pipeline.auth_service,
+            "verify_token",
+            new_callable=AsyncMock,
+            return_value={"user_id": "admin-123", "created_at": created_at.isoformat()},
+        ), patch.object(
+            pipeline.auth_service,
+            "token_identity_matches_user",
+            return_value=True,
+        ):
+            with pytest.raises(HTTPException, match="登录会话已失效，请重新登录"):
+                await pipeline._authenticate_admin(mock_request, mock_db)
 
 
 class TestPipelineUserAuth:
@@ -666,6 +766,8 @@ class TestPipelineUserAuth:
     async def test_authenticate_user_lowercase_bearer(self, pipeline: ApiRequestPipeline) -> None:
         """测试 bearer (小写) 前缀也能正确解析"""
         created_at = datetime.now(timezone.utc)
+        mock_session = MagicMock()
+        mock_session.id = "session-456"
 
         mock_user = MagicMock()
         mock_user.id = "user-123"
@@ -675,7 +777,10 @@ class TestPipelineUserAuth:
         mock_user.created_at = created_at
 
         mock_request = MagicMock()
-        mock_request.headers = {"authorization": "bearer valid-token"}
+        mock_request.headers = {
+            "authorization": "bearer valid-token",
+            "X-Client-Device-Id": "device-user-456",
+        }
         mock_request.state = MagicMock()
 
         mock_db = MagicMock()
@@ -685,10 +790,98 @@ class TestPipelineUserAuth:
             pipeline.auth_service,
             "verify_token",
             new_callable=AsyncMock,
-            return_value={"user_id": "user-123", "created_at": created_at.isoformat()},
-        ) as mock_verify:
+            return_value={
+                "user_id": "user-123",
+                "created_at": created_at.isoformat(),
+                "session_id": "session-456",
+            },
+        ) as mock_verify, patch(
+            "src.api.base.pipeline.SessionService.get_active_session",
+            return_value=mock_session,
+        ), patch(
+            "src.api.base.pipeline.SessionService.touch_session"
+        ), patch(
+            "src.api.base.pipeline.SessionService.assert_session_device_matches"
+        ):
             user, management_token = await pipeline._authenticate_user(mock_request, mock_db)
 
         mock_verify.assert_awaited_once_with("valid-token", token_type="access")
         assert user == mock_user
         assert management_token is None
+        assert mock_request.state.user_session_id == "session-456"
+
+    @pytest.mark.asyncio
+    async def test_authenticate_user_rejects_legacy_token_without_session_id(
+        self, pipeline: ApiRequestPipeline
+    ) -> None:
+        """历史 JWT 无 session_id 时应拒绝。"""
+        created_at = datetime.now(timezone.utc)
+
+        mock_request = MagicMock()
+        mock_request.headers = {
+            "authorization": "Bearer valid-token",
+            "X-Client-Device-Id": "device-user-legacy",
+        }
+        mock_request.state = MagicMock()
+
+        mock_user = MagicMock()
+        mock_user.id = "user-123"
+        mock_user.is_active = True
+        mock_user.is_deleted = False
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        with patch.object(
+            pipeline.auth_service,
+            "verify_token",
+            new_callable=AsyncMock,
+            return_value={"user_id": "user-123", "created_at": created_at.isoformat()},
+        ), patch.object(
+            pipeline.auth_service,
+            "token_identity_matches_user",
+            return_value=True,
+        ):
+            with pytest.raises(HTTPException, match="登录会话已失效，请重新登录"):
+                await pipeline._authenticate_user(mock_request, mock_db)
+
+    @pytest.mark.asyncio
+    async def test_authenticate_user_requires_device_id(self, pipeline: ApiRequestPipeline) -> None:
+        created_at = datetime.now(timezone.utc)
+
+        mock_request = MagicMock()
+        mock_request.headers = {"authorization": "Bearer valid-token"}
+        mock_request.query_params = {}
+        mock_request.state = MagicMock()
+
+        mock_user = MagicMock()
+        mock_user.id = "user-123"
+        mock_user.is_active = True
+        mock_user.is_deleted = False
+        mock_user.created_at = created_at
+
+        mock_session = MagicMock()
+        mock_session.id = "session-456"
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        with patch.object(
+            pipeline.auth_service,
+            "verify_token",
+            new_callable=AsyncMock,
+            return_value={
+                "user_id": "user-123",
+                "created_at": created_at.isoformat(),
+                "session_id": "session-456",
+            },
+        ), patch(
+            "src.api.base.pipeline.SessionService.get_active_session",
+            return_value=mock_session,
+        ), patch.object(
+            pipeline.auth_service,
+            "token_identity_matches_user",
+            return_value=True,
+        ):
+            with pytest.raises(HTTPException, match="缺少或无效的设备标识"):
+                await pipeline._authenticate_user(mock_request, mock_db)

--- a/tests/services/test_auth.py
+++ b/tests/services/test_auth.py
@@ -268,10 +268,10 @@ class TestUserAuthentication:
         assert isinstance(result, AuthenticatedUserSnapshot)
         assert result.user_id == "user-123"
         assert result.username == "tester"
-        thread_db.commit.assert_called_once()
+        thread_db.commit.assert_not_called()
         thread_db.close.assert_called_once()
         route_db.commit.assert_not_called()
-        invalidate_cache.assert_awaited_once_with("user-123", "test@example.com")
+        invalidate_cache.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_load_user_for_pipeline_threadsafe_prefetches_balance(self) -> None:

--- a/tests/services/test_oauth_service.py
+++ b/tests/services/test_oauth_service.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from src.core.enums import AuthSource
+from src.services.auth.oauth.service import OAuthService
+from src.services.auth.oauth.state import OAuthStateData
+
+
+@pytest.mark.asyncio
+async def test_build_bind_authorize_url_includes_client_device_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = MagicMock()
+    user = SimpleNamespace(id="user-1", auth_source=AuthSource.LOCAL)
+    provider = SimpleNamespace(
+        get_authorization_url=MagicMock(return_value="https://provider.example/authorize")
+    )
+    config = SimpleNamespace()
+    create_state = AsyncMock(return_value="state-1")
+
+    monkeypatch.setattr(
+        "src.services.auth.oauth.service.OAuthService._require_module_active",
+        lambda _db: None,
+    )
+    monkeypatch.setattr(
+        "src.services.auth.oauth.service.OAuthService._get_provider_impl",
+        lambda _provider_type: provider,
+    )
+    monkeypatch.setattr(
+        "src.services.auth.oauth.service.OAuthService._get_enabled_provider_config",
+        lambda _db, _provider_type: config,
+    )
+    monkeypatch.setattr(
+        "src.services.auth.oauth.service.get_redis_client",
+        AsyncMock(return_value=object()),
+    )
+    monkeypatch.setattr(
+        "src.services.auth.oauth.service.create_oauth_state",
+        create_state,
+    )
+
+    url = await OAuthService.build_bind_authorize_url(
+        db,
+        user,
+        "github",
+        client_device_id="device-1",
+    )
+
+    assert url == "https://provider.example/authorize"
+    assert create_state.await_args.kwargs["client_device_id"] == "device-1"
+
+
+@pytest.mark.asyncio
+async def test_handle_callback_allows_bind_state_without_device_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db = MagicMock()
+    provider = SimpleNamespace(
+        exchange_code=AsyncMock(return_value=SimpleNamespace(access_token="provider-access")),
+        get_user_info=AsyncMock(
+            return_value=SimpleNamespace(
+                id="oauth-user",
+                username="tester",
+                email="user@example.com",
+                email_verified=True,
+                raw={},
+            )
+        ),
+    )
+    config = SimpleNamespace(
+        frontend_callback_url="https://app.example.com/auth/callback",
+        display_name="GitHub",
+        is_enabled=True,
+    )
+
+    monkeypatch.setattr(
+        "src.services.auth.oauth.service.OAuthService._require_module_active",
+        lambda _db: None,
+    )
+    monkeypatch.setattr(
+        "src.services.auth.oauth.service.OAuthService._get_provider_impl",
+        lambda _provider_type: provider,
+    )
+    monkeypatch.setattr(
+        "src.services.auth.oauth.service.OAuthService._get_provider_config",
+        lambda _db, _provider_type: config,
+    )
+    monkeypatch.setattr(
+        "src.services.auth.oauth.service.get_redis_client",
+        AsyncMock(return_value=object()),
+    )
+    monkeypatch.setattr(
+        "src.services.auth.oauth.service.consume_oauth_state",
+        AsyncMock(
+            return_value=OAuthStateData(
+                nonce="state-1",
+                provider_type="github",
+                action="bind",
+                user_id="user-1",
+                client_device_id=None,
+                created_at=123,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "src.services.auth.oauth.service.OAuthService._handle_bind",
+        AsyncMock(return_value=SimpleNamespace()),
+    )
+
+    result = await OAuthService.handle_callback(
+        db=db,
+        provider_type="github",
+        state="state-1",
+        code="code-1",
+        error=None,
+        error_description=None,
+        client_ip=None,
+        user_agent="pytest-agent",
+        headers={},
+    )
+
+    parsed = urlparse(result.redirect_url)
+    assert result.refresh_token is None
+    assert parse_qs(parsed.query)["oauth_bound"] == ["GitHub"]

--- a/tests/unit/test_auth_login_adapter.py
+++ b/tests/unit/test_auth_login_adapter.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.auth.routes import AuthLoginAdapter
+from src.services.auth.service import AuthenticatedUserSnapshot
+from src.core.enums import UserRole
+
+
+def _build_login_context(db: MagicMock) -> SimpleNamespace:
+    return SimpleNamespace(
+        db=db,
+        request=SimpleNamespace(state=SimpleNamespace(), headers={}),
+        ensure_json_body=lambda: {
+            "email": "user@example.com",
+            "password": "password123",
+            "auth_type": "local",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_login_adapter_commits_login_success_metadata_with_session() -> None:
+    adapter = AuthLoginAdapter()
+    db = MagicMock()
+    db_user = SimpleNamespace(id="user-1", email="user@example.com", last_login_at=None)
+    db.query.return_value.filter.return_value.first.return_value = db_user
+    context = _build_login_context(db)
+    snapshot = AuthenticatedUserSnapshot(
+        user_id="user-1",
+        email="user@example.com",
+        username="tester",
+        role=UserRole.USER,
+        created_at=datetime.now(timezone.utc),
+    )
+
+    with patch(
+        "src.api.auth.routes.IPRateLimiter.check_limit",
+        new=AsyncMock(return_value=(True, 19, 0)),
+    ), patch(
+        "src.api.auth.routes.AuthService.authenticate_user_threadsafe",
+        new=AsyncMock(return_value=snapshot),
+    ), patch(
+        "src.api.auth.routes.get_client_ip",
+        return_value="127.0.0.1",
+    ), patch(
+        "src.api.auth.routes.get_user_agent",
+        return_value="pytest-agent",
+    ), patch(
+        "src.api.auth.routes.AuditService.log_login_attempt",
+    ) as mock_log, patch(
+        "src.api.auth.routes.UserCacheService.invalidate_user_cache",
+        new=AsyncMock(),
+    ) as mock_invalidate:
+
+        def _issue_tokens(**_kwargs: object) -> tuple[str, str, str]:
+            assert mock_log.call_count == 0
+            return ("session-1", "access-1", "refresh-1")
+
+        with patch(
+            "src.api.auth.routes._issue_session_bound_tokens",
+            side_effect=_issue_tokens,
+        ):
+            result = await adapter.handle(context)
+
+    assert result["access_token"] == "access-1"
+    assert result["_refresh_token"] == "refresh-1"
+    assert db_user.last_login_at is not None
+    db.commit.assert_called_once()
+    assert context.request.state.tx_committed_by_route is True
+    mock_log.assert_called_once_with(
+        db=db,
+        email="user@example.com",
+        success=True,
+        ip_address="127.0.0.1",
+        user_agent="pytest-agent",
+        user_id="user-1",
+    )
+    mock_invalidate.assert_awaited_once_with("user-1", "user@example.com")
+
+
+@pytest.mark.asyncio
+async def test_auth_login_adapter_skips_success_audit_when_session_creation_fails() -> None:
+    adapter = AuthLoginAdapter()
+    db = MagicMock()
+    db_user = SimpleNamespace(id="user-1", email="user@example.com", last_login_at=None)
+    db.query.return_value.filter.return_value.first.return_value = db_user
+    context = _build_login_context(db)
+    snapshot = AuthenticatedUserSnapshot(
+        user_id="user-1",
+        email="user@example.com",
+        username="tester",
+        role=UserRole.USER,
+        created_at=datetime.now(timezone.utc),
+    )
+
+    with patch(
+        "src.api.auth.routes.IPRateLimiter.check_limit",
+        new=AsyncMock(return_value=(True, 19, 0)),
+    ), patch(
+        "src.api.auth.routes.AuthService.authenticate_user_threadsafe",
+        new=AsyncMock(return_value=snapshot),
+    ), patch(
+        "src.api.auth.routes.get_client_ip",
+        return_value="127.0.0.1",
+    ), patch(
+        "src.api.auth.routes.get_user_agent",
+        return_value="pytest-agent",
+    ), patch(
+        "src.api.auth.routes.AuditService.log_login_attempt",
+    ) as mock_log, patch(
+        "src.api.auth.routes.UserCacheService.invalidate_user_cache",
+        new=AsyncMock(),
+    ) as mock_invalidate, patch(
+        "src.api.auth.routes._issue_session_bound_tokens",
+        side_effect=HTTPException(status_code=400, detail="缺少或无效的设备标识"),
+    ):
+        with pytest.raises(HTTPException, match="缺少或无效的设备标识"):
+            await adapter.handle(context)
+
+    db.commit.assert_not_called()
+    mock_log.assert_not_called()
+    mock_invalidate.assert_not_awaited()
+    assert not hasattr(context.request.state, "tx_committed_by_route")

--- a/tests/unit/test_auth_refresh_adapter.py
+++ b/tests/unit/test_auth_refresh_adapter.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.api.auth.routes import AuthRefreshAdapter
+from src.config import config
+
+
+@pytest.mark.asyncio
+async def test_auth_refresh_adapter_skips_rotation_for_grace_window_token() -> None:
+    adapter = AuthRefreshAdapter()
+    created_at = datetime.now(timezone.utc)
+    user = SimpleNamespace(
+        id="user-1",
+        role=SimpleNamespace(value="user"),
+        created_at=created_at,
+        is_active=True,
+        is_deleted=False,
+    )
+    session = SimpleNamespace(id="session-1", client_device_id="device-1")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = user
+    request = SimpleNamespace(
+        headers={"content-length": "0", "user-agent": "pytest"},
+        cookies={config.auth_refresh_cookie_name: "refresh-old"},
+        query_params={},
+        state=SimpleNamespace(),
+    )
+    context = SimpleNamespace(db=db, request=request)
+
+    with patch(
+        "src.api.auth.routes.AuthService.verify_token",
+        new=AsyncMock(
+            return_value={
+                "user_id": "user-1",
+                "session_id": "session-1",
+                "created_at": created_at.isoformat(),
+            }
+        ),
+    ), patch(
+        "src.api.auth.routes.AuthService.token_identity_matches_user",
+        return_value=True,
+    ), patch(
+        "src.api.auth.routes.SessionService.extract_client_device_id",
+        return_value="device-1",
+    ), patch(
+        "src.api.auth.routes.SessionService.validate_refresh_session",
+        return_value=(session, True),
+    ), patch(
+        "src.api.auth.routes.SessionService.assert_session_device_matches"
+    ), patch(
+        "src.api.auth.routes.AuthService.create_access_token",
+        return_value="access-new",
+    ), patch(
+        "src.api.auth.routes.AuthService.create_refresh_token"
+    ) as mock_create_refresh, patch(
+        "src.api.auth.routes.SessionService.rotate_refresh_token"
+    ) as mock_rotate, patch(
+        "src.api.auth.routes.get_client_ip",
+        return_value="127.0.0.1",
+    ), patch(
+        "src.api.auth.routes.get_user_agent",
+        return_value="pytest-agent",
+    ):
+        result = await adapter.handle(context)
+
+    assert result == {
+        "access_token": "access-new",
+        "token_type": "bearer",
+        "expires_in": 86400,
+    }
+    mock_create_refresh.assert_not_called()
+    mock_rotate.assert_not_called()
+    db.commit.assert_called_once()
+    assert context.request.state.tx_committed_by_route is True

--- a/tests/unit/test_config_auth_cookies.py
+++ b/tests/unit/test_config_auth_cookies.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+from src.config.settings import Config
+
+
+def test_production_defaults_refresh_cookie_to_cross_site(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("AUTH_REFRESH_COOKIE_SAMESITE", raising=False)
+    monkeypatch.delenv("AUTH_REFRESH_COOKIE_SECURE", raising=False)
+
+    cfg = Config()
+
+    assert cfg.auth_refresh_cookie_samesite == "none"
+    assert cfg.auth_refresh_cookie_secure is True
+
+
+def test_validate_security_config_rejects_insecure_none_cookie(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("AUTH_REFRESH_COOKIE_SAMESITE", "none")
+    monkeypatch.setenv("AUTH_REFRESH_COOKIE_SECURE", "false")
+
+    cfg = Config()
+
+    assert (
+        "AUTH_REFRESH_COOKIE_SECURE must be true when AUTH_REFRESH_COOKIE_SAMESITE=none."
+        in cfg.validate_security_config()
+    )
+
+
+def test_validate_security_config_rejects_invalid_refresh_cookie_samesite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AUTH_REFRESH_COOKIE_SAMESITE", "invalid-value")
+
+    cfg = Config()
+
+    assert "AUTH_REFRESH_COOKIE_SAMESITE must be one of: lax, strict, none." in (
+        cfg.validate_security_config()
+    )

--- a/tests/unit/test_password_policy.py
+++ b/tests/unit/test_password_policy.py
@@ -1,6 +1,8 @@
 import pytest
+from pydantic import ValidationError
 
 from src.core.validators import PasswordPolicyLevel, PasswordValidator
+from src.models.api import LoginRequest
 
 
 class TestPasswordPolicy:
@@ -52,3 +54,28 @@ class TestPasswordPolicy:
 
         assert valid is True
         assert error is None
+
+    def test_rejects_password_longer_than_72_bytes(self) -> None:
+        valid, error = PasswordValidator.validate("a" * 80)
+
+        assert valid is False
+        assert error == "密码长度不能超过72字节"
+
+    def test_rejects_multibyte_password_longer_than_72_bytes(self) -> None:
+        valid, error = PasswordValidator.validate("中" * 25)
+
+        assert valid is False
+        assert error == "密码长度不能超过72字节"
+
+    def test_login_request_preserves_leading_and_trailing_spaces(self) -> None:
+        request = LoginRequest.model_validate(
+            {"email": "tester", "password": "  pass word  ", "auth_type": "local"}
+        )
+
+        assert request.password == "  pass word  "
+
+    def test_login_request_rejects_password_longer_than_72_bytes(self) -> None:
+        with pytest.raises(ValidationError, match="密码长度不能超过72字节"):
+            LoginRequest.model_validate(
+                {"email": "tester", "password": "a" * 80, "auth_type": "local"}
+            )

--- a/tests/unit/test_session_service.py
+++ b/tests/unit/test_session_service.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from src.core.enums import AuthSource, UserRole
+from src.models.database import Base, User, UserSession
+from src.services.auth.session_service import (
+    MAX_SESSIONS_PER_USER,
+    SessionClientContext,
+    SessionService,
+    TERMINAL_SESSION_RETENTION_DAYS,
+    _DEVICE_ID_PATTERN,
+)
+
+
+def _make_session(
+    *,
+    token: str = "refresh-token-value",
+    expires_delta: timedelta | None = None,
+    revoked: bool = False,
+) -> UserSession:
+    expires_at = datetime.now(timezone.utc) + (expires_delta or timedelta(days=7))
+    session = UserSession(
+        user_id="user-1",
+        client_device_id="device-1",
+        refresh_token_hash="",
+        expires_at=expires_at,
+    )
+    session.set_refresh_token(token)
+    if revoked:
+        session.revoked_at = datetime.now(timezone.utc)
+    return session
+
+
+def _make_db_session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=[User.__table__, UserSession.__table__])
+    session_factory = sessionmaker(bind=engine)
+    return session_factory()
+
+
+def _make_user(db: Session, *, user_id: str = "user-1") -> User:
+    user = User(
+        id=user_id,
+        email=f"{user_id}@example.com",
+        email_verified=True,
+        username=user_id,
+        role=UserRole.USER,
+        auth_source=AuthSource.LOCAL,
+        is_active=True,
+        is_deleted=False,
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+def _make_client_context(device_id: str) -> SessionClientContext:
+    return SessionClientContext(
+        client_device_id=device_id,
+        device_label=f"Device {device_id}",
+        device_type="desktop",
+        browser_name="Chrome",
+        browser_version="136.0",
+        os_name="macOS",
+        os_version="15",
+        device_model=None,
+        client_hints={},
+        ip_address="127.0.0.1",
+        user_agent="pytest-agent",
+    )
+
+
+def test_build_client_context_prefers_client_hints() -> None:
+    context = SessionService.build_client_context(
+        client_device_id="device-1",
+        client_ip="127.0.0.1",
+        user_agent=(
+            "Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/134.0.0.0 Mobile Safari/537.36"
+        ),
+        headers={
+            "sec-ch-ua-platform": '"Android"',
+            "sec-ch-ua-platform-version": '"15.0.0"',
+            "sec-ch-ua-model": '"Pixel 9"',
+            "sec-ch-ua-mobile": "?1",
+        },
+    )
+
+    assert context.client_device_id == "device-1"
+    assert context.device_type == "mobile"
+    assert context.os_name == "Android"
+    assert context.os_version == "15.0.0"
+    assert context.device_model == "Pixel 9"
+    assert context.device_label == "Pixel 9"
+
+
+# ── Refresh token hash roundtrip ──
+
+
+def test_user_session_refresh_token_hash_roundtrip() -> None:
+    session = _make_session(token="refresh-token-value")
+
+    is_valid, is_prev = session.verify_refresh_token("refresh-token-value")
+    assert is_valid is True
+    assert is_prev is False
+
+    is_valid, is_prev = session.verify_refresh_token("different-token")
+    assert is_valid is False
+    assert is_prev is False
+
+
+def test_verify_refresh_token_grace_window() -> None:
+    """轮换后短时间内旧 token 仍应通过验证（grace window）。"""
+    session = _make_session(token="old-token")
+    # 模拟轮换
+    session.set_refresh_token("new-token")
+
+    # 新 token 正常通过
+    is_valid, is_prev = session.verify_refresh_token("new-token")
+    assert is_valid is True
+    assert is_prev is False
+
+    # 旧 token 在宽限窗口内通过
+    is_valid, is_prev = session.verify_refresh_token("old-token")
+    assert is_valid is True
+    assert is_prev is True
+
+    # 完全无关的 token 不通过
+    is_valid, is_prev = session.verify_refresh_token("random-token")
+    assert is_valid is False
+    assert is_prev is False
+
+
+def test_verify_refresh_token_grace_window_expired() -> None:
+    """宽限窗口超时后，旧 token 不再通过。"""
+    session = _make_session(token="old-token")
+    session.set_refresh_token("new-token")
+    # 手动把 rotated_at 设为 30 秒前，超过 REFRESH_GRACE_SECONDS
+    session.rotated_at = datetime.now(timezone.utc) - timedelta(seconds=30)
+
+    is_valid, is_prev = session.verify_refresh_token("old-token")
+    assert is_valid is False
+    assert is_prev is False
+
+
+# ── Session expiry ──
+
+
+def test_user_session_expired_property_handles_aware_datetime() -> None:
+    session = _make_session(expires_delta=timedelta(minutes=-1))
+    assert session.is_expired is True
+
+
+def test_user_session_not_expired() -> None:
+    session = _make_session(expires_delta=timedelta(days=7))
+    assert session.is_expired is False
+
+
+def test_user_session_revoked_property() -> None:
+    session = _make_session(revoked=True)
+    assert session.is_revoked is True
+
+    session2 = _make_session(revoked=False)
+    assert session2.is_revoked is False
+
+
+# ── Device ID validation ──
+
+
+def test_device_id_pattern_accepts_valid_ids() -> None:
+    assert _DEVICE_ID_PATTERN.match("abc-123_DEF")
+    assert _DEVICE_ID_PATTERN.match("a" * 128)
+    assert _DEVICE_ID_PATTERN.match("simple-uuid-v4-like-id")
+
+
+def test_device_id_pattern_rejects_invalid_ids() -> None:
+    assert not _DEVICE_ID_PATTERN.match("")
+    assert not _DEVICE_ID_PATTERN.match("a" * 129)
+    assert not _DEVICE_ID_PATTERN.match("has spaces")
+    assert not _DEVICE_ID_PATTERN.match("has<script>xss</script>")
+    assert not _DEVICE_ID_PATTERN.match("日本語")
+
+
+def test_normalize_device_id_strips_and_validates() -> None:
+    assert SessionService._normalize_device_id("  valid-id  ") == "valid-id"
+    assert SessionService._normalize_device_id("a" * 200) is not None  # truncated to 128
+    assert SessionService._normalize_device_id("<script>") is None
+    assert SessionService._normalize_device_id("   ") is None
+
+
+def test_extract_client_device_id_requires_valid_value() -> None:
+    request = SimpleNamespace(headers={}, query_params={})
+
+    with pytest.raises(HTTPException, match="缺少或无效的设备标识"):
+        SessionService.extract_client_device_id(request)  # type: ignore[arg-type]
+
+
+def test_assert_session_device_matches_rejects_mismatch() -> None:
+    session = _make_session()
+    session.client_device_id = "device-expected"
+
+    with pytest.raises(HTTPException, match="设备标识与登录会话不匹配"):
+        SessionService.assert_session_device_matches(session, "device-actual")
+
+
+# ── set_refresh_token preserves previous hash ──
+
+
+def test_set_refresh_token_stores_previous_hash() -> None:
+    session = _make_session(token="token-1")
+    original_hash = session.refresh_token_hash
+    assert session.prev_refresh_token_hash is None or session.prev_refresh_token_hash == ""
+
+    session.set_refresh_token("token-2")
+    assert session.prev_refresh_token_hash == original_hash
+    assert session.rotated_at is not None
+    assert session.refresh_token_hash != original_hash
+
+
+def test_get_session_for_user_can_lock_for_update() -> None:
+    expected = object()
+
+    class DummyQuery:
+        def __init__(self) -> None:
+            self.locked = False
+
+        def filter(self, *_args: object, **_kwargs: object) -> "DummyQuery":
+            return self
+
+        def with_for_update(self) -> "DummyQuery":
+            self.locked = True
+            return self
+
+        def first(self) -> object:
+            return expected
+
+    query = DummyQuery()
+    db = SimpleNamespace(query=lambda _model: query)
+
+    result = SessionService.get_session_for_user(
+        db,  # type: ignore[arg-type]
+        user_id="user-1",
+        session_id="session-1",
+        lock_for_update=True,
+    )
+
+    assert result is expected
+    assert query.locked is True
+
+
+def test_create_session_session_limit_ignores_expired_sessions() -> None:
+    db = _make_db_session()
+    try:
+        user = _make_user(db)
+        now = datetime.now(timezone.utc)
+        for idx in range(MAX_SESSIONS_PER_USER - 1):
+            session = UserSession(
+                id=f"active-{idx}",
+                user_id=user.id,
+                client_device_id=f"active-device-{idx}",
+                refresh_token_hash="",
+                expires_at=now + timedelta(days=7),
+                last_seen_at=now + timedelta(minutes=idx),
+            )
+            session.set_refresh_token(f"active-token-{idx}")
+            db.add(session)
+
+        expired = UserSession(
+            id="expired-1",
+            user_id=user.id,
+            client_device_id="expired-device",
+            refresh_token_hash="",
+            expires_at=now - timedelta(minutes=5),
+            last_seen_at=now - timedelta(days=1),
+        )
+        expired.set_refresh_token("expired-token")
+        db.add(expired)
+        db.commit()
+
+        created = SessionService.create_session(
+            db,
+            user=user,
+            session_id="new-session",
+            refresh_token="new-refresh-token",
+            expires_at=now + timedelta(days=7),
+            client=_make_client_context("new-device"),
+        )
+        db.commit()
+
+        assert created.id == "new-session"
+        active_sessions = SessionService.list_user_sessions(db, user_id=user.id)
+        assert len(active_sessions) == MAX_SESSIONS_PER_USER
+        assert all(session.revoke_reason != "session_limit_exceeded" for session in active_sessions)
+    finally:
+        db.close()
+
+
+def test_revoke_all_user_sessions_skips_expired_sessions() -> None:
+    db = _make_db_session()
+    try:
+        user = _make_user(db)
+        now = datetime.now(timezone.utc)
+
+        active = UserSession(
+            id="active-1",
+            user_id=user.id,
+            client_device_id="active-device",
+            refresh_token_hash="",
+            expires_at=now + timedelta(days=7),
+            last_seen_at=now,
+        )
+        active.set_refresh_token("active-token")
+        expired = UserSession(
+            id="expired-1",
+            user_id=user.id,
+            client_device_id="expired-device",
+            refresh_token_hash="",
+            expires_at=now - timedelta(minutes=1),
+            last_seen_at=now - timedelta(days=1),
+        )
+        expired.set_refresh_token("expired-token")
+        db.add_all([active, expired])
+        db.commit()
+
+        revoked_count = SessionService.revoke_all_user_sessions(
+            db,
+            user_id=user.id,
+            reason="security_review",
+        )
+
+        db.flush()
+        db.refresh(active)
+        db.refresh(expired)
+
+        assert revoked_count == 1
+        assert active.revoked_at is not None
+        assert expired.revoked_at is None
+    finally:
+        db.close()
+
+
+def test_list_user_sessions_prunes_old_terminal_sessions() -> None:
+    db = _make_db_session()
+    try:
+        user = _make_user(db)
+        now = datetime.now(timezone.utc)
+
+        active = UserSession(
+            id="active-1",
+            user_id=user.id,
+            client_device_id="active-device",
+            refresh_token_hash="",
+            expires_at=now + timedelta(days=7),
+            last_seen_at=now,
+        )
+        active.set_refresh_token("active-token")
+
+        old_expired = UserSession(
+            id="expired-old",
+            user_id=user.id,
+            client_device_id="expired-old-device",
+            refresh_token_hash="",
+            expires_at=now - timedelta(days=TERMINAL_SESSION_RETENTION_DAYS + 5),
+            last_seen_at=now - timedelta(days=40),
+        )
+        old_expired.set_refresh_token("expired-old-token")
+
+        old_revoked = UserSession(
+            id="revoked-old",
+            user_id=user.id,
+            client_device_id="revoked-old-device",
+            refresh_token_hash="",
+            expires_at=now + timedelta(days=7),
+            last_seen_at=now - timedelta(days=35),
+        )
+        old_revoked.set_refresh_token("revoked-old-token")
+        old_revoked.revoked_at = now - timedelta(days=TERMINAL_SESSION_RETENTION_DAYS + 1)
+        old_revoked.revoke_reason = "manual_revoke"
+
+        recent_expired = UserSession(
+            id="expired-recent",
+            user_id=user.id,
+            client_device_id="expired-recent-device",
+            refresh_token_hash="",
+            expires_at=now - timedelta(days=1),
+            last_seen_at=now - timedelta(days=2),
+        )
+        recent_expired.set_refresh_token("expired-recent-token")
+
+        db.add_all([active, old_expired, old_revoked, recent_expired])
+        db.commit()
+
+        sessions = SessionService.list_user_sessions(db, user_id=user.id)
+        remaining_ids = {session.id for session in db.query(UserSession).all()}
+
+        assert [session.id for session in sessions] == ["active-1"]
+        assert "expired-old" not in remaining_ids
+        assert "revoked-old" not in remaining_ids
+        assert "expired-recent" in remaining_ids
+    finally:
+        db.close()

--- a/tests/unit/test_user_me_password.py
+++ b/tests/unit/test_user_me_password.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.api.user_me.routes import _change_password_sync
+from src.core.exceptions import InvalidRequestException
+from src.core.validators import PasswordPolicyLevel
+from src.models.database import User
+
+
+def test_verify_password_returns_false_for_password_over_72_bytes() -> None:
+    user = User(email=None, email_verified=False, username="tester")
+    user.set_password("abc12345")
+
+    assert user.verify_password("a" * 80) is False
+
+
+def test_change_password_rejects_same_as_current_password(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = SimpleNamespace(
+        id="user-1",
+        email="user@example.com",
+        password_hash="hashed",
+        auth_source=SimpleNamespace(value="local"),
+        verify_password=MagicMock(side_effect=lambda password: password == "Abcd1234!"),
+        set_password=MagicMock(),
+        updated_at=None,
+    )
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = user
+
+    @contextmanager
+    def _fake_get_db_context() -> MagicMock:
+        yield db
+
+    monkeypatch.setattr("src.api.user_me.routes.get_db_context", _fake_get_db_context)
+    monkeypatch.setattr(
+        "src.api.user_me.routes.SystemConfigService.get_password_policy_level",
+        lambda _db: PasswordPolicyLevel.STRONG.value,
+    )
+
+    with pytest.raises(InvalidRequestException, match="新密码不能与当前密码相同"):
+        _change_password_sync(
+            "user-1",
+            SimpleNamespace(old_password="Abcd1234!", new_password="Abcd1234!"),
+        )
+
+    user.set_password.assert_not_called()


### PR DESCRIPTION
- 修复前端密码输入框的安全问题，恢复真实密码框行为，避免密码被当作明文输入显示
- 统一注册、登录、用户改密、管理员改密相关的密码校验逻辑
- 将密码长度限制与 `bcrypt` 的实际能力对齐，避免超长密码导致异常
- 修复登录时错误裁剪密码前后空格的问题，保证登录与存储校验一致
- 新增“新旧密码不能相同”的后端校验
- 补充前后端密码相关测试，覆盖超长密码、带空格密码和改密边界场景
- 引入设备级会话管理（UserSession），支持 refresh token 轮换、重放检测与自动吊销
- refresh token 改用 HttpOnly Cookie 存储，DB 仅保存 SHA256 哈希，常量时间比较防计时攻击
- 并发 refresh 使用 FOR UPDATE 行锁串行化，10 秒宽限窗口兼容多标签页场景
- 前端新增跨标签页 refresh 协调器（BroadcastChannel + localStorage 锁），防止 thundering herd
- 密码策略三级可配置（weak/medium/strong），bcrypt 哈希线程池隔离不阻塞事件循环
- 认证端点全面 IP 速率限制，Cookie SameSite/Secure 生产环境强制校验
- 管理员密码重置与用户自助改密均自动吊销所有会话
- 补充 session_service、auth routes、pipeline、cross-tab refresh 等单元测试