### PR TITLE
fix(stream): 提前检测 CLI 流空闲超时并默认 30 秒失败

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,11 @@ ADMIN_PASSWORD=admin123456
 #   - 需要更多调试上下文：4
 # RESPONSE_CHUNKS_MAX_SIZE_MB=2
 
+# 流式空闲超时（单位秒，默认 30）
+# 当流已经开始但连续一段时间没有任何新 chunk 时，提前中断并返回 504，
+# 避免一直等到 worker 超时（如 300s）
+# STREAM_IDLE_TIMEOUT_SECONDS=30
+
 # API Key 前缀（默认 sk）
 # API_KEY_PREFIX=sk
 

--- a/src/api/handlers/base/cli_monitor_mixin.py
+++ b/src/api/handlers/base/cli_monitor_mixin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
@@ -29,12 +30,23 @@ if TYPE_CHECKING:
     from src.api.handlers.base.cli_protocol import CliHandlerProtocol
 
 
+def _read_stream_idle_timeout_seconds() -> float:
+    raw_value = os.getenv("STREAM_IDLE_TIMEOUT_SECONDS", "30")
+    try:
+        parsed = float(raw_value)
+    except (TypeError, ValueError):
+        return 30.0
+    return parsed if parsed > 0 else 30.0
+
+
 class CliMonitorMixin:
     """监控和统计相关方法的 Mixin"""
 
     # CancelledError 归因时，断连检查参数（秒）
     CANCEL_DISCONNECT_CHECK_TIMEOUT_SECONDS = 0.5
     CANCEL_DISCONNECT_RETRY_DELAYS_SECONDS = (0.1, 0.2)
+    # 流式传输过程中若长时间没有任何 chunk，提前判定为 idle timeout，避免一直等到 worker 超时
+    STREAM_IDLE_TIMEOUT_SECONDS = _read_stream_idle_timeout_seconds()
 
     async def _probe_client_disconnect(
         self,
@@ -115,8 +127,26 @@ class CliMonitorMixin:
 
         last_chunk_time = time_module.time()
         chunk_count = 0
+        idle_timeout_triggered = False
+        idle_timeout = self.STREAM_IDLE_TIMEOUT_SECONDS
+        parent_task = asyncio.current_task()
+        idle_watch_task: asyncio.Task[None] | None = None
+
+        async def watch_stream_idle_timeout() -> None:
+            nonlocal idle_timeout_triggered
+            if parent_task is None:
+                return
+            poll_interval = min(1.0, max(0.1, idle_timeout / 5))
+            while not ctx.has_completion:
+                await asyncio.sleep(poll_interval)
+                if (time_module.time() - last_chunk_time) <= idle_timeout:
+                    continue
+                idle_timeout_triggered = True
+                parent_task.cancel()
+                return
 
         try:
+            idle_watch_task = asyncio.create_task(watch_stream_idle_timeout())
             if http_request is not None:
                 # 使用后台任务检测断连，完全不阻塞流式传输
                 disconnected = False
@@ -158,12 +188,26 @@ class CliMonitorMixin:
                         await check_task
                     except asyncio.CancelledError:
                         pass
+                    if idle_watch_task is not None:
+                        idle_watch_task.cancel()
+                        try:
+                            await idle_watch_task
+                        except asyncio.CancelledError:
+                            pass
             else:
                 # 无 http_request，仅被动监控
-                async for chunk in stream_generator:
-                    last_chunk_time = time_module.time()
-                    chunk_count += 1
-                    yield chunk
+                try:
+                    async for chunk in stream_generator:
+                        last_chunk_time = time_module.time()
+                        chunk_count += 1
+                        yield chunk
+                finally:
+                    if idle_watch_task is not None:
+                        idle_watch_task.cancel()
+                        try:
+                            await idle_watch_task
+                        except asyncio.CancelledError:
+                            pass
 
         except asyncio.CancelledError:
             # 注意：CancelledError 不等于"用户手动取消"，它既可能是客户端断连触发，
@@ -172,6 +216,28 @@ class CliMonitorMixin:
             time_since_last_chunk = time_module.time() - last_chunk_time
             if not ctx.has_completion:
                 ctx.ensure_estimated_output_tokens()
+
+            if not ctx.has_completion and idle_timeout_triggered:
+                ctx.status_code = 504
+                ctx.error_message = "stream_idle_timeout"
+                cancel_origin = "stream_idle_timeout"
+                logger.warning(
+                    f"ID:{ctx.request_id} | Stream idle timeout: "
+                    f"idle_timeout={idle_timeout:.0f}s, "
+                    f"chunks={chunk_count}, "
+                    f"has_completion={ctx.has_completion}, "
+                    f"time_since_last_chunk={time_since_last_chunk:.2f}s, "
+                    f"output_tokens={ctx.output_tokens}"
+                )
+                ctx.upstream_response = (
+                    f"cancel_origin={cancel_origin}, "
+                    f"chunks={chunk_count}, "
+                    f"has_completion={ctx.has_completion}, "
+                    f"time_since_last_chunk={time_since_last_chunk:.2f}s, "
+                    f"output_tokens={ctx.output_tokens}, "
+                    f"idle_timeout={idle_timeout:.0f}s"
+                )
+                raise
 
             is_client_disconnected = False
             disconnect_check_uncertain = False

--- a/tests/api/handlers/base/test_cli_monitor_mixin.py
+++ b/tests/api/handlers/base/test_cli_monitor_mixin.py
@@ -39,6 +39,12 @@ async def _yield_once_then_cancel(ctx: StreamContext) -> AsyncGenerator[bytes, N
     raise asyncio.CancelledError()
 
 
+async def _yield_once_then_hang(ctx: StreamContext) -> AsyncGenerator[bytes, None]:
+    ctx.append_text("partial output")
+    yield b"data: chunk\n\n"
+    await asyncio.sleep(3600)
+
+
 @pytest.mark.asyncio
 async def test_create_monitored_stream_marks_client_disconnected_when_confirmed() -> None:
     monitor = _DummyMonitor()
@@ -113,3 +119,23 @@ async def test_create_monitored_stream_estimates_output_tokens_before_unknown_ca
     assert ctx.error_message == "cancelled_unknown"
     assert ctx.output_tokens == expected_output_tokens
     assert f"output_tokens={expected_output_tokens}" in (ctx.upstream_response or "")
+
+
+@pytest.mark.asyncio
+async def test_create_monitored_stream_marks_idle_timeout_before_worker_timeout() -> None:
+    monitor = _DummyMonitor()
+    monitor.CANCEL_DISCONNECT_RETRY_DELAYS_SECONDS = ()
+    monitor.STREAM_IDLE_TIMEOUT_SECONDS = 1.0
+    ctx = StreamContext(model="test-model", api_format="openai:cli", request_id="req-idle-timeout")
+
+    monitored = monitor._create_monitored_stream(ctx, _yield_once_then_hang(ctx), None)
+
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in monitored:
+            pass
+
+    expected_output_tokens = max(1, len("partial output") // 4)
+    assert ctx.status_code == 504
+    assert ctx.error_message == "stream_idle_timeout"
+    assert ctx.output_tokens == expected_output_tokens
+    assert "cancel_origin=stream_idle_timeout" in (ctx.upstream_response or "")


### PR DESCRIPTION
- 在 `CliMonitorMixin` 增加 `STREAM_IDLE_TIMEOUT_SECONDS` 配置读取，默认值设为 `30s`
- 新增流空闲 watchdog：流开始后若长时间无新 chunk，提前取消并标记 `stream_idle_timeout`（504）
- 保留现有 client/server/unknown 取消归因逻辑，并在 `upstream_response` 中补充 idle timeout 信息
- 新增单测覆盖“先有输出后卡住”场景，验证会在 worker 超时前提前失败
- 在 `.env.example` 增加 `STREAM_IDLE_TIMEOUT_SECONDS=30` 示例与说明