### PR TITLE
fix(usage): 避免 cleanup 重复改写旧日志记录

### DIFF
--- a/src/services/system/maintenance_scheduler.py
+++ b/src/services/system/maintenance_scheduler.py
@@ -975,21 +975,23 @@ class MaintenanceScheduler:
             try:
                 now = datetime.now(timezone.utc)
 
-                # 1. 压缩详细日志 (body 字段 -> 压缩字段)
                 detail_cutoff = now - timedelta(days=detail_retention)
-                body_compressed = self._cleanup_body_fields(detail_cutoff, batch_size)
-
-                # 2. 清理压缩字段
                 compressed_cutoff = now - timedelta(days=compressed_retention)
-                compressed_cleaned = self._cleanup_compressed_fields(compressed_cutoff, batch_size)
-
-                # 3. 清理请求头
                 header_cutoff = now - timedelta(days=header_retention)
-                header_cleaned = self._cleanup_header_fields(header_cutoff, batch_size)
-
-                # 4. 删除过期记录
                 log_cutoff = now - timedelta(days=log_retention)
+
+                # 先删最老的整行，再按窗口处理剩余记录，避免同一行在一轮里被重复改写。
                 records_deleted = self._delete_old_records(log_cutoff, batch_size)
+                header_cleaned = self._cleanup_header_fields(
+                    header_cutoff, batch_size, newer_than=log_cutoff
+                )
+                body_cleaned = self._cleanup_stale_body_fields(
+                    compressed_cutoff, batch_size, newer_than=log_cutoff
+                )
+                # 仅压缩 7-30 天窗口内的 body；更老记录直接清空 body，不再先压缩再清理。
+                body_compressed = self._cleanup_body_fields(
+                    detail_cutoff, batch_size, newer_than=compressed_cutoff
+                )
 
                 # 5. 清理过期的API Keys
                 keys_db = create_session()
@@ -1005,7 +1007,7 @@ class MaintenanceScheduler:
 
                 logger.info(
                     f"清理完成: 压缩 {body_compressed} 条, "
-                    f"清理压缩字段 {compressed_cleaned} 条, "
+                    f"清理body {body_cleaned} 条, "
                     f"清理header {header_cleaned} 条, "
                     f"删除记录 {records_deleted} 条, "
                     f"清理过期Keys {keys_cleaned} 条"
@@ -1016,10 +1018,16 @@ class MaintenanceScheduler:
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _do_cleanup)
 
-    def _cleanup_body_fields(self, cutoff_time: datetime, batch_size: int) -> int:
+    def _cleanup_body_fields(
+        self,
+        cutoff_time: datetime,
+        batch_size: int,
+        *,
+        newer_than: datetime | None = None,
+    ) -> int:
         """压缩 request_body 和 response_body 字段到压缩字段
 
-        逐条处理，确保每条记录都正确更新（同步方法，在线程池中调用）
+        仅处理指定时间窗口内仍保留原始 body 的记录，避免对更老记录重复写放大。
         """
         from sqlalchemy import null, update
 
@@ -1027,84 +1035,45 @@ class MaintenanceScheduler:
         no_progress_count = 0
         memory_safe_batch_size = max(1, min(batch_size, 25))
 
+        if newer_than is not None and newer_than >= cutoff_time:
+            logger.warning(
+                "压缩 body 字段跳过: 无效时间窗口 newer_than={} cutoff_time={}",
+                newer_than,
+                cutoff_time,
+            )
+            return 0
+
         while True:
             batch_db = create_session()
             try:
-                record_ids = [
-                    row.id
-                    for row in (
-                        batch_db.query(Usage.id)
-                        .filter(Usage.created_at < cutoff_time)
-                        .filter(
-                            (Usage.request_body.isnot(None))
-                            | (Usage.response_body.isnot(None))
-                            | (Usage.provider_request_body.isnot(None))
-                            | (Usage.client_response_body.isnot(None))
-                        )
-                        .order_by(Usage.created_at.asc(), Usage.id.asc())
-                        .limit(memory_safe_batch_size)
-                        .all()
+                query = batch_db.query(
+                    Usage.id,
+                    Usage.request_body,
+                    Usage.response_body,
+                    Usage.provider_request_body,
+                    Usage.client_response_body,
+                ).filter(Usage.created_at < cutoff_time)
+                if newer_than is not None:
+                    query = query.filter(Usage.created_at >= newer_than)
+                records = (
+                    query.filter(
+                        (Usage.request_body.isnot(None))
+                        | (Usage.response_body.isnot(None))
+                        | (Usage.provider_request_body.isnot(None))
+                        | (Usage.client_response_body.isnot(None))
                     )
-                ]
-            except Exception as e:
-                logger.exception("加载待压缩 body 记录 ID 失败: {}", e)
-                try:
-                    batch_db.rollback()
-                except Exception:
-                    pass
-                break
-            finally:
-                batch_db.close()
+                    .order_by(Usage.created_at.asc(), Usage.id.asc())
+                    .limit(memory_safe_batch_size)
+                    .all()
+                )
 
-            if not record_ids:
-                break
+                if not records:
+                    break
 
-            batch_success = 0
-            batch_progress = False
-
-            for record_id in record_ids:
-                record_db = create_session()
-                try:
-                    record = (
-                        record_db.query(
-                            Usage.id,
-                            Usage.request_body,
-                            Usage.response_body,
-                            Usage.provider_request_body,
-                            Usage.client_response_body,
-                        )
-                        .filter(Usage.id == record_id)
-                        .first()
-                    )
-
-                    if record is None:
-                        continue
-
-                    has_body_payload = (
-                        record.request_body is not None
-                        or record.response_body is not None
-                        or record.provider_request_body is not None
-                        or record.client_response_body is not None
-                    )
-
-                    if not has_body_payload:
-                        result = record_db.execute(
-                            update(Usage)
-                            .where(Usage.id == record.id)
-                            .values(
-                                request_body=null(),
-                                response_body=null(),
-                                provider_request_body=null(),
-                                client_response_body=null(),
-                            )
-                            .execution_options(synchronize_session=False)
-                        )
-                        record_db.commit()
-                        if result.rowcount > 0:
-                            batch_progress = True
-                        continue
-
-                    result = record_db.execute(
+                batch_success = 0
+                batch_progress = False
+                for record in records:
+                    result = batch_db.execute(
                         update(Usage)
                         .where(Usage.id == record.id)
                         .values(
@@ -1133,20 +1102,20 @@ class MaintenanceScheduler:
                         )
                         .execution_options(synchronize_session=False)
                     )
-                    record_db.commit()
-
                     if result.rowcount > 0:
                         batch_success += 1
                         batch_progress = True
-                except Exception as e:
-                    logger.warning("压缩记录 {} 失败: {}", record_id, e)
-                    try:
-                        record_db.rollback()
-                    except Exception:
-                        pass
-                    continue
-                finally:
-                    record_db.close()
+
+                batch_db.commit()
+            except Exception as e:
+                logger.warning("压缩 body 批次失败: {}", e)
+                try:
+                    batch_db.rollback()
+                except Exception:
+                    pass
+                break
+            finally:
+                batch_db.close()
 
             if not batch_progress:
                 no_progress_count += 1
@@ -1166,27 +1135,47 @@ class MaintenanceScheduler:
 
         return total_compressed
 
-    def _cleanup_compressed_fields(self, cutoff_time: datetime, batch_size: int) -> int:
-        """清理压缩字段（删除压缩的body）
+    def _cleanup_stale_body_fields(
+        self,
+        cutoff_time: datetime,
+        batch_size: int,
+        *,
+        newer_than: datetime | None = None,
+    ) -> int:
+        """清理已超过压缩保留期的 body 字段
 
-        每批使用短生命周期 session（同步方法，在线程池中调用）
+        直接清空 raw/compressed body，避免更老记录先压缩再马上被清掉。
         """
         from sqlalchemy import null, update
 
         total_cleaned = 0
 
+        if newer_than is not None and newer_than >= cutoff_time:
+            logger.warning(
+                "清理 body 字段跳过: 无效时间窗口 newer_than={} cutoff_time={}",
+                newer_than,
+                cutoff_time,
+            )
+            return 0
+
         while True:
             batch_db = create_session()
             try:
+                query = batch_db.query(Usage.id).filter(Usage.created_at < cutoff_time)
+                if newer_than is not None:
+                    query = query.filter(Usage.created_at >= newer_than)
                 records_to_clean = (
-                    batch_db.query(Usage.id)
-                    .filter(Usage.created_at < cutoff_time)
-                    .filter(
-                        (Usage.request_body_compressed.isnot(None))
+                    query.filter(
+                        (Usage.request_body.isnot(None))
+                        | (Usage.response_body.isnot(None))
+                        | (Usage.provider_request_body.isnot(None))
+                        | (Usage.client_response_body.isnot(None))
+                        | (Usage.request_body_compressed.isnot(None))
                         | (Usage.response_body_compressed.isnot(None))
                         | (Usage.provider_request_body_compressed.isnot(None))
                         | (Usage.client_response_body_compressed.isnot(None))
                     )
+                    .order_by(Usage.created_at.asc(), Usage.id.asc())
                     .limit(batch_size)
                     .all()
                 )
@@ -1200,6 +1189,10 @@ class MaintenanceScheduler:
                     update(Usage)
                     .where(Usage.id.in_(record_ids))
                     .values(
+                        request_body=null(),
+                        response_body=null(),
+                        provider_request_body=null(),
+                        client_response_body=null(),
                         request_body_compressed=null(),
                         response_body_compressed=null(),
                         provider_request_body_compressed=null(),
@@ -1211,14 +1204,14 @@ class MaintenanceScheduler:
                 batch_db.commit()
 
                 if rows_updated == 0:
-                    logger.warning("清理压缩字段: rowcount=0，可能存在问题")
+                    logger.warning("清理 body 字段: rowcount=0，可能存在问题")
                     break
 
                 total_cleaned += rows_updated
-                logger.debug(f"已清理 {rows_updated} 条记录的压缩字段，累计 {total_cleaned} 条")
+                logger.debug(f"已清理 {rows_updated} 条记录的 body 字段，累计 {total_cleaned} 条")
 
             except Exception as e:
-                logger.exception(f"清理压缩字段失败: {e}")
+                logger.exception(f"清理 body 字段失败: {e}")
                 try:
                     batch_db.rollback()
                 except Exception:
@@ -1229,7 +1222,13 @@ class MaintenanceScheduler:
 
         return total_cleaned
 
-    def _cleanup_header_fields(self, cutoff_time: datetime, batch_size: int) -> int:
+    def _cleanup_header_fields(
+        self,
+        cutoff_time: datetime,
+        batch_size: int,
+        *,
+        newer_than: datetime | None = None,
+    ) -> int:
         """清理 request_headers, response_headers 和 provider_request_headers 字段
 
         每批使用短生命周期 session（同步方法，在线程池中调用）
@@ -1238,17 +1237,27 @@ class MaintenanceScheduler:
 
         total_cleaned = 0
 
+        if newer_than is not None and newer_than >= cutoff_time:
+            logger.warning(
+                "清理 header 字段跳过: 无效时间窗口 newer_than={} cutoff_time={}",
+                newer_than,
+                cutoff_time,
+            )
+            return 0
+
         while True:
             batch_db = create_session()
             try:
+                query = batch_db.query(Usage.id).filter(Usage.created_at < cutoff_time)
+                if newer_than is not None:
+                    query = query.filter(Usage.created_at >= newer_than)
                 records_to_clean = (
-                    batch_db.query(Usage.id)
-                    .filter(Usage.created_at < cutoff_time)
-                    .filter(
+                    query.filter(
                         (Usage.request_headers.isnot(None))
                         | (Usage.response_headers.isnot(None))
                         | (Usage.provider_request_headers.isnot(None))
                     )
+                    .order_by(Usage.created_at.asc(), Usage.id.asc())
                     .limit(batch_size)
                     .all()
                 )
@@ -1300,6 +1309,7 @@ class MaintenanceScheduler:
                 records_to_delete = (
                     batch_db.query(Usage.id)
                     .filter(Usage.created_at < cutoff_time)
+                    .order_by(Usage.created_at.asc(), Usage.id.asc())
                     .limit(batch_size)
                     .all()
                 )

--- a/src/services/system/maintenance_scheduler.py
+++ b/src/services/system/maintenance_scheduler.py
@@ -1256,6 +1256,7 @@ class MaintenanceScheduler:
                         (Usage.request_headers.isnot(None))
                         | (Usage.response_headers.isnot(None))
                         | (Usage.provider_request_headers.isnot(None))
+                        | (Usage.client_response_headers.isnot(None))
                     )
                     .order_by(Usage.created_at.asc(), Usage.id.asc())
                     .limit(batch_size)
@@ -1274,6 +1275,7 @@ class MaintenanceScheduler:
                         request_headers=null(),
                         response_headers=null(),
                         provider_request_headers=null(),
+                        client_response_headers=null(),
                     )
                 )
 

--- a/tests/services/test_startup_toggles.py
+++ b/tests/services/test_startup_toggles.py
@@ -204,6 +204,69 @@ def test_cleanup_body_fields_batches_records_with_single_commit(
     assert batch_two.closed is True
 
 
+def test_cleanup_header_fields_clears_client_response_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler = MaintenanceScheduler()
+
+    class _BatchSession:
+        def __init__(self, ids: list[str]) -> None:
+            self.ids = ids
+            self.closed = False
+            self.committed = False
+            self.query_obj = MagicMock()
+            self.filtered_by_time = MagicMock()
+            self.filtered_by_headers = MagicMock()
+            self.query_obj.filter.return_value = self.filtered_by_time
+            self.filtered_by_time.filter.return_value = self.filtered_by_headers
+            self.filtered_by_headers.order_by.return_value.limit.return_value.all.return_value = [
+                SimpleNamespace(id=value) for value in ids
+            ]
+            self.executed_statements: list[str] = []
+
+        def query(self, *args):  # type: ignore[no-untyped-def]
+            self.query_args = args
+            return self.query_obj
+
+        def execute(self, statement):  # type: ignore[no-untyped-def]
+            self.executed_statements.append(str(statement))
+            return SimpleNamespace(rowcount=len(self.ids))
+
+        def commit(self) -> None:
+            self.committed = True
+
+        def rollback(self) -> None:
+            raise AssertionError("rollback should not be called")
+
+        def close(self) -> None:
+            self.closed = True
+
+    batch_one = _BatchSession(["usage-1"])
+    batch_two = _BatchSession([])
+    sessions = iter([batch_one, batch_two])
+
+    monkeypatch.setattr(
+        maintenance_scheduler_module,
+        "create_session",
+        lambda: next(sessions),
+    )
+
+    cleaned = scheduler._cleanup_header_fields(
+        cutoff_time=SimpleNamespace(),  # type: ignore[arg-type]
+        batch_size=1000,
+    )
+
+    header_filter = str(batch_one.filtered_by_time.filter.call_args.args[0])
+
+    assert cleaned == 1
+    assert batch_one.query_args == (maintenance_scheduler_module.Usage.id,)
+    assert "client_response_headers" in header_filter
+    assert "client_response_headers" in batch_one.executed_statements[0]
+    assert batch_one.committed is True
+    assert batch_one.closed is True
+    assert batch_two.closed is True
+
+
 @pytest.mark.asyncio
 async def test_perform_cleanup_deletes_first_and_uses_non_overlapping_windows(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/services/test_startup_toggles.py
+++ b/tests/services/test_startup_toggles.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 import inspect
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -124,44 +125,29 @@ async def test_candidate_cleanup_uses_dedicated_retention_and_batch_settings(
     assert batch_two.closed is True
 
 
-def test_cleanup_body_fields_loads_ids_then_processes_records_individually(
+def test_cleanup_body_fields_batches_records_with_single_commit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     scheduler = MaintenanceScheduler()
 
-    class _IdBatchSession:
-        def __init__(self, ids: list[str]) -> None:
-            self.ids = ids
-            self.closed = False
-            self.query_obj = MagicMock()
-            filtered = self.query_obj.filter.return_value
-            filtered.filter.return_value.order_by.return_value.limit.return_value.all.return_value = [
-                SimpleNamespace(id=value) for value in ids
-            ]
-
-        def query(self, *args):  # type: ignore[no-untyped-def]
-            self.query_args = args
-            return self.query_obj
-
-        def rollback(self) -> None:
-            raise AssertionError("rollback should not be called")
-
-        def close(self) -> None:
-            self.closed = True
-
-    class _RecordSession:
-        def __init__(self, record: SimpleNamespace) -> None:
-            self.record = record
+    class _BatchSession:
+        def __init__(self, records: list[SimpleNamespace]) -> None:
+            self.records = records
             self.closed = False
             self.committed = False
+            self.executed = 0
             self.query_obj = MagicMock()
-            self.query_obj.filter.return_value.first.return_value = record
+            filtered = self.query_obj.filter.return_value
+            filtered.filter.return_value.order_by.return_value.limit.return_value.all.return_value = (
+                records
+            )
 
         def query(self, *args):  # type: ignore[no-untyped-def]
             self.query_args = args
             return self.query_obj
 
         def execute(self, _statement):  # type: ignore[no-untyped-def]
+            self.executed += 1
             return SimpleNamespace(rowcount=1)
 
         def commit(self) -> None:
@@ -173,27 +159,26 @@ def test_cleanup_body_fields_loads_ids_then_processes_records_individually(
         def close(self) -> None:
             self.closed = True
 
-    batch_one = _IdBatchSession(["usage-1", "usage-2"])
-    record_one = _RecordSession(
-        SimpleNamespace(
-            id="usage-1",
-            request_body={"hello": "world"},
-            response_body=None,
-            provider_request_body=None,
-            client_response_body=None,
-        )
+    batch_one = _BatchSession(
+        [
+            SimpleNamespace(
+                id="usage-1",
+                request_body={"hello": "world"},
+                response_body=None,
+                provider_request_body=None,
+                client_response_body=None,
+            ),
+            SimpleNamespace(
+                id="usage-2",
+                request_body=None,
+                response_body={"ok": True},
+                provider_request_body=None,
+                client_response_body=None,
+            ),
+        ]
     )
-    record_two = _RecordSession(
-        SimpleNamespace(
-            id="usage-2",
-            request_body=None,
-            response_body={"ok": True},
-            provider_request_body=None,
-            client_response_body=None,
-        )
-    )
-    batch_two = _IdBatchSession([])
-    sessions = iter([batch_one, record_one, record_two, batch_two])
+    batch_two = _BatchSession([])
+    sessions = iter([batch_one, batch_two])
 
     monkeypatch.setattr(
         maintenance_scheduler_module,
@@ -212,12 +197,109 @@ def test_cleanup_body_fields_loads_ids_then_processes_records_individually(
     )
 
     assert compressed == 2
-    assert batch_one.query_args == (maintenance_scheduler_module.Usage.id,)
-    assert len(record_one.query_args) == 5
-    assert len(record_two.query_args) == 5
+    assert len(batch_one.query_args) == 5
+    assert batch_one.executed == 2
+    assert batch_one.committed is True
     assert batch_one.closed is True
     assert batch_two.closed is True
-    assert record_one.committed is True
-    assert record_two.committed is True
-    assert record_one.closed is True
-    assert record_two.closed is True
+
+
+@pytest.mark.asyncio
+async def test_perform_cleanup_deletes_first_and_uses_non_overlapping_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduler = MaintenanceScheduler()
+    fixed_now = datetime(2026, 3, 18, 3, 0, 0, tzinfo=timezone.utc)
+
+    class _FakeDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            if tz is None:
+                return fixed_now.replace(tzinfo=None)
+            return fixed_now.astimezone(tz)
+
+    class _FakeLoop:
+        async def run_in_executor(self, _executor, func):  # type: ignore[no-untyped-def]
+            return func()
+
+    class _ConfigSession:
+        def close(self) -> None:
+            return None
+
+    calls: list[tuple[str, datetime, int, datetime | None]] = []
+
+    def _record(name: str, count: int):
+        def _inner(
+            cutoff_time: datetime,
+            batch_size: int,
+            *,
+            newer_than: datetime | None = None,
+        ) -> int:
+            calls.append((name, cutoff_time, batch_size, newer_than))
+            return count
+
+        return _inner
+
+    config_values = {
+        "enable_auto_cleanup": True,
+        "detail_log_retention_days": 7,
+        "compressed_log_retention_days": 30,
+        "header_retention_days": 90,
+        "log_retention_days": 365,
+        "cleanup_batch_size": 123,
+        "auto_delete_expired_keys": False,
+    }
+
+    monkeypatch.setattr(maintenance_scheduler_module, "datetime", _FakeDateTime)
+    monkeypatch.setattr(
+        maintenance_scheduler_module.asyncio, "get_running_loop", lambda: _FakeLoop()
+    )
+    monkeypatch.setattr(
+        maintenance_scheduler_module,
+        "create_session",
+        lambda: _ConfigSession(),
+    )
+    monkeypatch.setattr(
+        maintenance_scheduler_module.SystemConfigService,
+        "get_config",
+        lambda _db, key, default=None: config_values.get(key, default),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_delete_old_records",
+        lambda cutoff_time, batch_size: calls.append(("delete", cutoff_time, batch_size, None)) or 5,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_cleanup_header_fields",
+        _record("header", 4),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_cleanup_stale_body_fields",
+        _record("body", 3),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_cleanup_body_fields",
+        _record("compress", 2),
+    )
+    monkeypatch.setattr(
+        maintenance_scheduler_module.ApiKeyService,
+        "cleanup_expired_keys",
+        lambda _db, auto_delete=False: 0,
+    )
+
+    await scheduler._perform_cleanup()
+
+    detail_cutoff = fixed_now - timedelta(days=7)
+    compressed_cutoff = fixed_now - timedelta(days=30)
+    header_cutoff = fixed_now - timedelta(days=90)
+    log_cutoff = fixed_now - timedelta(days=365)
+
+    assert calls == [
+        ("delete", log_cutoff, 123, None),
+        ("header", header_cutoff, 123, log_cutoff),
+        ("body", compressed_cutoff, 123, log_cutoff),
+        ("compress", detail_cutoff, 123, compressed_cutoff),
+    ]


### PR DESCRIPTION
- 调整 usage 清理顺序，先删除超过 retention 的最老记录
- 将 header 清理、body 清理和 body 压缩拆成非重叠时间窗口
- 将 body 压缩改为批量处理并单批次提交，减少逐条写入开销
- 补充测试覆盖删除优先级、窗口边界和批量提交行为