### PR TITLE
fix(oauth): 统一 plan_type 解析优先级并优先使用实时元数据

### DIFF
--- a/src/api/admin/monitoring/trace.py
+++ b/src/api/admin/monitoring/trace.py
@@ -17,6 +17,7 @@ from src.api.base.admin_adapter import AdminApiAdapter
 from src.api.base.context import ApiRequestContext
 from src.api.base.pipeline import get_pipeline
 from src.core.crypto import crypto_service
+from src.core.oauth_plan import resolve_oauth_plan_type
 from src.database import get_db
 from src.models.database import Provider, ProviderAPIKey, ProviderEndpoint
 from src.services.request.candidate import RequestCandidateService
@@ -278,13 +279,12 @@ class AdminGetRequestTraceAdapter(AdminApiAdapter):
                 if is_oauth:
                     # OAuth: auth_type 使用具体的 provider_type（如 kiro/codex/antigravity）
                     pid = key_provider_map.get(k.id)
+                    provider_type = provider_type_map.get(pid, "") if pid else ""
                     key_auth_type_map[k.id] = (
-                        provider_type_map.get(pid, "oauth") if pid else "oauth"
+                        provider_type if provider_type else "oauth"
                     )
-                    # 提取 plan_type（不同 provider 存储位置不同）
                     oauth_plan_type = None
-                    # 1. Codex: auth_config.plan_type
-                    # 2. Antigravity: auth_config.tier
+                    auth_config = None
                     if k.auth_config:
                         try:
                             decrypted_config = crypto_service.decrypt(k.auth_config)
@@ -292,27 +292,14 @@ class AdminGetRequestTraceAdapter(AdminApiAdapter):
                             email = auth_config.get("email")
                             if isinstance(email, str) and email.strip():
                                 key_account_label_map[k.id] = email.strip()
-                            oauth_plan_type = auth_config.get("plan_type")
-                            if not oauth_plan_type:
-                                ag_tier = auth_config.get("tier")
-                                if ag_tier and isinstance(ag_tier, str):
-                                    oauth_plan_type = ag_tier.lower()
                         except Exception:
                             pass
-                    # 3. Kiro: upstream_metadata.kiro.subscription_title
-                    #    subscription_title 通常为 "KIRO FREE" / "KIRO PRO+" 等，
-                    #    去掉 provider 名称前缀，只保留等级部分
-                    if not oauth_plan_type:
-                        um = getattr(k, "upstream_metadata", None) or {}
-                        kiro_meta = um.get("kiro") if isinstance(um, dict) else None
-                        if isinstance(kiro_meta, dict):
-                            sub_title = kiro_meta.get("subscription_title")
-                            if sub_title and isinstance(sub_title, str):
-                                # "KIRO FREE" -> "Free", "KIRO PRO+" -> "Pro+"
-                                ptype = provider_type_map.get(pid, "") if pid else ""
-                                if ptype and sub_title.upper().startswith(ptype.upper()):
-                                    sub_title = sub_title[len(ptype) :].strip()
-                                oauth_plan_type = sub_title
+                    oauth_plan_type = resolve_oauth_plan_type(
+                        persisted_plan_type=getattr(k, "oauth_plan_type", None),
+                        auth_config=auth_config,
+                        upstream_metadata=getattr(k, "upstream_metadata", None),
+                        provider_type=provider_type or None,
+                    )
                     key_oauth_plan_map[k.id] = oauth_plan_type
                     continue
                 else:

--- a/src/api/admin/pool/routes.py
+++ b/src/api/admin/pool/routes.py
@@ -28,6 +28,7 @@ from src.api.base.pipeline import get_pipeline
 from src.core.crypto import crypto_service
 from src.core.exceptions import NotFoundException
 from src.core.logger import logger
+from src.core.oauth_plan import resolve_oauth_plan_type
 from src.core.provider_oauth_utils import normalize_oauth_organizations
 from src.database import get_db
 from src.models.database import Provider, ProviderAPIKey
@@ -264,23 +265,6 @@ def _is_known_banned_key(key: ProviderAPIKey, provider_type: str) -> bool:
 def _build_account_quota(provider_type: str, upstream_metadata: Any) -> str | None:
     return get_quota_reader(provider_type, upstream_metadata).display_summary()
 
-
-def _normalize_oauth_plan_type(plan_type: Any, provider_type: str) -> str | None:
-    if not isinstance(plan_type, str):
-        return None
-    text = plan_type.strip()
-    if not text:
-        return None
-
-    ptype = provider_type.strip().lower()
-    if ptype and text.lower().startswith(ptype):
-        trimmed = text[len(ptype) :].strip(" :-_")
-        if trimmed:
-            text = trimmed
-
-    return text or None
-
-
 def _extract_oauth_auth_config(key: ProviderAPIKey) -> dict[str, Any] | None:
     return extract_persisted_oauth_auth_config(key)
 
@@ -300,44 +284,16 @@ def _derive_oauth_plan_type(
     provider_type: str,
     auth_config: dict[str, Any] | None = None,
 ) -> str | None:
-    # Prefer persisted normalized field
-    persisted = _normalize_oauth_plan_type(getattr(key, "oauth_plan_type", None), provider_type)
-    if persisted:
-        return persisted
-
     if str(getattr(key, "auth_type", "") or "").strip().lower() != "oauth":
         return None
 
-    # Fallback 1: encrypted auth_config (common for Codex/Antigravity)
     cfg = auth_config if isinstance(auth_config, dict) else _extract_oauth_auth_config(key)
-    if cfg:
-        for plan_key in ("plan_type", "tier", "plan", "subscription_plan"):
-            normalized = _normalize_oauth_plan_type(cfg.get(plan_key), provider_type)
-            if normalized:
-                return normalized
-
-    # Fallback 2: upstream_metadata
-    upstream_metadata = getattr(key, "upstream_metadata", None)
-    if not isinstance(upstream_metadata, dict):
-        return None
-
-    provider_bucket = upstream_metadata.get(provider_type.strip().lower())
-    candidates: list[dict[str, Any]] = []
-    if isinstance(provider_bucket, dict):
-        candidates.append(provider_bucket)
-    candidates.append(upstream_metadata)
-
-    for source in candidates:
-        for plan_key in (
-            "plan_type",
-            "tier",
-            "subscription_title",
-            "subscription_plan",
-        ):
-            normalized = _normalize_oauth_plan_type(source.get(plan_key), provider_type)
-            if normalized:
-                return normalized
-    return None
+    return resolve_oauth_plan_type(
+        persisted_plan_type=getattr(key, "oauth_plan_type", None),
+        auth_config=cfg,
+        upstream_metadata=getattr(key, "upstream_metadata", None),
+        provider_type=provider_type,
+    )
 
 
 def _derive_oauth_account_id(auth_config: dict[str, Any] | None = None) -> str | None:

--- a/src/core/oauth_plan.py
+++ b/src/core/oauth_plan.py
@@ -15,17 +15,37 @@ def normalize_oauth_plan_type(plan_type: Any) -> str | None:
     return normalized
 
 
-def extract_oauth_plan_type_from_auth_config_data(auth_config: Any) -> str | None:
+def _normalize_oauth_plan_value(
+    plan_type: Any,
+    *,
+    provider_type: str | None = None,
+) -> str | None:
+    if not isinstance(plan_type, str):
+        return None
+    stripped = _strip_provider_prefix(plan_type, provider_type=provider_type)
+    if not stripped:
+        return None
+    return normalize_oauth_plan_type(stripped)
+
+
+def extract_oauth_plan_type_from_auth_config_data(
+    auth_config: Any,
+    *,
+    provider_type: str | None = None,
+) -> str | None:
     if not isinstance(auth_config, dict):
         return None
 
     # Codex: plan_type (free/plus/team/enterprise)
-    plan_type = normalize_oauth_plan_type(auth_config.get("plan_type"))
+    plan_type = _normalize_oauth_plan_value(
+        auth_config.get("plan_type"),
+        provider_type=provider_type,
+    )
     if plan_type:
         return plan_type
 
     # Antigravity: tier (PAID/FREE/...)
-    tier = normalize_oauth_plan_type(auth_config.get("tier"))
+    tier = _normalize_oauth_plan_value(auth_config.get("tier"), provider_type=provider_type)
     if tier:
         return tier
 
@@ -80,14 +100,69 @@ def extract_oauth_plan_type_from_upstream_metadata(
     if not isinstance(upstream_metadata, dict):
         return None
 
-    kiro_meta = upstream_metadata.get("kiro")
-    if isinstance(kiro_meta, dict):
-        subscription_title = kiro_meta.get("subscription_title")
-        if isinstance(subscription_title, str):
-            normalized = _strip_provider_prefix(subscription_title, provider_type=provider_type)
-            return normalize_oauth_plan_type(normalized)
+    normalized_provider = (
+        provider_type.strip().lower() if isinstance(provider_type, str) and provider_type.strip() else None
+    )
+    candidate_sources: list[tuple[dict[str, Any], str | None]] = []
+
+    def _append_bucket(bucket_key: str) -> None:
+        bucket = upstream_metadata.get(bucket_key)
+        if isinstance(bucket, dict):
+            candidate_sources.append((bucket, bucket_key))
+
+    if normalized_provider:
+        _append_bucket(normalized_provider)
+    else:
+        for bucket_key in ("codex", "kiro", "antigravity", "gemini_cli"):
+            _append_bucket(bucket_key)
+
+    candidate_sources.append((upstream_metadata, normalized_provider))
+
+    for source, source_provider in candidate_sources:
+        for key in ("plan_type", "tier", "plan", "subscription_plan"):
+            normalized = _normalize_oauth_plan_value(
+                source.get(key),
+                provider_type=source_provider,
+            )
+            if normalized:
+                return normalized
+
+        subscription_title = source.get("subscription_title")
+        normalized_subscription = _normalize_oauth_plan_value(
+            subscription_title,
+            provider_type=source_provider,
+        )
+        if normalized_subscription:
+            return normalized_subscription
 
     return None
+
+
+def resolve_oauth_plan_type(
+    *,
+    persisted_plan_type: Any = None,
+    auth_config: Any = None,
+    upstream_metadata: Any = None,
+    provider_type: str | None = None,
+) -> str | None:
+    upstream_plan = extract_oauth_plan_type_from_upstream_metadata(
+        upstream_metadata,
+        provider_type=provider_type,
+    )
+    if upstream_plan:
+        return upstream_plan
+
+    auth_plan = extract_oauth_plan_type_from_auth_config_data(
+        auth_config,
+        provider_type=provider_type,
+    )
+    if auth_plan:
+        return auth_plan
+
+    return _normalize_oauth_plan_value(
+        persisted_plan_type,
+        provider_type=provider_type,
+    )
 
 
 def extract_oauth_plan_type(
@@ -98,11 +173,10 @@ def extract_oauth_plan_type(
     silent: bool = True,
 ) -> str | None:
     auth_config = decrypt_auth_config_to_dict(encrypted_auth_config, silent=silent)
-    plan_type = extract_oauth_plan_type_from_auth_config_data(auth_config)
-    if plan_type:
-        return plan_type
-    return extract_oauth_plan_type_from_upstream_metadata(
-        upstream_metadata, provider_type=provider_type
+    return resolve_oauth_plan_type(
+        auth_config=auth_config,
+        upstream_metadata=upstream_metadata,
+        provider_type=provider_type,
     )
 
 

--- a/src/services/provider/pool/dimensions/_helpers.py
+++ b/src/services/provider/pool/dimensions/_helpers.py
@@ -96,17 +96,13 @@ def rank_descending(key_id: str, scores: dict[str, float], all_ids: list[str]) -
 
 
 def extract_plan_type(key_obj: Any) -> str | None:
-    direct = normalize_plan(getattr(key_obj, "oauth_plan_type", None))
-    if direct:
-        return direct
-
     metadata = safe_metadata(key_obj)
     for provider_type in (ProviderType.CODEX, ProviderType.KIRO, ProviderType.ANTIGRAVITY):
         plan_type = get_quota_reader(provider_type, metadata).plan_type()
         if plan_type:
             return plan_type
 
-    return None
+    return normalize_plan(getattr(key_obj, "oauth_plan_type", None))
 
 
 def _resolve_key_provider_type(key_obj: Any, provider_type: str | None = None) -> str | None:

--- a/src/services/provider_keys/response_builder.py
+++ b/src/services/provider_keys/response_builder.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from src.core.crypto import crypto_service
 from src.core.logger import logger
+from src.core.oauth_plan import resolve_oauth_plan_type
 from src.core.provider_oauth_utils import normalize_oauth_organizations
 from src.models.database import ProviderAPIKey
 from src.models.endpoint_models import EndpointAPIKeyResponse
@@ -91,6 +92,13 @@ def build_key_response(
             or str(getattr(provider_rel, "type", None) or "").strip()
             or None
         )
+
+    oauth_plan_type = resolve_oauth_plan_type(
+        persisted_plan_type=getattr(key, "oauth_plan_type", None),
+        auth_config=auth_config,
+        upstream_metadata=getattr(key, "upstream_metadata", None),
+        provider_type=provider_type,
+    )
 
     status_snapshot = resolve_provider_key_status_snapshot(
         key,

--- a/tests/services/test_pool_preset_dimensions.py
+++ b/tests/services/test_pool_preset_dimensions.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import src.services.provider.pool.dimensions  # noqa: F401
 from src.services.provider.pool.dimensions import get_preset_dimension, get_preset_names
+from src.services.provider.pool.dimensions._helpers import extract_plan_type
 
 
 def _key(metadata: dict, *, plan_type: str | None = None) -> SimpleNamespace:
@@ -91,3 +92,17 @@ def test_builtin_dimensions_compute_metric_in_range() -> None:
             mode=mode,
         )
         assert 0.0 <= metric <= 1.0
+
+
+def test_extract_plan_type_prefers_quota_metadata_over_stale_persisted_value() -> None:
+    key = _key(
+        {
+            "codex": {
+                "plan_type": "plus",
+                "primary_used_percent": 12,
+            }
+        },
+        plan_type="free",
+    )
+
+    assert extract_plan_type(key) == "plus"

--- a/tests/unit/test_pool_oauth_plan_type.py
+++ b/tests/unit/test_pool_oauth_plan_type.py
@@ -1,0 +1,21 @@
+from src.api.admin.pool.routes import _derive_oauth_plan_type
+from src.models.database import ProviderAPIKey
+
+
+def test_derive_oauth_plan_type_prefers_realtime_codex_metadata() -> None:
+    key = ProviderAPIKey(
+        id="pool-key-1",
+        provider_id="provider-1",
+        auth_type="oauth",
+        upstream_metadata={"codex": {"plan_type": "plus"}},
+        name="codex-user",
+    )
+    key.oauth_plan_type = "free"
+
+    plan_type = _derive_oauth_plan_type(
+        key,
+        "codex",
+        auth_config={"plan_type": "free"},
+    )
+
+    assert plan_type == "plus"

--- a/tests/unit/test_provider_key_response_builder.py
+++ b/tests/unit/test_provider_key_response_builder.py
@@ -114,3 +114,45 @@ def test_build_key_response_prefers_persisted_status_snapshot_layers(
     assert result.status_snapshot.oauth.code == "expired"
     assert result.status_snapshot.account.code == "workspace_deactivated"
     assert result.status_snapshot.quota.code == "exhausted"
+
+
+def test_build_key_response_prefers_realtime_plan_type_over_stale_auth_config(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> None:
+    key = ProviderAPIKey(
+        id="key-3",
+        provider_id="provider-1",
+        api_formats=["openai:cli"],
+        auth_type="oauth",
+        api_key="enc-access-token",
+        auth_config='{"email":"u@example.com","plan_type":"free","expires_at":2100000000}',
+        upstream_metadata={"codex": {"plan_type": "plus"}},
+        name="codex-user",
+    )
+    key.oauth_plan_type = "free"
+    now = datetime.now(timezone.utc)
+    key.success_count = 0
+    key.request_count = 0
+    key.error_count = 0
+    key.total_response_time_ms = 0
+    key.rpm_limit = None
+    key.global_priority_by_format = None
+    key.allowed_models = None
+    key.capabilities = None
+    key.is_active = True
+    key.created_at = now
+    key.updated_at = now
+    key.cache_ttl_minutes = 5
+    key.max_probe_interval_minutes = 32
+    key.health_by_format = None
+    key.circuit_breaker_by_format = None
+    key.oauth_invalid_at = None
+    key.oauth_invalid_reason = None
+    key.note = None
+    key.last_used_at = None
+
+    monkeypatch.setattr(module.crypto_service, "decrypt", lambda value: value)
+
+    result = build_key_response(key, provider_type="codex")
+
+    assert result.oauth_plan_type == "plus"


### PR DESCRIPTION
- 新增 resolve_oauth_plan_type，统一处理 persisted/auth_config/upstream_metadata 的套餐类型解析
- admin pool、trace 和 key response 复用同一解析逻辑，避免旧 auth_config 或持久化值覆盖实时元数据
- pool preset dimensions 改为优先读取 quota metadata，并补充相关回归测试