### PR TITLE
feat(pool): 重构号池管理交互并完善移动端体验与状态恢复

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -12,12 +12,15 @@ COPY frontend/ ./
 RUN npm run build
 
 # ==================== Rust gateway 构建 ====================
-FROM rust:1.86-slim AS gateway-builder
+FROM rust:1.94.1-slim AS gateway-builder
 WORKDIR /build
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    ca-certificates \
+    libjemalloc2 \
+    libssl-dev \
     pkg-config \
     perl
 COPY Cargo.toml Cargo.lock ./
@@ -28,30 +31,71 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release --locked -p aether-gateway && \
     cp target/release/aether-gateway /tmp/aether-gateway
 
-# ==================== 运行时镜像 ====================
-FROM debian:bookworm-slim
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    libjemalloc2 \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
+# ==================== 最小运行时打包 ====================
+FROM gateway-builder AS runtime-prep
 RUN set -eux; \
+    mkdir -p \
+    /runtime-root/app/data \
+    /runtime-root/app/logs \
+    /runtime-root/etc \
+    /runtime-root/etc/ssl \
+    /runtime-root/lib \
+    /runtime-root/lib64 \
+    /runtime-root/usr/local/bin \
+    /runtime-root/usr/local/lib; \
+    cp /tmp/aether-gateway /runtime-root/usr/local/bin/aether-gateway; \
+    : > /tmp/runtime-libs.txt; \
+    : > /tmp/runtime-scan-queue.txt; \
+    printf '%s\n' /tmp/aether-gateway >> /tmp/runtime-scan-queue.txt; \
     jemalloc_path="$(find /usr/lib -type f -name 'libjemalloc.so.2' | head -n1)"; \
     [ -n "$jemalloc_path" ]; \
-    ln -sf "$jemalloc_path" /usr/local/lib/libjemalloc.so.2
+    install -D "$jemalloc_path" /runtime-root/usr/local/lib/libjemalloc.so.2; \
+    printf '%s\n' "$jemalloc_path" >> /tmp/runtime-scan-queue.txt; \
+    while [ -s /tmp/runtime-scan-queue.txt ]; do \
+        current="$(head -n1 /tmp/runtime-scan-queue.txt)"; \
+        sed -i '1d' /tmp/runtime-scan-queue.txt; \
+        ldd "$current" | awk '/=>/ { print $3 } $1 ~ /^\// { print $1 }' | while read -r lib; do \
+            [ -n "$lib" ]; \
+            if ! grep -Fxq "$lib" /tmp/runtime-libs.txt; then \
+                printf '%s\n' "$lib" >> /tmp/runtime-libs.txt; \
+                printf '%s\n' "$lib" >> /tmp/runtime-scan-queue.txt; \
+            fi; \
+        done; \
+    done; \
+    sort -u /tmp/runtime-libs.txt -o /tmp/runtime-libs.txt; \
+    while read -r lib; do \
+        [ -n "$lib" ]; \
+        dest="/runtime-root$(dirname "$lib")"; \
+        mkdir -p "$dest"; \
+        cp -L "$lib" "$dest/"; \
+    done < /tmp/runtime-libs.txt; \
+    for lib in \
+        /lib/x86_64-linux-gnu/libnss_dns.so.2 \
+        /lib/x86_64-linux-gnu/libnss_files.so.2 \
+        /lib/x86_64-linux-gnu/libresolv.so.2; do \
+        if [ -f "$lib" ]; then \
+            dest="/runtime-root$(dirname "$lib")"; \
+            mkdir -p "$dest"; \
+            cp -L "$lib" "$dest/"; \
+        fi; \
+    done; \
+    cp -a /usr/lib/ssl /runtime-root/usr/lib/; \
+    cp -a /etc/ssl/certs /runtime-root/etc/ssl/; \
+    if [ -f /etc/ssl/openssl.cnf ]; then \
+        cp /etc/ssl/openssl.cnf /runtime-root/etc/ssl/openssl.cnf; \
+    fi; \
+    if [ -f /etc/nsswitch.conf ]; then \
+        cp /etc/nsswitch.conf /runtime-root/etc/nsswitch.conf; \
+    fi
+
+# ==================== 运行时镜像 ====================
+FROM scratch
 
 # 复制 gateway 二进制
-COPY --from=gateway-builder /tmp/aether-gateway /usr/local/bin/aether-gateway
+COPY --from=runtime-prep /runtime-root/ /
 
 # 复制前端构建产物
 COPY --from=frontend-builder /app/frontend/dist /srv/frontend
-RUN chmod -R 755 /srv/frontend
-
-RUN mkdir -p /app/logs /app/data
 WORKDIR /app
 
 ENV LANG=C.UTF-8 \
@@ -65,6 +109,6 @@ ENV LANG=C.UTF-8 \
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost/health || exit 1
+    CMD ["/usr/local/bin/aether-gateway", "--healthcheck"]
 
 ENTRYPOINT ["/usr/local/bin/aether-gateway"]

--- a/Dockerfile.app.local
+++ b/Dockerfile.app.local
@@ -11,13 +11,16 @@ COPY frontend/ ./
 RUN npm run build
 
 # ==================== Rust gateway 构建 ====================
-FROM rust:1.86-slim AS gateway-builder
+FROM rust:1.94.1-slim AS gateway-builder
 WORKDIR /build
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list.d/debian.sources && \
     apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    ca-certificates \
+    libjemalloc2 \
+    libssl-dev \
     pkg-config \
     perl
 COPY Cargo.toml Cargo.lock ./
@@ -28,31 +31,71 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release --locked -p aether-gateway && \
     cp target/release/aether-gateway /tmp/aether-gateway
 
-# ==================== 运行时镜像 ====================
-FROM debian:bookworm-slim
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    sed -i 's/deb.debian.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list.d/debian.sources && \
-    apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    libjemalloc2 \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
+# ==================== 最小运行时打包 ====================
+FROM gateway-builder AS runtime-prep
 RUN set -eux; \
+    mkdir -p \
+    /runtime-root/app/data \
+    /runtime-root/app/logs \
+    /runtime-root/etc \
+    /runtime-root/etc/ssl \
+    /runtime-root/lib \
+    /runtime-root/lib64 \
+    /runtime-root/usr/local/bin \
+    /runtime-root/usr/local/lib; \
+    cp /tmp/aether-gateway /runtime-root/usr/local/bin/aether-gateway; \
+    : > /tmp/runtime-libs.txt; \
+    : > /tmp/runtime-scan-queue.txt; \
+    printf '%s\n' /tmp/aether-gateway >> /tmp/runtime-scan-queue.txt; \
     jemalloc_path="$(find /usr/lib -type f -name 'libjemalloc.so.2' | head -n1)"; \
     [ -n "$jemalloc_path" ]; \
-    ln -sf "$jemalloc_path" /usr/local/lib/libjemalloc.so.2
+    install -D "$jemalloc_path" /runtime-root/usr/local/lib/libjemalloc.so.2; \
+    printf '%s\n' "$jemalloc_path" >> /tmp/runtime-scan-queue.txt; \
+    while [ -s /tmp/runtime-scan-queue.txt ]; do \
+        current="$(head -n1 /tmp/runtime-scan-queue.txt)"; \
+        sed -i '1d' /tmp/runtime-scan-queue.txt; \
+        ldd "$current" | awk '/=>/ { print $3 } $1 ~ /^\// { print $1 }' | while read -r lib; do \
+            [ -n "$lib" ]; \
+            if ! grep -Fxq "$lib" /tmp/runtime-libs.txt; then \
+                printf '%s\n' "$lib" >> /tmp/runtime-libs.txt; \
+                printf '%s\n' "$lib" >> /tmp/runtime-scan-queue.txt; \
+            fi; \
+        done; \
+    done; \
+    sort -u /tmp/runtime-libs.txt -o /tmp/runtime-libs.txt; \
+    while read -r lib; do \
+        [ -n "$lib" ]; \
+        dest="/runtime-root$(dirname "$lib")"; \
+        mkdir -p "$dest"; \
+        cp -L "$lib" "$dest/"; \
+    done < /tmp/runtime-libs.txt; \
+    for lib in \
+        /lib/x86_64-linux-gnu/libnss_dns.so.2 \
+        /lib/x86_64-linux-gnu/libnss_files.so.2 \
+        /lib/x86_64-linux-gnu/libresolv.so.2; do \
+        if [ -f "$lib" ]; then \
+            dest="/runtime-root$(dirname "$lib")"; \
+            mkdir -p "$dest"; \
+            cp -L "$lib" "$dest/"; \
+        fi; \
+    done; \
+    cp -a /usr/lib/ssl /runtime-root/usr/lib/; \
+    cp -a /etc/ssl/certs /runtime-root/etc/ssl/; \
+    if [ -f /etc/ssl/openssl.cnf ]; then \
+        cp /etc/ssl/openssl.cnf /runtime-root/etc/ssl/openssl.cnf; \
+    fi; \
+    if [ -f /etc/nsswitch.conf ]; then \
+        cp /etc/nsswitch.conf /runtime-root/etc/nsswitch.conf; \
+    fi
+
+# ==================== 运行时镜像 ====================
+FROM scratch
 
 # 复制 gateway 二进制
-COPY --from=gateway-builder /tmp/aether-gateway /usr/local/bin/aether-gateway
+COPY --from=runtime-prep /runtime-root/ /
 
 # 复制前端构建产物
 COPY --from=frontend-builder /app/frontend/dist /srv/frontend
-RUN chmod -R 755 /srv/frontend
-
-RUN mkdir -p /app/logs /app/data
 WORKDIR /app
 
 ENV LANG=C.UTF-8 \
@@ -66,6 +109,6 @@ ENV LANG=C.UTF-8 \
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost/health || exit 1
+    CMD ["/usr/local/bin/aether-gateway", "--healthcheck"]
 
 ENTRYPOINT ["/usr/local/bin/aether-gateway"]

--- a/apps/aether-gateway/src/main.rs
+++ b/apps/aether-gateway/src/main.rs
@@ -494,6 +494,18 @@ struct Args {
     #[arg(long, env = "AETHER_GATEWAY_BIND", default_value = "0.0.0.0:80")]
     bind: String,
 
+    /// 容器内健康检查入口：根据当前 bind 端口探测本地 /health。
+    #[arg(long, hide = true, default_value_t = false)]
+    healthcheck: bool,
+
+    #[arg(
+        long,
+        hide = true,
+        env = "AETHER_GATEWAY_HEALTHCHECK_TIMEOUT_MS",
+        default_value_t = 3_000
+    )]
+    healthcheck_timeout_ms: u64,
+
     #[arg(
         long,
         env = "AETHER_GATEWAY_DEPLOYMENT_TOPOLOGY",
@@ -609,6 +621,70 @@ fn resolve_gateway_log_instance_id() -> String {
         .unwrap_or_else(|| "local".to_string())
 }
 
+fn resolve_healthcheck_url(bind: &str) -> Result<String, std::io::Error> {
+    let trimmed = bind.trim();
+    if trimmed.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "AETHER_GATEWAY_BIND cannot be empty when --healthcheck is enabled",
+        ));
+    }
+
+    if let Ok(socket_addr) = trimmed.parse::<std::net::SocketAddr>() {
+        let host = match socket_addr.ip() {
+            std::net::IpAddr::V4(ip) if ip.is_unspecified() => "127.0.0.1".to_string(),
+            std::net::IpAddr::V4(ip) => ip.to_string(),
+            std::net::IpAddr::V6(ip) if ip.is_unspecified() => "[::1]".to_string(),
+            std::net::IpAddr::V6(ip) => format!("[{ip}]"),
+        };
+        return Ok(format!("http://{host}:{}/health", socket_addr.port()));
+    }
+
+    let (host, port) = trimmed.rsplit_once(':').ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "AETHER_GATEWAY_BIND must include a port when --healthcheck is enabled: {trimmed}"
+            ),
+        )
+    })?;
+    let port = port.parse::<u16>().map_err(|error| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid healthcheck port in AETHER_GATEWAY_BIND={trimmed}: {error}"),
+        )
+    })?;
+
+    let host = host.trim();
+    if host.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid host in AETHER_GATEWAY_BIND={trimmed}"),
+        ));
+    }
+    let host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+
+    Ok(format!("http://{host}:{port}/health"))
+}
+
+async fn run_healthcheck(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
+    let url = resolve_healthcheck_url(&args.bind)?;
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(
+            args.healthcheck_timeout_ms.max(1),
+        ))
+        .build()?
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(())
+}
+
 fn validate_deployment_topology(
     args: &Args,
     data_postgres_url: Option<&str>,
@@ -685,6 +761,9 @@ fn validate_deployment_topology(
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
+    if args.healthcheck {
+        return run_healthcheck(&args).await;
+    }
     init_service_runtime(args.runtime_config()?)?;
     let data_postgres_url = args.data.effective_postgres_url();
     let data_redis_url = args.data.effective_redis_url();
@@ -877,4 +956,55 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         handle.abort();
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_healthcheck_url;
+
+    #[test]
+    fn resolves_ipv4_healthcheck_url() {
+        assert_eq!(
+            resolve_healthcheck_url("0.0.0.0:80").unwrap(),
+            "http://127.0.0.1:80/health"
+        );
+    }
+
+    #[test]
+    fn resolves_ipv6_healthcheck_url() {
+        assert_eq!(
+            resolve_healthcheck_url("[::]:8080").unwrap(),
+            "http://[::1]:8080/health"
+        );
+    }
+
+    #[test]
+    fn preserves_explicit_ipv4_bind_for_healthcheck_url() {
+        assert_eq!(
+            resolve_healthcheck_url("172.18.0.2:9000").unwrap(),
+            "http://172.18.0.2:9000/health"
+        );
+    }
+
+    #[test]
+    fn preserves_explicit_ipv6_bind_for_healthcheck_url() {
+        assert_eq!(
+            resolve_healthcheck_url("[2001:db8::2]:9000").unwrap(),
+            "http://[2001:db8::2]:9000/health"
+        );
+    }
+
+    #[test]
+    fn preserves_hostname_healthcheck_url() {
+        assert_eq!(
+            resolve_healthcheck_url("gateway.internal:9000").unwrap(),
+            "http://gateway.internal:9000/health"
+        );
+    }
+
+    #[test]
+    fn rejects_bind_without_port() {
+        let error = resolve_healthcheck_url("not-a-socket").unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
 }

--- a/frontend/src/components/ui/dialog/Dialog.vue
+++ b/frontend/src/components/ui/dialog/Dialog.vue
@@ -43,7 +43,7 @@
             <slot name="header">
               <div
                 v-if="title"
-                class="border-b border-border px-6 py-4"
+                class="border-b border-border px-4 py-4 sm:px-6"
               >
                 <div class="flex items-center gap-3">
                   <div
@@ -73,14 +73,14 @@
             </slot>
 
             <!-- 内容区域：可选添加 padding -->
-            <div :class="noPadding ? '' : 'px-6 py-3'">
+            <div :class="noPadding ? '' : 'px-4 py-3 sm:px-6'">
               <slot />
             </div>
 
             <!-- Footer 区域：如果有 footer 插槽，自动添加样式 -->
             <div
               v-if="slots.footer"
-              class="border-t border-border px-6 py-4 bg-muted/10 flex flex-row-reverse gap-3"
+              class="border-t border-border bg-muted/10 px-4 py-4 sm:px-6 flex flex-row-reverse gap-3"
             >
               <slot name="footer" />
             </div>

--- a/frontend/src/composables/useRouteQuery.ts
+++ b/frontend/src/composables/useRouteQuery.ts
@@ -1,0 +1,44 @@
+import { useRoute, useRouter, type LocationQuery, type LocationQueryValue } from 'vue-router'
+
+type QueryValue = LocationQueryValue | LocationQueryValue[]
+
+function normalizeQueryValue(value: QueryValue): string | undefined {
+  if (Array.isArray(value)) {
+    return value.length > 0 ? (value[value.length - 1] ?? undefined) : undefined
+  }
+  return typeof value === 'string' ? value : undefined
+}
+
+function queriesEqual(left: LocationQuery, right: LocationQuery): boolean {
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)])
+  for (const key of keys) {
+    if (normalizeQueryValue(left[key]) !== normalizeQueryValue(right[key])) {
+      return false
+    }
+  }
+  return true
+}
+
+export function useRouteQuery() {
+  const route = useRoute()
+  const router = useRouter()
+
+  function getQueryValue(key: string): string | undefined {
+    return normalizeQueryValue(route.query[key])
+  }
+
+  function patchQuery(patch: Record<string, string | undefined | null>) {
+    const next: LocationQuery = { ...route.query }
+    for (const [key, value] of Object.entries(patch)) {
+      if (value == null || value.trim() === '') {
+        delete next[key]
+      } else {
+        next[key] = value
+      }
+    }
+    if (queriesEqual(route.query, next)) return
+    void router.replace({ query: next }).catch(() => {})
+  }
+
+  return { route, router, getQueryValue, patchQuery }
+}

--- a/frontend/src/features/pool/components/PoolAccountBatchDialog.vue
+++ b/frontend/src/features/pool/components/PoolAccountBatchDialog.vue
@@ -3,224 +3,235 @@
     :model-value="modelValue"
     title="账号批量操作"
     :description="dialogDescription"
-    size="xl"
+    size="3xl"
     persistent
     @update:model-value="emit('update:modelValue', $event)"
   >
     <div class="space-y-4">
-      <div class="flex items-center gap-2">
-        <MultiSelect
-          :model-value="activeQuickSelectors"
-          :options="QUICK_SELECT_OPTIONS"
-          placeholder="快捷多选"
-          trigger-class="h-8 w-40"
-          dropdown-min-width="10rem"
-          :disabled="loading || executing"
-          @update:model-value="onQuickSelectChange"
-        />
-        <Input
-          :model-value="searchText"
-          placeholder="搜索账号名 / 套餐 / 额度 / 代理状态"
-          class="h-8 flex-1"
-          @update:model-value="(v) => searchText = String(v || '')"
-        />
-        <Button
-          variant="ghost"
-          size="icon"
-          class="h-8 w-8 shrink-0"
-          :disabled="loading || executing"
-          @click="loadKeysPage()"
-        >
-          <RefreshCw
-            class="h-3.5 w-3.5"
-            :class="loading ? 'animate-spin' : ''"
-          />
-        </Button>
-      </div>
+      <div class="space-y-3 rounded-lg border bg-muted/20 px-3 py-2.5">
+        <div class="flex items-center justify-between gap-2">
+          <span class="text-xs font-medium text-foreground">快捷多选</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            class="h-7 px-2 text-[11px]"
+            :disabled="loading || executing || !hasActiveFilters"
+            @click="clearFilters"
+          >
+            重置筛选
+          </Button>
+        </div>
 
-      <div
-        v-if="activeQuickSelectors.length > 0"
-        class="flex flex-wrap gap-1"
-      >
-        <Badge
-          v-for="sel in activeQuickSelectors"
-          :key="sel"
-          variant="secondary"
-          class="text-[10px] px-1.5 py-0 h-5 cursor-pointer hover:bg-destructive/10 hover:text-destructive"
-          @click="removeQuickSelector(sel)"
-        >
-          {{ QUICK_SELECT_OPTIONS.find(s => s.value === sel)?.label }}
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="10"
-            height="10"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="ml-0.5"
-          ><path d="M18 6 6 18" /><path d="m6 6 12 12" /></svg>
-        </Badge>
-      </div>
+        <div class="flex flex-wrap gap-2">
+          <Button
+            v-for="option in QUICK_SELECT_OPTIONS"
+            :key="option.value"
+            variant="outline"
+            size="sm"
+            class="h-8 px-2.5 text-[11px]"
+            :class="activeQuickSelectorSet.has(option.value) ? 'border-primary/70 bg-primary/10 text-primary' : ''"
+            :disabled="loading || executing"
+            @click="toggleQuickSelector(option.value)"
+          >
+            {{ option.label }}
+          </Button>
+        </div>
 
-      <div class="flex items-center justify-between text-xs">
-        <div class="text-muted-foreground">
-          共 {{ filteredTotal }} 个匹配账号，当前页 {{ pageKeys.length }} 个，已选 {{ selectedCount }} 个
-        </div>
-        <div class="flex items-center gap-2">
-          <Checkbox
-            :checked="isAllFilteredSelected"
-            :indeterminate="isPartiallyFilteredSelected"
-            :disabled="filteredTotal === 0 || loading || executing"
-            @update:checked="toggleSelectFiltered"
-          />
-          <span class="text-muted-foreground">全选筛选结果</span>
-        </div>
-      </div>
+        <div class="space-y-3 rounded-md border bg-background/80 px-3 py-3">
+          <div class="flex items-center gap-2">
+            <Input
+              :model-value="searchText"
+              placeholder="搜索账号名 / 套餐 / 额度 / 代理状态"
+              class="h-8 flex-1"
+              @update:model-value="(v) => searchText = String(v || '')"
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              class="h-8 w-8 shrink-0"
+              :disabled="loading || executing"
+              @click="loadKeysPage()"
+            >
+              <RefreshCw
+                class="h-3.5 w-3.5"
+                :class="loading ? 'animate-spin' : ''"
+              />
+            </Button>
+          </div>
 
-      <div class="max-h-[380px] overflow-y-auto rounded-lg border">
-        <div
-          v-if="loading"
-          class="py-10 text-center text-sm text-muted-foreground"
-        >
-          正在加载账号列表...
-        </div>
-        <div
-          v-else-if="pageKeys.length === 0"
-          class="py-10 text-center text-sm text-muted-foreground"
-        >
-          无匹配账号
-        </div>
-        <label
-          v-for="key in pageKeys"
-          :key="key.key_id"
-          class="flex items-center gap-2.5 px-3 py-2 border-b last:border-b-0 cursor-pointer hover:bg-muted/30"
-        >
-          <Checkbox
-            :checked="selectAllFiltered || selectedIdSet.has(key.key_id)"
-            :disabled="executing || selectAllFiltered"
-            @update:checked="(checked) => toggleOne(key.key_id, checked === true)"
-          />
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center gap-1.5">
-              <span class="text-xs font-medium truncate">{{ key.key_name || '未命名' }}</span>
-              <Badge
-                variant="outline"
-                class="text-[10px] px-1 py-0 h-4 shrink-0"
-              >{{ normalizeAuthTypeLabel(key.auth_type) }}</Badge>
-              <Badge
-                v-if="getStatusBadgeLabel(key)"
-                variant="destructive"
-                class="text-[10px] px-1 py-0 h-4 shrink-0"
-                :title="getStatusBadgeTitle(key)"
-              >{{ getStatusBadgeLabel(key) }}</Badge>
-              <Badge
-                v-if="key.oauth_plan_type"
-                variant="outline"
-                class="text-[10px] px-1 py-0 h-4 shrink-0"
-              >{{ key.oauth_plan_type }}</Badge>
-              <Badge
-                v-if="getOAuthOrgBadge(key)"
-                variant="secondary"
-                class="text-[10px] px-1 py-0 h-4 shrink-0"
-                :title="getOAuthOrgBadge(key)?.title"
-              >{{ getOAuthOrgBadge(key)?.label }}</Badge>
+          <div class="flex flex-col gap-2 text-xs lg:flex-row lg:items-center lg:justify-between">
+            <div class="text-muted-foreground">
+              共 {{ filteredTotal }} 个匹配账号，当前页 {{ pageKeys.length }} 个，已选 {{ selectedCount }} 个
             </div>
-            <div class="flex items-center gap-1.5 mt-0.5 text-[11px] text-muted-foreground flex-wrap">
-              <span :class="key.is_active ? '' : 'text-destructive'">{{ key.is_active ? '启用' : '禁用' }}</span>
-              <span v-if="key.account_quota">{{ shortenQuota(key.account_quota) }}</span>
-              <span v-if="key.proxy?.node_id">独立代理</span>
-              <span
-                v-if="key.last_used_at"
-                class="ml-auto shrink-0"
-              >{{ formatRelativeTime(key.last_used_at) }}</span>
+            <div class="flex flex-wrap items-center gap-1">
+              <div class="mr-1 flex items-center gap-2">
+                <Checkbox
+                  :checked="isAllFilteredSelected"
+                  :indeterminate="isPartiallyFilteredSelected"
+                  :disabled="filteredTotal === 0 || loading || executing"
+                  @update:checked="toggleSelectFiltered"
+                />
+                <span class="text-muted-foreground">全选筛选结果</span>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                class="h-7 px-2 text-[11px]"
+                :disabled="pageKeys.length === 0 || loading || executing || selectAllFiltered"
+                @click="toggleSelectCurrentPage"
+              >
+                {{ isCurrentPageFullySelected ? '取消本页全选' : '本页全选' }}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                class="h-7 px-2 text-[11px]"
+                :disabled="!canClearSelection || loading || executing"
+                @click="clearSelection"
+              >
+                清空选择
+              </Button>
             </div>
           </div>
-        </label>
-      </div>
-
-      <div
-        v-if="totalPages > 1"
-        class="flex items-center justify-between text-xs text-muted-foreground"
-      >
-        <span>第 {{ currentPage }} / {{ totalPages }} 页</span>
-        <div class="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="icon"
-            class="h-7 w-7"
-            :disabled="currentPage <= 1"
-            @click="goToPage(1)"
-          >
-            <ChevronsLeft class="h-3.5 w-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            class="h-7 w-7"
-            :disabled="currentPage <= 1"
-            @click="goToPage(currentPage - 1)"
-          >
-            <ChevronLeft class="h-3.5 w-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            class="h-7 w-7"
-            :disabled="currentPage >= totalPages"
-            @click="goToPage(currentPage + 1)"
-          >
-            <ChevronRight class="h-3.5 w-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            class="h-7 w-7"
-            :disabled="currentPage >= totalPages"
-            @click="goToPage(totalPages)"
-          >
-            <ChevronsRight class="h-3.5 w-3.5" />
-          </Button>
         </div>
       </div>
 
-      <div class="space-y-2">
-        <div class="flex items-center gap-2">
-          <Select v-model="selectedAction">
-            <SelectTrigger class="h-8 text-xs flex-1">
-              <SelectValue placeholder="选择动作" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem
+      <div class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_19rem]">
+        <div class="min-w-0 space-y-3">
+          <div class="max-h-[420px] overflow-y-auto rounded-lg border">
+            <div
+              v-if="loading"
+              class="py-10 text-center text-sm text-muted-foreground"
+            >
+              正在加载账号列表...
+            </div>
+            <div
+              v-else-if="pageKeys.length === 0"
+              class="py-10 text-center text-sm text-muted-foreground"
+            >
+              无匹配账号
+            </div>
+            <label
+              v-for="key in pageKeys"
+              :key="key.key_id"
+              class="flex items-center gap-2.5 px-3 py-2 border-b last:border-b-0 cursor-pointer hover:bg-muted/30"
+            >
+              <Checkbox
+                :checked="selectAllFiltered || selectedIdSet.has(key.key_id)"
+                :disabled="executing || selectAllFiltered"
+                @update:checked="(checked) => toggleOne(key.key_id, checked === true)"
+              />
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-1.5">
+                  <span class="text-xs font-medium truncate">{{ key.key_name || '未命名' }}</span>
+                  <Badge
+                    variant="outline"
+                    class="text-[10px] px-1 py-0 h-4 shrink-0"
+                  >{{ normalizeAuthTypeLabel(key.auth_type) }}</Badge>
+                  <Badge
+                    v-if="getStatusBadgeLabel(key)"
+                    variant="destructive"
+                    class="text-[10px] px-1 py-0 h-4 shrink-0"
+                    :title="getStatusBadgeTitle(key)"
+                  >{{ getStatusBadgeLabel(key) }}</Badge>
+                  <Badge
+                    v-if="key.oauth_plan_type"
+                    variant="outline"
+                    class="text-[10px] px-1 py-0 h-4 shrink-0"
+                  >{{ key.oauth_plan_type }}</Badge>
+                  <Badge
+                    v-if="getOAuthOrgBadge(key)"
+                    variant="secondary"
+                    class="text-[10px] px-1 py-0 h-4 shrink-0"
+                    :title="getOAuthOrgBadge(key)?.title"
+                  >{{ getOAuthOrgBadge(key)?.label }}</Badge>
+                </div>
+                <div class="flex items-center gap-1.5 mt-0.5 text-[11px] text-muted-foreground flex-wrap">
+                  <span :class="key.is_active ? '' : 'text-destructive'">{{ key.is_active ? '启用' : '禁用' }}</span>
+                  <span v-if="key.account_quota">{{ shortenQuota(key.account_quota) }}</span>
+                  <span v-if="key.proxy?.node_id">独立代理</span>
+                  <span
+                    v-if="key.last_used_at"
+                    class="ml-auto shrink-0"
+                  >{{ formatRelativeTime(key.last_used_at) }}</span>
+                </div>
+              </div>
+            </label>
+          </div>
+
+          <div
+            v-if="totalPages > 1"
+            class="flex items-center justify-between text-xs text-muted-foreground"
+          >
+            <span>第 {{ currentPage }} / {{ totalPages }} 页</span>
+            <div class="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-7 w-7"
+                :disabled="currentPage <= 1"
+                @click="goToPage(1)"
+              >
+                <ChevronsLeft class="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-7 w-7"
+                :disabled="currentPage <= 1"
+                @click="goToPage(currentPage - 1)"
+              >
+                <ChevronLeft class="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-7 w-7"
+                :disabled="currentPage >= totalPages"
+                @click="goToPage(currentPage + 1)"
+              >
+                <ChevronRight class="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-7 w-7"
+                :disabled="currentPage >= totalPages"
+                @click="goToPage(totalPages)"
+              >
+                <ChevronsRight class="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div class="space-y-3 lg:sticky lg:top-1 lg:self-start">
+          <div class="space-y-2 rounded-lg border bg-background px-3 py-3">
+            <div class="text-xs font-medium text-foreground">
+              执行动作
+            </div>
+            <div class="text-[11px] text-muted-foreground">
+              代理节点（仅“配置代理”动作生效）
+            </div>
+            <ProxyNodeSelect
+              :model-value="proxyNodeIdForAction"
+              trigger-class="h-8"
+              @update:model-value="(v: string) => proxyNodeIdForAction = v"
+            />
+            <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
+              <Button
                 v-for="item in ACTION_OPTIONS"
                 :key="item.value"
-                :value="item.value"
+                class="h-8 w-full px-3 text-xs"
+                :variant="getActionButtonVariant(item)"
+                :disabled="!canExecuteSpecifiedAction(item.value)"
+                @click="confirmAndExecuteAction(item.value)"
               >
                 {{ item.label }}
-              </SelectItem>
-            </SelectContent>
-          </Select>
-          <Button
-            variant="ghost"
-            size="icon"
-            class="h-8 w-8 shrink-0"
-            :disabled="executing || selectedCount === 0 || loading"
-            @click="executeAction"
-          >
-            <Play
-              class="h-3.5 w-3.5"
-              :class="executing ? 'animate-pulse' : ''"
-            />
-          </Button>
+              </Button>
+            </div>
+          </div>
         </div>
-        <ProxyNodeSelect
-          v-if="selectedAction === 'set_proxy'"
-          :model-value="proxyNodeIdForAction"
-          trigger-class="h-8"
-          @update:model-value="(v: string) => proxyNodeIdForAction = v"
-        />
       </div>
 
       <div
@@ -260,10 +271,9 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
-import { Dialog, Button, Input, Select, SelectTrigger, SelectValue, SelectContent, SelectItem, Checkbox, Badge } from '@/components/ui'
-import { MultiSelect } from '@/components/common'
+import { Dialog, Button, Input, Checkbox, Badge } from '@/components/ui'
 import ProxyNodeSelect from '@/features/providers/components/ProxyNodeSelect.vue'
-import { RefreshCw, Play, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-vue-next'
+import { RefreshCw, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-vue-next'
 import { useToast } from '@/composables/useToast'
 import { useConfirm } from '@/composables/useConfirm'
 import { parseApiError } from '@/utils/errorParser'
@@ -308,6 +318,13 @@ type BatchActionValue =
   | 'enable'
   | 'disable'
 
+type BatchActionOption = {
+  value: BatchActionValue
+  label: string
+  hint: string
+  destructive?: boolean
+}
+
 const props = defineProps<{
   modelValue: boolean
   providerId: string
@@ -323,26 +340,26 @@ const emit = defineEmits<{
 
 const QUICK_SELECT_OPTIONS: Array<{ value: QuickSelectorValue; label: string }> = [
   { value: 'banned', label: '账号异常' },
+  { value: 'oauth_invalid', label: 'Token 异常' },
   { value: 'no_5h_limit', label: '无5H限额' },
   { value: 'no_weekly_limit', label: '无周限额' },
   { value: 'plan_free', label: '全部 Free' },
   { value: 'plan_team', label: '全部 Team' },
-  { value: 'oauth_invalid', label: 'Token 异常' },
   { value: 'proxy_unset', label: '未配置代理' },
   { value: 'proxy_set', label: '已配置独立代理' },
   { value: 'disabled', label: '已禁用' },
   { value: 'enabled', label: '已启用' },
 ]
 
-const ACTION_OPTIONS: Array<{ value: BatchActionValue; label: string }> = [
-  { value: 'export', label: '导出凭据' },
-  { value: 'delete', label: '删除账号' },
-  { value: 'refresh_oauth', label: '刷新 OAuth' },
-  { value: 'refresh_quota', label: '刷新额度' },
-  { value: 'clear_proxy', label: '清除代理' },
-  { value: 'set_proxy', label: '配置代理' },
-  { value: 'enable', label: '启用' },
-  { value: 'disable', label: '禁用' },
+const ACTION_OPTIONS: BatchActionOption[] = [
+  { value: 'refresh_quota', label: '刷新额度', hint: '调用额度刷新接口，适合核对最新配额状态。' },
+  { value: 'refresh_oauth', label: '刷新 OAuth', hint: '仅对 OAuth 账号有效，非 OAuth 账号会自动跳过。' },
+  { value: 'set_proxy', label: '配置代理', hint: '为选中账号绑定独立代理节点。' },
+  { value: 'clear_proxy', label: '清除代理', hint: '移除账号独立代理，回退到提供商默认代理。' },
+  { value: 'enable', label: '启用', hint: '批量启用账号，恢复可调度状态。' },
+  { value: 'disable', label: '禁用', hint: '批量禁用账号，保留数据但停止调度。' },
+  { value: 'export', label: '导出凭据', hint: '仅导出 OAuth 凭据，其他类型账号将被跳过。' },
+  { value: 'delete', label: '删除账号', hint: '永久删除账号数据，执行后不可恢复。', destructive: true },
 ]
 
 const { success, warning, error: showError } = useToast()
@@ -357,7 +374,7 @@ const selectedKeyIds = ref<string[]>([])
 const knownKeysById = ref<Record<string, PoolKeyDetail>>({})
 const selectAllFiltered = ref(false)
 const searchText = ref('')
-const selectedAction = ref<BatchActionValue>('delete')
+const selectedAction = ref<BatchActionValue>('refresh_quota')
 const proxyNodeIdForAction = ref('')
 const lastResultMessage = ref('')
 const progressTotal = ref(0)
@@ -383,6 +400,21 @@ const selectedCount = computed(() => (selectAllFiltered.value ? filteredTotal.va
 const totalPages = computed(() => Math.max(1, Math.ceil(filteredTotal.value / PAGE_SIZE)))
 const isAllFilteredSelected = computed(() => selectAllFiltered.value && filteredTotal.value > 0)
 const isPartiallyFilteredSelected = computed(() => !selectAllFiltered.value && selectedKeyIds.value.length > 0)
+const hasActiveFilters = computed(() => searchText.value.trim().length > 0 || activeQuickSelectors.value.length > 0)
+const selectedOnCurrentPageCount = computed(() => {
+  if (selectAllFiltered.value) return pageKeys.value.length
+  let count = 0
+  for (const key of pageKeys.value) {
+    if (selectedIdSet.value.has(key.key_id)) count += 1
+  }
+  return count
+})
+const isCurrentPageFullySelected = computed(() => {
+  if (selectAllFiltered.value || pageKeys.value.length === 0) return false
+  return selectedOnCurrentPageCount.value === pageKeys.value.length
+})
+const canClearSelection = computed(() => selectAllFiltered.value || selectedKeyIds.value.length > 0)
+const activeQuickSelectorSet = computed(() => new Set(activeQuickSelectors.value))
 
 function normalizeText(value: unknown): string {
   return String(value || '').trim().toLowerCase()
@@ -592,17 +624,76 @@ function toggleSelectFiltered(checked: boolean | 'indeterminate'): void {
   }
 }
 
-function onQuickSelectChange(values: string[]): void {
-  activeQuickSelectors.value = values as QuickSelectorValue[]
+function toggleSelectCurrentPage(): void {
+  if (selectAllFiltered.value || pageKeys.value.length === 0) return
+  const set = new Set(selectedKeyIds.value)
+  const pageIds = pageKeys.value.map((key) => key.key_id)
+  const shouldUnselect = pageIds.every((id) => set.has(id))
+  for (const id of pageIds) {
+    if (shouldUnselect) set.delete(id)
+    else set.add(id)
+  }
+  selectedKeyIds.value = [...set]
+}
+
+function clearSelection(): void {
+  resetSelection()
+}
+
+function clearFilters(): void {
+  if (!hasActiveFilters.value) return
+  clearSearchDebounce()
+  suppressFilterWatch = true
+  searchText.value = ''
+  activeQuickSelectors.value = []
+  suppressFilterWatch = false
   requestFilteredReload()
 }
 
-function removeQuickSelector(selector: QuickSelectorValue): void {
+function toggleQuickSelector(selector: QuickSelectorValue): void {
   const idx = activeQuickSelectors.value.indexOf(selector)
   if (idx >= 0) {
     activeQuickSelectors.value.splice(idx, 1)
-    requestFilteredReload()
+  } else {
+    activeQuickSelectors.value.push(selector)
   }
+  requestFilteredReload()
+}
+
+function canExecuteSpecifiedAction(action: BatchActionValue): boolean {
+  if (executing.value || loading.value || selectedCount.value === 0) return false
+  if (action === 'set_proxy') return Boolean(proxyNodeIdForAction.value)
+  return true
+}
+
+function getActionButtonVariant(option: BatchActionOption): 'default' | 'destructive' | 'outline' {
+  if (option.destructive) return 'destructive'
+  return 'outline'
+}
+
+async function confirmAndExecuteAction(action: BatchActionValue): Promise<void> {
+  selectedAction.value = action
+  if (selectedCount.value === 0) {
+    warning('请先选择账号')
+    return
+  }
+  if (action === 'set_proxy' && !proxyNodeIdForAction.value) {
+    warning('请先选择代理节点')
+    return
+  }
+  if (!canExecuteSpecifiedAction(action)) return
+
+  const actionOption = ACTION_OPTIONS.find((item) => item.value === action)
+  const actionLabel = actionOption?.label || '执行动作'
+  const scopeLabel = selectAllFiltered.value ? '筛选结果' : '已选账号'
+  const confirmed = await confirm({
+    title: actionLabel,
+    message: `将对${scopeLabel}（${selectedCount.value} 个）执行：${actionLabel}，是否继续？`,
+    confirmText: actionOption?.destructive ? '确认删除' : '确认执行',
+    ...(actionOption?.destructive ? { variant: 'destructive' as const } : {}),
+  })
+  if (!confirmed) return
+  await executeAction(action)
 }
 
 const DELETE_POLL_INTERVAL_MS = 2000
@@ -654,24 +745,17 @@ async function resolveSelectedItems(): Promise<PoolKeySelectionItem[]> {
   })
 }
 
-async function executeAction(): Promise<void> {
+async function executeAction(actionOverride?: BatchActionValue): Promise<void> {
   if (executing.value) return
+  if (actionOverride) {
+    selectedAction.value = actionOverride
+  }
   if (selectedCount.value === 0) {
     warning('请先选择账号')
     return
   }
 
   const requestedCount = selectedCount.value
-  if (selectedAction.value === 'delete') {
-    const confirmed = await confirm({
-      title: '删除账号',
-      message: `将删除 ${requestedCount} 个账号，操作不可恢复，是否继续？`,
-      confirmText: '确认删除',
-      variant: 'destructive',
-    })
-    if (!confirmed) return
-  }
-
   if (selectedAction.value === 'set_proxy' && !proxyNodeIdForAction.value) {
     warning('请先选择代理节点')
     return
@@ -918,6 +1002,8 @@ watch(
     searchText.value = ''
     lastResultMessage.value = ''
     activeQuickSelectors.value = []
+    selectedAction.value = 'refresh_quota'
+    proxyNodeIdForAction.value = ''
     resetSelection(true)
     filteredTotal.value = 0
     pageKeys.value = []

--- a/frontend/src/features/pool/components/PoolAdvancedDialog.vue
+++ b/frontend/src/features/pool/components/PoolAdvancedDialog.vue
@@ -3,71 +3,96 @@
     :model-value="modelValue"
     title="高级设置"
     description="冷却、健康、成本控制与其他高级参数"
-    size="lg"
+    size="3xl"
     @update:model-value="emit('update:modelValue', $event)"
   >
-    <div class="space-y-4">
-      <!-- Cooldown & Health -->
-      <div class="space-y-3">
-        <h3 class="text-sm font-medium border-b pb-2">
-          冷却与健康
-        </h3>
-        <div class="flex items-center justify-between p-3 border rounded-lg bg-muted/50">
-          <div class="space-y-0.5">
-            <span class="text-sm font-medium">健康策略</span>
-            <p class="text-xs text-muted-foreground">
-              按上游错误自动冷却并跳过账号
-            </p>
+    <div class="max-h-[calc(100dvh-13rem)] space-y-5 overflow-y-auto overscroll-contain pr-1 sm:max-h-[min(72vh,42rem)] sm:space-y-6 sm:pr-2">
+      <section class="space-y-4 rounded-2xl border border-border/60 bg-card/70 p-4 sm:p-5">
+        <div class="space-y-1">
+          <div class="flex flex-wrap items-center gap-2">
+            <h3 class="text-sm font-semibold">
+              冷却与健康
+            </h3>
+            <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+              核心策略
+            </span>
           </div>
-          <Switch
-            :model-value="form.health_policy_enabled"
-            @update:model-value="(v: boolean) => form.health_policy_enabled = v"
-          />
+          <p class="text-xs leading-5 text-muted-foreground">
+            控制自动冷却、主动探测、异常清理和全局调度优先级。
+          </p>
         </div>
-        <div class="flex items-center justify-between p-3 border rounded-lg bg-muted/50">
-          <div class="space-y-0.5">
-            <span class="text-sm font-medium">主动探测</span>
-            <p class="text-xs text-muted-foreground">
-              按固定间隔主动刷新 Key 的账号状态与额度
-            </p>
-          </div>
-          <Switch
-            :model-value="form.probing_enabled"
-            @update:model-value="(v: boolean) => form.probing_enabled = v"
-          />
-        </div>
-        <div
-          v-if="form.probing_enabled"
-          class="grid grid-cols-2 gap-4"
-        >
-          <div class="space-y-1.5">
-            <Label>
-              探测间隔
-              <span class="text-xs text-muted-foreground">(分钟)</span>
-            </Label>
-            <Input
-              :model-value="form.probing_interval_minutes ?? ''"
-              type="number"
-              min="1"
-              max="1440"
-              placeholder="10"
-              @update:model-value="(v) => form.probing_interval_minutes = parseNum(v)"
+
+        <div class="grid gap-3 lg:grid-cols-3">
+          <div
+            v-for="item in healthToggleCards"
+            :key="item.key"
+            class="flex flex-col gap-3 rounded-xl border border-border/60 bg-muted/30 p-4 sm:flex-row sm:items-start sm:justify-between lg:items-center"
+          >
+            <div class="min-w-0 flex-1 space-y-1">
+              <div class="flex items-center gap-1.5">
+                <span class="text-sm font-medium">{{ item.label }}</span>
+                <TooltipProvider
+                  :delay-duration="100"
+                >
+                  <Tooltip>
+                    <TooltipTrigger as-child>
+                      <button
+                        type="button"
+                        :title="item.description"
+                        :aria-label="`${item.label} 说明`"
+                        class="hidden lg:inline-flex items-center justify-center rounded-sm p-0.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                      >
+                        <CircleHelp class="h-3.5 w-3.5" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="top"
+                      :side-offset="8"
+                      class="max-w-xs px-3 py-2 text-xs leading-5"
+                    >
+                      {{ item.description }}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+              <p class="text-xs leading-5 text-muted-foreground lg:hidden">
+                {{ item.description }}
+              </p>
+            </div>
+            <Switch
+              :model-value="getHealthToggleValue(item.key)"
+              class="shrink-0"
+              @update:model-value="(v: boolean) => updateHealthToggleValue(item.key, v)"
             />
           </div>
         </div>
-        <div class="flex items-center justify-between p-3 border rounded-lg bg-muted/50">
-          <div class="space-y-0.5">
-            <span class="text-sm font-medium">异常自动清除</span>
-            <p class="text-xs text-muted-foreground">
-              仅在检测到不可恢复的账号异常时自动从号池中移除，不处理纯 Token 失效
-            </p>
+
+        <div
+          v-if="form.probing_enabled"
+          class="rounded-xl border border-dashed border-primary/25 bg-primary/5 p-4"
+        >
+          <div class="grid gap-3 sm:grid-cols-2">
+            <div class="space-y-1.5">
+              <Label>
+                探测间隔
+                <span class="text-xs text-muted-foreground">(分钟)</span>
+              </Label>
+              <Input
+                :model-value="form.probing_interval_minutes ?? ''"
+                type="number"
+                min="1"
+                max="1440"
+                placeholder="10"
+                @update:model-value="(v) => form.probing_interval_minutes = parseNum(v)"
+              />
+            </div>
           </div>
-          <Switch
-            :model-value="form.auto_remove_banned_keys"
-            @update:model-value="(v: boolean) => form.auto_remove_banned_keys = v"
-          />
         </div>
-        <div class="grid grid-cols-2 gap-4">
+
+        <div
+          class="grid gap-3 sm:grid-cols-2"
+          :class="cooldownFieldLayout.desktopColumnsClass"
+        >
           <div class="space-y-1.5">
             <Label>
               429 冷却
@@ -96,8 +121,6 @@
               @update:model-value="(v) => form.overload_cooldown_seconds = parseNum(v)"
             />
           </div>
-        </div>
-        <div class="grid grid-cols-2 gap-4">
           <div class="space-y-1.5">
             <Label>
               粘性会话 TTL
@@ -115,7 +138,6 @@
           <div class="space-y-1.5">
             <Label>
               全局优先级
-              <span class="text-xs text-muted-foreground">(global_key)</span>
             </Label>
             <Input
               :model-value="form.global_priority ?? ''"
@@ -127,93 +149,200 @@
             />
           </div>
         </div>
-      </div>
+      </section>
 
-      <!-- Batch Operations -->
-      <div class="space-y-3">
-        <h3 class="text-sm font-medium border-b pb-2">
-          批量操作
-        </h3>
-        <div class="grid grid-cols-2 gap-4">
-          <div class="space-y-1.5">
-            <Label>
-              并发数
-            </Label>
-            <Input
-              :model-value="form.batch_concurrency ?? ''"
-              type="number"
-              min="1"
-              max="32"
-              placeholder="8"
-              @update:model-value="(v) => form.batch_concurrency = parseNum(v)"
-            />
-            <p class="text-[11px] text-muted-foreground">
-              批量刷新 OAuth / 额度等操作的并行请求数
+      <div :class="secondarySectionLayout.wrapperClass">
+        <section class="space-y-4 rounded-2xl border border-border/60 bg-card/70 p-4 sm:p-5">
+          <div class="space-y-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <h3 class="text-sm font-semibold">
+                成本控制
+              </h3>
+              <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                额度保护
+              </span>
+            </div>
+            <p class="text-xs leading-5 text-muted-foreground">
+              控制窗口期、Key 限额与软阈值，防止个别账号短时间内过度消耗。
             </p>
           </div>
-        </div>
+
+          <div
+            class="grid gap-3 sm:grid-cols-2"
+            :class="costFieldLayout.desktopColumnsClass"
+          >
+            <div class="space-y-1.5">
+              <Label>
+                成本窗口
+                <span class="text-xs text-muted-foreground">(秒)</span>
+              </Label>
+              <Input
+                :model-value="form.cost_window_seconds ?? ''"
+                type="number"
+                min="3600"
+                max="86400"
+                placeholder="18000 (5 小时)"
+                @update:model-value="(v) => form.cost_window_seconds = parseNum(v)"
+              />
+            </div>
+            <div class="space-y-1.5">
+              <Label>
+                Key 窗口限额
+                <span class="text-xs text-muted-foreground">(tokens)</span>
+              </Label>
+              <Input
+                :model-value="form.cost_limit_per_key_tokens ?? ''"
+                type="number"
+                min="0"
+                placeholder="留空 = 不限"
+                @update:model-value="(v) => form.cost_limit_per_key_tokens = parseNum(v)"
+              />
+            </div>
+            <div class="space-y-1.5">
+              <Label>
+                软阈值
+                <span class="text-xs text-muted-foreground">(%)</span>
+              </Label>
+              <Input
+                :model-value="form.cost_soft_threshold_percent ?? ''"
+                type="number"
+                min="0"
+                max="100"
+                placeholder="80"
+                @update:model-value="(v) => form.cost_soft_threshold_percent = parseNum(v)"
+              />
+            </div>
+          </div>
+        </section>
+
+        <section class="space-y-4 rounded-2xl border border-border/60 bg-card/70 p-4 sm:p-5">
+          <div class="space-y-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <h3 class="text-sm font-semibold">
+                批量操作
+              </h3>
+              <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                任务效率
+              </span>
+            </div>
+            <p class="text-xs leading-5 text-muted-foreground">
+              控制刷新 OAuth、主动探测和批量额度处理时的并行请求数。
+            </p>
+          </div>
+
+          <div class="rounded-xl bg-muted/30 p-4">
+            <div class="space-y-1.5">
+              <Label>
+                并发数
+              </Label>
+              <Input
+                :model-value="form.batch_concurrency ?? ''"
+                type="number"
+                min="1"
+                max="32"
+                placeholder="8"
+                @update:model-value="(v) => form.batch_concurrency = parseNum(v)"
+              />
+              <p class="text-[11px] leading-5 text-muted-foreground">
+                为空时沿用默认值；数值越大，批量操作越快，但会增加瞬时请求压力。
+              </p>
+            </div>
+          </div>
+        </section>
       </div>
 
-      <!-- Claude Code -->
-      <div
+      <section
         v-if="isClaudeCode"
-        class="space-y-3"
+        class="space-y-4 rounded-2xl border border-border/60 bg-card/70 p-4 sm:p-5"
       >
-        <h3 class="text-sm font-medium border-b pb-2">
-          Claude Code
-        </h3>
-        <div class="flex items-center justify-between p-3 border rounded-lg bg-muted/50">
-          <div class="space-y-0.5">
-            <span class="text-sm font-medium">Session ID 伪装</span>
-            <p class="text-xs text-muted-foreground">
-              固定 metadata.user_id 中 session 片段
-            </p>
+        <div class="space-y-1">
+          <div class="flex flex-wrap items-center gap-2">
+            <h3 class="text-sm font-semibold">
+              Claude Code
+            </h3>
+            <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+              请求约束
+            </span>
           </div>
-          <Switch
-            :model-value="claudeForm.session_id_masking_enabled"
-            @update:model-value="(v: boolean) => claudeForm.session_id_masking_enabled = v"
-          />
+          <p class="text-xs leading-5 text-muted-foreground">
+            管理 CLI 请求限制、会话控制和 metadata / cache 相关的兼容行为。
+          </p>
         </div>
-        <div class="flex items-center justify-between p-3 border rounded-lg bg-muted/50">
-          <div class="space-y-0.5">
-            <span class="text-sm font-medium">仅限 CLI 客户端</span>
-            <p class="text-xs text-muted-foreground">
-              仅允许 Claude Code CLI 格式请求
-            </p>
+
+        <div class="grid gap-3 lg:grid-cols-2">
+          <div class="flex flex-col gap-3 rounded-xl border border-border/60 bg-muted/30 p-4 sm:flex-row sm:items-start sm:justify-between">
+            <div class="space-y-1">
+              <span class="text-sm font-medium">Session ID 伪装</span>
+              <p class="text-xs leading-5 text-muted-foreground">
+                固定 metadata.user_id 中 session 片段。
+              </p>
+            </div>
+            <Switch
+              :model-value="claudeForm.session_id_masking_enabled"
+              class="shrink-0"
+              @update:model-value="(v: boolean) => claudeForm.session_id_masking_enabled = v"
+            />
           </div>
-          <Switch
-            :model-value="claudeForm.cli_only_enabled"
-            @update:model-value="(v: boolean) => claudeForm.cli_only_enabled = v"
-          />
-        </div>
-        <div class="flex items-center justify-between p-3 border rounded-lg bg-muted/50">
-          <div class="space-y-0.5">
-            <span class="text-sm font-medium">Cache TTL 统一</span>
-            <p class="text-xs text-muted-foreground">
-              强制所有 cache_control 使用相同 TTL 类型
-            </p>
+
+          <div class="flex flex-col gap-3 rounded-xl border border-border/60 bg-muted/30 p-4 sm:flex-row sm:items-start sm:justify-between">
+            <div class="space-y-1">
+              <span class="text-sm font-medium">仅限 CLI 客户端</span>
+              <p class="text-xs leading-5 text-muted-foreground">
+                仅允许 Claude Code CLI 格式请求。
+              </p>
+            </div>
+            <Switch
+              :model-value="claudeForm.cli_only_enabled"
+              class="shrink-0"
+              @update:model-value="(v: boolean) => claudeForm.cli_only_enabled = v"
+            />
           </div>
-          <Switch
-            :model-value="claudeForm.cache_ttl_override_enabled"
-            @update:model-value="(v: boolean) => claudeForm.cache_ttl_override_enabled = v"
-          />
+
+          <div class="flex flex-col gap-3 rounded-xl border border-border/60 bg-muted/30 p-4 sm:flex-row sm:items-start sm:justify-between">
+            <div class="space-y-1">
+              <span class="text-sm font-medium">Cache TTL 统一</span>
+              <p class="text-xs leading-5 text-muted-foreground">
+                强制所有 cache_control 使用同一种 TTL 类型。
+              </p>
+            </div>
+            <Switch
+              :model-value="claudeForm.cache_ttl_override_enabled"
+              class="shrink-0"
+              @update:model-value="(v: boolean) => claudeForm.cache_ttl_override_enabled = v"
+            />
+          </div>
+
+          <div class="flex flex-col gap-3 rounded-xl border border-border/60 bg-muted/30 p-4 sm:flex-row sm:items-start sm:justify-between">
+            <div class="space-y-1">
+              <span class="text-sm font-medium">会话数量控制</span>
+              <p class="text-xs leading-5 text-muted-foreground">
+                限制单 Key 同时活跃会话数，降低长期占用风险。
+              </p>
+            </div>
+            <Switch
+              :model-value="claudeForm.session_control_enabled"
+              class="shrink-0"
+              @update:model-value="(v: boolean) => claudeForm.session_control_enabled = v"
+            />
+          </div>
         </div>
+
         <div
           v-if="claudeForm.cache_ttl_override_enabled"
-          class="pl-3"
+          class="rounded-xl border border-dashed border-primary/25 bg-primary/5 p-4"
         >
           <div class="space-y-1.5">
             <Label>TTL 类型</Label>
-            <div class="flex gap-0.5 p-0.5 bg-muted/40 rounded-md w-fit">
+            <div class="flex w-fit gap-0.5 rounded-md bg-muted/40 p-0.5">
               <button
                 v-for="opt in ['ephemeral']"
                 :key="opt"
                 type="button"
-                class="px-2.5 py-1 text-xs font-medium rounded transition-all"
+                class="rounded px-2.5 py-1 text-xs font-medium transition-all"
                 :class="[
                   claudeForm.cache_ttl_override_target === opt
                     ? 'bg-primary text-primary-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-background/50'
+                    : 'text-muted-foreground hover:bg-background/50 hover:text-foreground'
                 ]"
                 @click="claudeForm.cache_ttl_override_target = opt"
               >
@@ -222,112 +351,55 @@
             </div>
           </div>
         </div>
-        <div class="flex items-center justify-between p-3 border rounded-lg bg-muted/50">
-          <div class="space-y-0.5">
-            <span class="text-sm font-medium">会话数量控制</span>
-            <p class="text-xs text-muted-foreground">
-              限制单 Key 同时活跃会话数
-            </p>
-          </div>
-          <Switch
-            :model-value="claudeForm.session_control_enabled"
-            @update:model-value="(v: boolean) => claudeForm.session_control_enabled = v"
-          />
-        </div>
+
         <div
           v-if="claudeForm.session_control_enabled"
-          class="grid grid-cols-2 gap-4"
+          class="rounded-xl border border-dashed border-primary/25 bg-primary/5 p-4"
         >
-          <div class="space-y-1.5">
-            <Label>
-              最大会话数
-            </Label>
-            <Input
-              :model-value="claudeForm.max_sessions ?? ''"
-              type="number"
-              min="1"
-              max="100"
-              placeholder="留空 = 不限"
-              @update:model-value="(v) => claudeForm.max_sessions = parseNum(v)"
-            />
-          </div>
-          <div class="space-y-1.5">
-            <Label>
-              空闲超时
-              <span class="text-xs text-muted-foreground">(分钟)</span>
-            </Label>
-            <Input
-              :model-value="claudeForm.session_idle_timeout_minutes ?? ''"
-              type="number"
-              min="1"
-              max="1440"
-              placeholder="5"
-              @update:model-value="(v) => claudeForm.session_idle_timeout_minutes = parseNum(v) ?? 5"
-            />
-          </div>
-        </div>
-      </div>
-
-      <!-- Cost Control -->
-      <div class="space-y-3">
-        <h3 class="text-sm font-medium border-b pb-2">
-          成本控制
-        </h3>
-        <div class="grid grid-cols-2 gap-4">
-          <div class="space-y-1.5">
-            <Label>
-              成本窗口
-              <span class="text-xs text-muted-foreground">(秒)</span>
-            </Label>
-            <Input
-              :model-value="form.cost_window_seconds ?? ''"
-              type="number"
-              min="3600"
-              max="86400"
-              placeholder="18000 (5 小时)"
-              @update:model-value="(v) => form.cost_window_seconds = parseNum(v)"
-            />
-          </div>
-          <div class="space-y-1.5">
-            <Label>
-              Key 窗口限额
-              <span class="text-xs text-muted-foreground">(tokens)</span>
-            </Label>
-            <Input
-              :model-value="form.cost_limit_per_key_tokens ?? ''"
-              type="number"
-              min="0"
-              placeholder="留空 = 不限"
-              @update:model-value="(v) => form.cost_limit_per_key_tokens = parseNum(v)"
-            />
-          </div>
-          <div class="space-y-1.5">
-            <Label>
-              软阈值
-              <span class="text-xs text-muted-foreground">(%)</span>
-            </Label>
-            <Input
-              :model-value="form.cost_soft_threshold_percent ?? ''"
-              type="number"
-              min="0"
-              max="100"
-              placeholder="80"
-              @update:model-value="(v) => form.cost_soft_threshold_percent = parseNum(v)"
-            />
+          <div class="grid gap-3 sm:grid-cols-2">
+            <div class="space-y-1.5">
+              <Label>
+                最大会话数
+              </Label>
+              <Input
+                :model-value="claudeForm.max_sessions ?? ''"
+                type="number"
+                min="1"
+                max="100"
+                placeholder="留空 = 不限"
+                @update:model-value="(v) => claudeForm.max_sessions = parseNum(v)"
+              />
+            </div>
+            <div class="space-y-1.5">
+              <Label>
+                空闲超时
+                <span class="text-xs text-muted-foreground">(分钟)</span>
+              </Label>
+              <Input
+                :model-value="claudeForm.session_idle_timeout_minutes ?? ''"
+                type="number"
+                min="1"
+                max="1440"
+                placeholder="5"
+                @update:model-value="(v) => claudeForm.session_idle_timeout_minutes = parseNum(v) ?? 5"
+              />
+            </div>
           </div>
         </div>
-      </div>
+      </section>
     </div>
 
     <template #footer>
       <Button
         variant="outline"
+        class="min-w-[96px] flex-1 sm:flex-none"
         :disabled="loading"
         @click="emit('update:modelValue', false)"
       >
         取消
       </Button>
       <Button
+        class="min-w-[96px] flex-1 sm:flex-none"
         :disabled="loading"
         @click="handleSave"
       >
@@ -339,10 +411,18 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { Dialog, Button, Input, Label, Switch } from '@/components/ui'
+import { CircleHelp } from 'lucide-vue-next'
+import { Dialog, Button, Input, Label, Switch, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui'
 import { useToast } from '@/composables/useToast'
 import { parseApiError } from '@/utils/errorParser'
 import { updateProvider } from '@/api/endpoints'
+import {
+  buildPoolCooldownFieldLayout,
+  buildPoolCostFieldLayout,
+  buildPoolHealthToggleCards,
+  buildPoolSecondarySectionLayout,
+  type PoolHealthToggleKey,
+} from '@/features/pool/utils/poolAdvancedDialog'
 import type {
   PoolAdvancedConfig,
   ClaudeCodeAdvancedConfig,
@@ -368,6 +448,11 @@ const loading = ref(false)
 const isClaudeCode = computed(() => {
   return (props.providerType || '').trim().toLowerCase() === 'claude_code'
 })
+
+const healthToggleCards = buildPoolHealthToggleCards()
+const cooldownFieldLayout = buildPoolCooldownFieldLayout()
+const costFieldLayout = buildPoolCostFieldLayout()
+const secondarySectionLayout = buildPoolSecondarySectionLayout()
 
 const form = ref({
   global_priority: null as number | null | undefined,
@@ -408,6 +493,30 @@ function parseNum(v: string | number): number | undefined {
   if (v === '' || v === null || v === undefined) return undefined
   const n = Number(v)
   return Number.isNaN(n) ? undefined : n
+}
+
+function getHealthToggleValue(key: PoolHealthToggleKey): boolean {
+  switch (key) {
+    case 'health_policy_enabled':
+      return form.value.health_policy_enabled
+    case 'probing_enabled':
+      return form.value.probing_enabled
+    case 'auto_remove_banned_keys':
+      return form.value.auto_remove_banned_keys
+  }
+}
+
+function updateHealthToggleValue(key: PoolHealthToggleKey, value: boolean): void {
+  switch (key) {
+    case 'health_policy_enabled':
+      form.value.health_policy_enabled = value
+      return
+    case 'probing_enabled':
+      form.value.probing_enabled = value
+      return
+    case 'auto_remove_banned_keys':
+      form.value.auto_remove_banned_keys = value
+  }
 }
 
 watch(() => props.modelValue, (open) => {

--- a/frontend/src/features/pool/components/PoolSchedulingDialog.vue
+++ b/frontend/src/features/pool/components/PoolSchedulingDialog.vue
@@ -6,11 +6,11 @@
     size="lg"
     @update:model-value="emit('update:modelValue', $event)"
   >
-    <div class="space-y-6">
+    <div class="max-h-[calc(100dvh-13rem)] space-y-5 overflow-y-auto overscroll-contain pr-1 sm:max-h-[min(72vh,42rem)] sm:space-y-6 sm:pr-2">
       <!-- Section 1: 分配模式 (distribution_mode 互斥组, 四选一) -->
-      <div class="space-y-3">
+      <div class="space-y-4 rounded-2xl border border-border/60 bg-card/70 p-4">
         <div class="space-y-1">
-          <h3 class="text-sm font-medium border-b pb-2">
+          <h3 class="text-sm font-medium">
             分配模式
           </h3>
           <p class="text-xs text-muted-foreground">
@@ -18,19 +18,19 @@
           </p>
         </div>
 
-        <div class="flex gap-0.5 p-1 bg-muted/40 rounded-lg">
+        <div class="grid grid-cols-2 gap-2 sm:grid-cols-4">
           <button
             v-for="{ index, item } in distributionItems"
             :key="item.preset"
             type="button"
-            class="flex-1 px-3 py-2 text-sm font-medium rounded-md transition-all duration-200"
+            class="min-h-11 rounded-xl border px-3 py-2.5 text-sm font-medium leading-tight transition-all duration-200"
             :disabled="!item.applicable"
             :class="[
               activeDistributionPreset === item.preset
-                ? 'bg-primary text-primary-foreground shadow-sm'
+                ? 'border-primary bg-primary text-primary-foreground shadow-sm shadow-primary/20'
                 : item.applicable
-                  ? 'text-muted-foreground hover:text-foreground hover:bg-background/60'
-                  : 'text-muted-foreground/40 cursor-not-allowed'
+                  ? 'border-border/60 bg-background text-foreground hover:border-border hover:bg-muted/40'
+                  : 'border-border/30 bg-muted/20 text-muted-foreground/50 cursor-not-allowed'
             ]"
             @click="item.applicable && selectDistribution(index, item.preset)"
           >
@@ -38,38 +38,53 @@
           </button>
         </div>
 
-        <p
-          v-if="activeDistributionDesc"
-          class="text-xs text-muted-foreground px-1"
+        <div
+          v-if="activeDistributionLabel || activeDistributionDesc"
+          class="rounded-xl border border-primary/15 bg-primary/5 px-3 py-2.5"
         >
-          {{ activeDistributionDesc }}
-        </p>
+          <p
+            v-if="activeDistributionDesc"
+            class="mt-1 text-xs leading-5 text-muted-foreground"
+          >
+            {{ activeDistributionDesc }}
+          </p>
+        </div>
       </div>
 
       <!-- Section 2: 策略调度 (非互斥, 可叠加组合 + 拖拽排序) -->
-      <div class="space-y-3">
+      <div class="space-y-4 rounded-2xl border border-border/60 bg-card/70 p-4">
         <div class="space-y-1">
-          <h3 class="text-sm font-medium border-b pb-2">
-            策略调度
-          </h3>
+          <div class="flex flex-wrap items-center gap-2">
+            <h3 class="text-sm font-medium">
+              策略调度
+            </h3>
+            <span class="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+              已启用 {{ enabledStrategyCount }} 项
+            </span>
+          </div>
           <p class="text-xs text-muted-foreground">
-            在分配模式基础上叠加排序因素，可组合启用，拖拽调整优先级。
+            在分配模式基础上叠加排序因素，可组合启用。
+          </p>
+          <p class="text-xs text-muted-foreground">
+            桌面端支持拖拽排序，移动端可点按上下调整优先级。
           </p>
         </div>
 
-        <div class="space-y-0.5">
+        <div class="space-y-1.5">
           <div
             v-for="{ index, item } in strategyItems"
             :key="item.preset"
-            class="group flex items-center gap-3 px-3 py-2.5 rounded-lg border transition-all duration-200"
+            class="group rounded-xl border px-3 py-2.5 transition-all duration-200"
             :class="[
               !item.applicable
-                ? 'border-border/30 bg-muted/20 opacity-50'
+                ? 'border-border/40 bg-muted/20 opacity-80'
                 : draggedIndex === index
-                  ? 'border-primary/50 bg-primary/5 shadow-md scale-[1.01]'
+                  ? 'border-primary/50 bg-primary/5 shadow-md'
                   : dragOverIndex === index
                     ? 'border-primary/30 bg-primary/5'
-                    : 'border-border/50 bg-background hover:border-border hover:bg-muted/30'
+                    : item.enabled
+                      ? 'border-primary/20 bg-primary/5 hover:border-primary/30'
+                      : 'border-border/60 bg-background hover:border-border hover:bg-muted/30'
             ]"
             :draggable="item.applicable"
             @dragstart="item.applicable && handleDragStart(index, $event)"
@@ -78,57 +93,99 @@
             @dragleave="handleDragLeave"
             @drop="item.applicable && handleDrop(index)"
           >
-            <!-- Drag handle -->
-            <div
-              class="p-1 rounded transition-colors shrink-0"
-              :class="item.applicable
-                ? 'cursor-grab active:cursor-grabbing text-muted-foreground/40 group-hover:text-muted-foreground'
-                : 'text-muted-foreground/15 cursor-default'"
-            >
-              <GripVertical class="w-4 h-4" />
-            </div>
-
-            <Switch
-              :model-value="item.enabled"
-              :disabled="!item.applicable"
-              @update:model-value="(v: boolean) => togglePreset(index, v)"
-            />
-
-            <!-- Info -->
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2">
-                <span
-                  class="text-sm font-medium"
-                  :class="!item.applicable ? 'text-muted-foreground' : ''"
-                >{{ item.label }}</span>
-                <span
-                  v-if="!item.applicable"
-                  class="text-[10px] text-muted-foreground/60"
-                >(不适用)</span>
-              </div>
-              <p class="text-xs text-muted-foreground mt-0.5">
-                {{ item.desc }}
-              </p>
-
-              <!-- Mode sub-config -->
+            <div class="flex items-start gap-2.5">
+              <!-- Drag handle -->
               <div
-                v-if="item.modeOptions.length > 0 && item.enabled && item.applicable"
-                class="flex gap-0.5 mt-2 p-0.5 bg-muted/40 rounded-md w-fit"
+                class="hidden rounded-lg p-1 transition-colors sm:flex sm:shrink-0"
+                :class="item.applicable
+                  ? 'cursor-grab active:cursor-grabbing text-muted-foreground/40 group-hover:text-muted-foreground'
+                  : 'text-muted-foreground/20 cursor-default'"
               >
-                <button
-                  v-for="modeOpt in item.modeOptions"
-                  :key="modeOpt.value"
-                  type="button"
-                  class="px-2.5 py-1 text-xs font-medium rounded transition-all"
-                  :class="[
-                    item.mode === modeOpt.value
-                      ? 'bg-primary text-primary-foreground shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground hover:bg-background/50'
-                  ]"
-                  @click="setPresetModeByPreset(item.preset, modeOpt.value)"
+                <GripVertical class="h-4 w-4" />
+              </div>
+
+              <div class="min-w-0 flex-1">
+                <div class="flex items-start gap-2.5">
+                  <div class="min-w-0 flex-1">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <span
+                        class="text-sm font-medium"
+                        :class="!item.applicable ? 'text-muted-foreground' : 'text-foreground'"
+                      >{{ item.label }}</span>
+                      <span
+                        v-if="getStrategyPriority(index)"
+                        class="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
+                      >
+                        #{{ getStrategyPriority(index) }}
+                      </span>
+                      <span
+                        v-if="!item.applicable"
+                        class="rounded-full border border-border/60 bg-muted px-2 py-0.5 text-[11px] text-muted-foreground"
+                      >
+                        当前不可用
+                      </span>
+                    </div>
+                    <p class="mt-0.5 text-xs leading-5 text-muted-foreground">
+                      {{ item.desc }}
+                    </p>
+                  </div>
+
+                  <div
+                    v-if="item.applicable"
+                    class="flex shrink-0 items-center gap-1.5 sm:hidden"
+                  >
+                    <button
+                      type="button"
+                      class="inline-flex h-7 items-center justify-center rounded-lg border border-border/60 px-2.5 text-[11px] font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
+                      :disabled="!canMoveStrategy(index, -1)"
+                      @click="moveStrategy(index, -1)"
+                    >
+                      上移
+                    </button>
+                    <button
+                      type="button"
+                      class="inline-flex h-7 items-center justify-center rounded-lg border border-border/60 px-2.5 text-[11px] font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-40"
+                      :disabled="!canMoveStrategy(index, 1)"
+                      @click="moveStrategy(index, 1)"
+                    >
+                      下移
+                    </button>
+                  </div>
+
+                  <Switch
+                    :model-value="item.enabled && item.applicable"
+                    :disabled="!item.applicable"
+                    class="mt-0.5 shrink-0"
+                    @update:model-value="(v: boolean) => togglePreset(index, v)"
+                  />
+                </div>
+
+                <div
+                  v-if="(item.modeOptions.length > 0 && item.enabled && item.applicable) || item.applicable"
+                  class="mt-2 flex flex-col gap-1.5 sm:flex-row sm:items-center sm:justify-between"
                 >
-                  {{ modeOpt.label }}
-                </button>
+                  <!-- Mode sub-config -->
+                  <div
+                    v-if="item.modeOptions.length > 0 && item.enabled && item.applicable"
+                    class="flex flex-wrap gap-1 rounded-lg bg-muted/40 p-1"
+                  >
+                    <button
+                      v-for="modeOpt in item.modeOptions"
+                      :key="modeOpt.value"
+                      type="button"
+                      class="rounded-md px-2.5 py-1 text-xs font-medium transition-all"
+                      :class="[
+                        item.mode === modeOpt.value
+                          ? 'bg-primary text-primary-foreground shadow-sm'
+                          : 'text-muted-foreground hover:bg-background/70 hover:text-foreground'
+                      ]"
+                      @click="setPresetModeByPreset(item.preset, modeOpt.value)"
+                    >
+                      {{ modeOpt.label }}
+                    </button>
+                  </div>
+
+                </div>
               </div>
             </div>
           </div>
@@ -139,12 +196,14 @@
     <template #footer>
       <Button
         variant="outline"
+        class="min-w-[96px] flex-1 sm:flex-none"
         :disabled="loading"
         @click="emit('update:modelValue', false)"
       >
         取消
       </Button>
       <Button
+        class="min-w-[96px] flex-1 sm:flex-none"
         :disabled="loading"
         @click="handleSave"
       >
@@ -162,6 +221,7 @@ import { useToast } from '@/composables/useToast'
 import { parseApiError } from '@/utils/errorParser'
 import { updateProvider } from '@/api/endpoints'
 import { getPoolSchedulingPresets } from '@/api/endpoints/pool'
+import { moveStrategyItem } from '@/features/pool/utils/poolSchedulingDialog'
 import type { PoolPresetMeta } from '@/api/endpoints/pool'
 import type {
   PoolAdvancedConfig,
@@ -665,6 +725,11 @@ const activeDistributionDesc = computed(() => {
   return found?.item.desc ?? null
 })
 
+const activeDistributionLabel = computed(() => {
+  const found = distributionItems.value.find(({ item }) => item.enabled && item.applicable)
+  return found?.item.label ?? null
+})
+
 const strategyItems = computed(() => {
   const items: { index: number; item: PresetListItem }[] = []
   presetList.value.forEach((item, index) => {
@@ -674,6 +739,37 @@ const strategyItems = computed(() => {
   })
   return items
 })
+
+const enabledStrategyPriorityMap = computed(() => {
+  const priorities = new Map<number, number>()
+  let priority = 0
+
+  strategyItems.value.forEach(({ index, item }) => {
+    if (!item.enabled || !item.applicable) return
+    priority += 1
+    priorities.set(index, priority)
+  })
+
+  return priorities
+})
+
+const enabledStrategyCount = computed(() => enabledStrategyPriorityMap.value.size)
+
+function getStrategyPriority(index: number): number | null {
+  return enabledStrategyPriorityMap.value.get(index) ?? null
+}
+
+function canMoveStrategy(index: number, direction: -1 | 1): boolean {
+  const strategyIndexes = strategyItems.value.map(({ index: currentIndex }) => currentIndex)
+  const currentPosition = strategyIndexes.indexOf(index)
+  if (currentPosition === -1) return false
+  const targetPosition = currentPosition + direction
+  return targetPosition >= 0 && targetPosition < strategyIndexes.length
+}
+
+function moveStrategy(index: number, direction: -1 | 1) {
+  presetList.value = moveStrategyItem(presetList.value, index, direction)
+}
 
 function handleDragStart(index: number, event: DragEvent) {
   draggedIndex.value = index

--- a/frontend/src/features/pool/components/PoolSchedulingDialog.vue
+++ b/frontend/src/features/pool/components/PoolSchedulingDialog.vue
@@ -184,7 +184,6 @@
                       {{ modeOpt.label }}
                     </button>
                   </div>
-
                 </div>
               </div>
             </div>

--- a/frontend/src/features/pool/utils/__tests__/poolAdvancedDialog.spec.ts
+++ b/frontend/src/features/pool/utils/__tests__/poolAdvancedDialog.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildPoolCooldownFieldLayout,
+  buildPoolHealthToggleCards,
+  buildPoolCostFieldLayout,
+  buildPoolSecondarySectionLayout,
+} from '@/features/pool/utils/poolAdvancedDialog'
+
+describe('poolAdvancedDialog', () => {
+  it('returns health toggle cards in the desktop display order', () => {
+    expect(buildPoolHealthToggleCards().map(item => item.key)).toEqual([
+      'health_policy_enabled',
+      'probing_enabled',
+      'auto_remove_banned_keys',
+    ])
+  })
+
+  it('provides tooltip copy for every desktop health toggle card', () => {
+    expect(buildPoolHealthToggleCards()).toEqual([
+      {
+        key: 'health_policy_enabled',
+        label: '健康策略',
+        description: '按上游错误自动冷却并跳过异常账号。',
+      },
+      {
+        key: 'probing_enabled',
+        label: '主动探测',
+        description: '按固定间隔刷新 Key 的状态与额度，减少号池状态滞后。',
+      },
+      {
+        key: 'auto_remove_banned_keys',
+        label: '异常自动清除',
+        description: '仅在检测到不可恢复的账号异常时自动从号池移除，不处理纯 Token 失效。',
+      },
+    ])
+  })
+
+  it('returns the four cooldown-related fields in one desktop row order', () => {
+    expect(buildPoolCooldownFieldLayout()).toEqual({
+      fields: [
+        'rate_limit_cooldown_seconds',
+        'overload_cooldown_seconds',
+        'sticky_session_ttl_seconds',
+        'global_priority',
+      ],
+      desktopColumnsClass: 'xl:grid-cols-4',
+    })
+  })
+
+  it('stacks batch and cost sections as full-width rows on desktop', () => {
+    expect(buildPoolSecondarySectionLayout()).toEqual({
+      wrapperClass: 'space-y-4',
+    })
+  })
+
+  it('returns the three cost fields in one desktop row order', () => {
+    expect(buildPoolCostFieldLayout()).toEqual({
+      fields: [
+        'cost_window_seconds',
+        'cost_limit_per_key_tokens',
+        'cost_soft_threshold_percent',
+      ],
+      desktopColumnsClass: 'xl:grid-cols-3',
+    })
+  })
+})

--- a/frontend/src/features/pool/utils/__tests__/poolManagementState.spec.ts
+++ b/frontend/src/features/pool/utils/__tests__/poolManagementState.spec.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  buildPoolManagementQueryPatch,
+  readPoolManagementViewState,
+  writePoolManagementViewState,
+} from '@/features/pool/utils/poolManagementState'
+
+function createMemoryStorage() {
+  const store = new Map<string, string>()
+  return {
+    getItem(key: string) {
+      return store.get(key) ?? null
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value)
+    },
+    removeItem(key: string) {
+      store.delete(key)
+    },
+  }
+}
+
+describe('poolManagementState', () => {
+  let storage: ReturnType<typeof createMemoryStorage>
+
+  beforeEach(() => {
+    storage = createMemoryStorage()
+  })
+
+  it('restores provider, filters and paging from query first', () => {
+    writePoolManagementViewState(
+      {
+        providerId: 'provider-a',
+        search: 'stored search',
+        status: 'cooldown',
+        page: 5,
+        pageSize: 20,
+      },
+      storage,
+    )
+
+    const state = readPoolManagementViewState(
+      {
+        providerId: 'provider-b',
+        search: 'query search',
+        status: 'inactive',
+        page: '3',
+        pageSize: '100',
+      },
+      storage,
+    )
+
+    expect(state).toEqual({
+      providerId: 'provider-b',
+      search: 'query search',
+      status: 'inactive',
+      page: 3,
+      pageSize: 100,
+    })
+  })
+
+  it('falls back to storage when query is missing', () => {
+    writePoolManagementViewState(
+      {
+        providerId: 'provider-c',
+        search: 'stored only',
+        status: 'active',
+        page: 2,
+        pageSize: 50,
+      },
+      storage,
+    )
+
+    const state = readPoolManagementViewState({}, storage)
+
+    expect(state).toEqual({
+      providerId: 'provider-c',
+      search: 'stored only',
+      status: 'active',
+      page: 2,
+      pageSize: 50,
+    })
+  })
+
+  it('omits defaults when building query patch', () => {
+    expect(
+      buildPoolManagementQueryPatch({
+        providerId: 'provider-d',
+        search: '  ',
+        status: 'all',
+        page: 1,
+        pageSize: 50,
+      }),
+    ).toEqual({
+      providerId: 'provider-d',
+      search: undefined,
+      status: undefined,
+      page: undefined,
+      pageSize: undefined,
+    })
+  })
+})

--- a/frontend/src/features/pool/utils/__tests__/poolMobilePresentation.spec.ts
+++ b/frontend/src/features/pool/utils/__tests__/poolMobilePresentation.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildPoolMobileTagItems,
+  splitPoolMobileActions,
+} from '@/features/pool/utils/poolMobilePresentation'
+
+describe('poolMobilePresentation', () => {
+  it('prioritizes critical mobile tags before secondary identity tags', () => {
+    expect(
+      buildPoolMobileTagItems({
+        priorityLabel: 'P40',
+        authLabel: 'OAuth',
+        oauthStatusLabel: 'Token 过期',
+        oauthStatusTone: 'danger',
+        accountStatusLabel: '账号停用',
+        accountStatusTone: 'danger',
+        planLabel: 'Team',
+        orgLabel: 'Org A',
+        proxyLabel: '独立代理',
+      }).map(item => item.label),
+    ).toEqual([
+      '账号停用',
+      'Token 过期',
+      'P40',
+      'OAuth',
+      'Team',
+      'Org A',
+      '独立代理',
+    ])
+  })
+
+  it('keeps all available mobile actions inline without overflow grouping', () => {
+    expect(
+      splitPoolMobileActions({
+        canRefreshToken: true,
+        canClearCooldown: true,
+        canRecoverHealth: true,
+        canDownloadOrCopy: true,
+        hasProxy: true,
+      }),
+    ).toEqual({
+      primary: [
+        'copy_or_download',
+        'refresh_token',
+        'clear_cooldown',
+        'recover_health',
+        'permissions',
+        'proxy',
+        'edit',
+        'toggle',
+        'delete',
+      ],
+      overflow: [],
+    })
+  })
+})

--- a/frontend/src/features/pool/utils/__tests__/poolSchedulingDialog.spec.ts
+++ b/frontend/src/features/pool/utils/__tests__/poolSchedulingDialog.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { moveStrategyItem } from '@/features/pool/utils/poolSchedulingDialog'
+
+interface TestPresetItem {
+  preset: string
+  mutexGroup: string | null
+  enabled: boolean
+}
+
+function buildItems(): TestPresetItem[] {
+  return [
+    { preset: 'cache_affinity', mutexGroup: 'distribution_mode', enabled: false },
+    { preset: 'lru', mutexGroup: 'distribution_mode', enabled: true },
+    { preset: 'single_account', mutexGroup: 'distribution_mode', enabled: false },
+    { preset: 'load_balance', mutexGroup: 'distribution_mode', enabled: false },
+    { preset: 'recent_refresh', mutexGroup: null, enabled: true },
+    { preset: 'quota_balanced', mutexGroup: null, enabled: false },
+    { preset: 'priority_first', mutexGroup: null, enabled: true },
+  ]
+}
+
+describe('poolSchedulingDialog', () => {
+  it('moves only strategy items upward without disturbing distribution presets', () => {
+    const moved = moveStrategyItem(buildItems(), 6, -1)
+
+    expect(moved.map(item => item.preset)).toEqual([
+      'cache_affinity',
+      'lru',
+      'single_account',
+      'load_balance',
+      'recent_refresh',
+      'priority_first',
+      'quota_balanced',
+    ])
+  })
+
+  it('keeps the original order when a strategy item is already at the top boundary', () => {
+    const original = buildItems()
+    const moved = moveStrategyItem(original, 4, -1)
+
+    expect(moved.map(item => item.preset)).toEqual(original.map(item => item.preset))
+  })
+
+  it('moves a strategy item downward within the strategy group', () => {
+    const moved = moveStrategyItem(buildItems(), 4, 1)
+
+    expect(moved.map(item => item.preset)).toEqual([
+      'cache_affinity',
+      'lru',
+      'single_account',
+      'load_balance',
+      'quota_balanced',
+      'recent_refresh',
+      'priority_first',
+    ])
+  })
+
+  it('keeps the original order when a strategy item is already at the bottom boundary', () => {
+    const original = buildItems()
+    const moved = moveStrategyItem(original, 6, 1)
+
+    expect(moved.map(item => item.preset)).toEqual(original.map(item => item.preset))
+  })
+
+  it('keeps the original order when the target item is not a strategy preset', () => {
+    const original = buildItems()
+    const moved = moveStrategyItem(original, 1, 1)
+
+    expect(moved.map(item => item.preset)).toEqual(original.map(item => item.preset))
+  })
+})

--- a/frontend/src/features/pool/utils/poolAdvancedDialog.ts
+++ b/frontend/src/features/pool/utils/poolAdvancedDialog.ts
@@ -1,0 +1,73 @@
+export type PoolHealthToggleKey =
+  | 'health_policy_enabled'
+  | 'probing_enabled'
+  | 'auto_remove_banned_keys'
+
+export interface PoolHealthToggleCard {
+  key: PoolHealthToggleKey
+  label: string
+  description: string
+}
+
+export interface PoolCooldownFieldLayout {
+  fields: string[]
+  desktopColumnsClass: string
+}
+
+export interface PoolSecondarySectionLayout {
+  wrapperClass: string
+}
+
+export interface PoolCostFieldLayout {
+  fields: string[]
+  desktopColumnsClass: string
+}
+
+export function buildPoolHealthToggleCards(): PoolHealthToggleCard[] {
+  return [
+    {
+      key: 'health_policy_enabled',
+      label: '健康策略',
+      description: '按上游错误自动冷却并跳过异常账号。',
+    },
+    {
+      key: 'probing_enabled',
+      label: '主动探测',
+      description: '按固定间隔刷新 Key 的状态与额度，减少号池状态滞后。',
+    },
+    {
+      key: 'auto_remove_banned_keys',
+      label: '异常自动清除',
+      description: '仅在检测到不可恢复的账号异常时自动从号池移除，不处理纯 Token 失效。',
+    },
+  ]
+}
+
+export function buildPoolCooldownFieldLayout(): PoolCooldownFieldLayout {
+  return {
+    fields: [
+      'rate_limit_cooldown_seconds',
+      'overload_cooldown_seconds',
+      'sticky_session_ttl_seconds',
+      'global_priority',
+    ],
+    desktopColumnsClass: 'xl:grid-cols-4',
+  }
+}
+
+export function buildPoolSecondarySectionLayout(): PoolSecondarySectionLayout {
+  return {
+    wrapperClass: 'space-y-4',
+  }
+}
+
+export function buildPoolCostFieldLayout(): PoolCostFieldLayout {
+  return {
+    fields: [
+      'cost_window_seconds',
+      'cost_limit_per_key_tokens',
+      'cost_soft_threshold_percent',
+    ],
+    desktopColumnsClass: 'xl:grid-cols-3',
+  }
+}

--- a/frontend/src/features/pool/utils/poolManagementState.ts
+++ b/frontend/src/features/pool/utils/poolManagementState.ts
@@ -1,0 +1,129 @@
+export type PoolManagementStatus = 'all' | 'active' | 'cooldown' | 'inactive'
+
+export interface PoolManagementViewState {
+  providerId: string | null
+  search: string
+  status: PoolManagementStatus
+  page: number
+  pageSize: number
+}
+
+export interface PoolManagementStateSource {
+  providerId?: string
+  search?: string
+  status?: string
+  page?: string
+  pageSize?: string
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+export const POOL_MANAGEMENT_VIEW_STORAGE_KEY = 'aether:pool-management:view-state'
+
+export const DEFAULT_POOL_MANAGEMENT_VIEW_STATE: PoolManagementViewState = {
+  providerId: null,
+  search: '',
+  status: 'all',
+  page: 1,
+  pageSize: 50,
+}
+
+function normalizeProviderId(value: unknown): string | null {
+  const normalized = String(value ?? '').trim()
+  return normalized || null
+}
+
+function normalizeSearch(value: unknown): string {
+  return String(value ?? '')
+}
+
+function normalizeStatus(value: unknown): PoolManagementStatus {
+  if (value === 'active' || value === 'cooldown' || value === 'inactive') {
+    return value
+  }
+  return 'all'
+}
+
+function normalizePositiveInteger(value: unknown, fallback: number): number {
+  const normalized = Number.parseInt(String(value ?? ''), 10)
+  if (!Number.isFinite(normalized) || normalized <= 0) {
+    return fallback
+  }
+  return normalized
+}
+
+function normalizeViewState(input: Partial<PoolManagementViewState>): PoolManagementViewState {
+  return {
+    providerId: normalizeProviderId(input.providerId),
+    search: normalizeSearch(input.search),
+    status: normalizeStatus(input.status),
+    page: normalizePositiveInteger(input.page, DEFAULT_POOL_MANAGEMENT_VIEW_STATE.page),
+    pageSize: normalizePositiveInteger(input.pageSize, DEFAULT_POOL_MANAGEMENT_VIEW_STATE.pageSize),
+  }
+}
+
+function readStoredState(storage?: StorageLike): Partial<PoolManagementViewState> {
+  if (!storage) return {}
+
+  try {
+    const raw = storage.getItem(POOL_MANAGEMENT_VIEW_STORAGE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as Partial<PoolManagementViewState> | null
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export function readPoolManagementViewState(
+  source: PoolManagementStateSource,
+  storage?: StorageLike,
+): PoolManagementViewState {
+  const stored = normalizeViewState(readStoredState(storage))
+
+  return normalizeViewState({
+    providerId: source.providerId ?? stored.providerId,
+    search: source.search ?? stored.search,
+    status: source.status ?? stored.status,
+    page: source.page ?? stored.page,
+    pageSize: source.pageSize ?? stored.pageSize,
+  })
+}
+
+export function writePoolManagementViewState(
+  state: PoolManagementViewState,
+  storage?: StorageLike,
+): void {
+  if (!storage) return
+
+  try {
+    storage.setItem(
+      POOL_MANAGEMENT_VIEW_STORAGE_KEY,
+      JSON.stringify(normalizeViewState(state)),
+    )
+  } catch {
+    // 忽略存储失败，避免影响主流程。
+  }
+}
+
+export function buildPoolManagementQueryPatch(
+  state: PoolManagementViewState,
+): Record<string, string | undefined> {
+  const normalized = normalizeViewState(state)
+  const search = normalized.search.trim()
+
+  return {
+    providerId: normalized.providerId || undefined,
+    search: search || undefined,
+    status: normalized.status === 'all' ? undefined : normalized.status,
+    page: normalized.page <= 1 ? undefined : String(normalized.page),
+    pageSize:
+      normalized.pageSize === DEFAULT_POOL_MANAGEMENT_VIEW_STATE.pageSize
+        ? undefined
+        : String(normalized.pageSize),
+  }
+}

--- a/frontend/src/features/pool/utils/poolMobilePresentation.ts
+++ b/frontend/src/features/pool/utils/poolMobilePresentation.ts
@@ -1,0 +1,108 @@
+export type PoolMobileTagTone = 'default' | 'muted' | 'warning' | 'danger' | 'accent'
+
+export interface PoolMobileTagItem {
+  key: string
+  label: string
+  tone: PoolMobileTagTone
+}
+
+export interface PoolMobileTagInput {
+  priorityLabel?: string | null
+  authLabel?: string | null
+  oauthStatusLabel?: string | null
+  oauthStatusTone?: PoolMobileTagTone | null
+  accountStatusLabel?: string | null
+  accountStatusTone?: PoolMobileTagTone | null
+  planLabel?: string | null
+  orgLabel?: string | null
+  proxyLabel?: string | null
+}
+
+export type PoolMobileActionId =
+  | 'copy_or_download'
+  | 'refresh_token'
+  | 'clear_cooldown'
+  | 'recover_health'
+  | 'permissions'
+  | 'proxy'
+  | 'edit'
+  | 'toggle'
+  | 'delete'
+
+export interface PoolMobileActionInput {
+  canDownloadOrCopy?: boolean
+  canRefreshToken?: boolean
+  canClearCooldown?: boolean
+  canRecoverHealth?: boolean
+  hasProxy?: boolean
+}
+
+function createTagItem(
+  key: string,
+  label: string | null | undefined,
+  tone: PoolMobileTagTone,
+): PoolMobileTagItem | null {
+  if (!label) return null
+  return { key, label, tone }
+}
+
+export function buildPoolMobileTagItems(input: PoolMobileTagInput): PoolMobileTagItem[] {
+  return [
+    createTagItem('account', input.accountStatusLabel, input.accountStatusTone ?? 'warning'),
+    createTagItem('oauth', input.oauthStatusLabel, input.oauthStatusTone ?? 'warning'),
+    createTagItem('priority', input.priorityLabel, 'muted'),
+    createTagItem('auth', input.authLabel, 'default'),
+    createTagItem('plan', input.planLabel, 'accent'),
+    createTagItem('org', input.orgLabel, 'accent'),
+    createTagItem('proxy', input.proxyLabel, 'muted'),
+  ].filter((item): item is PoolMobileTagItem => item !== null)
+}
+
+export function splitPoolMobileActions(input: PoolMobileActionInput): {
+  primary: PoolMobileActionId[]
+  overflow: PoolMobileActionId[]
+} {
+  if (input.canDownloadOrCopy) {
+    const primary: PoolMobileActionId[] = ['copy_or_download']
+    if (input.canRefreshToken) {
+      primary.push('refresh_token')
+    }
+    if (input.canClearCooldown) {
+      primary.push('clear_cooldown')
+    }
+    if (input.canRecoverHealth) {
+      primary.push('recover_health')
+    }
+    primary.push('permissions')
+    if (input.hasProxy) {
+      primary.push('proxy')
+    }
+    primary.push('edit', 'toggle', 'delete')
+
+    return {
+      primary,
+      overflow: [],
+    }
+  }
+
+  const primary: PoolMobileActionId[] = []
+  if (input.canRefreshToken) {
+    primary.push('refresh_token')
+  }
+  if (input.canClearCooldown) {
+    primary.push('clear_cooldown')
+  }
+  if (input.canRecoverHealth) {
+    primary.push('recover_health')
+  }
+  primary.push('permissions')
+  if (input.hasProxy) {
+    primary.push('proxy')
+  }
+  primary.push('edit', 'toggle', 'delete')
+
+  return {
+    primary,
+    overflow: [],
+  }
+}

--- a/frontend/src/features/pool/utils/poolSchedulingDialog.ts
+++ b/frontend/src/features/pool/utils/poolSchedulingDialog.ts
@@ -1,0 +1,35 @@
+export interface SchedulingDialogPresetLike {
+  mutexGroup: string | null
+}
+
+export function moveStrategyItem<T extends SchedulingDialogPresetLike>(
+  items: readonly T[],
+  itemIndex: number,
+  direction: -1 | 1,
+): T[] {
+  const strategyIndexes: number[] = []
+
+  items.forEach((item, index) => {
+    if (!item.mutexGroup) {
+      strategyIndexes.push(index)
+    }
+  })
+
+  const currentPosition = strategyIndexes.indexOf(itemIndex)
+  if (currentPosition === -1) {
+    return [...items]
+  }
+
+  const targetPosition = currentPosition + direction
+  if (targetPosition < 0 || targetPosition >= strategyIndexes.length) {
+    return [...items]
+  }
+
+  const sourceIndex = strategyIndexes[currentPosition]
+  const targetIndex = strategyIndexes[targetPosition]
+  const nextItems = [...items]
+
+  ;[nextItems[sourceIndex], nextItems[targetIndex]] = [nextItems[targetIndex], nextItems[sourceIndex]]
+
+  return nextItems
+}

--- a/frontend/src/features/providers/components/provider-tabs/ModelMappingTab.vue
+++ b/frontend/src/features/providers/components/provider-tabs/ModelMappingTab.vue
@@ -409,7 +409,7 @@ const { error: showError, success: showSuccess } = useToast()
 const modelTest = useModelTest({ providerId: () => props.provider.id })
 
 // 状态
-const loading = ref(false)
+const localLoading = ref(false)
 const dialogOpen = ref(false)
 const deleteConfirmOpen = ref(false)
 const editingGroup = ref<AliasGroup | null>(null)
@@ -429,7 +429,7 @@ const parsedTestRequestHeaders = computed(() => parseModelTestRequestHeadersDraf
 const testRequestHeadersError = computed(() => parsedTestRequestHeaders.value.error)
 const parsedTestRequestBody = computed(() => parseModelTestRequestBodyDraft(testRequestBodyDraft.value))
 const testRequestBodyError = computed(() => parsedTestRequestBody.value.error)
-const isLoading = computed(() => Boolean(props.loading) || loading.value)
+const isLoading = computed(() => Boolean(props.loading) || localLoading.value)
 
 // 使用 props 传入的数据
 const models = computed(() => props.models ?? [])

--- a/frontend/src/features/providers/components/provider-tabs/ModelsTab.vue
+++ b/frontend/src/features/providers/components/provider-tabs/ModelsTab.vue
@@ -285,7 +285,7 @@ const { copyToClipboard } = useClipboard()
 const modelTest = useModelTest({ providerId: () => props.provider.id })
 
 // 状态
-const loading = ref(false)
+const localLoading = ref(false)
 const localModels = ref<Model[]>([])
 const togglingModelId = ref<string | null>(null)
 const pendingTestModel = ref<Model | null>(null)
@@ -301,7 +301,7 @@ const testRequestHeadersError = computed(() => parsedTestRequestHeaders.value.er
 const parsedTestRequestBody = computed(() => parseModelTestRequestBodyDraft(testRequestBodyDraft.value))
 const testRequestBodyError = computed(() => parsedTestRequestBody.value.error)
 const models = computed(() => props.models ?? localModels.value)
-const isLoading = computed(() => Boolean(props.loading) || loading.value)
+const isLoading = computed(() => Boolean(props.loading) || localLoading.value)
 // 按名称排序的模型列表
 const sortedModels = computed(() => {
   return [...models.value].sort((a, b) => {

--- a/frontend/src/views/admin/PoolManagement.vue
+++ b/frontend/src/views/admin/PoolManagement.vue
@@ -7,98 +7,27 @@
       <!-- Header -->
       <div class="px-4 sm:px-6 py-3 sm:py-3.5 border-b border-border/60">
         <!-- Mobile -->
-        <div class="flex flex-col gap-3 sm:hidden">
-          <div class="flex items-center justify-between">
-            <div class="flex items-center gap-2">
-              <h3 class="text-base font-semibold">
-                号池管理
-                <span
-                  v-if="poolHeaderMetaText"
-                  class="ml-2 text-xs font-normal text-muted-foreground"
-                >
-                  | {{ poolHeaderMetaText }}
-                </span>
-              </h3>
-            </div>
-            <div class="flex items-center gap-1.5">
-              <Button
-                v-if="selectedProviderId"
-                variant="ghost"
-                size="icon"
-                class="h-8 w-8"
-                title="添加账号"
-                @click="showImportDialog = true"
-              >
-                <Upload class="w-3.5 h-3.5" />
-              </Button>
-              <ProviderProxyPopover
-                v-if="selectedProviderId"
-                :open="providerProxyMobilePopoverOpen"
-                :node-id="selectedProviderData?.proxy?.node_id"
-                :saving="savingProviderProxy"
-                :title="getProviderProxyButtonTitle()"
-                @update:open="(open: boolean) => handleProviderProxyPopoverToggle('mobile', open)"
-                @select="setProviderProxy"
-                @clear="clearProviderProxy"
-              />
-              <Button
-                v-if="selectedProviderId"
-                variant="ghost"
-                size="icon"
-                class="h-8 w-8"
-                title="高级设置"
-                @click="showAdvancedDialog = true"
-              >
-                <Settings2 class="w-3.5 h-3.5" />
-              </Button>
-              <Button
-                v-if="selectedProviderId"
-                variant="outline"
-                size="sm"
-                class="h-8 px-2 text-xs gap-1"
-                title="号池调度"
-                @click="openSchedulingDialog()"
-              >
-                调度
-                <ChevronDown class="w-3 h-3 text-muted-foreground" />
-              </Button>
-              <Button
-                v-if="selectedProviderId"
-                variant="ghost"
-                size="icon"
-                class="h-8 w-8"
-                title="账号"
-                @click="showAccountBatchDialog = true"
-              >
-                <Users class="w-3.5 h-3.5" />
-              </Button>
-              <Button
-                v-if="selectedProviderId"
-                variant="ghost"
-                size="icon"
-                class="h-8 w-8"
-                :class="getProviderToggleButtonClass()"
-                :disabled="togglingProviderStatus"
-                :title="getProviderToggleButtonTitle()"
-                @click="toggleSelectedProviderStatus"
-              >
-                <Power class="w-3.5 h-3.5" />
-              </Button>
-              <RefreshButton
-                :loading="refreshCurrentPageLoading"
-                :title="refreshButtonTitle"
-                @click="refreshCurrentPage"
-              />
-            </div>
+        <div class="flex flex-col gap-3 xl:hidden">
+          <div class="min-w-0">
+            <h3 class="text-base font-semibold">
+              号池管理
+            </h3>
+            <p
+              v-if="poolHeaderMetaText"
+              class="mt-1 text-xs text-muted-foreground"
+            >
+              {{ poolHeaderMetaText }}
+            </p>
           </div>
-          <!-- Filters (mobile) -->
-          <div class="flex items-center gap-2">
+          <div
+            class="grid grid-cols-3 items-center gap-2"
+          >
             <Select
               v-model="selectedProviderIdProxy"
               :disabled="providerSelectDisabled"
             >
               <SelectTrigger
-                class="flex-1 h-8 text-xs border-border/60"
+                class="h-9 text-xs border-border/60"
                 :disabled="providerSelectDisabled"
               >
                 <SelectValue placeholder="选择 Provider" />
@@ -119,7 +48,7 @@
               </SelectContent>
             </Select>
             <Select v-model="statusFilter">
-              <SelectTrigger class="w-24 h-8 text-xs border-border/60">
+              <SelectTrigger class="h-9 w-full text-xs border-border/60">
                 <SelectValue placeholder="状态" />
               </SelectTrigger>
               <SelectContent>
@@ -137,23 +66,100 @@
                 </SelectItem>
               </SelectContent>
             </Select>
+            <div class="relative min-w-0">
+              <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground z-10 pointer-events-none" />
+              <Input
+                v-model="searchQuery"
+                type="text"
+                placeholder="搜索账号..."
+                class="w-full pl-8 pr-3 h-9 text-sm bg-background/50 border-border/60"
+              />
+            </div>
           </div>
           <div
             v-if="selectedProviderId"
-            class="relative"
+            class="flex items-center gap-1"
           >
-            <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground z-10 pointer-events-none" />
-            <Input
-              v-model="searchQuery"
-              type="text"
-              placeholder="搜索账号..."
-              class="w-full pl-8 pr-3 h-8 text-sm bg-background/50 border-border/60"
-            />
+            <div class="min-w-0 flex-1 flex justify-center">
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-8 w-8 shrink-0"
+                title="添加账号"
+                @click="showImportDialog = true"
+              >
+                <Upload class="w-3.5 h-3.5" />
+              </Button>
+            </div>
+            <div class="min-w-0 flex-1 flex justify-center">
+              <ProviderProxyPopover
+                :open="providerProxyMobilePopoverOpen"
+                :node-id="selectedProviderData?.proxy?.node_id"
+                :saving="savingProviderProxy"
+                :title="getProviderProxyButtonTitle()"
+                @update:open="(open: boolean) => handleProviderProxyPopoverToggle('mobile', open)"
+                @select="setProviderProxy"
+                @clear="clearProviderProxy"
+              />
+            </div>
+            <div class="min-w-0 flex-1 flex justify-center">
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-8 w-8 shrink-0"
+                title="号池调度"
+                @click="openSchedulingDialog()"
+              >
+                <SlidersHorizontal class="w-3.5 h-3.5" />
+              </Button>
+            </div>
+            <div class="min-w-0 flex-1 flex justify-center">
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-8 w-8 shrink-0"
+                title="账号批量操作"
+                @click="showAccountBatchDialog = true"
+              >
+                <Users class="w-3.5 h-3.5" />
+              </Button>
+            </div>
+            <div class="min-w-0 flex-1 flex justify-center">
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-8 w-8 shrink-0"
+                title="高级设置"
+                @click="showAdvancedDialog = true"
+              >
+                <Settings2 class="w-3.5 h-3.5" />
+              </Button>
+            </div>
+            <div class="min-w-0 flex-1 flex justify-center">
+              <Button
+                variant="ghost"
+                size="icon"
+                class="h-8 w-8 shrink-0"
+                :class="getProviderToggleButtonClass()"
+                :disabled="togglingProviderStatus"
+                :title="getProviderToggleButtonTitle()"
+                @click="toggleSelectedProviderStatus"
+              >
+                <Power class="w-3.5 h-3.5" />
+              </Button>
+            </div>
+            <div class="min-w-0 flex-1 flex justify-center">
+              <RefreshButton
+                :loading="refreshCurrentPageLoading"
+                :title="refreshButtonTitle"
+                @click="refreshCurrentPage"
+              />
+            </div>
           </div>
         </div>
 
         <!-- Desktop -->
-        <div class="hidden sm:flex items-center justify-between gap-4">
+        <div class="hidden xl:flex items-center justify-between gap-4">
           <div class="flex items-center gap-2">
             <h3 class="text-base font-semibold">
               号池管理
@@ -715,251 +721,83 @@
             class="p-4 sm:p-5 hover:bg-muted/30 transition-colors"
             :class="getRowClass(key)"
           >
-            <div class="flex items-center gap-3">
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2">
-                  <span class="text-sm font-medium truncate">
-                    {{ key.key_name || '未命名' }}
-                  </span>
-                  <Badge
-                    :variant="getSchedulingBadgeVariant(key)"
-                    class="text-[10px] shrink-0"
-                    :title="getSchedulingTitle(key)"
-                  >
-                    {{ getSchedulingBadgeLabel(key) }}
-                  </Badge>
-                  <span
-                    class="text-[10px] font-medium tabular-nums"
-                    :class="getHealthScoreColor(key.health_score ?? 1)"
-                  >
-                    {{ ((key.health_score ?? 1) * 100).toFixed(0) }}%
-                  </span>
-                </div>
-                <div class="flex items-center gap-1 text-[11px] text-muted-foreground mt-0.5 min-w-0">
+            <div class="space-y-3">
+              <div class="text-sm font-medium truncate">
+                {{ key.key_name || '未命名' }}
+              </div>
+
+              <div class="flex flex-wrap items-center gap-1.5">
+                <Badge
+                  :variant="getSchedulingBadgeVariant(key)"
+                  class="text-[10px] shrink-0"
+                  :title="getSchedulingTitle(key)"
+                >
+                  {{ getSchedulingBadgeLabel(key) }}
+                </Badge>
+                <span
+                  v-if="key.cooldown_ttl_seconds"
+                  class="inline-flex items-center rounded-full border border-red-500/30 bg-red-500/10 px-2 py-0.5 text-[10px] font-medium leading-4 text-red-700 dark:text-red-300"
+                >
+                  冷却 {{ formatTTL(key.cooldown_ttl_seconds) }}
+                </span>
+                <template
+                  v-for="item in getMobileTagItems(key)"
+                  :key="`${key.key_id}-${item.key}`"
+                >
                   <button
+                    v-if="item.key === 'priority'"
                     type="button"
-                    class="h-4 px-1 rounded text-[10px] tabular-nums text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors shrink-0"
-                    title="点击修改优先级"
+                    class="inline-flex max-w-full items-center rounded-full border px-2 py-0.5 text-[10px] font-medium leading-4"
+                    :class="`${getMobileTagClass(item)} hover:border-primary/40 hover:text-foreground`"
+                    :title="`${item.label}，点击编辑优先级`"
                     @click="quickEditInternalPriority(key)"
                   >
-                    P{{ key.internal_priority ?? 50 }}
+                    {{ item.label }}
                   </button>
-                  <Button
-                    v-if="key.auth_type === 'oauth'"
-                    variant="ghost"
-                    size="icon"
-                    class="h-4 w-4 shrink-0"
-                    title="下载 OAuth 授权文件"
-                    @click.stop="downloadRefreshToken(key)"
-                  >
-                    <Download class="w-2.5 h-2.5" />
-                  </Button>
-                  <Button
-                    v-else
-                    variant="ghost"
-                    size="icon"
-                    class="h-4 w-4 shrink-0"
-                    title="复制密钥"
-                    @click.stop="copyFullKey(key)"
-                  >
-                    <Copy class="w-2.5 h-2.5" />
-                  </Button>
-                  <span class="font-mono">
-                    {{ key.auth_type === 'oauth' ? '[OAuth Token]' : (key.auth_type === 'service_account' ? '[Service Account]' : '[Key]') }}
-                  </span>
-                  <template v-if="key.auth_type === 'oauth'">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      class="h-4 w-4 shrink-0"
-                      :disabled="refreshingOAuthKeyId === key.key_id"
-                      :title="getOAuthRefreshButtonTitle(key)"
-                      @click.stop="handleRefreshOAuth(key)"
-                    >
-                      <RefreshCw
-                        class="w-2.5 h-2.5"
-                        :class="{ 'animate-spin': refreshingOAuthKeyId === key.key_id }"
-                      />
-                    </Button>
-                    <span
-                      v-if="getVisibleOAuthState(key)"
-                      class="text-[10px]"
-                      :class="{
-                        'text-destructive': getVisibleOAuthState(key)?.isInvalid || getVisibleOAuthState(key)?.isExpired,
-                        'text-warning': getVisibleOAuthState(key)?.isExpiringSoon && !getVisibleOAuthState(key)?.isExpired && !getVisibleOAuthState(key)?.isInvalid,
-                        'text-muted-foreground': !getVisibleOAuthState(key)?.isExpired && !getVisibleOAuthState(key)?.isExpiringSoon && !getVisibleOAuthState(key)?.isInvalid
-                      }"
-                      :title="getOAuthStatusTitle(key)"
-                    >
-                      {{ getVisibleOAuthState(key)?.text }}
-                    </span>
-                  </template>
                   <Badge
-                    v-if="key.oauth_plan_type"
+                    v-else-if="item.key === 'plan'"
                     variant="outline"
                     class="text-[9px] px-1 py-0 h-4 shrink-0"
-                    :class="getOAuthPlanTypeClass(key.oauth_plan_type)"
+                    :class="key.oauth_plan_type ? getOAuthPlanTypeClass(key.oauth_plan_type) : ''"
                   >
-                    {{ formatOAuthPlanType(key.oauth_plan_type) }}
+                    {{ item.label }}
                   </Badge>
                   <Badge
-                    v-if="getOAuthOrgBadge(key)"
+                    v-else-if="item.key === 'org'"
                     variant="secondary"
                     class="text-[9px] px-1 py-0 h-4 shrink-0"
                     :title="getOAuthOrgBadge(key)?.title"
                   >
-                    {{ getOAuthOrgBadge(key)?.label }}
+                    {{ item.label }}
                   </Badge>
-                </div>
-              </div>
-              <div class="flex items-center gap-0.5 shrink-0 flex-wrap justify-end max-w-[210px]">
-                <Button
-                  v-if="key.cooldown_reason"
-                  variant="ghost"
-                  size="icon"
-                  class="h-7 w-7 text-muted-foreground hover:text-green-600"
-                  title="清除冷却"
-                  @click="clearCooldown(key.key_id)"
-                >
-                  <RefreshCw class="w-3.5 h-3.5" />
-                </Button>
-                <Button
-                  v-if="key.circuit_breaker_open || (key.health_score ?? 1) < 0.5"
-                  variant="ghost"
-                  size="icon"
-                  class="h-7 w-7 text-green-600"
-                  :disabled="recoveringHealthKeyId === key.key_id"
-                  title="刷新健康状态"
-                  @click="handleRecoverKey(key)"
-                >
-                  <RefreshCw
-                    class="w-3.5 h-3.5"
-                    :class="{ 'animate-spin': recoveringHealthKeyId === key.key_id }"
-                  />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  class="h-7 w-7"
-                  title="模型权限"
-                  @click="handleKeyPermissions(key)"
-                >
-                  <Shield class="w-3.5 h-3.5" />
-                </Button>
-                <Popover
-                  :open="proxyMobilePopoverOpenKeyId === key.key_id"
-                  @update:open="(v: boolean) => handleProxyMobilePopoverToggle(key.key_id, v)"
-                >
-                  <PopoverTrigger as-child>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      class="h-7 w-7"
-                      :class="key.proxy?.node_id ? 'text-blue-500' : ''"
-                      :disabled="savingProxyKeyId === key.key_id"
-                      :title="key.proxy?.node_id ? `代理: ${getKeyProxyNodeName(key)}` : '设置代理节点'"
-                      @click.stop
-                    >
-                      <Globe class="w-3.5 h-3.5" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    class="w-72 p-3"
-                    side="bottom"
-                    align="end"
+                  <span
+                    v-else
+                    class="inline-flex max-w-full items-center rounded-full border px-2 py-0.5 text-[10px] font-medium leading-4"
+                    :class="getMobileTagClass(item)"
+                    :title="item.label"
                   >
-                    <div class="space-y-2">
-                      <div class="flex items-center justify-between">
-                        <span class="text-xs font-medium">代理节点</span>
-                        <Button
-                          v-if="key.proxy?.node_id"
-                          variant="ghost"
-                          size="sm"
-                          class="h-6 px-2 text-[10px] text-muted-foreground"
-                          :disabled="savingProxyKeyId === key.key_id"
-                          @click="clearKeyProxy(key)"
-                        >
-                          清除
-                        </Button>
-                      </div>
-                      <ProxyNodeSelect
-                        :model-value="key.proxy?.node_id || ''"
-                        trigger-class="h-8"
-                        @update:model-value="(v: string) => setKeyProxy(key, v)"
-                      />
-                      <p class="text-[10px] text-muted-foreground">
-                        {{ key.proxy?.node_id ? '当前使用独立代理' : '未设置，使用提供商级别代理' }}
-                      </p>
-                    </div>
-                  </PopoverContent>
-                </Popover>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  class="h-7 w-7"
-                  title="编辑账号"
-                  @click="handleEditKey(key)"
-                >
-                  <SquarePen class="w-3.5 h-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  class="h-7 w-7 text-foreground hover:text-foreground"
-                  :disabled="togglingKeyId === key.key_id"
-                  :title="key.is_active ? '禁用' : '启用'"
-                  @click="toggleKeyActive(key)"
-                >
-                  <Power class="w-3.5 h-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  class="h-7 w-7 text-destructive hover:text-destructive"
-                  :disabled="deletingKeyId === key.key_id"
-                  title="删除账号"
-                  @click="handleDeleteKey(key)"
-                >
-                  <Trash2 class="w-3.5 h-3.5" />
-                </Button>
+                    {{ item.label }}
+                  </span>
+                </template>
               </div>
-            </div>
-            <div
-              class="mt-2.5 grid gap-2"
-              :class="showAccountQuotaColumn ? 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-4' : 'grid-cols-2 sm:grid-cols-3'"
-            >
-              <div class="p-2 bg-muted/50 rounded-lg text-xs">
-                <div class="text-muted-foreground mb-0.5">
-                  最后使用
-                </div>
-                <div class="text-[11px]">
-                  {{ key.last_used_at ? formatRelativeTime(key.last_used_at) : '-' }}
+
+              <div class="overflow-x-auto rounded-xl border border-border/50 bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
+                <div class="flex min-w-max items-center justify-center whitespace-nowrap text-center">
+                  <span class="font-medium text-foreground/90">请求:{{ formatStatInteger(key.request_count) }}</span>
+                  <span class="mx-1.5 text-muted-foreground/40">|</span>
+                  <span class="font-medium text-foreground/90">Token:{{ formatTokenCount(key.total_tokens) }}</span>
+                  <span class="mx-1.5 text-muted-foreground/40">|</span>
+                  <span class="font-medium text-foreground/90">费用:{{ formatStatUsd(key.total_cost_usd) }}</span>
+                  <span class="mx-1.5 text-muted-foreground/40">|</span>
+                  <span class="font-medium text-foreground/90">最后使用:{{ key.last_used_at ? formatRelativeTime(key.last_used_at) : '-' }}</span>
                 </div>
               </div>
-              <div class="p-2 bg-muted/50 rounded-lg text-xs">
-                <div class="text-muted-foreground mb-0.5">
-                  统计
-                </div>
-                <div class="space-y-0.5 text-[10px]">
-                  <div class="flex items-center justify-between gap-2">
-                    <span class="text-muted-foreground">请求</span>
-                    <span class="tabular-nums">{{ formatStatInteger(key.request_count) }}</span>
-                  </div>
-                  <div class="flex items-center justify-between gap-2">
-                    <span class="text-muted-foreground">Token</span>
-                    <span class="tabular-nums">{{ formatTokenCount(key.total_tokens) }}</span>
-                  </div>
-                  <div class="flex items-center justify-between gap-2">
-                    <span class="text-muted-foreground">费用</span>
-                    <span class="tabular-nums">{{ formatStatUsd(key.total_cost_usd) }}</span>
-                  </div>
-                </div>
-              </div>
+
               <div
                 v-if="showAccountQuotaColumn"
-                class="p-2 bg-muted/50 rounded-lg text-xs"
+                class="rounded-xl border border-border/50 bg-muted/30 px-3 py-2 text-xs"
               >
-                <div class="text-muted-foreground mb-0.5">
+                <div class="text-muted-foreground mb-1">
                   配额
                 </div>
                 <div
@@ -1005,6 +843,163 @@
                   class="text-muted-foreground"
                 >
                   -
+                </div>
+              </div>
+
+              <div class="flex items-center gap-0.5">
+                <div
+                  v-for="actionId in getMobileActionIds(key)"
+                  :key="`${key.key_id}-${actionId}`"
+                  class="min-w-0 flex-1 flex justify-center"
+                >
+                  <Button
+                    v-if="actionId === 'copy_or_download' && key.auth_type === 'oauth'"
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7 shrink-0"
+                    title="下载 OAuth 授权文件"
+                    @click.stop="downloadRefreshToken(key)"
+                  >
+                    <Download class="w-3.5 h-3.5" />
+                  </Button>
+                  <Button
+                    v-else-if="actionId === 'copy_or_download'"
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7 shrink-0"
+                    title="复制密钥"
+                    @click.stop="copyFullKey(key)"
+                  >
+                    <Copy class="w-3.5 h-3.5" />
+                  </Button>
+                  <Button
+                    v-else-if="actionId === 'refresh_token'"
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7 shrink-0"
+                    :disabled="refreshingOAuthKeyId === key.key_id"
+                    :title="getOAuthRefreshButtonTitle(key)"
+                    @click.stop="handleRefreshOAuth(key)"
+                  >
+                    <RefreshCw
+                      class="w-3.5 h-3.5"
+                      :class="{ 'animate-spin': refreshingOAuthKeyId === key.key_id }"
+                    />
+                  </Button>
+                  <Button
+                    v-else-if="actionId === 'clear_cooldown'"
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7 shrink-0 text-muted-foreground hover:text-green-600"
+                    title="清除冷却"
+                    @click="clearCooldown(key.key_id)"
+                  >
+                    <RefreshCw class="w-3.5 h-3.5" />
+                  </Button>
+                  <Button
+                    v-else-if="actionId === 'recover_health'"
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7 shrink-0 text-green-600"
+                    :disabled="recoveringHealthKeyId === key.key_id"
+                    title="刷新健康状态"
+                    @click="handleRecoverKey(key)"
+                  >
+                    <RefreshCw
+                      class="w-3.5 h-3.5"
+                      :class="{ 'animate-spin': recoveringHealthKeyId === key.key_id }"
+                    />
+                  </Button>
+                  <Button
+                    v-else-if="actionId === 'permissions'"
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7 shrink-0"
+                    title="模型权限"
+                    @click="handleKeyPermissions(key)"
+                  >
+                    <Shield class="w-3.5 h-3.5" />
+                  </Button>
+                  <Popover
+                    v-else-if="actionId === 'proxy'"
+                    :open="proxyMobilePopoverOpenKeyId === key.key_id"
+                    @update:open="(v: boolean) => handleProxyMobilePopoverToggle(key.key_id, v)"
+                  >
+                    <PopoverTrigger as-child>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        class="h-7 w-7 shrink-0"
+                        :class="key.proxy?.node_id ? 'text-blue-500' : ''"
+                        :disabled="savingProxyKeyId === key.key_id"
+                        :title="key.proxy?.node_id ? `代理: ${getKeyProxyNodeName(key)}` : '设置代理节点'"
+                        @click.stop
+                      >
+                        <Globe class="w-3.5 h-3.5" />
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent
+                      class="w-72 p-3"
+                      side="bottom"
+                      align="end"
+                    >
+                      <div class="space-y-2">
+                        <div class="flex items-center justify-between">
+                          <span class="text-xs font-medium">代理节点</span>
+                          <Button
+                            v-if="key.proxy?.node_id"
+                            variant="ghost"
+                            size="sm"
+                            class="h-6 px-2 text-[10px] text-muted-foreground"
+                            :disabled="savingProxyKeyId === key.key_id"
+                            @click="clearKeyProxy(key)"
+                          >
+                            清除
+                          </Button>
+                        </div>
+                        <ProxyNodeSelect
+                          :model-value="key.proxy?.node_id || ''"
+                          trigger-class="h-8"
+                          @update:model-value="(v: string) => setKeyProxy(key, v)"
+                        />
+                        <p class="text-[10px] text-muted-foreground">
+                          {{ key.proxy?.node_id ? '当前使用独立代理' : '未设置，使用提供商级别代理' }}
+                        </p>
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                  <Button
+                    v-else-if="actionId === 'edit'"
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7 shrink-0"
+                    title="编辑账号"
+                    @click="handleEditKey(key)"
+                  >
+                    <SquarePen class="w-3.5 h-3.5" />
+                  </Button>
+                  <Button
+                    v-else-if="actionId === 'toggle'"
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7 shrink-0 text-foreground hover:text-foreground"
+                    :disabled="togglingKeyId === key.key_id"
+                    :title="key.is_active ? '禁用' : '启用'"
+                    @click="toggleKeyActive(key)"
+                  >
+                    <Power class="w-3.5 h-3.5" />
+                  </Button>
+                  <Button
+                    v-else-if="actionId === 'delete'"
+                    variant="ghost"
+                    size="icon"
+                    class="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
+                    :disabled="deletingKeyId === key.key_id"
+                    title="删除账号"
+                    @click="handleDeleteKey(key)"
+                  >
+                    <Trash2 class="w-3.5 h-3.5" />
+                  </Button>
                 </div>
               </div>
             </div>
@@ -1127,6 +1122,7 @@ import {
   Trash2,
   Users,
   Settings2,
+  SlidersHorizontal,
 } from 'lucide-vue-next'
 
 import {
@@ -1155,6 +1151,7 @@ import { useToast } from '@/composables/useToast'
 import { useClipboard } from '@/composables/useClipboard'
 import { useCountdownTimer, getCodexResetCountdown } from '@/composables/useCountdownTimer'
 import { useConfirm } from '@/composables/useConfirm'
+import { useRouteQuery } from '@/composables/useRouteQuery'
 import { parseApiError } from '@/utils/errorParser'
 import {
   getPoolOverview,
@@ -1194,6 +1191,19 @@ import KeyFormDialog from '@/features/providers/components/KeyFormDialog.vue'
 import OAuthKeyEditDialog from '@/features/providers/components/OAuthKeyEditDialog.vue'
 import OAuthAccountDialog from '@/features/providers/components/OAuthAccountDialog.vue'
 import ProxyNodeSelect from '@/features/providers/components/ProxyNodeSelect.vue'
+import {
+  buildPoolMobileTagItems,
+  splitPoolMobileActions,
+  type PoolMobileActionId,
+  type PoolMobileTagItem,
+  type PoolMobileTagTone,
+} from '@/features/pool/utils/poolMobilePresentation'
+import {
+  buildPoolManagementQueryPatch,
+  readPoolManagementViewState,
+  type PoolManagementViewState,
+  writePoolManagementViewState,
+} from '@/features/pool/utils/poolManagementState'
 import { getOAuthOrgBadge } from '@/utils/oauthIdentity'
 import { getOAuthRefreshFeedback } from '@/utils/oauthRefreshFeedback'
 import {
@@ -1209,6 +1219,19 @@ const { confirm } = useConfirm()
 const { copyToClipboard } = useClipboard()
 const { tick: countdownTick, start: startCountdownTimer } = useCountdownTimer()
 const proxyNodesStore = useProxyNodesStore()
+const { getQueryValue, patchQuery } = useRouteQuery()
+
+const poolManagementViewStorage = typeof window === 'undefined' ? undefined : window.sessionStorage
+const restoredViewState = readPoolManagementViewState(
+  {
+    providerId: getQueryValue('providerId'),
+    search: getQueryValue('search'),
+    status: getQueryValue('status'),
+    page: getQueryValue('page'),
+    pageSize: getQueryValue('pageSize'),
+  },
+  poolManagementViewStorage,
+)
 
 // --- Overview ---
 const poolProviders = ref<PoolOverviewItem[]>([])
@@ -1219,6 +1242,7 @@ let providerDataRequestId = 0
 let keysRequestId = 0
 let keysSearchDebounceTimer: number | null = null
 let suppressFiltersWatch = false
+let hasHydratedInitialProviderSelection = false
 
 async function loadOverview() {
   const requestId = ++overviewRequestId
@@ -1236,17 +1260,34 @@ async function loadOverview() {
       selectedId && enabledProviders.some(item => item.provider_id === selectedId),
     )
 
-    if (!selectedStillExists) {
-      if (enabledProviders.length > 0) {
-        // Do not block overview loading on key list fetch; keys area has its own loader.
-        void selectProvider(enabledProviders[0].provider_id)
-      } else {
-        selectedProviderId.value = null
-        selectedProviderData.value = null
-        showAccountBatchDialog.value = false
-        closeProviderProxyPopovers()
-        resetKeyPage()
+    if (selectedStillExists && selectedId) {
+      // 页面刷新时可能先恢复了选中的 Provider，但列表请求尚未触发；
+      // overview 回来后补一次初始化拉取，确保空态不会卡住。
+      if (!hasHydratedInitialProviderSelection) {
+        void selectProvider(selectedId, {
+          preserveSearch: true,
+          preserveStatus: true,
+          preservePagination: true,
+        })
       }
+      return
+    }
+
+    if (enabledProviders.length > 0) {
+      // Do not block overview loading on key list fetch; keys area has its own loader.
+      const fallbackProviderId = enabledProviders[0].provider_id
+      const shouldPreserveViewState = Boolean(selectedId)
+      void selectProvider(fallbackProviderId, {
+        preserveSearch: shouldPreserveViewState,
+        preserveStatus: shouldPreserveViewState,
+        preservePagination: shouldPreserveViewState,
+      })
+    } else {
+      selectedProviderId.value = null
+      selectedProviderData.value = null
+      showAccountBatchDialog.value = false
+      closeProviderProxyPopovers()
+      resetKeyPage()
     }
   } catch (err) {
     if (requestId !== overviewRequestId) return
@@ -1269,7 +1310,7 @@ async function handleSchedulingSaved(updatedProvider: ProviderWithEndpointsSumma
 }
 
 // --- Provider Selection ---
-const selectedProviderId = ref<string | null>(null)
+const selectedProviderId = ref<string | null>(restoredViewState.providerId)
 const selectedProviderData = ref<ProviderWithEndpointsSummary | null>(null)
 
 // Proxy for Select v-model (string, not string|null)
@@ -1430,8 +1471,16 @@ const desktopColumnWidths = computed(() => {
   }
 })
 
-async function selectProvider(id: string) {
+async function selectProvider(
+  id: string,
+  options: {
+    preserveSearch?: boolean
+    preserveStatus?: boolean
+    preservePagination?: boolean
+  } = {},
+) {
   const requestId = ++selectProviderRequestId
+  hasHydratedInitialProviderSelection = true
   selectedProviderId.value = id
   selectedProviderData.value = null
   editingKeyDetail.value = null
@@ -1443,15 +1492,21 @@ async function selectProvider(id: string) {
   proxyDesktopPopoverOpenKeyId.value = null
   proxyMobilePopoverOpenKeyId.value = null
   suppressFiltersWatch = true
-  currentPage.value = 1
-  searchQuery.value = ''
-  statusFilter.value = 'all'
+  if (!options.preservePagination) {
+    currentPage.value = 1
+  }
+  if (!options.preserveSearch) {
+    searchQuery.value = ''
+  }
+  if (!options.preserveStatus) {
+    statusFilter.value = 'all'
+  }
   suppressFiltersWatch = false
   if (keysSearchDebounceTimer !== null) {
     clearTimeout(keysSearchDebounceTimer)
     keysSearchDebounceTimer = null
   }
-  resetKeyPage(1, pageSize.value)
+  resetKeyPage(currentPage.value, pageSize.value)
   const keysTask = loadKeys()
   // Provider summary is non-blocking for key list rendering.
   void loadProviderData(id)
@@ -1483,10 +1538,10 @@ function createEmptyKeyPage(page = 1, pageSizeValue = 50): PoolKeysPageResponse 
 const keyPage = ref<PoolKeysPageResponse>(createEmptyKeyPage())
 const keysLoading = ref(false)
 const refreshingCurrentPageQuota = ref(false)
-const searchQuery = ref('')
-const statusFilter = ref('all')
-const currentPage = ref(1)
-const pageSize = ref(50)
+const searchQuery = ref(restoredViewState.search)
+const statusFilter = ref(restoredViewState.status)
+const currentPage = ref(restoredViewState.page)
+const pageSize = ref(restoredViewState.pageSize)
 const MANUAL_QUOTA_REFRESH_COOLDOWN_SECONDS = 5 * 60
 const refreshingOAuthKeyId = ref<string | null>(null)
 const recoveringHealthKeyId = ref<string | null>(null)
@@ -1504,6 +1559,72 @@ const keyFormDialogOpen = ref(false)
 const oauthKeyEditDialogOpen = ref(false)
 const editingKeyDetail = ref<PoolKeyDetail | null>(null)
 
+watch(
+  () => getQueryValue('search') ?? '',
+  (value) => {
+    if (searchQuery.value === value) return
+    searchQuery.value = value
+  },
+  { immediate: true },
+)
+
+watch(
+  () => readPoolManagementViewState({ status: getQueryValue('status') }).status,
+  (value) => {
+    if (statusFilter.value === value) return
+    suppressFiltersWatch = true
+    statusFilter.value = value
+    suppressFiltersWatch = false
+  },
+  { immediate: true },
+)
+
+watch(
+  () => readPoolManagementViewState({ page: getQueryValue('page') }).page,
+  (value) => {
+    if (currentPage.value === value) return
+    currentPage.value = value
+  },
+  { immediate: true },
+)
+
+watch(
+  () => readPoolManagementViewState({ pageSize: getQueryValue('pageSize') }).pageSize,
+  (value) => {
+    if (pageSize.value === value) return
+    pageSize.value = value
+  },
+  { immediate: true },
+)
+
+watch(
+  () => getQueryValue('providerId'),
+  (value) => {
+    if (!value || value === selectedProviderId.value) return
+    void selectProvider(value, {
+      preserveSearch: true,
+      preserveStatus: true,
+      preservePagination: true,
+    })
+  },
+  { immediate: true },
+)
+
+watch(
+  [selectedProviderId, searchQuery, statusFilter, currentPage, pageSize],
+  ([providerId, search, status, page, pageSizeValue]) => {
+    const nextState: PoolManagementViewState = {
+      providerId,
+      search,
+      status: status as PoolManagementViewState['status'],
+      page,
+      pageSize: pageSizeValue,
+    }
+    patchQuery(buildPoolManagementQueryPatch(nextState))
+    writePoolManagementViewState(nextState, poolManagementViewStorage)
+  },
+  { immediate: true },
+)
 interface QuotaProgressItem {
   label: string
   remainingPercent: number
@@ -2324,10 +2445,62 @@ function getRowClass(key: PoolKeyDetail): string {
   return ''
 }
 
-function getHealthScoreColor(score: number): string {
-  if (score >= 0.8) return 'text-green-600 dark:text-green-400'
-  if (score >= 0.5) return 'text-yellow-600 dark:text-yellow-400'
-  return 'text-red-600 dark:text-red-400'
+function getAuthTypeChipLabel(authType: string): string {
+  if (authType === 'oauth') return 'OAuth'
+  if (authType === 'service_account') return '服务账号'
+  return 'API Key'
+}
+
+function getMobileOAuthTone(key: PoolKeyDetail): PoolMobileTagTone | null {
+  const oauthState = getVisibleOAuthState(key)
+  if (!oauthState) return null
+  if (oauthState.isInvalid || oauthState.isExpired) return 'danger'
+  if (oauthState.isExpiringSoon) return 'warning'
+  return 'muted'
+}
+
+function getMobileTagItems(key: PoolKeyDetail): PoolMobileTagItem[] {
+  const accountAlert = getAccountAlertLabel(key)
+  const oauthState = getVisibleOAuthState(key)
+  const orgBadge = getOAuthOrgBadge(key)
+
+  return buildPoolMobileTagItems({
+    accountStatusLabel: accountAlert,
+    accountStatusTone: accountAlert ? 'danger' : null,
+    oauthStatusLabel: oauthState?.text ?? null,
+    oauthStatusTone: getMobileOAuthTone(key),
+    priorityLabel: `P${key.internal_priority ?? 50}`,
+    authLabel: getAuthTypeChipLabel(key.auth_type),
+    planLabel: key.oauth_plan_type ? formatOAuthPlanType(key.oauth_plan_type) : null,
+    orgLabel: orgBadge?.label ?? null,
+    proxyLabel: key.proxy?.node_id ? '独立代理' : null,
+  })
+}
+
+function getMobileActionIds(key: PoolKeyDetail): PoolMobileActionId[] {
+  return splitPoolMobileActions({
+    canDownloadOrCopy: true,
+    canRefreshToken: key.auth_type === 'oauth',
+    canClearCooldown: Boolean(key.cooldown_reason),
+    canRecoverHealth: key.circuit_breaker_open || (key.health_score ?? 1) < 0.5,
+    hasProxy: true,
+  }).primary
+}
+
+function getMobileTagClass(item: PoolMobileTagItem): string {
+  if (item.tone === 'danger') {
+    return 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300'
+  }
+  if (item.tone === 'warning') {
+    return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+  }
+  if (item.tone === 'accent') {
+    return 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300'
+  }
+  if (item.tone === 'muted') {
+    return 'border-border/60 bg-background/70 text-muted-foreground'
+  }
+  return 'border-border/60 bg-background/80 text-foreground/80'
 }
 
 function formatOAuthPlanType(planType: string): string {


### PR DESCRIPTION
- 重构号池管理页移动端头部筛选、操作区与标签展示，优化展示逻辑并补充排序测试
- 恢复页面刷新后的 provider、搜索词、状态筛选及分页状态，避免刷新后列表状态丢失
- 优化号池调度弹窗的响应式布局与移动端排序交互，提升桌面端和移动端可读性
- 重构号池高级设置弹窗布局，完善配置抽象与移动端账号快捷操作
- 重构账号批量操作弹窗交互与执行流程，统一筛选、选择、确认与可执行性校验