### PR TITLE
refactor(runtime): 优化管理端摘要查询与维护聚合链路

### DIFF
--- a/apps/aether-gateway/src/async_task/mod.rs
+++ b/apps/aether-gateway/src/async_task/mod.rs
@@ -10,9 +10,9 @@ pub(crate) use http::{
     CancelVideoTaskError,
 };
 pub(crate) use query::{
-    read_video_task_detail, read_video_task_page, read_video_task_stats,
-    read_video_task_video_source, VideoTaskPageResponse, VideoTaskStatsResponse,
-    VideoTaskVideoSource,
+    read_video_task_detail, read_video_task_page, read_video_task_page_summary,
+    read_video_task_stats, read_video_task_video_source, VideoTaskPageResponse,
+    VideoTaskStatsResponse, VideoTaskVideoSource,
 };
 pub(crate) use runtime::{
     execute_video_task_refresh_plan, finalize_video_task_if_terminal, spawn_video_task_poller,

--- a/apps/aether-gateway/src/async_task/query.rs
+++ b/apps/aether-gateway/src/async_task/query.rs
@@ -67,6 +67,34 @@ pub(crate) async fn read_video_task_page(
     })
 }
 
+pub(crate) async fn read_video_task_page_summary(
+    state: &AppState,
+    filter: &VideoTaskQueryFilter,
+    page: usize,
+    page_size: usize,
+) -> Result<VideoTaskPageResponse, GatewayError> {
+    let page = page.max(1);
+    let page_size = page_size.clamp(1, 100);
+    let total = state.count_video_tasks(filter).await?;
+    let offset = page_size.saturating_mul(page.saturating_sub(1));
+    let items = state
+        .list_video_task_page_summary(filter, offset, page_size)
+        .await?;
+    let pages = if total == 0 {
+        0
+    } else {
+        ((total as usize) + page_size - 1) / page_size
+    };
+
+    Ok(VideoTaskPageResponse {
+        items,
+        total,
+        page,
+        page_size,
+        pages,
+    })
+}
+
 pub(crate) async fn read_video_task_detail(
     state: &AppState,
     task_id: &str,

--- a/apps/aether-gateway/src/async_task/runtime.rs
+++ b/apps/aether-gateway/src/async_task/runtime.rs
@@ -267,11 +267,14 @@ fn build_successful_poll_update(
     record.format_converted = task.format_converted;
     record.model = task.model.clone().or(record.model);
     record.prompt = task.prompt.clone().or(record.prompt);
-    record.original_request_body = task.original_request_body.clone();
-    record.duration_seconds = task.duration_seconds;
-    record.resolution = task.resolution.clone();
-    record.aspect_ratio = task.aspect_ratio.clone();
-    record.size = task.size.clone();
+    record.original_request_body = task
+        .original_request_body
+        .clone()
+        .or(record.original_request_body);
+    record.duration_seconds = task.duration_seconds.or(record.duration_seconds);
+    record.resolution = task.resolution.clone().or(record.resolution);
+    record.aspect_ratio = task.aspect_ratio.clone().or(record.aspect_ratio);
+    record.size = task.size.clone().or(record.size);
     record.created_at_unix_ms = task.created_at_unix_ms;
     record.submitted_at_unix_secs = task.submitted_at_unix_secs;
     record.updated_at_unix_secs = now_unix_secs;
@@ -349,6 +352,8 @@ fn build_failed_poll_update(
 }
 
 fn stored_task_to_upsert(task: &StoredVideoTask) -> UpsertVideoTask {
+    let snapshot_record =
+        LocalVideoTaskSnapshot::from_stored_task(task).map(|snapshot| snapshot.to_upsert_record());
     UpsertVideoTask {
         id: task.id.clone(),
         short_id: task.short_id.clone(),
@@ -365,12 +370,36 @@ fn stored_task_to_upsert(task: &StoredVideoTask) -> UpsertVideoTask {
         provider_api_format: task.provider_api_format.clone(),
         format_converted: task.format_converted,
         model: task.model.clone(),
-        prompt: task.prompt.clone(),
-        original_request_body: task.original_request_body.clone(),
-        duration_seconds: task.duration_seconds,
-        resolution: task.resolution.clone(),
-        aspect_ratio: task.aspect_ratio.clone(),
-        size: task.size.clone(),
+        prompt: task.prompt.clone().or_else(|| {
+            snapshot_record
+                .as_ref()
+                .and_then(|record| record.prompt.clone())
+        }),
+        original_request_body: task.original_request_body.clone().or_else(|| {
+            snapshot_record
+                .as_ref()
+                .and_then(|record| record.original_request_body.clone())
+        }),
+        duration_seconds: task.duration_seconds.or_else(|| {
+            snapshot_record
+                .as_ref()
+                .and_then(|record| record.duration_seconds)
+        }),
+        resolution: task.resolution.clone().or_else(|| {
+            snapshot_record
+                .as_ref()
+                .and_then(|record| record.resolution.clone())
+        }),
+        aspect_ratio: task.aspect_ratio.clone().or_else(|| {
+            snapshot_record
+                .as_ref()
+                .and_then(|record| record.aspect_ratio.clone())
+        }),
+        size: task.size.clone().or_else(|| {
+            snapshot_record
+                .as_ref()
+                .and_then(|record| record.size.clone())
+        }),
         status: task.status,
         progress_percent: task.progress_percent,
         progress_message: task.progress_message.clone(),
@@ -549,4 +578,155 @@ fn now_unix_secs() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_failed_poll_update, stored_task_to_upsert, VideoTaskRefreshError};
+    use crate::video_tasks::{
+        LocalVideoTaskPersistence, LocalVideoTaskSnapshot, LocalVideoTaskStatus,
+        LocalVideoTaskTransport, OpenAiVideoTaskSeed,
+    };
+    use aether_data_contracts::repository::video_tasks::{StoredVideoTask, VideoTaskStatus};
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    fn sample_sparse_stored_task() -> StoredVideoTask {
+        let snapshot = LocalVideoTaskSnapshot::OpenAi(OpenAiVideoTaskSeed {
+            local_task_id: "task-1".to_string(),
+            upstream_task_id: "ext-1".to_string(),
+            created_at_unix_ms: 1,
+            user_id: Some("user-1".to_string()),
+            api_key_id: Some("api-key-1".to_string()),
+            model: Some("sora-2".to_string()),
+            prompt: Some("hello".to_string()),
+            size: Some("1280x720".to_string()),
+            seconds: Some("4".to_string()),
+            remixed_from_video_id: None,
+            status: LocalVideoTaskStatus::Processing,
+            progress_percent: 50,
+            completed_at_unix_secs: None,
+            expires_at_unix_secs: None,
+            error_code: None,
+            error_message: None,
+            video_url: None,
+            persistence: LocalVideoTaskPersistence {
+                request_id: "request-1".to_string(),
+                username: Some("user".to_string()),
+                api_key_name: Some("primary".to_string()),
+                client_api_format: "openai:video".to_string(),
+                provider_api_format: "openai:video".to_string(),
+                original_request_body: json!({
+                    "prompt": "hello",
+                    "seconds": "4",
+                    "resolution": "720p",
+                    "aspect_ratio": "16:9",
+                    "size": "1280x720"
+                }),
+                format_converted: false,
+            },
+            transport: LocalVideoTaskTransport {
+                upstream_base_url: "https://example.com".to_string(),
+                provider_name: Some("provider".to_string()),
+                provider_id: "provider-1".to_string(),
+                endpoint_id: "endpoint-1".to_string(),
+                key_id: "key-1".to_string(),
+                headers: BTreeMap::new(),
+                content_type: Some("application/json".to_string()),
+                model_name: Some("sora-2".to_string()),
+                proxy: None,
+                tls_profile: None,
+                timeouts: None,
+            },
+        });
+
+        StoredVideoTask {
+            id: "task-1".to_string(),
+            short_id: Some("short-task-1".to_string()),
+            request_id: "request-1".to_string(),
+            user_id: Some("user-1".to_string()),
+            api_key_id: Some("api-key-1".to_string()),
+            username: Some("user".to_string()),
+            api_key_name: Some("primary".to_string()),
+            external_task_id: Some("ext-1".to_string()),
+            provider_id: Some("provider-1".to_string()),
+            endpoint_id: Some("endpoint-1".to_string()),
+            key_id: Some("key-1".to_string()),
+            client_api_format: Some("openai:video".to_string()),
+            provider_api_format: Some("openai:video".to_string()),
+            format_converted: false,
+            model: Some("sora-2".to_string()),
+            prompt: None,
+            original_request_body: None,
+            duration_seconds: None,
+            resolution: None,
+            aspect_ratio: None,
+            size: None,
+            status: VideoTaskStatus::Processing,
+            progress_percent: 50,
+            progress_message: Some("polling".to_string()),
+            retry_count: 1,
+            poll_interval_seconds: 10,
+            next_poll_at_unix_secs: Some(20),
+            poll_count: 2,
+            max_poll_count: 360,
+            created_at_unix_ms: 1,
+            submitted_at_unix_secs: Some(1),
+            completed_at_unix_secs: None,
+            updated_at_unix_secs: 20,
+            error_code: None,
+            error_message: None,
+            video_url: None,
+            request_metadata: Some(json!({
+                "rust_local_snapshot": serde_json::to_value(snapshot)
+                    .expect("snapshot should serialize")
+            })),
+        }
+    }
+
+    #[test]
+    fn stored_task_to_upsert_restores_sparse_fields_from_snapshot() {
+        let record = stored_task_to_upsert(&sample_sparse_stored_task());
+
+        assert_eq!(record.prompt.as_deref(), Some("hello"));
+        assert_eq!(
+            record.original_request_body,
+            Some(json!({
+                "prompt": "hello",
+                "seconds": "4",
+                "resolution": "720p",
+                "aspect_ratio": "16:9",
+                "size": "1280x720"
+            }))
+        );
+        assert_eq!(record.duration_seconds, Some(4));
+        assert_eq!(record.resolution.as_deref(), Some("720p"));
+        assert_eq!(record.aspect_ratio.as_deref(), Some("16:9"));
+        assert_eq!(record.size.as_deref(), Some("1280x720"));
+    }
+
+    #[test]
+    fn failed_poll_update_keeps_snapshot_backed_request_body() {
+        let record = build_failed_poll_update(
+            &sample_sparse_stored_task(),
+            &VideoTaskRefreshError {
+                message: "temporary failure".to_string(),
+                permanent: false,
+            },
+            100,
+        );
+
+        assert_eq!(
+            record.original_request_body,
+            Some(json!({
+                "prompt": "hello",
+                "seconds": "4",
+                "resolution": "720p",
+                "aspect_ratio": "16:9",
+                "size": "1280x720"
+            }))
+        );
+        assert_eq!(record.prompt.as_deref(), Some("hello"));
+        assert_eq!(record.resolution.as_deref(), Some("720p"));
+    }
 }

--- a/apps/aether-gateway/src/data/state/auth.rs
+++ b/apps/aether-gateway/src/data/state/auth.rs
@@ -14,6 +14,7 @@ use aether_data::repository::auth::{
     read_resolved_auth_api_key_snapshot_by_key_hash,
     read_resolved_auth_api_key_snapshot_by_user_api_key_ids,
 };
+use futures_util::TryStreamExt;
 use sqlx::Row;
 use uuid::Uuid;
 
@@ -1108,12 +1109,14 @@ impl GatewayDataState {
         let Some(pool) = self.postgres_pool() else {
             return Ok(Vec::new());
         };
-        let rows = sqlx::query(LIST_USER_SESSIONS_SQL)
+        let mut rows = sqlx::query(LIST_USER_SESSIONS_SQL)
             .bind(user_id)
-            .fetch_all(&pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_user_session_row).collect()
+            .fetch(&pool);
+        let mut sessions = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            sessions.push(map_user_session_row(&row)?);
+        }
+        Ok(sessions)
     }
 
     pub(crate) async fn create_user_session(

--- a/apps/aether-gateway/src/data/state/catalog.rs
+++ b/apps/aether-gateway/src/data/state/catalog.rs
@@ -280,6 +280,20 @@ impl GatewayDataState {
         }
     }
 
+    pub(crate) async fn list_provider_catalog_key_summaries_by_provider_ids(
+        &self,
+        provider_ids: &[String],
+    ) -> Result<Vec<StoredProviderCatalogKey>, DataLayerError> {
+        match &self.provider_catalog_reader {
+            Some(repository) => {
+                repository
+                    .list_key_summaries_by_provider_ids(provider_ids)
+                    .await
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+
     pub(crate) async fn list_provider_catalog_key_page(
         &self,
         query: &ProviderCatalogKeyListQuery,

--- a/apps/aether-gateway/src/data/state/runtime.rs
+++ b/apps/aether-gateway/src/data/state/runtime.rs
@@ -135,6 +135,18 @@ impl GatewayDataState {
         }
     }
 
+    pub(crate) async fn list_video_task_page_summary(
+        &self,
+        filter: &VideoTaskQueryFilter,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<StoredVideoTask>, DataLayerError> {
+        match &self.video_task_reader {
+            Some(repository) => repository.list_page_summary(filter, offset, limit).await,
+            None => Ok(Vec::new()),
+        }
+    }
+
     pub(crate) async fn count_video_tasks(
         &self,
         filter: &VideoTaskQueryFilter,

--- a/apps/aether-gateway/src/handlers/admin/endpoint/health_builders/keys.rs
+++ b/apps/aether-gateway/src/handlers/admin/endpoint/health_builders/keys.rs
@@ -315,7 +315,7 @@ pub(crate) async fn recover_all_admin_key_health(
         Vec::new()
     } else {
         state
-            .list_provider_catalog_keys_by_provider_ids(&provider_ids)
+            .list_provider_catalog_key_summaries_by_provider_ids(&provider_ids)
             .await
             .ok()
             .unwrap_or_default()

--- a/apps/aether-gateway/src/handlers/admin/endpoint/health_builders/status.rs
+++ b/apps/aether-gateway/src/handlers/admin/endpoint/health_builders/status.rs
@@ -69,7 +69,7 @@ pub(crate) async fn build_admin_endpoint_health_status_payload(
     let mut health_scores_by_format = BTreeMap::<String, Vec<f64>>::new();
     if !provider_ids.is_empty() {
         let keys = state
-            .list_provider_catalog_keys_by_provider_ids(&provider_ids)
+            .list_provider_catalog_key_summaries_by_provider_ids(&provider_ids)
             .await
             .ok()
             .unwrap_or_default();
@@ -235,7 +235,7 @@ pub(crate) async fn build_admin_health_summary_payload(
         Vec::new()
     } else {
         state
-            .list_provider_catalog_keys_by_provider_ids(&provider_ids)
+            .list_provider_catalog_key_summaries_by_provider_ids(&provider_ids)
             .await
             .ok()
             .unwrap_or_default()

--- a/apps/aether-gateway/src/handlers/admin/features/video_tasks/routes.rs
+++ b/apps/aether-gateway/src/handlers/admin/features/video_tasks/routes.rs
@@ -60,7 +60,9 @@ pub(super) async fn maybe_build_local_admin_video_tasks_response(
         let page_size = query_param_value(request_context.query_string(), "page_size")
             .and_then(|value| value.parse::<usize>().ok())
             .unwrap_or(20);
-        let response = state.read_video_task_page(&filter, page, page_size).await?;
+        let response = state
+            .read_video_task_page_summary(&filter, page, page_size)
+            .await?;
         let provider_names = build_admin_video_task_provider_names(state, &response.items).await?;
         return Ok(Some(
             Json(json!({

--- a/apps/aether-gateway/src/handlers/admin/observability/monitoring/resilience/snapshot.rs
+++ b/apps/aether-gateway/src/handlers/admin/observability/monitoring/resilience/snapshot.rs
@@ -58,7 +58,7 @@ pub(super) async fn build_admin_monitoring_provider_name_by_id_and_keys(
         Vec::new()
     } else {
         state
-            .list_provider_catalog_keys_by_provider_ids(&provider_ids)
+            .list_provider_catalog_key_summaries_by_provider_ids(&provider_ids)
             .await?
     };
     Ok((provider_name_by_id, keys))

--- a/apps/aether-gateway/src/handlers/admin/provider/pool_admin/mod.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/pool_admin/mod.rs
@@ -49,7 +49,9 @@ pub(crate) use crate::handlers::admin::provider::pool::runtime::{
 };
 pub(crate) use crate::handlers::admin::provider::shared::support::AdminProviderPoolRuntimeState;
 pub(crate) use crate::handlers::admin::shared::attach_admin_audit_response;
-pub(crate) use aether_data_contracts::repository::provider_catalog::ProviderCatalogKeyListQuery;
+pub(crate) use aether_data_contracts::repository::provider_catalog::{
+    ProviderCatalogKeyListOrder, ProviderCatalogKeyListQuery,
+};
 
 pub(crate) async fn maybe_build_local_admin_pool_response(
     state: &AdminAppState<'_>,

--- a/apps/aether-gateway/src/handlers/admin/provider/pool_admin/read_routes/keys.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/pool_admin/read_routes/keys.rs
@@ -3,7 +3,7 @@ use super::{
     parse_admin_pool_page, parse_admin_pool_page_size, parse_admin_pool_search,
     parse_admin_pool_status_filter, pool_payloads, pool_selection,
     read_admin_provider_pool_cooldown_key_ids, read_admin_provider_pool_runtime_state,
-    AdminProviderPoolRuntimeState, ProviderCatalogKeyListQuery,
+    AdminProviderPoolRuntimeState, ProviderCatalogKeyListOrder, ProviderCatalogKeyListQuery,
     ADMIN_POOL_PROVIDER_CATALOG_READER_UNAVAILABLE_DETAIL,
 };
 use crate::handlers::admin::request::{AdminAppState, AdminRequestContext};
@@ -118,6 +118,7 @@ pub(super) async fn build_admin_pool_list_keys_response(
                 },
                 offset: page_offset,
                 limit: page_size,
+                order: ProviderCatalogKeyListOrder::Name,
             })
             .await?;
         (key_page.items, key_page.total)

--- a/apps/aether-gateway/src/handlers/admin/provider/summary/aggregates.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/summary/aggregates.rs
@@ -31,7 +31,7 @@ pub(crate) async fn build_admin_provider_summary_payload(
         active_global_model_ids_result,
     ) = tokio::join!(
         state.list_provider_catalog_endpoints_by_provider_ids(&provider_ids),
-        state.list_provider_catalog_keys_by_provider_ids(&provider_ids),
+        state.list_provider_catalog_key_summaries_by_provider_ids(&provider_ids),
         state.read_provider_quota_snapshot(provider_id),
         state.list_provider_model_stats(&provider_ids),
         state.list_active_global_model_ids_by_provider_ids(&provider_ids),
@@ -204,7 +204,7 @@ pub(crate) async fn build_admin_providers_summary_payload(
         Vec::new()
     } else {
         state
-            .list_provider_catalog_keys_by_provider_ids(&provider_ids)
+            .list_provider_catalog_key_summaries_by_provider_ids(&provider_ids)
             .await
             .ok()
             .unwrap_or_default()

--- a/apps/aether-gateway/src/handlers/admin/provider/summary/list.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/summary/list.rs
@@ -48,11 +48,11 @@ pub(crate) async fn build_admin_providers_payload(
             .ok()
             .unwrap_or_default()
     };
-    let keys = if provider_ids.is_empty() {
+    let key_stats = if provider_ids.is_empty() {
         Vec::new()
     } else {
         state
-            .list_provider_catalog_keys_by_provider_ids(&provider_ids)
+            .list_provider_catalog_key_stats_by_provider_ids(&provider_ids)
             .await
             .ok()
             .unwrap_or_default()
@@ -68,9 +68,12 @@ pub(crate) async fn build_admin_providers_payload(
             },
         );
     let has_any_key_by_provider =
-        keys.into_iter()
-            .fold(BTreeSet::<String>::new(), |mut acc, key| {
-                acc.insert(key.provider_id);
+        key_stats
+            .into_iter()
+            .fold(BTreeSet::<String>::new(), |mut acc, stats| {
+                if stats.total_keys > 0 {
+                    acc.insert(stats.provider_id);
+                }
                 acc
             });
 

--- a/apps/aether-gateway/src/handlers/admin/provider/write/keys/payload.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/write/keys/payload.rs
@@ -1,4 +1,7 @@
 use crate::handlers::admin::request::AdminAppState;
+use aether_data_contracts::repository::provider_catalog::{
+    ProviderCatalogKeyListOrder, ProviderCatalogKeyListQuery,
+};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(crate) async fn build_admin_provider_keys_payload(
@@ -15,30 +18,26 @@ pub(crate) async fn build_admin_provider_keys_payload(
         .await
         .ok()
         .and_then(|mut providers| providers.drain(..).next())?;
-    let mut keys = state
-        .list_provider_catalog_keys_by_provider_ids(std::slice::from_ref(&provider.id))
+    let key_page = state
+        .list_provider_catalog_key_page(&ProviderCatalogKeyListQuery {
+            provider_id: provider.id.clone(),
+            search: None,
+            is_active: None,
+            offset: skip,
+            limit,
+            order: ProviderCatalogKeyListOrder::CreatedAt,
+        })
         .await
-        .ok()
-        .unwrap_or_default();
-    keys.sort_by(|left, right| {
-        left.internal_priority
-            .cmp(&right.internal_priority)
-            .then_with(|| {
-                left.created_at_unix_ms
-                    .unwrap_or_default()
-                    .cmp(&right.created_at_unix_ms.unwrap_or_default())
-            })
-            .then_with(|| left.id.cmp(&right.id))
-    });
+        .ok()?;
     let now_unix_secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .ok()
         .map(|duration| duration.as_secs())
         .unwrap_or(0);
     Some(serde_json::Value::Array(
-        keys.into_iter()
-            .skip(skip)
-            .take(limit)
+        key_page
+            .items
+            .into_iter()
             .map(|key| {
                 state.build_admin_provider_key_response(
                     &key,

--- a/apps/aether-gateway/src/handlers/admin/request/features.rs
+++ b/apps/aether-gateway/src/handlers/admin/request/features.rs
@@ -55,6 +55,15 @@ impl<'a> AdminAppState<'a> {
         crate::async_task::read_video_task_page(self.app, filter, page, page_size).await
     }
 
+    pub(crate) async fn read_video_task_page_summary(
+        &self,
+        filter: &aether_data_contracts::repository::video_tasks::VideoTaskQueryFilter,
+        page: usize,
+        page_size: usize,
+    ) -> Result<crate::async_task::VideoTaskPageResponse, GatewayError> {
+        crate::async_task::read_video_task_page_summary(self.app, filter, page, page_size).await
+    }
+
     pub(crate) async fn read_video_task_stats(
         &self,
         filter: &aether_data_contracts::repository::video_tasks::VideoTaskQueryFilter,

--- a/apps/aether-gateway/src/handlers/admin/request/provider/catalog.rs
+++ b/apps/aether-gateway/src/handlers/admin/request/provider/catalog.rs
@@ -69,6 +69,18 @@ impl<'a> AdminAppState<'a> {
             .await
     }
 
+    pub(crate) async fn list_provider_catalog_key_summaries_by_provider_ids(
+        &self,
+        provider_ids: &[String],
+    ) -> Result<
+        Vec<aether_data_contracts::repository::provider_catalog::StoredProviderCatalogKey>,
+        GatewayError,
+    > {
+        self.app
+            .list_provider_catalog_key_summaries_by_provider_ids(provider_ids)
+            .await
+    }
+
     pub(crate) async fn list_provider_catalog_keys_by_ids(
         &self,
         key_ids: &[String],

--- a/apps/aether-gateway/src/handlers/admin/system/shared/modules.rs
+++ b/apps/aether-gateway/src/handlers/admin/system/shared/modules.rs
@@ -148,7 +148,7 @@ pub(crate) async fn build_admin_module_runtime_state(
         false
     } else {
         state
-            .list_provider_catalog_keys_by_provider_ids(&provider_ids)
+            .list_provider_catalog_key_summaries_by_provider_ids(&provider_ids)
             .await
             .ok()
             .unwrap_or_default()

--- a/apps/aether-gateway/src/handlers/public/catalog_helpers.rs
+++ b/apps/aether-gateway/src/handlers/public/catalog_helpers.rs
@@ -350,7 +350,7 @@ pub(crate) async fn build_api_format_health_monitor_payload(
     let mut key_counts_by_format = BTreeMap::<String, usize>::new();
     if options.include_key_count && !provider_ids.is_empty() {
         let keys = state
-            .list_provider_catalog_keys_by_provider_ids(&provider_ids)
+            .list_provider_catalog_key_summaries_by_provider_ids(&provider_ids)
             .await
             .ok()
             .unwrap_or_default();

--- a/apps/aether-gateway/src/handlers/public/system_modules_helpers/keys_grouped.rs
+++ b/apps/aether-gateway/src/handlers/public/system_modules_helpers/keys_grouped.rs
@@ -41,7 +41,7 @@ pub(crate) async fn build_admin_keys_grouped_by_format_payload(
 
     let (endpoints_result, keys_result) = tokio::join!(
         state.list_provider_catalog_endpoints_by_provider_ids(&provider_ids),
-        state.list_provider_catalog_keys_by_provider_ids(&provider_ids),
+        state.list_provider_catalog_key_summaries_by_provider_ids(&provider_ids),
     );
 
     let endpoint_base_url_by_provider_and_format = endpoints_result

--- a/apps/aether-gateway/src/maintenance/runtime.rs
+++ b/apps/aether-gateway/src/maintenance/runtime.rs
@@ -109,26 +109,26 @@ const DB_MAINTENANCE_HOUR: u32 = 5;
 const DB_MAINTENANCE_MINUTE: u32 = 0;
 const MAINTENANCE_DEFAULT_TIMEZONE: &str = "Asia/Shanghai";
 const DB_MAINTENANCE_TABLES: &[&str] = &["usage", "request_candidates", "audit_logs"];
-const SELECT_WALLET_DAILY_USAGE_AGGREGATION_ROWS_SQL: &str = r#"
-SELECT
-    wallet_id,
-    COUNT(id) AS total_requests,
-    CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost_usd,
-    COALESCE(SUM(input_tokens), 0) AS input_tokens,
-    COALESCE(SUM(output_tokens), 0) AS output_tokens,
-    COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_tokens,
-    COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_tokens,
-    MIN(finalized_at) AS first_finalized_at,
-    MAX(finalized_at) AS last_finalized_at
-FROM usage
-WHERE wallet_id IS NOT NULL
-  AND billing_status = 'settled'
-  AND total_cost_usd > 0
-  AND finalized_at >= $1
-  AND finalized_at < $2
-GROUP BY wallet_id
-"#;
 const UPSERT_WALLET_DAILY_USAGE_LEDGER_SQL: &str = r#"
+WITH aggregated AS (
+    SELECT
+        wallet_id,
+        COUNT(id) AS total_requests,
+        CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost_usd,
+        COALESCE(SUM(input_tokens), 0) AS input_tokens,
+        COALESCE(SUM(output_tokens), 0) AS output_tokens,
+        COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_tokens,
+        COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_tokens,
+        MIN(finalized_at) AS first_finalized_at,
+        MAX(finalized_at) AS last_finalized_at
+    FROM usage
+    WHERE wallet_id IS NOT NULL
+      AND billing_status = 'settled'
+      AND total_cost_usd > 0
+      AND finalized_at >= $1
+      AND finalized_at < $2
+    GROUP BY wallet_id
+)
 INSERT INTO wallet_daily_usage_ledgers (
     id,
     wallet_id,
@@ -146,11 +146,23 @@ INSERT INTO wallet_daily_usage_ledgers (
     created_at,
     updated_at
 )
-VALUES (
-    $1, $2, $3, $4, $5,
-    $6, $7, $8, $9, $10,
-    $11, $12, $13, $14, $15
-)
+SELECT
+    md5(CONCAT('wallet-daily-usage:', aggregated.wallet_id, ':', CAST($3 AS TEXT), ':', $4)),
+    aggregated.wallet_id,
+    $3,
+    $4,
+    aggregated.total_cost_usd,
+    aggregated.total_requests,
+    aggregated.input_tokens,
+    aggregated.output_tokens,
+    aggregated.cache_creation_tokens,
+    aggregated.cache_read_tokens,
+    aggregated.first_finalized_at,
+    aggregated.last_finalized_at,
+    $5,
+    $5,
+    $5
+FROM aggregated
 ON CONFLICT (wallet_id, billing_date, billing_timezone)
 DO UPDATE SET
     total_cost_usd = EXCLUDED.total_cost_usd,
@@ -311,11 +323,7 @@ WHERE id = ANY($1)
 "#;
 const SELECT_USAGE_BODY_COMPRESSION_BATCH_SQL: &str = r#"
 SELECT
-    id,
-    request_body,
-    response_body,
-    provider_request_body,
-    client_response_body
+    id
 FROM usage
 WHERE created_at < $1
   AND ($2::timestamptz IS NULL OR created_at >= $2)
@@ -327,6 +335,17 @@ WHERE created_at < $1
   )
 ORDER BY created_at ASC, id ASC
 LIMIT $3
+"#;
+const SELECT_USAGE_BODY_COMPRESSION_ROW_SQL: &str = r#"
+SELECT
+    id,
+    request_body,
+    response_body,
+    provider_request_body,
+    client_response_body
+FROM usage
+WHERE id = $1
+LIMIT 1
 "#;
 const UPDATE_USAGE_BODY_COMPRESSION_SQL: &str = r#"
 UPDATE usage
@@ -520,24 +539,24 @@ DO UPDATE SET
     aggregated_at = EXCLUDED.aggregated_at,
     updated_at = EXCLUDED.updated_at
 "#;
-const SELECT_STATS_DAILY_MODEL_AGGREGATES_SQL: &str = r#"
-SELECT
-    model,
-    CAST(COUNT(id) AS BIGINT) AS total_requests,
-    CAST(COALESCE(SUM(input_tokens), 0) AS BIGINT) AS input_tokens,
-    CAST(COALESCE(SUM(output_tokens), 0) AS BIGINT) AS output_tokens,
-    CAST(COALESCE(SUM(cache_creation_input_tokens), 0) AS BIGINT) AS cache_creation_tokens,
-    CAST(COALESCE(SUM(cache_read_input_tokens), 0) AS BIGINT) AS cache_read_tokens,
-    CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost,
-    CAST(COALESCE(AVG(response_time_ms), 0) AS DOUBLE PRECISION) AS avg_response_time_ms
-FROM usage
-WHERE created_at >= $1
-  AND created_at < $2
-  AND model IS NOT NULL
-  AND model <> ''
-GROUP BY model
-"#;
 const UPSERT_STATS_DAILY_MODEL_SQL: &str = r#"
+WITH aggregated AS (
+    SELECT
+        model,
+        CAST(COUNT(id) AS BIGINT) AS total_requests,
+        CAST(COALESCE(SUM(input_tokens), 0) AS BIGINT) AS input_tokens,
+        CAST(COALESCE(SUM(output_tokens), 0) AS BIGINT) AS output_tokens,
+        CAST(COALESCE(SUM(cache_creation_input_tokens), 0) AS BIGINT) AS cache_creation_tokens,
+        CAST(COALESCE(SUM(cache_read_input_tokens), 0) AS BIGINT) AS cache_read_tokens,
+        CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost,
+        CAST(COALESCE(AVG(response_time_ms), 0) AS DOUBLE PRECISION) AS avg_response_time_ms
+    FROM usage
+    WHERE created_at >= $1
+      AND created_at < $2
+      AND model IS NOT NULL
+      AND model <> ''
+    GROUP BY model
+)
 INSERT INTO stats_daily_model (
     id,
     date,
@@ -552,7 +571,20 @@ INSERT INTO stats_daily_model (
     created_at,
     updated_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+SELECT
+    md5(CONCAT('stats-daily-model:', aggregated.model, ':', CAST($1 AS TEXT))),
+    $1,
+    aggregated.model,
+    aggregated.total_requests,
+    aggregated.input_tokens,
+    aggregated.output_tokens,
+    aggregated.cache_creation_tokens,
+    aggregated.cache_read_tokens,
+    aggregated.total_cost,
+    aggregated.avg_response_time_ms,
+    $3,
+    $3
+FROM aggregated
 ON CONFLICT (date, model)
 DO UPDATE SET
     total_requests = EXCLUDED.total_requests,
@@ -564,21 +596,21 @@ DO UPDATE SET
     avg_response_time_ms = EXCLUDED.avg_response_time_ms,
     updated_at = EXCLUDED.updated_at
 "#;
-const SELECT_STATS_DAILY_PROVIDER_AGGREGATES_SQL: &str = r#"
-SELECT
-    COALESCE(provider_name, 'Unknown') AS provider_name,
-    CAST(COUNT(id) AS BIGINT) AS total_requests,
-    CAST(COALESCE(SUM(input_tokens), 0) AS BIGINT) AS input_tokens,
-    CAST(COALESCE(SUM(output_tokens), 0) AS BIGINT) AS output_tokens,
-    CAST(COALESCE(SUM(cache_creation_input_tokens), 0) AS BIGINT) AS cache_creation_tokens,
-    CAST(COALESCE(SUM(cache_read_input_tokens), 0) AS BIGINT) AS cache_read_tokens,
-    CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost
-FROM usage
-WHERE created_at >= $1
-  AND created_at < $2
-GROUP BY COALESCE(provider_name, 'Unknown')
-"#;
 const UPSERT_STATS_DAILY_PROVIDER_SQL: &str = r#"
+WITH aggregated AS (
+    SELECT
+        COALESCE(provider_name, 'Unknown') AS provider_name,
+        CAST(COUNT(id) AS BIGINT) AS total_requests,
+        CAST(COALESCE(SUM(input_tokens), 0) AS BIGINT) AS input_tokens,
+        CAST(COALESCE(SUM(output_tokens), 0) AS BIGINT) AS output_tokens,
+        CAST(COALESCE(SUM(cache_creation_input_tokens), 0) AS BIGINT) AS cache_creation_tokens,
+        CAST(COALESCE(SUM(cache_read_input_tokens), 0) AS BIGINT) AS cache_read_tokens,
+        CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost
+    FROM usage
+    WHERE created_at >= $1
+      AND created_at < $2
+    GROUP BY COALESCE(provider_name, 'Unknown')
+)
 INSERT INTO stats_daily_provider (
     id,
     date,
@@ -592,7 +624,19 @@ INSERT INTO stats_daily_provider (
     created_at,
     updated_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+SELECT
+    md5(CONCAT('stats-daily-provider:', aggregated.provider_name, ':', CAST($1 AS TEXT))),
+    $1,
+    aggregated.provider_name,
+    aggregated.total_requests,
+    aggregated.input_tokens,
+    aggregated.output_tokens,
+    aggregated.cache_creation_tokens,
+    aggregated.cache_read_tokens,
+    aggregated.total_cost,
+    $3,
+    $3
+FROM aggregated
 ON CONFLICT (date, provider_name)
 DO UPDATE SET
     total_requests = EXCLUDED.total_requests,
@@ -603,24 +647,34 @@ DO UPDATE SET
     total_cost = EXCLUDED.total_cost,
     updated_at = EXCLUDED.updated_at
 "#;
-const SELECT_STATS_DAILY_API_KEY_AGGREGATES_SQL: &str = r#"
-SELECT
-    api_key_id,
-    MAX(api_key_name) AS api_key_name,
-    CAST(COUNT(id) AS BIGINT) AS total_requests,
-    CAST(COALESCE(SUM(CASE WHEN status_code >= 400 OR error_message IS NOT NULL THEN 1 ELSE 0 END), 0) AS BIGINT) AS error_requests,
-    CAST(COALESCE(SUM(input_tokens), 0) AS BIGINT) AS input_tokens,
-    CAST(COALESCE(SUM(output_tokens), 0) AS BIGINT) AS output_tokens,
-    CAST(COALESCE(SUM(cache_creation_input_tokens), 0) AS BIGINT) AS cache_creation_tokens,
-    CAST(COALESCE(SUM(cache_read_input_tokens), 0) AS BIGINT) AS cache_read_tokens,
-    CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost
-FROM usage
-WHERE created_at >= $1
-  AND created_at < $2
-  AND api_key_id IS NOT NULL
-GROUP BY api_key_id
-"#;
 const UPSERT_STATS_DAILY_API_KEY_SQL: &str = r#"
+WITH aggregated AS (
+    SELECT
+        api_key_id,
+        MAX(api_key_name) AS api_key_name,
+        CAST(COUNT(id) AS BIGINT) AS total_requests,
+        CAST(
+            COALESCE(
+                SUM(
+                    CASE
+                        WHEN status_code >= 400 OR error_message IS NOT NULL THEN 1
+                        ELSE 0
+                    END
+                ),
+                0
+            ) AS BIGINT
+        ) AS error_requests,
+        CAST(COALESCE(SUM(input_tokens), 0) AS BIGINT) AS input_tokens,
+        CAST(COALESCE(SUM(output_tokens), 0) AS BIGINT) AS output_tokens,
+        CAST(COALESCE(SUM(cache_creation_input_tokens), 0) AS BIGINT) AS cache_creation_tokens,
+        CAST(COALESCE(SUM(cache_read_input_tokens), 0) AS BIGINT) AS cache_read_tokens,
+        CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost
+    FROM usage
+    WHERE created_at >= $1
+      AND created_at < $2
+      AND api_key_id IS NOT NULL
+    GROUP BY api_key_id
+)
 INSERT INTO stats_daily_api_key (
     id,
     api_key_id,
@@ -637,7 +691,22 @@ INSERT INTO stats_daily_api_key (
     created_at,
     updated_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+SELECT
+    md5(CONCAT('stats-daily-api-key:', aggregated.api_key_id, ':', CAST($1 AS TEXT))),
+    aggregated.api_key_id,
+    aggregated.api_key_name,
+    $1,
+    aggregated.total_requests,
+    GREATEST(aggregated.total_requests - aggregated.error_requests, 0),
+    aggregated.error_requests,
+    aggregated.input_tokens,
+    aggregated.output_tokens,
+    aggregated.cache_creation_tokens,
+    aggregated.cache_read_tokens,
+    aggregated.total_cost,
+    $3,
+    $3
+FROM aggregated
 ON CONFLICT (api_key_id, date)
 DO UPDATE SET
     api_key_name = COALESCE(EXCLUDED.api_key_name, stats_daily_api_key.api_key_name),
@@ -655,19 +724,19 @@ const DELETE_STATS_DAILY_ERRORS_FOR_DATE_SQL: &str = r#"
 DELETE FROM stats_daily_error
 WHERE date = $1
 "#;
-const SELECT_STATS_DAILY_ERROR_AGGREGATES_SQL: &str = r#"
-SELECT
-    error_category,
-    provider_name,
-    model,
-    CAST(COUNT(id) AS BIGINT) AS total_count
-FROM usage
-WHERE created_at >= $1
-  AND created_at < $2
-  AND error_category IS NOT NULL
-GROUP BY error_category, provider_name, model
-"#;
 const INSERT_STATS_DAILY_ERROR_SQL: &str = r#"
+WITH aggregated AS (
+    SELECT
+        error_category,
+        provider_name,
+        model,
+        CAST(COUNT(id) AS BIGINT) AS total_count
+    FROM usage
+    WHERE created_at >= $1
+      AND created_at < $2
+      AND error_category IS NOT NULL
+    GROUP BY error_category, provider_name, model
+)
 INSERT INTO stats_daily_error (
     id,
     date,
@@ -678,32 +747,56 @@ INSERT INTO stats_daily_error (
     created_at,
     updated_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-"#;
-const SELECT_ACTIVE_USER_IDS_SQL: &str = r#"
-SELECT id
-FROM users
-WHERE is_active IS TRUE
-ORDER BY id ASC
-"#;
-const SELECT_STATS_USER_DAILY_AGGREGATES_SQL: &str = r#"
 SELECT
-    user_id,
-    MAX(username) AS username,
-    CAST(COUNT(id) AS BIGINT) AS total_requests,
-    CAST(COALESCE(SUM(CASE WHEN status_code >= 400 OR error_message IS NOT NULL THEN 1 ELSE 0 END), 0) AS BIGINT) AS error_requests,
-    CAST(COALESCE(SUM(input_tokens), 0) AS BIGINT) AS input_tokens,
-    CAST(COALESCE(SUM(output_tokens), 0) AS BIGINT) AS output_tokens,
-    CAST(COALESCE(SUM(cache_creation_input_tokens), 0) AS BIGINT) AS cache_creation_tokens,
-    CAST(COALESCE(SUM(cache_read_input_tokens), 0) AS BIGINT) AS cache_read_tokens,
-    CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost
-FROM usage
-WHERE created_at >= $1
-  AND created_at < $2
-  AND user_id IS NOT NULL
-GROUP BY user_id
+    md5(
+        CONCAT(
+            'stats-daily-error:',
+            CAST($1 AS TEXT),
+            ':',
+            aggregated.error_category,
+            ':',
+            COALESCE(aggregated.provider_name, ''),
+            ':',
+            COALESCE(aggregated.model, '')
+        )
+    ),
+    $1,
+    aggregated.error_category,
+    aggregated.provider_name,
+    aggregated.model,
+    aggregated.total_count,
+    $3,
+    $3
+FROM aggregated
 "#;
 const UPSERT_STATS_USER_DAILY_SQL: &str = r#"
+WITH aggregated AS (
+    SELECT
+        user_id,
+        MAX(username) AS username,
+        CAST(COUNT(id) AS BIGINT) AS total_requests,
+        CAST(
+            COALESCE(
+                SUM(
+                    CASE
+                        WHEN status_code >= 400 OR error_message IS NOT NULL THEN 1
+                        ELSE 0
+                    END
+                ),
+                0
+            ) AS BIGINT
+        ) AS error_requests,
+        CAST(COALESCE(SUM(input_tokens), 0) AS BIGINT) AS input_tokens,
+        CAST(COALESCE(SUM(output_tokens), 0) AS BIGINT) AS output_tokens,
+        CAST(COALESCE(SUM(cache_creation_input_tokens), 0) AS BIGINT) AS cache_creation_tokens,
+        CAST(COALESCE(SUM(cache_read_input_tokens), 0) AS BIGINT) AS cache_read_tokens,
+        CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost
+    FROM usage
+    WHERE created_at >= $1
+      AND created_at < $2
+      AND user_id IS NOT NULL
+    GROUP BY user_id
+)
 INSERT INTO stats_user_daily (
     id,
     user_id,
@@ -720,7 +813,24 @@ INSERT INTO stats_user_daily (
     created_at,
     updated_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+SELECT
+    md5(CONCAT('stats-user-daily:', users.id, ':', CAST($1 AS TEXT))),
+    users.id,
+    aggregated.username,
+    $1,
+    COALESCE(aggregated.total_requests, 0),
+    GREATEST(COALESCE(aggregated.total_requests, 0) - COALESCE(aggregated.error_requests, 0), 0),
+    COALESCE(aggregated.error_requests, 0),
+    COALESCE(aggregated.input_tokens, 0),
+    COALESCE(aggregated.output_tokens, 0),
+    COALESCE(aggregated.cache_creation_tokens, 0),
+    COALESCE(aggregated.cache_read_tokens, 0),
+    COALESCE(aggregated.total_cost, 0),
+    $3,
+    $3
+FROM users
+LEFT JOIN aggregated ON aggregated.user_id = users.id
+WHERE users.is_active IS TRUE
 ON CONFLICT (user_id, date)
 DO UPDATE SET
     username = COALESCE(EXCLUDED.username, stats_user_daily.username),
@@ -859,21 +969,29 @@ DO UPDATE SET
     aggregated_at = EXCLUDED.aggregated_at,
     updated_at = EXCLUDED.updated_at
 "#;
-const SELECT_STATS_HOURLY_USER_AGGREGATES_SQL: &str = r#"
-SELECT
-    user_id,
-    COUNT(id) AS total_requests,
-    COALESCE(SUM(CASE WHEN status_code >= 400 OR error_message IS NOT NULL THEN 1 ELSE 0 END), 0) AS error_requests,
-    COALESCE(SUM(input_tokens), 0) AS input_tokens,
-    COALESCE(SUM(output_tokens), 0) AS output_tokens,
-    CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost
-FROM usage
-WHERE created_at >= $1
-  AND created_at < $2
-  AND user_id IS NOT NULL
-GROUP BY user_id
-"#;
 const UPSERT_STATS_HOURLY_USER_SQL: &str = r#"
+WITH aggregated AS (
+    SELECT
+        user_id,
+        COUNT(id) AS total_requests,
+        COALESCE(
+            SUM(
+                CASE
+                    WHEN status_code >= 400 OR error_message IS NOT NULL THEN 1
+                    ELSE 0
+                END
+            ),
+            0
+        ) AS error_requests,
+        COALESCE(SUM(input_tokens), 0) AS input_tokens,
+        COALESCE(SUM(output_tokens), 0) AS output_tokens,
+        CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost
+    FROM usage
+    WHERE created_at >= $1
+      AND created_at < $2
+      AND user_id IS NOT NULL
+    GROUP BY user_id
+)
 INSERT INTO stats_hourly_user (
     id,
     hour_utc,
@@ -887,7 +1005,19 @@ INSERT INTO stats_hourly_user (
     created_at,
     updated_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+SELECT
+    md5(CONCAT('stats-hourly-user:', aggregated.user_id, ':', CAST($1 AS TEXT))),
+    $1,
+    aggregated.user_id,
+    aggregated.total_requests,
+    GREATEST(aggregated.total_requests - aggregated.error_requests, 0),
+    aggregated.error_requests,
+    aggregated.input_tokens,
+    aggregated.output_tokens,
+    aggregated.total_cost,
+    $3,
+    $3
+FROM aggregated
 ON CONFLICT (hour_utc, user_id)
 DO UPDATE SET
     total_requests = EXCLUDED.total_requests,
@@ -898,20 +1028,22 @@ DO UPDATE SET
     total_cost = EXCLUDED.total_cost,
     updated_at = EXCLUDED.updated_at
 "#;
-const SELECT_STATS_HOURLY_MODEL_AGGREGATES_SQL: &str = r#"
-SELECT
-    model,
-    COUNT(id) AS total_requests,
-    COALESCE(SUM(input_tokens), 0) AS input_tokens,
-    COALESCE(SUM(output_tokens), 0) AS output_tokens,
-    CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost,
-    CAST(COALESCE(AVG(response_time_ms), 0) AS DOUBLE PRECISION) AS avg_response_time_ms
-FROM usage
-WHERE created_at >= $1
-  AND created_at < $2
-GROUP BY model
-"#;
 const UPSERT_STATS_HOURLY_MODEL_SQL: &str = r#"
+WITH aggregated AS (
+    SELECT
+        model,
+        COUNT(id) AS total_requests,
+        COALESCE(SUM(input_tokens), 0) AS input_tokens,
+        COALESCE(SUM(output_tokens), 0) AS output_tokens,
+        CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost,
+        CAST(COALESCE(AVG(response_time_ms), 0) AS DOUBLE PRECISION) AS avg_response_time_ms
+    FROM usage
+    WHERE created_at >= $1
+      AND created_at < $2
+      AND model IS NOT NULL
+      AND model <> ''
+    GROUP BY model
+)
 INSERT INTO stats_hourly_model (
     id,
     hour_utc,
@@ -924,7 +1056,18 @@ INSERT INTO stats_hourly_model (
     created_at,
     updated_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+SELECT
+    md5(CONCAT('stats-hourly-model:', aggregated.model, ':', CAST($1 AS TEXT))),
+    $1,
+    aggregated.model,
+    aggregated.total_requests,
+    aggregated.input_tokens,
+    aggregated.output_tokens,
+    aggregated.total_cost,
+    aggregated.avg_response_time_ms,
+    $3,
+    $3
+FROM aggregated
 ON CONFLICT (hour_utc, model)
 DO UPDATE SET
     total_requests = EXCLUDED.total_requests,
@@ -934,19 +1077,21 @@ DO UPDATE SET
     avg_response_time_ms = EXCLUDED.avg_response_time_ms,
     updated_at = EXCLUDED.updated_at
 "#;
-const SELECT_STATS_HOURLY_PROVIDER_AGGREGATES_SQL: &str = r#"
-SELECT
-    provider_name,
-    COUNT(id) AS total_requests,
-    COALESCE(SUM(input_tokens), 0) AS input_tokens,
-    COALESCE(SUM(output_tokens), 0) AS output_tokens,
-    CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost
-FROM usage
-WHERE created_at >= $1
-  AND created_at < $2
-GROUP BY provider_name
-"#;
 const UPSERT_STATS_HOURLY_PROVIDER_SQL: &str = r#"
+WITH aggregated AS (
+    SELECT
+        provider_name,
+        COUNT(id) AS total_requests,
+        COALESCE(SUM(input_tokens), 0) AS input_tokens,
+        COALESCE(SUM(output_tokens), 0) AS output_tokens,
+        CAST(COALESCE(SUM(total_cost_usd), 0) AS DOUBLE PRECISION) AS total_cost
+    FROM usage
+    WHERE created_at >= $1
+      AND created_at < $2
+      AND provider_name IS NOT NULL
+      AND provider_name <> ''
+    GROUP BY provider_name
+)
 INSERT INTO stats_hourly_provider (
     id,
     hour_utc,
@@ -958,7 +1103,17 @@ INSERT INTO stats_hourly_provider (
     created_at,
     updated_at
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+SELECT
+    md5(CONCAT('stats-hourly-provider:', aggregated.provider_name, ':', CAST($1 AS TEXT))),
+    $1,
+    aggregated.provider_name,
+    aggregated.total_requests,
+    aggregated.input_tokens,
+    aggregated.output_tokens,
+    aggregated.total_cost,
+    $3,
+    $3
+FROM aggregated
 ON CONFLICT (hour_utc, provider_name)
 DO UPDATE SET
     total_requests = EXCLUDED.total_requests,

--- a/apps/aether-gateway/src/maintenance/runtime/pending_cleanup.rs
+++ b/apps/aether-gateway/src/maintenance/runtime/pending_cleanup.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use chrono::Utc;
+use futures_util::TryStreamExt;
 use sqlx::Row;
 
 use crate::data::GatewayDataState;
@@ -59,13 +60,18 @@ pub(crate) async fn cleanup_stale_pending_requests_once(
 
     loop {
         let mut tx = pool.begin().await.map_err(postgres_error)?;
-        let stale_rows = sqlx::query(SELECT_STALE_PENDING_USAGE_BATCH_SQL)
-            .bind(active_statuses.clone())
-            .bind(cutoff_time)
-            .bind(i64::try_from(batch_size).unwrap_or(i64::MAX))
-            .fetch_all(&mut *tx)
-            .await
-            .map_err(postgres_error)?;
+        let stale_rows = {
+            let mut stale_rows_stream = sqlx::query(SELECT_STALE_PENDING_USAGE_BATCH_SQL)
+                .bind(active_statuses.clone())
+                .bind(cutoff_time)
+                .bind(i64::try_from(batch_size).unwrap_or(i64::MAX))
+                .fetch(&mut *tx);
+            let mut stale_rows = Vec::new();
+            while let Some(row) = stale_rows_stream.try_next().await.map_err(postgres_error)? {
+                stale_rows.push(row);
+            }
+            stale_rows
+        };
         if stale_rows.is_empty() {
             tx.rollback().await.map_err(postgres_error)?;
             break;
@@ -93,14 +99,18 @@ pub(crate) async fn cleanup_stale_pending_requests_once(
         let completed_request_ids = if request_ids.is_empty() {
             HashSet::new()
         } else {
-            sqlx::query(SELECT_COMPLETED_PENDING_REQUEST_IDS_SQL)
-                .bind(request_ids)
-                .fetch_all(&mut *tx)
-                .await
-                .map_err(postgres_error)?
-                .into_iter()
-                .filter_map(|row| row.try_get::<String, _>("request_id").ok())
-                .collect::<HashSet<_>>()
+            {
+                let mut completed_rows = sqlx::query(SELECT_COMPLETED_PENDING_REQUEST_IDS_SQL)
+                    .bind(request_ids)
+                    .fetch(&mut *tx);
+                let mut completed_request_ids = HashSet::new();
+                while let Some(row) = completed_rows.try_next().await.map_err(postgres_error)? {
+                    if let Ok(request_id) = row.try_get::<String, _>("request_id") {
+                        completed_request_ids.insert(request_id);
+                    }
+                }
+                completed_request_ids
+            }
         };
         let plan = plan_pending_cleanup_batch(stale_rows, &completed_request_ids, timeout_minutes);
         let now = Utc::now();

--- a/apps/aether-gateway/src/maintenance/runtime/stats_daily.rs
+++ b/apps/aether-gateway/src/maintenance/runtime/stats_daily.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use chrono::{DateTime, Utc};
 use sqlx::Row;
 use uuid::Uuid;
@@ -10,15 +8,13 @@ use aether_data_contracts::DataLayerError;
 use super::{
     postgres_error, stats_aggregation_target_day, system_config_bool, PercentileSummary,
     StatsAggregationSummary, DELETE_STATS_DAILY_ERRORS_FOR_DATE_SQL, INSERT_STATS_DAILY_ERROR_SQL,
-    INSERT_STATS_SUMMARY_SQL, SELECT_ACTIVE_USER_IDS_SQL, SELECT_EXISTING_STATS_SUMMARY_ID_SQL,
-    SELECT_STATS_DAILY_AGGREGATE_SQL, SELECT_STATS_DAILY_API_KEY_AGGREGATES_SQL,
-    SELECT_STATS_DAILY_ERROR_AGGREGATES_SQL, SELECT_STATS_DAILY_FALLBACK_COUNT_SQL,
-    SELECT_STATS_DAILY_FIRST_BYTE_PERCENTILES_SQL, SELECT_STATS_DAILY_MODEL_AGGREGATES_SQL,
-    SELECT_STATS_DAILY_PROVIDER_AGGREGATES_SQL, SELECT_STATS_DAILY_RESPONSE_TIME_PERCENTILES_SQL,
-    SELECT_STATS_SUMMARY_ENTITY_COUNTS_SQL, SELECT_STATS_SUMMARY_TOTALS_SQL,
-    SELECT_STATS_USER_DAILY_AGGREGATES_SQL, UPDATE_STATS_SUMMARY_SQL,
-    UPSERT_STATS_DAILY_API_KEY_SQL, UPSERT_STATS_DAILY_MODEL_SQL, UPSERT_STATS_DAILY_PROVIDER_SQL,
-    UPSERT_STATS_DAILY_SQL, UPSERT_STATS_USER_DAILY_SQL,
+    INSERT_STATS_SUMMARY_SQL, SELECT_EXISTING_STATS_SUMMARY_ID_SQL,
+    SELECT_STATS_DAILY_AGGREGATE_SQL, SELECT_STATS_DAILY_FALLBACK_COUNT_SQL,
+    SELECT_STATS_DAILY_FIRST_BYTE_PERCENTILES_SQL,
+    SELECT_STATS_DAILY_RESPONSE_TIME_PERCENTILES_SQL, SELECT_STATS_SUMMARY_ENTITY_COUNTS_SQL,
+    SELECT_STATS_SUMMARY_TOTALS_SQL, UPDATE_STATS_SUMMARY_SQL, UPSERT_STATS_DAILY_API_KEY_SQL,
+    UPSERT_STATS_DAILY_MODEL_SQL, UPSERT_STATS_DAILY_PROVIDER_SQL, UPSERT_STATS_DAILY_SQL,
+    UPSERT_STATS_USER_DAILY_SQL,
 };
 
 pub(super) async fn perform_stats_aggregation_once(
@@ -226,31 +222,15 @@ async fn upsert_stats_daily_model_rows(
     day_end_utc: DateTime<Utc>,
     now_utc: DateTime<Utc>,
 ) -> Result<usize, sqlx::Error> {
-    let rows = sqlx::query(SELECT_STATS_DAILY_MODEL_AGGREGATES_SQL)
+    let rows_affected = sqlx::query(UPSERT_STATS_DAILY_MODEL_SQL)
         .bind(day_start_utc)
         .bind(day_end_utc)
-        .fetch_all(&mut **tx)
-        .await?;
+        .bind(now_utc)
+        .execute(&mut **tx)
+        .await?
+        .rows_affected();
 
-    for row in &rows {
-        sqlx::query(UPSERT_STATS_DAILY_MODEL_SQL)
-            .bind(Uuid::new_v4().to_string())
-            .bind(day_start_utc)
-            .bind(row.try_get::<String, _>("model")?)
-            .bind(row.try_get::<i64, _>("total_requests")?)
-            .bind(row.try_get::<i64, _>("input_tokens")?)
-            .bind(row.try_get::<i64, _>("output_tokens")?)
-            .bind(row.try_get::<i64, _>("cache_creation_tokens")?)
-            .bind(row.try_get::<i64, _>("cache_read_tokens")?)
-            .bind(row.try_get::<f64, _>("total_cost")?)
-            .bind(row.try_get::<f64, _>("avg_response_time_ms")?)
-            .bind(now_utc)
-            .bind(now_utc)
-            .execute(&mut **tx)
-            .await?;
-    }
-
-    Ok(rows.len())
+    Ok(usize::try_from(rows_affected).unwrap_or(usize::MAX))
 }
 
 async fn upsert_stats_daily_provider_rows(
@@ -259,30 +239,15 @@ async fn upsert_stats_daily_provider_rows(
     day_end_utc: DateTime<Utc>,
     now_utc: DateTime<Utc>,
 ) -> Result<usize, sqlx::Error> {
-    let rows = sqlx::query(SELECT_STATS_DAILY_PROVIDER_AGGREGATES_SQL)
+    let rows_affected = sqlx::query(UPSERT_STATS_DAILY_PROVIDER_SQL)
         .bind(day_start_utc)
         .bind(day_end_utc)
-        .fetch_all(&mut **tx)
-        .await?;
+        .bind(now_utc)
+        .execute(&mut **tx)
+        .await?
+        .rows_affected();
 
-    for row in &rows {
-        sqlx::query(UPSERT_STATS_DAILY_PROVIDER_SQL)
-            .bind(Uuid::new_v4().to_string())
-            .bind(day_start_utc)
-            .bind(row.try_get::<String, _>("provider_name")?)
-            .bind(row.try_get::<i64, _>("total_requests")?)
-            .bind(row.try_get::<i64, _>("input_tokens")?)
-            .bind(row.try_get::<i64, _>("output_tokens")?)
-            .bind(row.try_get::<i64, _>("cache_creation_tokens")?)
-            .bind(row.try_get::<i64, _>("cache_read_tokens")?)
-            .bind(row.try_get::<f64, _>("total_cost")?)
-            .bind(now_utc)
-            .bind(now_utc)
-            .execute(&mut **tx)
-            .await?;
-    }
-
-    Ok(rows.len())
+    Ok(usize::try_from(rows_affected).unwrap_or(usize::MAX))
 }
 
 async fn upsert_stats_daily_api_key_rows(
@@ -291,35 +256,15 @@ async fn upsert_stats_daily_api_key_rows(
     day_end_utc: DateTime<Utc>,
     now_utc: DateTime<Utc>,
 ) -> Result<usize, sqlx::Error> {
-    let rows = sqlx::query(SELECT_STATS_DAILY_API_KEY_AGGREGATES_SQL)
+    let rows_affected = sqlx::query(UPSERT_STATS_DAILY_API_KEY_SQL)
         .bind(day_start_utc)
         .bind(day_end_utc)
-        .fetch_all(&mut **tx)
-        .await?;
+        .bind(now_utc)
+        .execute(&mut **tx)
+        .await?
+        .rows_affected();
 
-    for row in &rows {
-        let total_requests = row.try_get::<i64, _>("total_requests")?;
-        let error_requests = row.try_get::<i64, _>("error_requests")?;
-        sqlx::query(UPSERT_STATS_DAILY_API_KEY_SQL)
-            .bind(Uuid::new_v4().to_string())
-            .bind(row.try_get::<String, _>("api_key_id")?)
-            .bind(row.try_get::<Option<String>, _>("api_key_name")?)
-            .bind(day_start_utc)
-            .bind(total_requests)
-            .bind(total_requests.saturating_sub(error_requests))
-            .bind(error_requests)
-            .bind(row.try_get::<i64, _>("input_tokens")?)
-            .bind(row.try_get::<i64, _>("output_tokens")?)
-            .bind(row.try_get::<i64, _>("cache_creation_tokens")?)
-            .bind(row.try_get::<i64, _>("cache_read_tokens")?)
-            .bind(row.try_get::<f64, _>("total_cost")?)
-            .bind(now_utc)
-            .bind(now_utc)
-            .execute(&mut **tx)
-            .await?;
-    }
-
-    Ok(rows.len())
+    Ok(usize::try_from(rows_affected).unwrap_or(usize::MAX))
 }
 
 async fn refresh_stats_daily_error_rows(
@@ -332,27 +277,15 @@ async fn refresh_stats_daily_error_rows(
         .bind(day_start_utc)
         .execute(&mut **tx)
         .await?;
-    let rows = sqlx::query(SELECT_STATS_DAILY_ERROR_AGGREGATES_SQL)
+    let rows_affected = sqlx::query(INSERT_STATS_DAILY_ERROR_SQL)
         .bind(day_start_utc)
         .bind(day_end_utc)
-        .fetch_all(&mut **tx)
-        .await?;
+        .bind(now_utc)
+        .execute(&mut **tx)
+        .await?
+        .rows_affected();
 
-    for row in &rows {
-        sqlx::query(INSERT_STATS_DAILY_ERROR_SQL)
-            .bind(Uuid::new_v4().to_string())
-            .bind(day_start_utc)
-            .bind(row.try_get::<String, _>("error_category")?)
-            .bind(row.try_get::<Option<String>, _>("provider_name")?)
-            .bind(row.try_get::<Option<String>, _>("model")?)
-            .bind(row.try_get::<i64, _>("total_count")?)
-            .bind(now_utc)
-            .bind(now_utc)
-            .execute(&mut **tx)
-            .await?;
-    }
-
-    Ok(rows.len())
+    Ok(usize::try_from(rows_affected).unwrap_or(usize::MAX))
 }
 
 async fn upsert_stats_user_daily_rows(
@@ -361,87 +294,15 @@ async fn upsert_stats_user_daily_rows(
     day_end_utc: DateTime<Utc>,
     now_utc: DateTime<Utc>,
 ) -> Result<usize, sqlx::Error> {
-    let active_user_ids = sqlx::query(SELECT_ACTIVE_USER_IDS_SQL)
-        .fetch_all(&mut **tx)
-        .await?
-        .into_iter()
-        .map(|row| row.try_get::<String, _>("id"))
-        .collect::<Result<Vec<_>, _>>()?;
-    if active_user_ids.is_empty() {
-        return Ok(0);
-    }
-
-    let aggregated_rows = sqlx::query(SELECT_STATS_USER_DAILY_AGGREGATES_SQL)
+    let rows_affected = sqlx::query(UPSERT_STATS_USER_DAILY_SQL)
         .bind(day_start_utc)
         .bind(day_end_utc)
-        .fetch_all(&mut **tx)
-        .await?;
-    let mut aggregated_by_user = HashMap::with_capacity(aggregated_rows.len());
-    for row in aggregated_rows {
-        let user_id = row.try_get::<String, _>("user_id")?;
-        aggregated_by_user.insert(user_id, row);
-    }
+        .bind(now_utc)
+        .execute(&mut **tx)
+        .await?
+        .rows_affected();
 
-    for user_id in &active_user_ids {
-        let aggregated = aggregated_by_user.get(user_id);
-        let total_requests = aggregated
-            .map(|row| row.try_get::<i64, _>("total_requests"))
-            .transpose()?
-            .unwrap_or_default();
-        let error_requests = aggregated
-            .map(|row| row.try_get::<i64, _>("error_requests"))
-            .transpose()?
-            .unwrap_or_default();
-        sqlx::query(UPSERT_STATS_USER_DAILY_SQL)
-            .bind(Uuid::new_v4().to_string())
-            .bind(user_id)
-            .bind(
-                aggregated
-                    .map(|row| row.try_get::<Option<String>, _>("username"))
-                    .transpose()?
-                    .flatten(),
-            )
-            .bind(day_start_utc)
-            .bind(total_requests)
-            .bind(total_requests.saturating_sub(error_requests))
-            .bind(error_requests)
-            .bind(
-                aggregated
-                    .map(|row| row.try_get::<i64, _>("input_tokens"))
-                    .transpose()?
-                    .unwrap_or_default(),
-            )
-            .bind(
-                aggregated
-                    .map(|row| row.try_get::<i64, _>("output_tokens"))
-                    .transpose()?
-                    .unwrap_or_default(),
-            )
-            .bind(
-                aggregated
-                    .map(|row| row.try_get::<i64, _>("cache_creation_tokens"))
-                    .transpose()?
-                    .unwrap_or_default(),
-            )
-            .bind(
-                aggregated
-                    .map(|row| row.try_get::<i64, _>("cache_read_tokens"))
-                    .transpose()?
-                    .unwrap_or_default(),
-            )
-            .bind(
-                aggregated
-                    .map(|row| row.try_get::<f64, _>("total_cost"))
-                    .transpose()?
-                    .unwrap_or_default(),
-            )
-            .bind(now_utc)
-            .bind(now_utc)
-            .execute(&mut **tx)
-            .await?;
-    }
-
-    Ok(active_user_ids.len())
+    Ok(usize::try_from(rows_affected).unwrap_or(usize::MAX))
 }
 
 async fn refresh_stats_summary_row(

--- a/apps/aether-gateway/src/maintenance/runtime/stats_hourly.rs
+++ b/apps/aether-gateway/src/maintenance/runtime/stats_hourly.rs
@@ -7,9 +7,8 @@ use aether_data_contracts::DataLayerError;
 
 use super::{
     stats_hourly_aggregation_target_hour, system_config_bool, SELECT_STATS_HOURLY_AGGREGATE_SQL,
-    SELECT_STATS_HOURLY_MODEL_AGGREGATES_SQL, SELECT_STATS_HOURLY_PROVIDER_AGGREGATES_SQL,
-    SELECT_STATS_HOURLY_USER_AGGREGATES_SQL, UPSERT_STATS_HOURLY_MODEL_SQL,
-    UPSERT_STATS_HOURLY_PROVIDER_SQL, UPSERT_STATS_HOURLY_SQL, UPSERT_STATS_HOURLY_USER_SQL,
+    UPSERT_STATS_HOURLY_MODEL_SQL, UPSERT_STATS_HOURLY_PROVIDER_SQL, UPSERT_STATS_HOURLY_SQL,
+    UPSERT_STATS_HOURLY_USER_SQL,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -115,51 +114,16 @@ async fn upsert_stats_hourly_user_rows(
     hour_end: DateTime<Utc>,
     now_utc: DateTime<Utc>,
 ) -> Result<usize, DataLayerError> {
-    let rows = sqlx::query(SELECT_STATS_HOURLY_USER_AGGREGATES_SQL)
+    let rows_affected = sqlx::query(UPSERT_STATS_HOURLY_USER_SQL)
         .bind(hour_utc)
         .bind(hour_end)
-        .fetch_all(&mut **tx)
+        .bind(now_utc)
+        .execute(&mut **tx)
         .await
-        .map_err(postgres_error)?;
+        .map_err(postgres_error)?
+        .rows_affected();
 
-    for row in &rows {
-        let user_id = row
-            .try_get::<String, _>("user_id")
-            .map_err(postgres_error)?;
-        let total_requests = row
-            .try_get::<i64, _>("total_requests")
-            .map_err(postgres_error)?;
-        let error_requests = row
-            .try_get::<i64, _>("error_requests")
-            .map_err(postgres_error)?;
-        let success_requests = total_requests.saturating_sub(error_requests);
-        sqlx::query(UPSERT_STATS_HOURLY_USER_SQL)
-            .bind(Uuid::new_v4().to_string())
-            .bind(hour_utc)
-            .bind(user_id)
-            .bind(total_requests)
-            .bind(success_requests)
-            .bind(error_requests)
-            .bind(
-                row.try_get::<i64, _>("input_tokens")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<i64, _>("output_tokens")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<f64, _>("total_cost")
-                    .map_err(postgres_error)?,
-            )
-            .bind(now_utc)
-            .bind(now_utc)
-            .execute(&mut **tx)
-            .await
-            .map_err(postgres_error)?;
-    }
-
-    Ok(rows.len())
+    Ok(usize::try_from(rows_affected).unwrap_or(usize::MAX))
 }
 
 async fn upsert_stats_hourly_model_rows(
@@ -168,54 +132,16 @@ async fn upsert_stats_hourly_model_rows(
     hour_end: DateTime<Utc>,
     now_utc: DateTime<Utc>,
 ) -> Result<usize, DataLayerError> {
-    let rows = sqlx::query(SELECT_STATS_HOURLY_MODEL_AGGREGATES_SQL)
+    let rows_affected = sqlx::query(UPSERT_STATS_HOURLY_MODEL_SQL)
         .bind(hour_utc)
         .bind(hour_end)
-        .fetch_all(&mut **tx)
+        .bind(now_utc)
+        .execute(&mut **tx)
         .await
-        .map_err(postgres_error)?;
-    let mut inserted = 0usize;
+        .map_err(postgres_error)?
+        .rows_affected();
 
-    for row in &rows {
-        let model = row
-            .try_get::<Option<String>, _>("model")
-            .map_err(postgres_error)?;
-        let Some(model) = model.filter(|value| !value.is_empty()) else {
-            continue;
-        };
-        sqlx::query(UPSERT_STATS_HOURLY_MODEL_SQL)
-            .bind(Uuid::new_v4().to_string())
-            .bind(hour_utc)
-            .bind(model)
-            .bind(
-                row.try_get::<i64, _>("total_requests")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<i64, _>("input_tokens")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<i64, _>("output_tokens")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<f64, _>("total_cost")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<f64, _>("avg_response_time_ms")
-                    .map_err(postgres_error)?,
-            )
-            .bind(now_utc)
-            .bind(now_utc)
-            .execute(&mut **tx)
-            .await
-            .map_err(postgres_error)?;
-        inserted += 1;
-    }
-
-    Ok(inserted)
+    Ok(usize::try_from(rows_affected).unwrap_or(usize::MAX))
 }
 
 async fn upsert_stats_hourly_provider_rows(
@@ -224,50 +150,16 @@ async fn upsert_stats_hourly_provider_rows(
     hour_end: DateTime<Utc>,
     now_utc: DateTime<Utc>,
 ) -> Result<usize, DataLayerError> {
-    let rows = sqlx::query(SELECT_STATS_HOURLY_PROVIDER_AGGREGATES_SQL)
+    let rows_affected = sqlx::query(UPSERT_STATS_HOURLY_PROVIDER_SQL)
         .bind(hour_utc)
         .bind(hour_end)
-        .fetch_all(&mut **tx)
+        .bind(now_utc)
+        .execute(&mut **tx)
         .await
-        .map_err(postgres_error)?;
-    let mut inserted = 0usize;
+        .map_err(postgres_error)?
+        .rows_affected();
 
-    for row in &rows {
-        let provider_name = row
-            .try_get::<Option<String>, _>("provider_name")
-            .map_err(postgres_error)?;
-        let Some(provider_name) = provider_name.filter(|value| !value.is_empty()) else {
-            continue;
-        };
-        sqlx::query(UPSERT_STATS_HOURLY_PROVIDER_SQL)
-            .bind(Uuid::new_v4().to_string())
-            .bind(hour_utc)
-            .bind(provider_name)
-            .bind(
-                row.try_get::<i64, _>("total_requests")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<i64, _>("input_tokens")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<i64, _>("output_tokens")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<f64, _>("total_cost")
-                    .map_err(postgres_error)?,
-            )
-            .bind(now_utc)
-            .bind(now_utc)
-            .execute(&mut **tx)
-            .await
-            .map_err(postgres_error)?;
-        inserted += 1;
-    }
-
-    Ok(inserted)
+    Ok(usize::try_from(rows_affected).unwrap_or(usize::MAX))
 }
 
 fn postgres_error(error: sqlx::Error) -> DataLayerError {

--- a/apps/aether-gateway/src/maintenance/runtime/usage_cleanup.rs
+++ b/apps/aether-gateway/src/maintenance/runtime/usage_cleanup.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use aether_data_contracts::DataLayerError;
 use chrono::{DateTime, Utc};
 use flate2::{write::GzEncoder, Compression};
+use futures_util::TryStreamExt;
 use serde_json::Value;
 use sqlx::Row;
 use tracing::warn;
@@ -16,8 +17,8 @@ use super::{
     DISABLE_EXPIRED_API_KEY_SQL, EXPIRED_API_KEY_PRE_CLEAN_BATCH_SIZE,
     NULLIFY_REQUEST_CANDIDATE_API_KEY_BATCH_SQL, NULLIFY_USAGE_API_KEY_BATCH_SQL,
     SELECT_EXPIRED_ACTIVE_API_KEYS_SQL, SELECT_USAGE_BODY_COMPRESSION_BATCH_SQL,
-    SELECT_USAGE_HEADER_BATCH_SQL, SELECT_USAGE_STALE_BODY_BATCH_SQL,
-    UPDATE_USAGE_BODY_COMPRESSION_SQL,
+    SELECT_USAGE_BODY_COMPRESSION_ROW_SQL, SELECT_USAGE_HEADER_BATCH_SQL,
+    SELECT_USAGE_STALE_BODY_BATCH_SQL, UPDATE_USAGE_BODY_COMPRESSION_SQL,
 };
 
 pub(super) async fn perform_usage_cleanup_once(
@@ -113,16 +114,15 @@ async fn cleanup_usage_header_fields(
 
     let mut total_cleaned = 0usize;
     loop {
-        let ids = sqlx::query(SELECT_USAGE_HEADER_BATCH_SQL)
+        let mut rows = sqlx::query(SELECT_USAGE_HEADER_BATCH_SQL)
             .bind(cutoff_time)
             .bind(newer_than)
             .bind(i64::try_from(batch_size).unwrap_or(i64::MAX))
-            .fetch_all(pool)
-            .await
-            .map_err(postgres_error)?
-            .into_iter()
-            .map(|row| row.try_get::<String, _>("id").map_err(postgres_error))
-            .collect::<Result<Vec<_>, DataLayerError>>()?;
+            .fetch(pool);
+        let mut ids = Vec::new();
+        while let Some(row) = rows.try_next().await.map_err(postgres_error)? {
+            ids.push(row.try_get::<String, _>("id").map_err(postgres_error)?);
+        }
         if ids.is_empty() {
             break;
         }
@@ -159,16 +159,15 @@ async fn cleanup_usage_stale_body_fields(
 
     let mut total_cleaned = 0usize;
     loop {
-        let ids = sqlx::query(SELECT_USAGE_STALE_BODY_BATCH_SQL)
+        let mut rows = sqlx::query(SELECT_USAGE_STALE_BODY_BATCH_SQL)
             .bind(cutoff_time)
             .bind(newer_than)
             .bind(i64::try_from(batch_size).unwrap_or(i64::MAX))
-            .fetch_all(pool)
-            .await
-            .map_err(postgres_error)?
-            .into_iter()
-            .map(|row| row.try_get::<String, _>("id").map_err(postgres_error))
-            .collect::<Result<Vec<_>, DataLayerError>>()?;
+            .fetch(pool);
+        let mut ids = Vec::new();
+        while let Some(row) = rows.try_next().await.map_err(postgres_error)? {
+            ids.push(row.try_get::<String, _>("id").map_err(postgres_error)?);
+        }
         if ids.is_empty() {
             break;
         }
@@ -207,38 +206,44 @@ async fn compress_usage_body_fields(
     let mut no_progress_count = 0usize;
     let batch_size = batch_size.clamp(1, 25);
     loop {
-        let rows = sqlx::query(SELECT_USAGE_BODY_COMPRESSION_BATCH_SQL)
+        let mut rows = sqlx::query(SELECT_USAGE_BODY_COMPRESSION_BATCH_SQL)
             .bind(cutoff_time)
             .bind(newer_than)
             .bind(i64::try_from(batch_size).unwrap_or(i64::MAX))
-            .fetch_all(pool)
-            .await
-            .map_err(postgres_error)?
-            .into_iter()
-            .map(|row| {
-                Ok(UsageBodyCompressionRow {
-                    id: row.try_get::<String, _>("id").map_err(postgres_error)?,
-                    request_body: row
-                        .try_get::<Option<Value>, _>("request_body")
-                        .map_err(postgres_error)?,
-                    response_body: row
-                        .try_get::<Option<Value>, _>("response_body")
-                        .map_err(postgres_error)?,
-                    provider_request_body: row
-                        .try_get::<Option<Value>, _>("provider_request_body")
-                        .map_err(postgres_error)?,
-                    client_response_body: row
-                        .try_get::<Option<Value>, _>("client_response_body")
-                        .map_err(postgres_error)?,
-                })
-            })
-            .collect::<Result<Vec<_>, DataLayerError>>()?;
-        if rows.is_empty() {
+            .fetch(pool);
+        let mut ids = Vec::new();
+        while let Some(row) = rows.try_next().await.map_err(postgres_error)? {
+            ids.push(row.try_get::<String, _>("id").map_err(postgres_error)?);
+        }
+        if ids.is_empty() {
             break;
         }
 
         let mut batch_success = 0usize;
-        for row in rows {
+        for id in ids {
+            let row = sqlx::query(SELECT_USAGE_BODY_COMPRESSION_ROW_SQL)
+                .bind(&id)
+                .fetch_optional(pool)
+                .await
+                .map_err(postgres_error)?;
+            let Some(row) = row else {
+                continue;
+            };
+            let row = UsageBodyCompressionRow {
+                id: row.try_get::<String, _>("id").map_err(postgres_error)?,
+                request_body: row
+                    .try_get::<Option<Value>, _>("request_body")
+                    .map_err(postgres_error)?,
+                response_body: row
+                    .try_get::<Option<Value>, _>("response_body")
+                    .map_err(postgres_error)?,
+                provider_request_body: row
+                    .try_get::<Option<Value>, _>("provider_request_body")
+                    .map_err(postgres_error)?,
+                client_response_body: row
+                    .try_get::<Option<Value>, _>("client_response_body")
+                    .map_err(postgres_error)?,
+            };
             let compressed = (
                 compress_usage_json_value(row.request_body.as_ref()),
                 compress_usage_json_value(row.response_body.as_ref()),
@@ -288,12 +293,9 @@ async fn cleanup_expired_api_keys(
     pool: &aether_data::postgres::PostgresPool,
     auto_delete_expired_keys: bool,
 ) -> Result<usize, DataLayerError> {
-    let expired_keys = sqlx::query(SELECT_EXPIRED_ACTIVE_API_KEYS_SQL)
-        .fetch_all(pool)
-        .await
-        .map_err(postgres_error)?;
+    let mut expired_keys = sqlx::query(SELECT_EXPIRED_ACTIVE_API_KEYS_SQL).fetch(pool);
     let mut cleaned = 0usize;
-    for row in &expired_keys {
+    while let Some(row) = expired_keys.try_next().await.map_err(postgres_error)? {
         let api_key_id = row.try_get::<String, _>("id").map_err(postgres_error)?;
         let key = ExpiredApiKeyRow {
             id: api_key_id.as_str(),

--- a/apps/aether-gateway/src/maintenance/runtime/wallet_daily_usage.rs
+++ b/apps/aether-gateway/src/maintenance/runtime/wallet_daily_usage.rs
@@ -1,14 +1,11 @@
 use chrono::{DateTime, Utc};
-use sqlx::Row;
-use uuid::Uuid;
 
 use crate::data::GatewayDataState;
 use aether_data_contracts::DataLayerError;
 
 use super::{
     maintenance_timezone, wallet_daily_usage_aggregation_target,
-    DELETE_STALE_WALLET_DAILY_USAGE_LEDGERS_SQL, SELECT_WALLET_DAILY_USAGE_AGGREGATION_ROWS_SQL,
-    UPSERT_WALLET_DAILY_USAGE_LEDGER_SQL,
+    DELETE_STALE_WALLET_DAILY_USAGE_LEDGERS_SQL, UPSERT_WALLET_DAILY_USAGE_LEDGER_SQL,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -43,60 +40,16 @@ pub(super) async fn perform_wallet_daily_usage_aggregation_once(
     };
 
     let mut tx = pool.begin().await.map_err(postgres_error)?;
-    let rows = sqlx::query(SELECT_WALLET_DAILY_USAGE_AGGREGATION_ROWS_SQL)
+    let aggregated_wallets = sqlx::query(UPSERT_WALLET_DAILY_USAGE_LEDGER_SQL)
         .bind(target.window_start_utc)
         .bind(target.window_end_utc)
-        .fetch_all(&mut *tx)
+        .bind(target.billing_date)
+        .bind(target.billing_timezone.as_str())
+        .bind(now_utc)
+        .execute(&mut *tx)
         .await
-        .map_err(postgres_error)?;
-    for row in &rows {
-        sqlx::query(UPSERT_WALLET_DAILY_USAGE_LEDGER_SQL)
-            .bind(Uuid::new_v4().to_string())
-            .bind(
-                row.try_get::<String, _>("wallet_id")
-                    .map_err(postgres_error)?,
-            )
-            .bind(target.billing_date)
-            .bind(target.billing_timezone.as_str())
-            .bind(
-                row.try_get::<f64, _>("total_cost_usd")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<i64, _>("total_requests")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<i64, _>("input_tokens")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<i64, _>("output_tokens")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<i64, _>("cache_creation_tokens")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<i64, _>("cache_read_tokens")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<Option<DateTime<Utc>>, _>("first_finalized_at")
-                    .map_err(postgres_error)?,
-            )
-            .bind(
-                row.try_get::<Option<DateTime<Utc>>, _>("last_finalized_at")
-                    .map_err(postgres_error)?,
-            )
-            .bind(now_utc)
-            .bind(now_utc)
-            .bind(now_utc)
-            .execute(&mut *tx)
-            .await
-            .map_err(postgres_error)?;
-    }
+        .map_err(postgres_error)?
+        .rows_affected();
 
     let deleted_stale_ledgers = sqlx::query(DELETE_STALE_WALLET_DAILY_USAGE_LEDGERS_SQL)
         .bind(target.billing_date)
@@ -112,7 +65,7 @@ pub(super) async fn perform_wallet_daily_usage_aggregation_once(
     Ok(WalletDailyUsageAggregationSummary {
         billing_date: target.billing_date,
         billing_timezone: target.billing_timezone,
-        aggregated_wallets: rows.len(),
+        aggregated_wallets: usize::try_from(aggregated_wallets).unwrap_or(usize::MAX),
         deleted_stale_ledgers: usize::try_from(deleted_stale_ledgers).unwrap_or(usize::MAX),
     })
 }

--- a/apps/aether-gateway/src/query/billing.rs
+++ b/apps/aether-gateway/src/query/billing.rs
@@ -4,6 +4,7 @@ use crate::{
     AdminBillingRuleWriteInput, GatewayError, LocalMutationOutcome,
 };
 use aether_data::postgres::PostgresPool;
+use futures_util::TryStreamExt;
 use sqlx::Row;
 
 fn internal(err: impl ToString) -> GatewayError {
@@ -136,7 +137,7 @@ WHERE ($1::TEXT IS NULL OR task_type = $1)
     )?;
 
     let offset = u64::from(page.saturating_sub(1) * page_size);
-    let rows = sqlx::query(
+    let mut rows = sqlx::query(
         r#"
 SELECT
   id,
@@ -162,16 +163,13 @@ LIMIT $4
     .bind(is_enabled)
     .bind(i64::try_from(offset).map_err(|err| GatewayError::Internal(err.to_string()))?)
     .bind(i64::from(page_size))
-    .fetch_all(pool)
-    .await
-    .map_err(internal)?;
+    .fetch(pool);
+    let mut items = Vec::new();
+    while let Some(row) = rows.try_next().await.map_err(internal)? {
+        items.push(admin_billing_rule_from_row(&row)?);
+    }
 
-    Ok((
-        rows.iter()
-            .map(admin_billing_rule_from_row)
-            .collect::<Result<Vec<_>, _>>()?,
-        total,
-    ))
+    Ok((items, total))
 }
 
 pub(crate) async fn find_admin_billing_rule(
@@ -374,7 +372,7 @@ WHERE ($1::TEXT IS NULL OR api_format = $1)
     )?;
 
     let offset = u64::from(page.saturating_sub(1) * page_size);
-    let rows = sqlx::query(
+    let mut rows = sqlx::query(
         r#"
 SELECT
   id,
@@ -406,16 +404,13 @@ LIMIT $6
     .bind(is_enabled)
     .bind(i64::try_from(offset).map_err(|err| GatewayError::Internal(err.to_string()))?)
     .bind(i64::from(page_size))
-    .fetch_all(pool)
-    .await
-    .map_err(internal)?;
+    .fetch(pool);
+    let mut items = Vec::new();
+    while let Some(row) = rows.try_next().await.map_err(internal)? {
+        items.push(admin_billing_collector_from_row(&row)?);
+    }
 
-    Ok((
-        rows.iter()
-            .map(admin_billing_collector_from_row)
-            .collect::<Result<Vec<_>, _>>()?,
-        total,
-    ))
+    Ok((items, total))
 }
 
 pub(crate) async fn find_admin_billing_collector(

--- a/apps/aether-gateway/src/query/monitoring.rs
+++ b/apps/aether-gateway/src/query/monitoring.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use aether_data::postgres::PostgresPool;
 use chrono::{DateTime, Utc};
+use futures_util::TryStreamExt;
 use serde_json::{json, Value};
 use sqlx::Row;
 
@@ -36,7 +37,7 @@ WHERE a.created_at >= $1
     .await
     .map_err(|err| GatewayError::Internal(format!("admin audit logs count failed: {err}")))?;
 
-    let rows = sqlx::query(
+    let mut rows = sqlx::query(
         r#"
 SELECT
   a.id,
@@ -64,21 +65,24 @@ LIMIT $4 OFFSET $5
     .bind(event_type)
     .bind(i64::try_from(limit).unwrap_or(i64::MAX))
     .bind(i64::try_from(offset).unwrap_or(i64::MAX))
-    .fetch_all(pool)
-    .await
-    .map_err(|err| GatewayError::Internal(format!("admin audit logs read failed: {err}")))?;
+    .fetch(pool);
+    let mut items = Vec::new();
+    while let Some(row) = rows
+        .try_next()
+        .await
+        .map_err(|err| GatewayError::Internal(format!("admin audit logs read failed: {err}")))?
+    {
+        items.push(admin_audit_log_row_to_json(row));
+    }
 
-    Ok((
-        rows.into_iter().map(admin_audit_log_row_to_json).collect(),
-        usize::try_from(total.max(0)).unwrap_or(usize::MAX),
-    ))
+    Ok((items, usize::try_from(total.max(0)).unwrap_or(usize::MAX)))
 }
 
 pub(crate) async fn list_admin_suspicious_activities(
     pool: &PostgresPool,
     cutoff_time: DateTime<Utc>,
 ) -> Result<Vec<Value>, GatewayError> {
-    let rows = sqlx::query(
+    let mut rows = sqlx::query(
         r#"
 SELECT
   id,
@@ -102,13 +106,15 @@ LIMIT 100
         "login_failed",
         "request_rate_limited",
     ])
-    .fetch_all(pool)
-    .await
-    .map_err(|err| {
+    .fetch(pool);
+    let mut items = Vec::new();
+    while let Some(row) = rows.try_next().await.map_err(|err| {
         GatewayError::Internal(format!("admin suspicious activities read failed: {err}"))
-    })?;
+    })? {
+        items.push(admin_suspicious_row_to_json(row));
+    }
 
-    Ok(rows.into_iter().map(admin_suspicious_row_to_json).collect())
+    Ok(items)
 }
 
 pub(crate) async fn read_admin_user_behavior_event_counts(
@@ -116,7 +122,7 @@ pub(crate) async fn read_admin_user_behavior_event_counts(
     user_id: &str,
     cutoff_time: DateTime<Utc>,
 ) -> Result<BTreeMap<String, u64>, GatewayError> {
-    let rows = sqlx::query(
+    let mut rows = sqlx::query(
         r#"
 SELECT event_type, COUNT(*)::bigint AS count
 FROM audit_logs
@@ -127,22 +133,25 @@ GROUP BY event_type
     )
     .bind(user_id)
     .bind(cutoff_time)
-    .fetch_all(pool)
-    .await
-    .map_err(|err| GatewayError::Internal(format!("admin user behavior read failed: {err}")))?;
+    .fetch(pool);
+    let mut counts = BTreeMap::new();
+    while let Some(row) = rows
+        .try_next()
+        .await
+        .map_err(|err| GatewayError::Internal(format!("admin user behavior read failed: {err}")))?
+    {
+        let Ok(event_type) = row.try_get::<String, _>("event_type") else {
+            continue;
+        };
+        let count = row
+            .try_get::<i64, _>("count")
+            .ok()
+            .and_then(|value| u64::try_from(value.max(0)).ok())
+            .unwrap_or(0);
+        counts.insert(event_type, count);
+    }
 
-    Ok(rows
-        .into_iter()
-        .filter_map(|row| {
-            let event_type = row.try_get::<String, _>("event_type").ok()?;
-            let count = row
-                .try_get::<i64, _>("count")
-                .ok()
-                .and_then(|value| u64::try_from(value.max(0)).ok())
-                .unwrap_or(0);
-            Some((event_type, count))
-        })
-        .collect())
+    Ok(counts)
 }
 
 pub(crate) async fn list_user_audit_logs(
@@ -176,7 +185,7 @@ WHERE user_id = $1
         }
     };
 
-    let rows = match sqlx::query(
+    let mut rows = sqlx::query(
         r#"
 SELECT id, event_type, description, ip_address, status_code, created_at
 FROM audit_logs
@@ -192,21 +201,17 @@ LIMIT $4 OFFSET $5
     .bind(event_type)
     .bind(i64::try_from(limit).unwrap_or(i64::MAX))
     .bind(i64::try_from(offset).unwrap_or(i64::MAX))
-    .fetch_all(pool)
-    .await
+    .fetch(pool);
+    let mut items = Vec::new();
+    while let Some(row) = rows
+        .try_next()
+        .await
+        .map_err(|err| GatewayError::Internal(format!("user audit logs read failed: {err}")))?
     {
-        Ok(value) => value,
-        Err(err) => {
-            return Err(GatewayError::Internal(format!(
-                "user audit logs read failed: {err}"
-            )))
-        }
-    };
+        items.push(user_audit_log_row_to_json(row));
+    }
 
-    Ok((
-        rows.into_iter().map(user_audit_log_row_to_json).collect(),
-        total,
-    ))
+    Ok((items, total))
 }
 
 fn admin_audit_log_row_to_json(row: sqlx::postgres::PgRow) -> Value {

--- a/apps/aether-gateway/src/state/catalog.rs
+++ b/apps/aether-gateway/src/state/catalog.rs
@@ -416,6 +416,16 @@ impl AppState {
             .map_err(|err| GatewayError::Internal(err.to_string()))
     }
 
+    pub(crate) async fn list_provider_catalog_key_summaries_by_provider_ids(
+        &self,
+        provider_ids: &[String],
+    ) -> Result<Vec<provider_catalog::StoredProviderCatalogKey>, GatewayError> {
+        self.data
+            .list_provider_catalog_key_summaries_by_provider_ids(provider_ids)
+            .await
+            .map_err(|err| GatewayError::Internal(err.to_string()))
+    }
+
     pub(crate) async fn list_provider_catalog_keys_by_ids(
         &self,
         key_ids: &[String],

--- a/apps/aether-gateway/src/state/video.rs
+++ b/apps/aether-gateway/src/state/video.rs
@@ -120,6 +120,18 @@ impl AppState {
             .map_err(|err| GatewayError::Internal(err.to_string()))
     }
 
+    pub(crate) async fn list_video_task_page_summary(
+        &self,
+        filter: &VideoTaskQueryFilter,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<StoredVideoTask>, GatewayError> {
+        self.data
+            .list_video_task_page_summary(filter, offset, limit)
+            .await
+            .map_err(|err| GatewayError::Internal(err.to_string()))
+    }
+
     pub(crate) async fn count_video_tasks(
         &self,
         filter: &VideoTaskQueryFilter,

--- a/crates/aether-data-contracts/src/repository/provider_catalog/mod.rs
+++ b/crates/aether-data-contracts/src/repository/provider_catalog/mod.rs
@@ -1,7 +1,7 @@
 mod types;
 
 pub use types::{
-    ProviderCatalogKeyListQuery, ProviderCatalogReadRepository, ProviderCatalogWriteRepository,
-    StoredProviderCatalogEndpoint, StoredProviderCatalogKey, StoredProviderCatalogKeyPage,
-    StoredProviderCatalogKeyStats, StoredProviderCatalogProvider,
+    ProviderCatalogKeyListOrder, ProviderCatalogKeyListQuery, ProviderCatalogReadRepository,
+    ProviderCatalogWriteRepository, StoredProviderCatalogEndpoint, StoredProviderCatalogKey,
+    StoredProviderCatalogKeyPage, StoredProviderCatalogKeyStats, StoredProviderCatalogProvider,
 };

--- a/crates/aether-data-contracts/src/repository/provider_catalog/types.rs
+++ b/crates/aether-data-contracts/src/repository/provider_catalog/types.rs
@@ -451,12 +451,20 @@ impl StoredProviderCatalogKey {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ProviderCatalogKeyListOrder {
+    #[default]
+    Name,
+    CreatedAt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ProviderCatalogKeyListQuery {
     pub provider_id: String,
     pub search: Option<String>,
     pub is_active: Option<bool>,
     pub offset: usize,
     pub limit: usize,
+    pub order: ProviderCatalogKeyListOrder,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -525,6 +533,11 @@ pub trait ProviderCatalogReadRepository: Send + Sync {
     ) -> Result<Vec<StoredProviderCatalogKey>, crate::DataLayerError>;
 
     async fn list_keys_by_provider_ids(
+        &self,
+        provider_ids: &[String],
+    ) -> Result<Vec<StoredProviderCatalogKey>, crate::DataLayerError>;
+
+    async fn list_key_summaries_by_provider_ids(
         &self,
         provider_ids: &[String],
     ) -> Result<Vec<StoredProviderCatalogKey>, crate::DataLayerError>;

--- a/crates/aether-data-contracts/src/repository/video_tasks/types.rs
+++ b/crates/aether-data-contracts/src/repository/video_tasks/types.rs
@@ -394,6 +394,13 @@ pub trait VideoTaskReadRepository: Send + Sync {
         limit: usize,
     ) -> Result<Vec<StoredVideoTask>, crate::DataLayerError>;
 
+    async fn list_page_summary(
+        &self,
+        filter: &VideoTaskQueryFilter,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<StoredVideoTask>, crate::DataLayerError>;
+
     async fn count(&self, filter: &VideoTaskQueryFilter) -> Result<u64, crate::DataLayerError>;
 
     async fn count_by_status(

--- a/crates/aether-data/src/backends/postgres.rs
+++ b/crates/aether-data/src/backends/postgres.rs
@@ -63,6 +63,7 @@ use crate::repository::wallet::{
     SqlxWalletRepository, WalletReadRepository, WalletWriteRepository,
 };
 use crate::DataLayerError;
+use futures_util::TryStreamExt;
 use sqlx::Row;
 
 const FIND_SYSTEM_CONFIG_VALUE_SQL: &str = r#"
@@ -332,23 +333,20 @@ impl PostgresBackend {
     pub async fn list_system_config_entries(
         &self,
     ) -> Result<Vec<StoredSystemConfigEntry>, DataLayerError> {
-        let rows = sqlx::query(LIST_SYSTEM_CONFIG_ENTRIES_SQL)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.into_iter()
-            .map(|row| {
-                Ok(StoredSystemConfigEntry {
-                    key: row.try_get("key").map_postgres_err()?,
-                    value: row.try_get("value").map_postgres_err()?,
-                    description: row.try_get("description").map_postgres_err()?,
-                    updated_at_unix_secs: row
-                        .try_get::<Option<i64>, _>("updated_at_unix_secs")
-                        .map_postgres_err()?
-                        .map(|value| value.max(0) as u64),
-                })
-            })
-            .collect::<Result<Vec<_>, DataLayerError>>()
+        let mut rows = sqlx::query(LIST_SYSTEM_CONFIG_ENTRIES_SQL).fetch(&self.pool);
+        let mut entries = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            entries.push(StoredSystemConfigEntry {
+                key: row.try_get("key").map_postgres_err()?,
+                value: row.try_get("value").map_postgres_err()?,
+                description: row.try_get("description").map_postgres_err()?,
+                updated_at_unix_secs: row
+                    .try_get::<Option<i64>, _>("updated_at_unix_secs")
+                    .map_postgres_err()?
+                    .map(|value| value.max(0) as u64),
+            });
+        }
+        Ok(entries)
     }
 
     pub async fn upsert_system_config_entry(

--- a/crates/aether-data/src/postgres/lease.rs
+++ b/crates/aether-data/src/postgres/lease.rs
@@ -1,7 +1,7 @@
 use crate::error::SqlxResultExt;
 use crate::postgres::{DatabaseRecordId, PostgresTransactionOptions, PostgresTransactionRunner};
 use crate::DataLayerError;
-use futures_util::FutureExt;
+use futures_util::{FutureExt, TryStreamExt};
 use sqlx::query_scalar;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -105,13 +105,15 @@ impl PostgresLeaseRunner {
         self.transaction_runner
             .run(tx_options, |tx| {
                 async move {
-                    let rows = query_scalar::<_, String>(&sql)
+                    let mut rows = query_scalar::<_, String>(&sql)
                         .bind(owner)
                         .bind(lease_ms)
-                        .fetch_all(&mut **tx)
-                        .await
-                        .map_postgres_err()?;
-                    Ok(rows.into_iter().map(DatabaseRecordId).collect())
+                        .fetch(&mut **tx);
+                    let mut ids = Vec::new();
+                    while let Some(id) = rows.try_next().await.map_postgres_err()? {
+                        ids.push(DatabaseRecordId(id));
+                    }
+                    Ok(ids)
                 }
                 .boxed()
             })
@@ -140,13 +142,15 @@ impl PostgresLeaseRunner {
         self.transaction_runner
             .run(tx_options, |tx| {
                 async move {
-                    let rows = query_scalar::<_, String>(&sql)
+                    let mut rows = query_scalar::<_, String>(&sql)
                         .bind(ids)
                         .bind(owner)
-                        .fetch_all(&mut **tx)
-                        .await
-                        .map_postgres_err()?;
-                    Ok(rows.into_iter().map(DatabaseRecordId).collect())
+                        .fetch(&mut **tx);
+                    let mut released = Vec::new();
+                    while let Some(id) = rows.try_next().await.map_postgres_err()? {
+                        released.push(DatabaseRecordId(id));
+                    }
+                    Ok(released)
                 }
                 .boxed()
             })
@@ -184,14 +188,16 @@ impl PostgresLeaseRunner {
         self.transaction_runner
             .run(tx_options, |tx| {
                 async move {
-                    let rows = query_scalar::<_, String>(&sql)
+                    let mut rows = query_scalar::<_, String>(&sql)
                         .bind(ids)
                         .bind(owner)
                         .bind(lease_ms)
-                        .fetch_all(&mut **tx)
-                        .await
-                        .map_postgres_err()?;
-                    Ok(rows.into_iter().map(DatabaseRecordId).collect())
+                        .fetch(&mut **tx);
+                    let mut renewed = Vec::new();
+                    while let Some(id) = rows.try_next().await.map_postgres_err()? {
+                        renewed.push(DatabaseRecordId(id));
+                    }
+                    Ok(renewed)
                 }
                 .boxed()
             })

--- a/crates/aether-data/src/repository/announcements/sql.rs
+++ b/crates/aether-data/src/repository/announcements/sql.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use chrono::{TimeZone, Utc};
+use futures_util::TryStreamExt;
 use sqlx::{postgres::PgRow, PgPool, Row};
 
 use super::types::{
@@ -220,18 +221,16 @@ impl AnnouncementReadRepository for SqlxAnnouncementReadRepository {
             .map_postgres_err()?
             .max(0) as u64;
 
-        let rows = sqlx::query(LIST_ANNOUNCEMENTS_SQL)
+        let mut rows = sqlx::query(LIST_ANNOUNCEMENTS_SQL)
             .bind(query.active_only)
             .bind(now_unix_secs as f64)
             .bind(query.offset as i64)
             .bind(query.limit as i64)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_announcement_row)
-            .collect::<Result<Vec<_>, _>>()?;
+            .fetch(&self.pool);
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            items.push(map_announcement_row(&row)?);
+        }
 
         Ok(StoredAnnouncementPage { items, total })
     }

--- a/crates/aether-data/src/repository/auth/sql.rs
+++ b/crates/aether-data/src/repository/auth/sql.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
-use sqlx::{PgPool, Row};
+use futures_util::{stream::TryStream, TryStreamExt};
+use sqlx::{postgres::PgRow, PgPool, Row};
 
 use super::types::{
     AuthApiKeyExportSummary, AuthApiKeyLookupKey, AuthApiKeyReadRepository,
@@ -644,6 +645,20 @@ impl SqlxAuthApiKeySnapshotReadRepository {
         &self.pool
     }
 
+    async fn collect_query_rows<T, S>(
+        mut rows: S,
+        map_row: fn(&PgRow) -> Result<T, DataLayerError>,
+    ) -> Result<Vec<T>, DataLayerError>
+    where
+        S: TryStream<Ok = PgRow, Error = sqlx::Error> + Unpin,
+    {
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            items.push(map_row(&row)?);
+        }
+        Ok(items)
+    }
+
     pub async fn find_api_key_snapshot(
         &self,
         key: AuthApiKeyLookupKey<'_>,
@@ -681,12 +696,13 @@ impl SqlxAuthApiKeySnapshotReadRepository {
             return Ok(Vec::new());
         }
 
-        let rows = sqlx::query(LIST_BY_API_KEY_IDS_SQL)
-            .bind(api_key_ids)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_auth_api_key_snapshot_row).collect()
+        Self::collect_query_rows(
+            sqlx::query(LIST_BY_API_KEY_IDS_SQL)
+                .bind(api_key_ids)
+                .fetch(&self.pool),
+            map_auth_api_key_snapshot_row,
+        )
+        .await
     }
 
     pub async fn list_export_api_keys_by_user_ids(
@@ -697,12 +713,13 @@ impl SqlxAuthApiKeySnapshotReadRepository {
             return Ok(Vec::new());
         }
 
-        let rows = sqlx::query(LIST_EXPORT_BY_USER_IDS_SQL)
-            .bind(user_ids)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_auth_api_key_export_row).collect()
+        Self::collect_query_rows(
+            sqlx::query(LIST_EXPORT_BY_USER_IDS_SQL)
+                .bind(user_ids)
+                .fetch(&self.pool),
+            map_auth_api_key_export_row,
+        )
+        .await
     }
 
     pub async fn list_export_api_keys_by_ids(
@@ -713,12 +730,13 @@ impl SqlxAuthApiKeySnapshotReadRepository {
             return Ok(Vec::new());
         }
 
-        let rows = sqlx::query(LIST_EXPORT_BY_API_KEY_IDS_SQL)
-            .bind(api_key_ids)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_auth_api_key_export_row).collect()
+        Self::collect_query_rows(
+            sqlx::query(LIST_EXPORT_BY_API_KEY_IDS_SQL)
+                .bind(api_key_ids)
+                .fetch(&self.pool),
+            map_auth_api_key_export_row,
+        )
+        .await
     }
 
     pub async fn summarize_export_api_keys_by_user_ids(
@@ -760,11 +778,11 @@ impl SqlxAuthApiKeySnapshotReadRepository {
     pub async fn list_export_standalone_api_keys(
         &self,
     ) -> Result<Vec<StoredAuthApiKeyExportRecord>, DataLayerError> {
-        let rows = sqlx::query(LIST_EXPORT_STANDALONE_SQL)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_auth_api_key_export_row).collect()
+        Self::collect_query_rows(
+            sqlx::query(LIST_EXPORT_STANDALONE_SQL).fetch(&self.pool),
+            map_auth_api_key_export_row,
+        )
+        .await
     }
 
     pub async fn list_export_standalone_api_keys_page(
@@ -775,14 +793,15 @@ impl SqlxAuthApiKeySnapshotReadRepository {
             .map_err(|_| DataLayerError::InvalidInput("limit is too large".to_string()))?;
         let skip = i64::try_from(query.skip)
             .map_err(|_| DataLayerError::InvalidInput("skip is too large".to_string()))?;
-        let rows = sqlx::query(LIST_EXPORT_STANDALONE_PAGE_SQL)
-            .bind(query.is_active)
-            .bind(skip)
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_auth_api_key_export_row).collect()
+        Self::collect_query_rows(
+            sqlx::query(LIST_EXPORT_STANDALONE_PAGE_SQL)
+                .bind(query.is_active)
+                .bind(skip)
+                .bind(limit)
+                .fetch(&self.pool),
+            map_auth_api_key_export_row,
+        )
+        .await
     }
 
     pub async fn count_export_standalone_api_keys(

--- a/crates/aether-data/src/repository/auth_modules/sql.rs
+++ b/crates/aether-data/src/repository/auth_modules/sql.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_util::{stream::TryStream, TryStreamExt};
 use sqlx::{postgres::PgRow, PgPool, Row};
 
 use super::types::{
@@ -145,16 +146,30 @@ impl SqlxAuthModuleRepository {
     }
 }
 
+async fn collect_query_rows<T, S>(
+    mut rows: S,
+    map_row: fn(&PgRow) -> Result<T, DataLayerError>,
+) -> Result<Vec<T>, DataLayerError>
+where
+    S: TryStream<Ok = PgRow, Error = sqlx::Error> + Unpin,
+{
+    let mut items = Vec::new();
+    while let Some(row) = rows.try_next().await.map_postgres_err()? {
+        items.push(map_row(&row)?);
+    }
+    Ok(items)
+}
+
 #[async_trait]
 impl AuthModuleReadRepository for SqlxAuthModuleReadRepository {
     async fn list_enabled_oauth_providers(
         &self,
     ) -> Result<Vec<StoredOAuthProviderModuleConfig>, DataLayerError> {
-        let rows = sqlx::query(LIST_ENABLED_OAUTH_PROVIDERS_SQL)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_oauth_row).collect()
+        collect_query_rows(
+            sqlx::query(LIST_ENABLED_OAUTH_PROVIDERS_SQL).fetch(&self.pool),
+            map_oauth_row,
+        )
+        .await
     }
 
     async fn get_ldap_config(&self) -> Result<Option<StoredLdapModuleConfig>, DataLayerError> {
@@ -171,11 +186,11 @@ impl AuthModuleReadRepository for SqlxAuthModuleRepository {
     async fn list_enabled_oauth_providers(
         &self,
     ) -> Result<Vec<StoredOAuthProviderModuleConfig>, DataLayerError> {
-        let rows = sqlx::query(LIST_ENABLED_OAUTH_PROVIDERS_SQL)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_oauth_row).collect()
+        collect_query_rows(
+            sqlx::query(LIST_ENABLED_OAUTH_PROVIDERS_SQL).fetch(&self.pool),
+            map_oauth_row,
+        )
+        .await
     }
 
     async fn get_ldap_config(&self) -> Result<Option<StoredLdapModuleConfig>, DataLayerError> {

--- a/crates/aether-data/src/repository/candidate_selection/sql.rs
+++ b/crates/aether-data/src/repository/candidate_selection/sql.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_util::{stream::TryStream, TryStreamExt};
 use sqlx::{PgPool, Row};
 
 use super::{
@@ -165,16 +166,31 @@ impl SqlxMinimalCandidateSelectionReadRepository {
         &self.pool
     }
 
+    async fn collect_query_rows<T, S>(
+        mut rows: S,
+        map_row: fn(&sqlx::postgres::PgRow) -> Result<T, DataLayerError>,
+    ) -> Result<Vec<T>, DataLayerError>
+    where
+        S: TryStream<Ok = sqlx::postgres::PgRow, Error = sqlx::Error> + Unpin,
+    {
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            items.push(map_row(&row)?);
+        }
+        Ok(items)
+    }
+
     pub async fn list_for_exact_api_format(
         &self,
         api_format: &str,
     ) -> Result<Vec<StoredMinimalCandidateSelectionRow>, DataLayerError> {
-        let rows = sqlx::query(LIST_FOR_EXACT_API_FORMAT_SQL)
-            .bind(api_format)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_candidate_selection_row).collect()
+        Self::collect_query_rows(
+            sqlx::query(LIST_FOR_EXACT_API_FORMAT_SQL)
+                .bind(api_format)
+                .fetch(&self.pool),
+            map_candidate_selection_row,
+        )
+        .await
     }
 
     pub async fn list_for_exact_api_format_and_global_model(
@@ -182,13 +198,14 @@ impl SqlxMinimalCandidateSelectionReadRepository {
         api_format: &str,
         global_model_name: &str,
     ) -> Result<Vec<StoredMinimalCandidateSelectionRow>, DataLayerError> {
-        let rows = sqlx::query(LIST_FOR_EXACT_API_FORMAT_AND_GLOBAL_MODEL_SQL)
-            .bind(api_format)
-            .bind(global_model_name)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_candidate_selection_row).collect()
+        Self::collect_query_rows(
+            sqlx::query(LIST_FOR_EXACT_API_FORMAT_AND_GLOBAL_MODEL_SQL)
+                .bind(api_format)
+                .bind(global_model_name)
+                .fetch(&self.pool),
+            map_candidate_selection_row,
+        )
+        .await
     }
 }
 

--- a/crates/aether-data/src/repository/candidates/sql.rs
+++ b/crates/aether-data/src/repository/candidates/sql.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use futures_util::future::BoxFuture;
-use sqlx::{PgPool, Row};
+use futures_util::{future::BoxFuture, stream::TryStream, TryStreamExt};
+use sqlx::{postgres::PgRow, PgPool, Row};
 use uuid::Uuid;
 
 use super::{
@@ -306,12 +306,13 @@ impl SqlxRequestCandidateReadRepository {
         &self,
         request_id: &str,
     ) -> Result<Vec<StoredRequestCandidate>, DataLayerError> {
-        let rows = sqlx::query(LIST_BY_REQUEST_ID_SQL)
-            .bind(request_id)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_request_candidate_row).collect()
+        collect_query_rows(
+            sqlx::query(LIST_BY_REQUEST_ID_SQL)
+                .bind(request_id)
+                .fetch(&self.pool),
+            map_request_candidate_row,
+        )
+        .await
     }
 
     pub async fn list_recent(
@@ -322,16 +323,17 @@ impl SqlxRequestCandidateReadRepository {
             return Ok(Vec::new());
         }
 
-        let rows = sqlx::query(LIST_RECENT_SQL)
-            .bind(i64::try_from(limit).map_err(|_| {
-                DataLayerError::UnexpectedValue(format!(
-                    "invalid recent request candidate limit: {limit}"
-                ))
-            })?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_request_candidate_row).collect()
+        collect_query_rows(
+            sqlx::query(LIST_RECENT_SQL)
+                .bind(i64::try_from(limit).map_err(|_| {
+                    DataLayerError::UnexpectedValue(format!(
+                        "invalid recent request candidate limit: {limit}"
+                    ))
+                })?)
+                .fetch(&self.pool),
+            map_request_candidate_row,
+        )
+        .await
     }
 
     pub async fn list_by_provider_id(
@@ -349,13 +351,14 @@ impl SqlxRequestCandidateReadRepository {
             ))
         })?;
 
-        let rows = sqlx::query(LIST_BY_PROVIDER_ID_SQL)
-            .bind(provider_id)
-            .bind(limit_value)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_request_candidate_row).collect()
+        collect_query_rows(
+            sqlx::query(LIST_BY_PROVIDER_ID_SQL)
+                .bind(provider_id)
+                .bind(limit_value)
+                .fetch(&self.pool),
+            map_request_candidate_row,
+        )
+        .await
     }
 
     pub async fn list_finalized_by_endpoint_ids_since(
@@ -368,18 +371,19 @@ impl SqlxRequestCandidateReadRepository {
             return Ok(Vec::new());
         }
 
-        let rows = sqlx::query(LIST_FINALIZED_BY_ENDPOINT_IDS_SINCE_SQL)
-            .bind(endpoint_ids)
-            .bind(since_unix_secs as f64)
-            .bind(i64::try_from(limit).map_err(|_| {
-                DataLayerError::UnexpectedValue(format!(
-                    "invalid finalized request candidate limit: {limit}"
-                ))
-            })?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_request_candidate_row).collect()
+        collect_query_rows(
+            sqlx::query(LIST_FINALIZED_BY_ENDPOINT_IDS_SINCE_SQL)
+                .bind(endpoint_ids)
+                .bind(since_unix_secs as f64)
+                .bind(i64::try_from(limit).map_err(|_| {
+                    DataLayerError::UnexpectedValue(format!(
+                        "invalid finalized request candidate limit: {limit}"
+                    ))
+                })?)
+                .fetch(&self.pool),
+            map_request_candidate_row,
+        )
+        .await
     }
 
     pub async fn count_finalized_statuses_by_endpoint_ids_since(
@@ -391,29 +395,29 @@ impl SqlxRequestCandidateReadRepository {
             return Ok(Vec::new());
         }
 
-        let rows = sqlx::query(COUNT_FINALIZED_STATUSES_BY_ENDPOINT_IDS_SINCE_SQL)
+        let mut rows = sqlx::query(COUNT_FINALIZED_STATUSES_BY_ENDPOINT_IDS_SINCE_SQL)
             .bind(endpoint_ids)
             .bind(since_unix_secs as f64)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-
-        rows.iter()
-            .map(|row| {
+            .fetch(&self.pool);
+        let mut counts = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            let entry = {
                 let status = RequestCandidateStatus::from_database(
-                    row_get::<String>(row, "status")?.as_str(),
+                    row_get::<String>(&row, "status")?.as_str(),
                 )?;
-                Ok(PublicHealthStatusCount {
-                    endpoint_id: row_get(row, "endpoint_id")?,
+                PublicHealthStatusCount {
+                    endpoint_id: row_get(&row, "endpoint_id")?,
                     status,
-                    count: u64::try_from(row_get::<i64>(row, "count")?).map_err(|_| {
+                    count: u64::try_from(row_get::<i64>(&row, "count")?).map_err(|_| {
                         DataLayerError::UnexpectedValue(
                             "public health status count out of range".to_string(),
                         )
                     })?,
-                })
-            })
-            .collect()
+                }
+            };
+            counts.push(entry);
+        }
+        Ok(counts)
     }
 
     pub async fn aggregate_finalized_timeline_by_endpoint_ids_since(
@@ -434,18 +438,16 @@ impl SqlxRequestCandidateReadRepository {
             (span_seconds as f64) / (segments as f64)
         };
 
-        let rows = sqlx::query(AGGREGATE_FINALIZED_TIMELINE_BY_ENDPOINT_IDS_SINCE_SQL)
+        let mut rows = sqlx::query(AGGREGATE_FINALIZED_TIMELINE_BY_ENDPOINT_IDS_SINCE_SQL)
             .bind(endpoint_ids)
             .bind(since_unix_secs as f64)
             .bind(until_unix_secs as f64)
             .bind(segment_seconds)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-
-        rows.iter()
-            .map(|row| {
-                let raw_segment_idx = row_get::<i64>(row, "segment_idx")?;
+            .fetch(&self.pool);
+        let mut buckets = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            let bucket = {
+                let raw_segment_idx = row_get::<i64>(&row, "segment_idx")?;
                 let segment_idx = if raw_segment_idx < 0 {
                     0
                 } else {
@@ -457,31 +459,31 @@ impl SqlxRequestCandidateReadRepository {
                 }
                 .min(segments.saturating_sub(1));
 
-                Ok(PublicHealthTimelineBucket {
-                    endpoint_id: row_get(row, "endpoint_id")?,
+                PublicHealthTimelineBucket {
+                    endpoint_id: row_get(&row, "endpoint_id")?,
                     segment_idx,
-                    total_count: u64::try_from(row_get::<i64>(row, "total_count")?).map_err(
+                    total_count: u64::try_from(row_get::<i64>(&row, "total_count")?).map_err(
                         |_| {
                             DataLayerError::UnexpectedValue(
                                 "public health total_count out of range".to_string(),
                             )
                         },
                     )?,
-                    success_count: u64::try_from(row_get::<i64>(row, "success_count")?).map_err(
+                    success_count: u64::try_from(row_get::<i64>(&row, "success_count")?).map_err(
                         |_| {
                             DataLayerError::UnexpectedValue(
                                 "public health success_count out of range".to_string(),
                             )
                         },
                     )?,
-                    failed_count: u64::try_from(row_get::<i64>(row, "failed_count")?).map_err(
+                    failed_count: u64::try_from(row_get::<i64>(&row, "failed_count")?).map_err(
                         |_| {
                             DataLayerError::UnexpectedValue(
                                 "public health failed_count out of range".to_string(),
                             )
                         },
                     )?,
-                    min_created_at_unix_ms: row_get::<Option<i64>>(row, "min_created_at_unix_ms")?
+                    min_created_at_unix_ms: row_get::<Option<i64>>(&row, "min_created_at_unix_ms")?
                         .map(|value| {
                             u64::try_from(value).map_err(|_| {
                                 DataLayerError::UnexpectedValue(format!(
@@ -490,7 +492,7 @@ impl SqlxRequestCandidateReadRepository {
                             })
                         })
                         .transpose()?,
-                    max_created_at_unix_ms: row_get::<Option<i64>>(row, "max_created_at_unix_ms")?
+                    max_created_at_unix_ms: row_get::<Option<i64>>(&row, "max_created_at_unix_ms")?
                         .map(|value| {
                             u64::try_from(value).map_err(|_| {
                                 DataLayerError::UnexpectedValue(format!(
@@ -499,9 +501,11 @@ impl SqlxRequestCandidateReadRepository {
                             })
                         })
                         .transpose()?,
-                })
-            })
-            .collect()
+                }
+            };
+            buckets.push(bucket);
+        }
+        Ok(buckets)
     }
 
     pub async fn upsert(
@@ -651,9 +655,21 @@ impl RequestCandidateWriteRepository for SqlxRequestCandidateReadRepository {
     }
 }
 
-fn map_request_candidate_row(
-    row: &sqlx::postgres::PgRow,
-) -> Result<StoredRequestCandidate, DataLayerError> {
+async fn collect_query_rows<T, S>(
+    mut rows: S,
+    map_row: fn(&PgRow) -> Result<T, DataLayerError>,
+) -> Result<Vec<T>, DataLayerError>
+where
+    S: TryStream<Ok = PgRow, Error = sqlx::Error> + Unpin,
+{
+    let mut items = Vec::new();
+    while let Some(row) = rows.try_next().await.map_postgres_err()? {
+        items.push(map_row(&row)?);
+    }
+    Ok(items)
+}
+
+fn map_request_candidate_row(row: &PgRow) -> Result<StoredRequestCandidate, DataLayerError> {
     let status = RequestCandidateStatus::from_database(row_get::<String>(row, "status")?.as_str())?;
     StoredRequestCandidate::new(
         row_get(row, "id")?,
@@ -683,7 +699,7 @@ fn map_request_candidate_row(
     )
 }
 
-fn row_get<T>(row: &sqlx::postgres::PgRow, column: &str) -> Result<T, DataLayerError>
+fn row_get<T>(row: &PgRow, column: &str) -> Result<T, DataLayerError>
 where
     for<'r> T: sqlx::Decode<'r, sqlx::Postgres> + sqlx::Type<sqlx::Postgres>,
 {

--- a/crates/aether-data/src/repository/gemini_file_mappings/sql.rs
+++ b/crates/aether-data/src/repository/gemini_file_mappings/sql.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_util::TryStreamExt;
 use sqlx::{postgres::PgRow, PgPool, Postgres, QueryBuilder, Row};
 
 use super::types::{
@@ -91,16 +92,15 @@ WHERE file_name = $1
             .fetch_one(&self.pool)
             .await
             .map_postgres_err()?;
-        let rows = build_list_rows_query(query)
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
+        let mut builder = build_list_rows_query(query);
+        let built_query = builder.build();
+        let mut rows = built_query.fetch(&self.pool);
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            items.push(Self::map_row(&row)?);
+        }
         Ok(StoredGeminiFileMappingListPage {
-            items: rows
-                .iter()
-                .map(Self::map_row)
-                .collect::<Result<Vec<_>, _>>()?,
+            items,
             total: usize::try_from(total).unwrap_or_default(),
         })
     }
@@ -133,7 +133,7 @@ FROM gemini_file_mappings
                 .map_postgres_err()?,
         )
         .unwrap_or_default();
-        let by_mime_type_rows = sqlx::query(
+        let mut by_mime_type_rows = sqlx::query(
             r#"
 SELECT
   COALESCE(NULLIF(TRIM(mime_type), ''), 'unknown') AS mime_type,
@@ -145,23 +145,20 @@ ORDER BY mime_type ASC
 "#,
         )
         .bind(now_unix_secs as f64)
-        .fetch_all(&self.pool)
-        .await
-        .map_postgres_err()?;
+        .fetch(&self.pool);
+        let mut by_mime_type = Vec::new();
+        while let Some(row) = by_mime_type_rows.try_next().await.map_postgres_err()? {
+            by_mime_type.push(GeminiFileMappingMimeTypeCount {
+                mime_type: row.try_get("mime_type").map_postgres_err()?,
+                count: usize::try_from(row.try_get::<i64, _>("count").map_postgres_err()?)
+                    .unwrap_or_default(),
+            });
+        }
         Ok(GeminiFileMappingStats {
             total_mappings,
             active_mappings,
             expired_mappings: total_mappings.saturating_sub(active_mappings),
-            by_mime_type: by_mime_type_rows
-                .into_iter()
-                .map(|row| {
-                    Ok(GeminiFileMappingMimeTypeCount {
-                        mime_type: row.try_get("mime_type").map_postgres_err()?,
-                        count: usize::try_from(row.try_get::<i64, _>("count").map_postgres_err()?)
-                            .unwrap_or_default(),
-                    })
-                })
-                .collect::<Result<Vec<_>, DataLayerError>>()?,
+            by_mime_type,
         })
     }
 }

--- a/crates/aether-data/src/repository/global_models/sql.rs
+++ b/crates/aether-data/src/repository/global_models/sql.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_util::{stream::TryStream, TryStreamExt};
 use serde_json::Value;
 use sqlx::{postgres::PgRow, PgPool, Postgres, QueryBuilder, Row};
 
@@ -180,12 +181,8 @@ impl SqlxGlobalModelReadRepository {
             .push_bind(query.offset as i64)
             .push(" LIMIT ")
             .push_bind(query.limit as i64);
-        let rows = list_builder
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows.iter().map(map_row).collect::<Result<Vec<_>, _>>()?;
+        let query = list_builder.build();
+        let items = collect_query_rows(query.fetch(&self.pool), map_row).await?;
 
         Ok(StoredPublicGlobalModelPage { items, total })
     }
@@ -198,17 +195,13 @@ impl SqlxGlobalModelReadRepository {
             return Ok(Vec::new());
         }
 
-        let rows = build_provider_id_list_query(
+        let mut builder = build_provider_id_list_query(
             LIST_PROVIDER_MODEL_STATS_PREFIX,
             provider_ids,
             ")\nGROUP BY provider_id\nORDER BY provider_id ASC",
-        )
-        .build()
-        .fetch_all(&self.pool)
-        .await
-        .map_postgres_err()?;
-
-        rows.iter().map(map_provider_model_stats_row).collect()
+        );
+        let query = builder.build();
+        collect_query_rows(query.fetch(&self.pool), map_provider_model_stats_row).await
     }
 
     pub async fn list_active_global_model_ids_by_provider_ids(
@@ -219,19 +212,17 @@ impl SqlxGlobalModelReadRepository {
             return Ok(Vec::new());
         }
 
-        let rows = build_provider_id_list_query(
+        let mut builder = build_provider_id_list_query(
             LIST_ACTIVE_GLOBAL_MODEL_IDS_BY_PROVIDER_IDS_PREFIX,
             provider_ids,
             ")\nAND is_active = TRUE\nAND global_model_id IS NOT NULL\nORDER BY provider_id ASC, global_model_id ASC",
+        );
+        let query = builder.build();
+        collect_query_rows(
+            query.fetch(&self.pool),
+            map_provider_active_global_model_row,
         )
-        .build()
-        .fetch_all(&self.pool)
         .await
-        .map_postgres_err()?;
-
-        rows.iter()
-            .map(map_provider_active_global_model_row)
-            .collect()
     }
 
     pub async fn list_admin_provider_models(
@@ -250,12 +241,8 @@ impl SqlxGlobalModelReadRepository {
             .push_bind(query.offset as i64)
             .push(" LIMIT ")
             .push_bind(query.limit as i64);
-        let rows = builder
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_admin_provider_model_row).collect()
+        let query = builder.build();
+        collect_query_rows(query.fetch(&self.pool), map_admin_provider_model_row).await
     }
 
     pub async fn list_admin_global_models(
@@ -281,15 +268,8 @@ impl SqlxGlobalModelReadRepository {
             .push_bind(query.offset as i64)
             .push(" LIMIT ")
             .push_bind(query.limit as i64);
-        let rows = list_builder
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_admin_global_model_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let query = list_builder.build();
+        let items = collect_query_rows(query.fetch(&self.pool), map_admin_global_model_row).await?;
         Ok(StoredAdminGlobalModelPage { items, total })
     }
 
@@ -343,8 +323,9 @@ LIMIT 1
         &self,
         provider_id: &str,
     ) -> Result<Vec<StoredAdminProviderModel>, DataLayerError> {
-        let rows = sqlx::query(
-            r#"
+        collect_query_rows(
+            sqlx::query(
+                r#"
 SELECT
   m.id,
   m.provider_id,
@@ -375,13 +356,12 @@ WHERE m.provider_id = $1
   AND gm.is_active = TRUE
 ORDER BY gm.name ASC, m.created_at DESC, m.id ASC
             "#,
+            )
+            .bind(provider_id)
+            .fetch(&self.pool),
+            map_admin_provider_model_row,
         )
-        .bind(provider_id)
-        .fetch_all(&self.pool)
         .await
-        .map_postgres_err()?;
-
-        rows.iter().map(map_admin_provider_model_row).collect()
     }
 
     pub async fn get_admin_global_model_by_id(
@@ -482,8 +462,9 @@ LIMIT 1
         &self,
         global_model_id: &str,
     ) -> Result<Vec<StoredAdminProviderModel>, DataLayerError> {
-        let rows = sqlx::query(
-            r#"
+        collect_query_rows(
+            sqlx::query(
+                r#"
 SELECT
   m.id,
   m.provider_id,
@@ -512,13 +493,12 @@ LEFT JOIN global_models gm ON gm.id = m.global_model_id
 WHERE m.global_model_id = $1
 ORDER BY m.created_at DESC, m.id ASC
             "#,
+            )
+            .bind(global_model_id)
+            .fetch(&self.pool),
+            map_admin_provider_model_row,
         )
-        .bind(global_model_id)
-        .fetch_all(&self.pool)
         .await
-        .map_postgres_err()?;
-
-        rows.iter().map(map_admin_provider_model_row).collect()
     }
 
     pub async fn create_admin_provider_model(
@@ -801,12 +781,8 @@ LIMIT 1
             .push_bind(query.offset as i64)
             .push(" LIMIT ")
             .push_bind(query.limit as i64);
-        let rows = builder
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_public_catalog_model_row).collect()
+        let query = builder.build();
+        collect_query_rows(query.fetch(&self.pool), map_public_catalog_model_row).await
     }
 
     async fn search_public_catalog_models(
@@ -822,12 +798,8 @@ LIMIT 1
         builder
             .push(" ORDER BY p.provider_priority ASC, p.name ASC, COALESCE(gm.name, m.provider_model_name) ASC, m.id ASC LIMIT ")
             .push_bind(query.limit as i64);
-        let rows = builder
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_public_catalog_model_row).collect()
+        let query = builder.build();
+        collect_query_rows(query.fetch(&self.pool), map_public_catalog_model_row).await
     }
 
     async fn list_admin_global_models(
@@ -1010,6 +982,20 @@ fn map_row(row: &PgRow) -> Result<StoredPublicGlobalModel, DataLayerError> {
         row.try_get("config").map_postgres_err()?,
         0,
     )
+}
+
+async fn collect_query_rows<T, S>(
+    mut rows: S,
+    map_row: fn(&PgRow) -> Result<T, DataLayerError>,
+) -> Result<Vec<T>, DataLayerError>
+where
+    S: TryStream<Ok = PgRow, Error = sqlx::Error> + Unpin,
+{
+    let mut items = Vec::new();
+    while let Some(row) = rows.try_next().await.map_postgres_err()? {
+        items.push(map_row(&row)?);
+    }
+    Ok(items)
 }
 
 fn apply_public_catalog_model_filters(

--- a/crates/aether-data/src/repository/management_tokens/sql.rs
+++ b/crates/aether-data/src/repository/management_tokens/sql.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_util::TryStreamExt;
 use sqlx::{postgres::PgRow, PgPool, Row};
 
 use super::types::{
@@ -269,20 +270,19 @@ impl ManagementTokenReadRepository for SqlxManagementTokenRepository {
             .map_postgres_err()?;
         let total = count_row.try_get::<i64, _>("total").map_postgres_err()?;
 
-        let rows = sqlx::query(LIST_MANAGEMENT_TOKENS_SQL)
+        let mut rows = sqlx::query(LIST_MANAGEMENT_TOKENS_SQL)
             .bind(query.user_id.as_deref())
             .bind(query.is_active)
             .bind(i64::try_from(query.offset).unwrap_or(i64::MAX))
             .bind(i64::try_from(query.limit).unwrap_or(i64::MAX))
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
+            .fetch(&self.pool);
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            items.push(map_token_with_user_row(&row)?);
+        }
 
         Ok(StoredManagementTokenListPage {
-            items: rows
-                .iter()
-                .map(map_token_with_user_row)
-                .collect::<Result<Vec<_>, _>>()?,
+            items,
             total: usize::try_from(total.max(0)).unwrap_or(usize::MAX),
         })
     }

--- a/crates/aether-data/src/repository/oauth_providers/sql.rs
+++ b/crates/aether-data/src/repository/oauth_providers/sql.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_util::TryStreamExt;
 use sqlx::{postgres::PgRow, PgPool, Row};
 
 use super::types::{
@@ -181,11 +182,12 @@ impl OAuthProviderReadRepository for SqlxOAuthProviderRepository {
     async fn list_oauth_provider_configs(
         &self,
     ) -> Result<Vec<StoredOAuthProviderConfig>, DataLayerError> {
-        let rows = sqlx::query(LIST_OAUTH_PROVIDER_CONFIGS_SQL)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_oauth_provider_row).collect()
+        let mut rows = sqlx::query(LIST_OAUTH_PROVIDER_CONFIGS_SQL).fetch(&self.pool);
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            items.push(map_oauth_provider_row(&row)?);
+        }
+        Ok(items)
     }
 
     async fn get_oauth_provider_config(

--- a/crates/aether-data/src/repository/provider_catalog/memory.rs
+++ b/crates/aether-data/src/repository/provider_catalog/memory.rs
@@ -4,9 +4,9 @@ use std::sync::RwLock;
 use async_trait::async_trait;
 
 use super::{
-    ProviderCatalogKeyListQuery, ProviderCatalogReadRepository, ProviderCatalogWriteRepository,
-    StoredProviderCatalogEndpoint, StoredProviderCatalogKey, StoredProviderCatalogKeyPage,
-    StoredProviderCatalogKeyStats, StoredProviderCatalogProvider,
+    ProviderCatalogKeyListOrder, ProviderCatalogKeyListQuery, ProviderCatalogReadRepository,
+    ProviderCatalogWriteRepository, StoredProviderCatalogEndpoint, StoredProviderCatalogKey,
+    StoredProviderCatalogKeyPage, StoredProviderCatalogKeyStats, StoredProviderCatalogProvider,
 };
 use crate::DataLayerError;
 
@@ -146,6 +146,13 @@ impl ProviderCatalogReadRepository for InMemoryProviderCatalogReadRepository {
         Ok(keys)
     }
 
+    async fn list_key_summaries_by_provider_ids(
+        &self,
+        provider_ids: &[String],
+    ) -> Result<Vec<StoredProviderCatalogKey>, DataLayerError> {
+        Self::list_keys_by_provider_ids(self, provider_ids).await
+    }
+
     async fn list_keys_page(
         &self,
         query: &ProviderCatalogKeyListQuery,
@@ -170,12 +177,28 @@ impl ProviderCatalogReadRepository for InMemoryProviderCatalogReadRepository {
             })
             .cloned()
             .collect::<Vec<_>>();
-        keys.sort_by(|left, right| {
-            left.internal_priority
-                .cmp(&right.internal_priority)
-                .then(left.name.cmp(&right.name))
-                .then(left.id.cmp(&right.id))
-        });
+        match query.order {
+            ProviderCatalogKeyListOrder::Name => {
+                keys.sort_by(|left, right| {
+                    left.internal_priority
+                        .cmp(&right.internal_priority)
+                        .then(left.name.cmp(&right.name))
+                        .then(left.id.cmp(&right.id))
+                });
+            }
+            ProviderCatalogKeyListOrder::CreatedAt => {
+                keys.sort_by(|left, right| {
+                    left.internal_priority
+                        .cmp(&right.internal_priority)
+                        .then(
+                            left.created_at_unix_ms
+                                .unwrap_or_default()
+                                .cmp(&right.created_at_unix_ms.unwrap_or_default()),
+                        )
+                        .then(left.id.cmp(&right.id))
+                });
+            }
+        }
         let total = keys.len();
         let items = keys
             .into_iter()
@@ -415,8 +438,9 @@ impl ProviderCatalogWriteRepository for InMemoryProviderCatalogReadRepository {
 mod tests {
     use super::InMemoryProviderCatalogReadRepository;
     use crate::repository::provider_catalog::{
-        ProviderCatalogKeyListQuery, ProviderCatalogReadRepository, ProviderCatalogWriteRepository,
-        StoredProviderCatalogEndpoint, StoredProviderCatalogKey, StoredProviderCatalogProvider,
+        ProviderCatalogKeyListOrder, ProviderCatalogKeyListQuery, ProviderCatalogReadRepository,
+        ProviderCatalogWriteRepository, StoredProviderCatalogEndpoint, StoredProviderCatalogKey,
+        StoredProviderCatalogProvider,
     };
 
     fn sample_provider(id: &str) -> StoredProviderCatalogProvider {
@@ -583,6 +607,7 @@ mod tests {
                 is_active: Some(true),
                 offset: 0,
                 limit: 10,
+                order: ProviderCatalogKeyListOrder::Name,
             })
             .await
             .expect("keys should page");
@@ -595,6 +620,44 @@ mod tests {
                 .map(|item| item.name.as_str())
                 .collect::<Vec<_>>(),
             vec!["beta", "alpha"]
+        );
+    }
+
+    #[tokio::test]
+    async fn paginates_provider_keys_by_created_at_when_requested() {
+        let mut early = sample_key("key-1", "provider-1");
+        early.name = "zeta".to_string();
+        early.internal_priority = 10;
+        early.created_at_unix_ms = Some(10);
+        let mut late = sample_key("key-2", "provider-1");
+        late.name = "alpha".to_string();
+        late.internal_priority = 10;
+        late.created_at_unix_ms = Some(20);
+        let repository = InMemoryProviderCatalogReadRepository::seed(
+            vec![sample_provider("provider-1")],
+            vec![],
+            vec![late, early],
+        );
+
+        let page = repository
+            .list_keys_page(&ProviderCatalogKeyListQuery {
+                provider_id: "provider-1".to_string(),
+                search: None,
+                is_active: None,
+                offset: 0,
+                limit: 10,
+                order: ProviderCatalogKeyListOrder::CreatedAt,
+            })
+            .await
+            .expect("keys should page");
+
+        assert_eq!(page.total, 2);
+        assert_eq!(
+            page.items
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["key-1", "key-2"]
         );
     }
 

--- a/crates/aether-data/src/repository/provider_catalog/mod.rs
+++ b/crates/aether-data/src/repository/provider_catalog/mod.rs
@@ -3,9 +3,9 @@ mod sql;
 
 #[allow(unused_imports)]
 pub(crate) use aether_data_contracts::repository::provider_catalog::{
-    ProviderCatalogKeyListQuery, ProviderCatalogReadRepository, ProviderCatalogWriteRepository,
-    StoredProviderCatalogEndpoint, StoredProviderCatalogKey, StoredProviderCatalogKeyPage,
-    StoredProviderCatalogKeyStats, StoredProviderCatalogProvider,
+    ProviderCatalogKeyListOrder, ProviderCatalogKeyListQuery, ProviderCatalogReadRepository,
+    ProviderCatalogWriteRepository, StoredProviderCatalogEndpoint, StoredProviderCatalogKey,
+    StoredProviderCatalogKeyPage, StoredProviderCatalogKeyStats, StoredProviderCatalogProvider,
 };
 pub use memory::InMemoryProviderCatalogReadRepository;
 pub use sql::SqlxProviderCatalogReadRepository;

--- a/crates/aether-data/src/repository/provider_catalog/sql.rs
+++ b/crates/aether-data/src/repository/provider_catalog/sql.rs
@@ -1,10 +1,11 @@
 use async_trait::async_trait;
+use futures_util::TryStreamExt;
 use sqlx::{postgres::PgRow, PgPool, Postgres, QueryBuilder, Row};
 
 use super::{
-    ProviderCatalogKeyListQuery, ProviderCatalogReadRepository, ProviderCatalogWriteRepository,
-    StoredProviderCatalogEndpoint, StoredProviderCatalogKey, StoredProviderCatalogKeyPage,
-    StoredProviderCatalogKeyStats, StoredProviderCatalogProvider,
+    ProviderCatalogKeyListOrder, ProviderCatalogKeyListQuery, ProviderCatalogReadRepository,
+    ProviderCatalogWriteRepository, StoredProviderCatalogEndpoint, StoredProviderCatalogKey,
+    StoredProviderCatalogKeyPage, StoredProviderCatalogKeyStats, StoredProviderCatalogProvider,
 };
 use crate::{
     error::{postgres_error, SqlxResultExt},
@@ -240,6 +241,61 @@ FROM provider_api_keys
 WHERE provider_id IN (
 "#;
 
+const LIST_KEY_SUMMARIES_BY_PROVIDER_IDS_PREFIX: &str = r#"
+SELECT
+  id,
+  provider_id,
+  COALESCE(NULLIF(name, ''), id) AS name,
+  COALESCE(NULLIF(auth_type, ''), 'summary') AS auth_type,
+  capabilities,
+  is_active,
+  api_formats,
+  'summary' AS api_key,
+  NULL::text AS auth_config,
+  NULL::text AS note,
+  internal_priority,
+  rate_multipliers,
+  global_priority_by_format,
+  NULL::jsonb AS allowed_models,
+  NULL::bigint AS expires_at_unix_secs,
+  cache_ttl_minutes,
+  max_probe_interval_minutes,
+  NULL::jsonb AS proxy,
+  NULL::jsonb AS fingerprint,
+  NULL::integer AS rpm_limit,
+  NULL::integer AS learned_rpm_limit,
+  NULL::integer AS concurrent_429_count,
+  NULL::integer AS rpm_429_count,
+  NULL::bigint AS last_429_at_unix_secs,
+  NULL::text AS last_429_type,
+  NULL::jsonb AS adjustment_history,
+  NULL::jsonb AS utilization_samples,
+  NULL::bigint AS last_probe_increase_at_unix_secs,
+  request_count,
+  0::bigint AS total_tokens,
+  0::double precision AS total_cost_usd,
+  success_count,
+  NULL::integer AS error_count,
+  total_response_time_ms,
+  EXTRACT(EPOCH FROM last_used_at)::bigint AS last_used_at_unix_secs,
+  auto_fetch_models,
+  NULL::bigint AS last_models_fetch_at_unix_secs,
+  NULL::text AS last_models_fetch_error,
+  NULL::jsonb AS locked_models,
+  NULL::jsonb AS model_include_patterns,
+  NULL::jsonb AS model_exclude_patterns,
+  NULL::jsonb AS upstream_metadata,
+  EXTRACT(EPOCH FROM oauth_invalid_at)::bigint AS oauth_invalid_at_unix_secs,
+  oauth_invalid_reason,
+  NULL::jsonb AS status_snapshot,
+  EXTRACT(EPOCH FROM created_at)::bigint AS created_at_unix_ms,
+  EXTRACT(EPOCH FROM updated_at)::bigint AS updated_at_unix_secs,
+  health_by_format,
+  circuit_breaker_by_format
+FROM provider_api_keys
+WHERE provider_id IN (
+"#;
+
 const LIST_KEY_STATS_BY_PROVIDER_IDS_PREFIX: &str = r#"
 SELECT
   provider_id,
@@ -271,24 +327,26 @@ impl SqlxProviderCatalogReadRepository {
             return Ok(Vec::new());
         }
 
-        let rows = build_list_query(
-            LIST_PROVIDERS_BY_IDS_PREFIX,
-            provider_ids,
-            " ORDER BY name ASC",
+        collect_query_rows(
+            build_list_query(
+                LIST_PROVIDERS_BY_IDS_PREFIX,
+                provider_ids,
+                " ORDER BY name ASC",
+            )
+            .build()
+            .fetch(&self.pool),
+            map_provider_row,
         )
-        .build()
-        .fetch_all(&self.pool)
         .await
-        .map_postgres_err()?;
-        rows.iter().map(map_provider_row).collect()
     }
 
     pub async fn list_providers(
         &self,
         active_only: bool,
     ) -> Result<Vec<StoredProviderCatalogProvider>, DataLayerError> {
-        let rows = sqlx::query(
-            r#"
+        collect_query_rows(
+            sqlx::query(
+                r#"
 SELECT
   id,
   name,
@@ -317,12 +375,12 @@ FROM providers
 WHERE ($1::boolean = false OR is_active = true)
 ORDER BY provider_priority ASC, name ASC
 "#,
+            )
+            .bind(active_only)
+            .fetch(&self.pool),
+            map_provider_row,
         )
-        .bind(active_only)
-        .fetch_all(&self.pool)
         .await
-        .map_postgres_err()?;
-        rows.iter().map(map_provider_row).collect()
     }
 
     pub async fn list_endpoints_by_ids(
@@ -333,28 +391,35 @@ ORDER BY provider_priority ASC, name ASC
             return Ok(Vec::new());
         }
 
-        let rows = match build_list_query(
-            LIST_ENDPOINTS_BY_IDS_PREFIX,
-            endpoint_ids,
-            " ORDER BY api_format ASC, id ASC",
-        )
-        .build()
-        .fetch_all(&self.pool)
-        .await
-        {
-            Ok(rows) => rows,
-            Err(error) if is_missing_endpoint_health_score_column(&error) => build_list_query(
-                LIST_ENDPOINTS_BY_IDS_PREFIX_LEGACY,
+        let rows = match collect_query_rows(
+            build_list_query(
+                LIST_ENDPOINTS_BY_IDS_PREFIX,
                 endpoint_ids,
                 " ORDER BY api_format ASC, id ASC",
             )
             .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?,
+            .fetch(&self.pool),
+            map_endpoint_row,
+        )
+        .await
+        {
+            Ok(rows) => rows,
+            Err(error) if is_missing_endpoint_health_score_column_sql(&error) => {
+                collect_query_rows(
+                    build_list_query(
+                        LIST_ENDPOINTS_BY_IDS_PREFIX_LEGACY,
+                        endpoint_ids,
+                        " ORDER BY api_format ASC, id ASC",
+                    )
+                    .build()
+                    .fetch(&self.pool),
+                    map_endpoint_row,
+                )
+                .await?
+            }
             Err(error) => return Err(postgres_error(error)),
         };
-        rows.iter().map(map_endpoint_row).collect()
+        Ok(rows)
     }
 
     pub async fn list_endpoints_by_provider_ids(
@@ -365,28 +430,35 @@ ORDER BY provider_priority ASC, name ASC
             return Ok(Vec::new());
         }
 
-        let rows = match build_list_query(
-            LIST_ENDPOINTS_BY_PROVIDER_IDS_PREFIX,
-            provider_ids,
-            " ORDER BY provider_id ASC, api_format ASC, id ASC",
-        )
-        .build()
-        .fetch_all(&self.pool)
-        .await
-        {
-            Ok(rows) => rows,
-            Err(error) if is_missing_endpoint_health_score_column(&error) => build_list_query(
-                LIST_ENDPOINTS_BY_PROVIDER_IDS_PREFIX_LEGACY,
+        let rows = match collect_query_rows(
+            build_list_query(
+                LIST_ENDPOINTS_BY_PROVIDER_IDS_PREFIX,
                 provider_ids,
                 " ORDER BY provider_id ASC, api_format ASC, id ASC",
             )
             .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?,
+            .fetch(&self.pool),
+            map_endpoint_row,
+        )
+        .await
+        {
+            Ok(rows) => rows,
+            Err(error) if is_missing_endpoint_health_score_column_sql(&error) => {
+                collect_query_rows(
+                    build_list_query(
+                        LIST_ENDPOINTS_BY_PROVIDER_IDS_PREFIX_LEGACY,
+                        provider_ids,
+                        " ORDER BY provider_id ASC, api_format ASC, id ASC",
+                    )
+                    .build()
+                    .fetch(&self.pool),
+                    map_endpoint_row,
+                )
+                .await?
+            }
             Err(error) => return Err(postgres_error(error)),
         };
-        rows.iter().map(map_endpoint_row).collect()
+        Ok(rows)
     }
 
     pub async fn list_keys_by_ids(
@@ -397,16 +469,17 @@ ORDER BY provider_priority ASC, name ASC
             return Ok(Vec::new());
         }
 
-        let rows = build_list_query(
-            LIST_KEYS_BY_IDS_PREFIX,
-            key_ids,
-            " ORDER BY name ASC, id ASC",
+        collect_query_rows(
+            build_list_query(
+                LIST_KEYS_BY_IDS_PREFIX,
+                key_ids,
+                " ORDER BY name ASC, id ASC",
+            )
+            .build()
+            .fetch(&self.pool),
+            map_key_row,
         )
-        .build()
-        .fetch_all(&self.pool)
         .await
-        .map_postgres_err()?;
-        rows.iter().map(map_key_row).collect()
     }
 
     pub async fn list_keys_by_provider_ids(
@@ -417,16 +490,38 @@ ORDER BY provider_priority ASC, name ASC
             return Ok(Vec::new());
         }
 
-        let rows = build_list_query(
-            LIST_KEYS_BY_PROVIDER_IDS_PREFIX,
-            provider_ids,
-            " ORDER BY provider_id ASC, name ASC, id ASC",
+        collect_query_rows(
+            build_list_query(
+                LIST_KEYS_BY_PROVIDER_IDS_PREFIX,
+                provider_ids,
+                " ORDER BY provider_id ASC, name ASC, id ASC",
+            )
+            .build()
+            .fetch(&self.pool),
+            map_key_row,
         )
-        .build()
-        .fetch_all(&self.pool)
         .await
-        .map_postgres_err()?;
-        rows.iter().map(map_key_row).collect()
+    }
+
+    pub async fn list_key_summaries_by_provider_ids(
+        &self,
+        provider_ids: &[String],
+    ) -> Result<Vec<StoredProviderCatalogKey>, DataLayerError> {
+        if provider_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        collect_query_rows(
+            build_list_query(
+                LIST_KEY_SUMMARIES_BY_PROVIDER_IDS_PREFIX,
+                provider_ids,
+                " ORDER BY provider_id ASC, id ASC",
+            )
+            .build()
+            .fetch(&self.pool),
+            map_key_row,
+        )
+        .await
     }
 
     pub async fn list_keys_page(
@@ -457,6 +552,12 @@ ORDER BY provider_priority ASC, name ASC
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(|value| format!("%{}%", value.to_ascii_lowercase()));
+        let order_by = match query.order {
+            ProviderCatalogKeyListOrder::Name => "internal_priority ASC, name ASC, id ASC",
+            ProviderCatalogKeyListOrder::CreatedAt => {
+                "internal_priority ASC, COALESCE(created_at, TO_TIMESTAMP(0)) ASC, id ASC"
+            }
+        };
 
         let count_row = sqlx::query(
             r#"
@@ -475,7 +576,7 @@ WHERE provider_id = $1
         .map_postgres_err()?;
         let total = row_get::<i64>(&count_row, "total")?.max(0) as usize;
 
-        let rows = sqlx::query(
+        let sql = format!(
             r#"
 SELECT
   id,
@@ -531,23 +632,22 @@ FROM provider_api_keys
 WHERE provider_id = $1
   AND ($2::TEXT IS NULL OR LOWER(name) LIKE $2 OR LOWER(id) LIKE $2)
   AND ($3::BOOLEAN IS NULL OR is_active = $3)
-ORDER BY internal_priority ASC, name ASC, id ASC
+ORDER BY {order_by}
 OFFSET $4
 LIMIT $5
 "#,
+        );
+        let items = collect_query_rows(
+            sqlx::query(&sql)
+                .bind(&query.provider_id)
+                .bind(search_pattern.as_deref())
+                .bind(query.is_active)
+                .bind(offset)
+                .bind(limit)
+                .fetch(&self.pool),
+            map_key_row,
         )
-        .bind(&query.provider_id)
-        .bind(search_pattern.as_deref())
-        .bind(query.is_active)
-        .bind(offset)
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await
-        .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_key_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        .await?;
 
         Ok(StoredProviderCatalogKeyPage { items, total })
     }
@@ -560,16 +660,17 @@ LIMIT $5
             return Ok(Vec::new());
         }
 
-        let rows = build_list_query(
-            LIST_KEY_STATS_BY_PROVIDER_IDS_PREFIX,
-            provider_ids,
-            "\nGROUP BY provider_id\nORDER BY provider_id ASC",
+        collect_query_rows(
+            build_list_query(
+                LIST_KEY_STATS_BY_PROVIDER_IDS_PREFIX,
+                provider_ids,
+                "\nGROUP BY provider_id\nORDER BY provider_id ASC",
+            )
+            .build()
+            .fetch(&self.pool),
+            map_key_stats_row,
         )
-        .build()
-        .fetch_all(&self.pool)
         .await
-        .map_postgres_err()?;
-        rows.iter().map(map_key_stats_row).collect()
     }
 
     pub async fn update_key_oauth_credentials(
@@ -1794,6 +1895,13 @@ impl ProviderCatalogReadRepository for SqlxProviderCatalogReadRepository {
         Self::list_keys_by_provider_ids(self, provider_ids).await
     }
 
+    async fn list_key_summaries_by_provider_ids(
+        &self,
+        provider_ids: &[String],
+    ) -> Result<Vec<StoredProviderCatalogKey>, DataLayerError> {
+        Self::list_key_summaries_by_provider_ids(self, provider_ids).await
+    }
+
     async fn list_keys_page(
         &self,
         query: &ProviderCatalogKeyListQuery,
@@ -2049,6 +2157,29 @@ fn is_missing_endpoint_health_score_column(error: &sqlx::Error) -> bool {
             .as_database_error()
             .map(|db| db.message().contains("health_score"))
             .unwrap_or(false)
+}
+
+fn is_missing_endpoint_health_score_column_sql(error: &DataLayerError) -> bool {
+    match error {
+        DataLayerError::Postgres(message) => {
+            message.contains("endpoint_health_score") && message.contains("does not exist")
+        }
+        _ => false,
+    }
+}
+
+async fn collect_query_rows<T, S>(
+    mut rows: S,
+    mapper: fn(&PgRow) -> Result<T, DataLayerError>,
+) -> Result<Vec<T>, DataLayerError>
+where
+    S: futures_util::TryStream<Ok = PgRow, Error = sqlx::Error> + Unpin,
+{
+    let mut items = Vec::new();
+    while let Some(row) = rows.try_next().await.map_postgres_err()? {
+        items.push(mapper(&row)?);
+    }
+    Ok(items)
 }
 
 fn map_key_stats_row(row: &PgRow) -> Result<StoredProviderCatalogKeyStats, DataLayerError> {

--- a/crates/aether-data/src/repository/proxy_nodes/sql.rs
+++ b/crates/aether-data/src/repository/proxy_nodes/sql.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_util::TryStreamExt;
 use sha2::{Digest, Sha256};
 use sqlx::{postgres::PgRow, PgPool, Row};
 
@@ -414,11 +415,12 @@ impl SqlxProxyNodeRepository {
 #[async_trait]
 impl ProxyNodeReadRepository for SqlxProxyNodeRepository {
     async fn list_proxy_nodes(&self) -> Result<Vec<StoredProxyNode>, DataLayerError> {
-        let rows = sqlx::query(LIST_PROXY_NODES_SQL)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(Self::row_to_stored).collect()
+        let mut rows = sqlx::query(LIST_PROXY_NODES_SQL).fetch(&self.pool);
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            items.push(Self::row_to_stored(&row)?);
+        }
+        Ok(items)
     }
 
     async fn find_proxy_node(
@@ -438,13 +440,15 @@ impl ProxyNodeReadRepository for SqlxProxyNodeRepository {
         node_id: &str,
         limit: usize,
     ) -> Result<Vec<StoredProxyNodeEvent>, DataLayerError> {
-        let rows = sqlx::query(LIST_PROXY_NODE_EVENTS_SQL)
+        let mut rows = sqlx::query(LIST_PROXY_NODE_EVENTS_SQL)
             .bind(node_id)
             .bind(i64::try_from(limit).unwrap_or(i64::MAX))
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(Self::row_to_event).collect()
+            .fetch(&self.pool);
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            items.push(Self::row_to_event(&row)?);
+        }
+        Ok(items)
     }
 }
 

--- a/crates/aether-data/src/repository/shadow_results/sql.rs
+++ b/crates/aether-data/src/repository/shadow_results/sql.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use futures_util::future::BoxFuture;
+use futures_util::TryStreamExt;
 use sqlx::{PgPool, Row};
 
 use super::types::{
@@ -161,17 +162,18 @@ impl SqlxShadowResultRepository {
             return Ok(Vec::new());
         }
 
-        let rows = sqlx::query(LIST_RECENT_SQL)
+        let mut rows = sqlx::query(LIST_RECENT_SQL)
             .bind(i64::try_from(limit).map_err(|_| {
                 DataLayerError::UnexpectedValue(format!(
                     "invalid recent shadow result limit: {limit}"
                 ))
             })?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-
-        rows.iter().map(map_shadow_result_row).collect()
+            .fetch(&self.pool);
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            items.push(map_shadow_result_row(&row)?);
+        }
+        Ok(items)
     }
 
     pub async fn upsert(

--- a/crates/aether-data/src/repository/usage/sql.rs
+++ b/crates/aether-data/src/repository/usage/sql.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use futures_util::future::BoxFuture;
+use futures_util::TryStreamExt;
 use serde_json::Value;
 use sqlx::{PgPool, Postgres, QueryBuilder, Row};
 use uuid::Uuid;
@@ -634,12 +635,13 @@ impl SqlxUsageReadRepository {
         }
 
         builder.push(" ORDER BY created_at ASC, request_id ASC");
-        let rows = builder
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_usage_row).collect()
+        let query = builder.build();
+        let mut rows = query.fetch(&self.pool);
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            items.push(map_usage_row(&row)?);
+        }
+        Ok(items)
     }
 
     pub async fn list_recent_usage_audits(
@@ -658,12 +660,13 @@ impl SqlxUsageReadRepository {
             .push_bind(i64::try_from(limit).map_err(|_| {
                 DataLayerError::InvalidInput(format!("invalid recent usage limit: {limit}"))
             })?);
-        let rows = builder
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_usage_row).collect()
+        let query = builder.build();
+        let mut rows = query.fetch(&self.pool);
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            items.push(map_usage_row(&row)?);
+        }
+        Ok(items)
     }
 
     pub async fn summarize_total_tokens_by_api_key_ids(
@@ -674,14 +677,12 @@ impl SqlxUsageReadRepository {
             return Ok(std::collections::BTreeMap::new());
         }
 
-        let rows = sqlx::query(SUMMARIZE_TOTAL_TOKENS_BY_API_KEY_IDS_SQL)
+        let mut rows = sqlx::query(SUMMARIZE_TOTAL_TOKENS_BY_API_KEY_IDS_SQL)
             .bind(api_key_ids)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
+            .fetch(&self.pool);
 
         let mut totals = std::collections::BTreeMap::new();
-        for row in rows {
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
             let api_key_id: String = row.try_get("api_key_id").map_postgres_err()?;
             let total_tokens = row
                 .try_get::<i64, _>("total_tokens")
@@ -701,14 +702,12 @@ impl SqlxUsageReadRepository {
             return Ok(std::collections::BTreeMap::new());
         }
 
-        let rows = sqlx::query(SUMMARIZE_USAGE_BY_PROVIDER_API_KEY_IDS_SQL)
+        let mut rows = sqlx::query(SUMMARIZE_USAGE_BY_PROVIDER_API_KEY_IDS_SQL)
             .bind(provider_api_key_ids)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
+            .fetch(&self.pool);
 
         let mut summaries = std::collections::BTreeMap::new();
-        for row in rows {
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
             let provider_api_key_id: String =
                 row.try_get("provider_api_key_id").map_postgres_err()?;
             let request_count = row

--- a/crates/aether-data/src/repository/users/sql.rs
+++ b/crates/aether-data/src/repository/users/sql.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_util::TryStreamExt;
 use sqlx::{PgPool, Postgres, QueryBuilder, Row};
 
 use super::types::{
@@ -189,30 +190,31 @@ impl SqlxUserReadRepository {
         if user_ids.is_empty() {
             return Ok(Vec::new());
         }
-        let rows = sqlx::query(LIST_USERS_BY_IDS_SQL)
-            .bind(user_ids)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_user_row).collect()
+        collect_query_rows(
+            sqlx::query(LIST_USERS_BY_IDS_SQL)
+                .bind(user_ids)
+                .fetch(&self.pool),
+            map_user_row,
+        )
+        .await
     }
 
     pub async fn list_non_admin_export_users(
         &self,
     ) -> Result<Vec<StoredUserExportRow>, DataLayerError> {
-        let rows = sqlx::query(LIST_NON_ADMIN_EXPORT_USERS_SQL)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_user_export_row).collect()
+        collect_query_rows(
+            sqlx::query(LIST_NON_ADMIN_EXPORT_USERS_SQL).fetch(&self.pool),
+            map_user_export_row,
+        )
+        .await
     }
 
     pub async fn list_export_users(&self) -> Result<Vec<StoredUserExportRow>, DataLayerError> {
-        let rows = sqlx::query(LIST_EXPORT_USERS_SQL)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_user_export_row).collect()
+        collect_query_rows(
+            sqlx::query(LIST_EXPORT_USERS_SQL).fetch(&self.pool),
+            map_user_export_row,
+        )
+        .await
     }
 
     pub async fn list_export_users_page(
@@ -240,12 +242,8 @@ impl SqlxUserReadRepository {
                 DataLayerError::InvalidInput(format!("invalid user export limit: {}", query.limit))
             })?);
 
-        let rows = builder
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_user_export_row).collect()
+        let query = builder.build();
+        collect_query_rows(query.fetch(&self.pool), map_user_export_row).await
     }
 
     pub async fn summarize_export_users(&self) -> Result<UserExportSummary, DataLayerError> {
@@ -279,12 +277,13 @@ impl SqlxUserReadRepository {
             return Ok(Vec::new());
         }
 
-        let rows = sqlx::query(LIST_USER_AUTH_BY_IDS_SQL)
-            .bind(user_ids)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_user_auth_row).collect()
+        collect_query_rows(
+            sqlx::query(LIST_USER_AUTH_BY_IDS_SQL)
+                .bind(user_ids)
+                .fetch(&self.pool),
+            map_user_auth_row,
+        )
+        .await
     }
 
     pub async fn find_user_auth_by_id(
@@ -359,6 +358,20 @@ fn map_user_auth_row(row: &sqlx::postgres::PgRow) -> Result<StoredUserAuthRecord
         row.try_get("created_at").map_postgres_err()?,
         row.try_get("last_login_at").map_postgres_err()?,
     )
+}
+
+async fn collect_query_rows<T, S>(
+    mut rows: S,
+    mapper: fn(&sqlx::postgres::PgRow) -> Result<T, DataLayerError>,
+) -> Result<Vec<T>, DataLayerError>
+where
+    S: futures_util::TryStream<Ok = sqlx::postgres::PgRow, Error = sqlx::Error> + Unpin,
+{
+    let mut items = Vec::new();
+    while let Some(row) = rows.try_next().await.map_postgres_err()? {
+        items.push(mapper(&row)?);
+    }
+    Ok(items)
 }
 
 #[async_trait]

--- a/crates/aether-data/src/repository/video_tasks/memory.rs
+++ b/crates/aether-data/src/repository/video_tasks/memory.rs
@@ -187,6 +187,15 @@ impl VideoTaskReadRepository for InMemoryVideoTaskRepository {
         Ok(tasks.into_iter().skip(offset).take(limit).collect())
     }
 
+    async fn list_page_summary(
+        &self,
+        filter: &VideoTaskQueryFilter,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<StoredVideoTask>, DataLayerError> {
+        Self::list_page(self, filter, offset, limit).await
+    }
+
     async fn count(&self, filter: &VideoTaskQueryFilter) -> Result<u64, DataLayerError> {
         Ok(self
             .index

--- a/crates/aether-data/src/repository/video_tasks/sql.rs
+++ b/crates/aether-data/src/repository/video_tasks/sql.rs
@@ -1,6 +1,6 @@
-use sqlx::{PgPool, Postgres, QueryBuilder, Row};
-
 use async_trait::async_trait;
+use futures_util::{stream::TryStream, TryStreamExt};
+use sqlx::{postgres::PgRow, PgPool, Postgres, QueryBuilder, Row};
 
 use crate::error::SqlxResultExt;
 use crate::repository::video_tasks::{
@@ -10,7 +10,7 @@ use crate::repository::video_tasks::{
 };
 use crate::DataLayerError;
 
-const SELECT_VIDEO_TASK_COLUMNS: &str = r#"
+const SELECT_VIDEO_TASK_COLUMNS_PREFIX: &str = r#"
   id,
   short_id,
   request_id,
@@ -26,12 +26,9 @@ const SELECT_VIDEO_TASK_COLUMNS: &str = r#"
   provider_api_format,
   format_converted,
   model,
-  prompt,
-  original_request_body,
-  duration_seconds,
-  resolution,
-  aspect_ratio,
-  size,
+"#;
+
+const SELECT_VIDEO_TASK_COLUMNS_SUFFIX: &str = r#"
   status,
   progress_percent,
   progress_message,
@@ -50,8 +47,53 @@ const SELECT_VIDEO_TASK_COLUMNS: &str = r#"
   request_metadata
 "#;
 
+fn select_video_task_columns(
+    prompt_sql: &str,
+    original_request_body_sql: &str,
+    duration_seconds_sql: &str,
+    resolution_sql: &str,
+    aspect_ratio_sql: &str,
+    size_sql: &str,
+) -> String {
+    format!(
+        "{SELECT_VIDEO_TASK_COLUMNS_PREFIX}
+  {prompt_sql} AS prompt,
+  {original_request_body_sql} AS original_request_body,
+  {duration_seconds_sql} AS duration_seconds,
+  {resolution_sql} AS resolution,
+  {aspect_ratio_sql} AS aspect_ratio,
+  {size_sql} AS size,
+{SELECT_VIDEO_TASK_COLUMNS_SUFFIX}"
+    )
+}
+
+fn select_video_task_full_columns() -> String {
+    select_video_task_columns(
+        "prompt",
+        "original_request_body",
+        "duration_seconds",
+        "resolution",
+        "aspect_ratio",
+        "size",
+    )
+}
+
+fn select_video_task_claim_columns() -> String {
+    select_video_task_columns(
+        "NULL::TEXT",
+        "NULL::jsonb",
+        "NULL::INTEGER",
+        "NULL::TEXT",
+        "NULL::TEXT",
+        "NULL::TEXT",
+    )
+}
+
 fn select_video_task_sql(where_clause: &str) -> String {
-    format!("SELECT\n{SELECT_VIDEO_TASK_COLUMNS}\nFROM video_tasks\n{where_clause}\n")
+    format!(
+        "SELECT\n{}\nFROM video_tasks\n{where_clause}\n",
+        select_video_task_full_columns()
+    )
 }
 
 fn find_by_id_sql() -> String {
@@ -76,7 +118,54 @@ fn list_due_sql() -> String {
     )
 }
 
+fn select_video_task_page_summary_columns() -> &'static str {
+    r#"
+  id,
+  NULL::TEXT AS short_id,
+  request_id,
+  user_id,
+  NULL::TEXT AS api_key_id,
+  username,
+  NULL::TEXT AS api_key_name,
+  external_task_id,
+  provider_id,
+  NULL::TEXT AS endpoint_id,
+  NULL::TEXT AS key_id,
+  NULL::TEXT AS client_api_format,
+  NULL::TEXT AS provider_api_format,
+  FALSE AS format_converted,
+  model,
+  CASE
+    WHEN prompt IS NULL THEN NULL
+    WHEN char_length(prompt) <= 100 THEN prompt
+    ELSE LEFT(prompt, 100) || '...'
+  END AS prompt,
+  NULL::jsonb AS original_request_body,
+  duration_seconds,
+  resolution,
+  aspect_ratio,
+  NULL::TEXT AS size,
+  status,
+  progress_percent,
+  progress_message,
+  0::INTEGER AS retry_count,
+  1::INTEGER AS poll_interval_seconds,
+  NULL::BIGINT AS next_poll_at_unix_secs,
+  poll_count,
+  max_poll_count,
+  CAST(EXTRACT(EPOCH FROM created_at) AS BIGINT) AS created_at_unix_ms,
+  CAST(EXTRACT(EPOCH FROM submitted_at) AS BIGINT) AS submitted_at_unix_secs,
+  CAST(EXTRACT(EPOCH FROM completed_at) AS BIGINT) AS completed_at_unix_secs,
+  CAST(EXTRACT(EPOCH FROM updated_at) AS BIGINT) AS updated_at_unix_secs,
+  error_code,
+  error_message,
+  video_url,
+  NULL::jsonb AS request_metadata
+"#
+}
+
 fn claim_due_sql() -> String {
+    let columns = select_video_task_claim_columns();
     format!(
         "WITH due AS (
   SELECT id
@@ -94,12 +183,13 @@ SET next_poll_at = TO_TIMESTAMP($4),
     updated_at = TO_TIMESTAMP($5)
 WHERE id IN (SELECT id FROM due)
 RETURNING
-{SELECT_VIDEO_TASK_COLUMNS}
+{columns}
 "
     )
 }
 
 fn upsert_sql() -> String {
+    let columns = select_video_task_full_columns();
     format!(
         "INSERT INTO video_tasks (
   id,
@@ -216,12 +306,13 @@ ON CONFLICT (id) DO UPDATE SET
   completed_at = EXCLUDED.completed_at,
   updated_at = EXCLUDED.updated_at
 RETURNING
-{SELECT_VIDEO_TASK_COLUMNS}
+{columns}
 "
     )
 }
 
 fn update_if_active_sql() -> String {
+    let columns = select_video_task_full_columns();
     format!(
         "UPDATE video_tasks SET
   short_id = $2,
@@ -263,7 +354,7 @@ fn update_if_active_sql() -> String {
 WHERE id = $1
   AND status = ANY($38)
 RETURNING
-{SELECT_VIDEO_TASK_COLUMNS}
+{columns}
 "
     )
 }
@@ -343,16 +434,16 @@ impl SqlxVideoTaskRepository {
 
         let active_statuses = vec!["pending", "submitted", "queued", "processing"];
         let sql = list_active_sql();
-        let rows = sqlx::query(&sql)
-            .bind(active_statuses)
-            .bind(i64::try_from(limit).map_err(|_| {
-                DataLayerError::UnexpectedValue(format!("invalid active task limit: {limit}"))
-            })?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-
-        rows.iter().map(map_video_task_row).collect()
+        collect_query_rows(
+            sqlx::query(&sql)
+                .bind(active_statuses)
+                .bind(i64::try_from(limit).map_err(|_| {
+                    DataLayerError::UnexpectedValue(format!("invalid active task limit: {limit}"))
+                })?)
+                .fetch(&self.pool),
+            map_video_task_row,
+        )
+        .await
     }
 
     pub async fn list_due(
@@ -366,17 +457,17 @@ impl SqlxVideoTaskRepository {
 
         let active_statuses = vec!["submitted", "queued", "processing"];
         let sql = list_due_sql();
-        let rows = sqlx::query(&sql)
-            .bind(active_statuses)
-            .bind(now_unix_secs as f64)
-            .bind(i64::try_from(limit).map_err(|_| {
-                DataLayerError::UnexpectedValue(format!("invalid due task limit: {limit}"))
-            })?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-
-        rows.iter().map(map_video_task_row).collect()
+        collect_query_rows(
+            sqlx::query(&sql)
+                .bind(active_statuses)
+                .bind(now_unix_secs as f64)
+                .bind(i64::try_from(limit).map_err(|_| {
+                    DataLayerError::UnexpectedValue(format!("invalid due task limit: {limit}"))
+                })?)
+                .fetch(&self.pool),
+            map_video_task_row,
+        )
+        .await
     }
 
     pub async fn list_page(
@@ -395,7 +486,7 @@ impl SqlxVideoTaskRepository {
             .map_err(|_| DataLayerError::UnexpectedValue(format!("invalid limit: {limit}")))?;
 
         let mut builder = QueryBuilder::<Postgres>::new("SELECT\n");
-        builder.push(SELECT_VIDEO_TASK_COLUMNS);
+        builder.push(select_video_task_full_columns());
         builder.push("\nFROM video_tasks");
         push_video_task_filter(&mut builder, filter, None);
         builder.push("\nORDER BY created_at DESC, updated_at DESC");
@@ -404,12 +495,37 @@ impl SqlxVideoTaskRepository {
         builder.push("\nLIMIT ");
         builder.push_bind(limit);
 
-        let rows = builder
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.iter().map(map_video_task_row).collect()
+        let query = builder.build();
+        collect_query_rows(query.fetch(&self.pool), map_video_task_row).await
+    }
+
+    pub async fn list_page_summary(
+        &self,
+        filter: &VideoTaskQueryFilter,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<StoredVideoTask>, DataLayerError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let offset = i64::try_from(offset)
+            .map_err(|_| DataLayerError::UnexpectedValue(format!("invalid offset: {offset}")))?;
+        let limit = i64::try_from(limit)
+            .map_err(|_| DataLayerError::UnexpectedValue(format!("invalid limit: {limit}")))?;
+
+        let mut builder = QueryBuilder::<Postgres>::new("SELECT\n");
+        builder.push(select_video_task_page_summary_columns());
+        builder.push("\nFROM video_tasks");
+        push_video_task_filter(&mut builder, filter, None);
+        builder.push("\nORDER BY created_at DESC, updated_at DESC");
+        builder.push("\nOFFSET ");
+        builder.push_bind(offset);
+        builder.push("\nLIMIT ");
+        builder.push_bind(limit);
+
+        let query = builder.build();
+        collect_query_rows(query.fetch(&self.pool), map_video_task_row).await
     }
 
     pub async fn count(&self, filter: &VideoTaskQueryFilter) -> Result<u64, DataLayerError> {
@@ -436,29 +552,29 @@ impl SqlxVideoTaskRepository {
         push_video_task_filter(&mut builder, filter, None);
         builder.push("\nGROUP BY status\nORDER BY status ASC");
 
-        let rows = builder
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.into_iter()
-            .map(|row| {
+        let query = builder.build();
+        let mut rows = query.fetch(&self.pool);
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            let entry = {
                 let status = VideoTaskStatus::from_database(
                     row.try_get::<String, _>("status")
                         .map_postgres_err()?
                         .as_str(),
                 )?;
                 let total = row.try_get::<i64, _>("total").map_postgres_err()?;
-                Ok(VideoTaskStatusCount {
+                VideoTaskStatusCount {
                     status,
                     count: u64::try_from(total).map_err(|_| {
                         DataLayerError::UnexpectedValue(format!(
                             "invalid status count result: {total}"
                         ))
                     })?,
-                })
-            })
-            .collect()
+                }
+            };
+            items.push(entry);
+        }
+        Ok(items)
     }
 
     pub async fn count_distinct_users(
@@ -504,25 +620,25 @@ impl SqlxVideoTaskRepository {
         builder.push("\nGROUP BY model\nORDER BY total DESC, model ASC\nLIMIT ");
         builder.push_bind(limit);
 
-        let rows = builder
-            .build()
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        rows.into_iter()
-            .map(|row| {
+        let query = builder.build();
+        let mut rows = query.fetch(&self.pool);
+        let mut items = Vec::new();
+        while let Some(row) = rows.try_next().await.map_postgres_err()? {
+            let entry = {
                 let model = row.try_get::<String, _>("model").map_postgres_err()?;
                 let total = row.try_get::<i64, _>("total").map_postgres_err()?;
-                Ok(VideoTaskModelCount {
+                VideoTaskModelCount {
                     model,
                     count: u64::try_from(total).map_err(|_| {
                         DataLayerError::UnexpectedValue(format!(
                             "invalid model count result: {total}"
                         ))
                     })?,
-                })
-            })
-            .collect()
+                }
+            };
+            items.push(entry);
+        }
+        Ok(items)
     }
 
     pub async fn count_created_since(
@@ -693,20 +809,17 @@ impl SqlxVideoTaskRepository {
         let limit = i64::try_from(limit)
             .map_err(|_| DataLayerError::UnexpectedValue(format!("invalid limit: {limit}")))?;
         let sql = claim_due_sql();
-        let rows = sqlx::query(&sql)
-            .bind(vec!["submitted", "queued", "processing"])
-            .bind(now_unix_secs as f64)
-            .bind(limit)
-            .bind(claim_until_unix_secs as f64)
-            .bind(now_unix_secs as f64)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-
-        let mut tasks = rows
-            .iter()
-            .map(map_video_task_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut tasks = collect_query_rows(
+            sqlx::query(&sql)
+                .bind(vec!["submitted", "queued", "processing"])
+                .bind(now_unix_secs as f64)
+                .bind(limit)
+                .bind(claim_until_unix_secs as f64)
+                .bind(now_unix_secs as f64)
+                .fetch(&self.pool),
+            map_video_task_row,
+        )
+        .await?;
         tasks.sort_by(|left, right| {
             left.next_poll_at_unix_secs
                 .cmp(&right.next_poll_at_unix_secs)
@@ -744,6 +857,15 @@ impl VideoTaskReadRepository for SqlxVideoTaskRepository {
         limit: usize,
     ) -> Result<Vec<StoredVideoTask>, DataLayerError> {
         Self::list_page(self, filter, offset, limit).await
+    }
+
+    async fn list_page_summary(
+        &self,
+        filter: &VideoTaskQueryFilter,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<StoredVideoTask>, DataLayerError> {
+        Self::list_page_summary(self, filter, offset, limit).await
     }
 
     async fn count(&self, filter: &VideoTaskQueryFilter) -> Result<u64, DataLayerError> {
@@ -881,7 +1003,21 @@ fn map_status_for_database(status: VideoTaskStatus) -> &'static str {
     }
 }
 
-fn map_video_task_row(row: &sqlx::postgres::PgRow) -> Result<StoredVideoTask, DataLayerError> {
+async fn collect_query_rows<T, S>(
+    mut rows: S,
+    map_row: fn(&PgRow) -> Result<T, DataLayerError>,
+) -> Result<Vec<T>, DataLayerError>
+where
+    S: TryStream<Ok = PgRow, Error = sqlx::Error> + Unpin,
+{
+    let mut items = Vec::new();
+    while let Some(row) = rows.try_next().await.map_postgres_err()? {
+        items.push(map_row(&row)?);
+    }
+    Ok(items)
+}
+
+fn map_video_task_row(row: &PgRow) -> Result<StoredVideoTask, DataLayerError> {
     let status = VideoTaskStatus::from_database(
         row.try_get::<String, _>("status")
             .map_postgres_err()?

--- a/crates/aether-data/src/repository/wallet/sql.rs
+++ b/crates/aether-data/src/repository/wallet/sql.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use chrono::Utc;
+use futures_util::{stream::TryStream, TryStreamExt};
 use sqlx::{postgres::PgRow, PgPool, Row};
 use uuid::Uuid;
 
@@ -24,7 +25,6 @@ use crate::{
     postgres::PostgresTransactionRunner,
     DataLayerError,
 };
-use std::collections::BTreeMap;
 
 const FIND_BY_WALLET_ID_SQL: &str = r#"
 SELECT
@@ -638,21 +638,13 @@ impl WalletReadRepository for SqlxWalletRepository {
         if user_ids.is_empty() {
             return Ok(Vec::new());
         }
-        let mut ids_map = BTreeMap::new();
-        for (index, id) in user_ids.iter().enumerate() {
-            ids_map.entry(id).or_insert_with(Vec::new).push(index);
-        }
-        let rows = sqlx::query(LIST_BY_USER_IDS_SQL)
-            .bind(user_ids)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let mut wallets = Vec::with_capacity(rows.len());
-        for row in rows {
-            let wallet = map_wallet_row(&row)?;
-            wallets.push(wallet);
-        }
-        Ok(wallets)
+        collect_query_rows(
+            sqlx::query(LIST_BY_USER_IDS_SQL)
+                .bind(user_ids)
+                .fetch(&self.pool),
+            map_wallet_row,
+        )
+        .await
     }
     async fn list_wallets_by_api_key_ids(
         &self,
@@ -661,17 +653,13 @@ impl WalletReadRepository for SqlxWalletRepository {
         if api_key_ids.is_empty() {
             return Ok(Vec::new());
         }
-        let rows = sqlx::query(LIST_BY_API_KEY_IDS_SQL)
-            .bind(api_key_ids)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let mut wallets = Vec::with_capacity(rows.len());
-        for row in rows {
-            let wallet = map_wallet_row(&row)?;
-            wallets.push(wallet);
-        }
-        Ok(wallets)
+        collect_query_rows(
+            sqlx::query(LIST_BY_API_KEY_IDS_SQL)
+                .bind(api_key_ids)
+                .fetch(&self.pool),
+            map_wallet_row,
+        )
+        .await
     }
 
     async fn list_admin_wallets(
@@ -686,18 +674,16 @@ impl WalletReadRepository for SqlxWalletRepository {
                 .await
                 .map_postgres_err()?,
         )?;
-        let rows = sqlx::query(LIST_ADMIN_WALLETS_SQL)
-            .bind(query.status.as_deref())
-            .bind(query.owner_type.as_deref())
-            .bind(as_i64(query.offset, "wallet offset")?)
-            .bind(as_i64(query.limit, "wallet limit")?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_admin_wallet_list_item_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let items = collect_query_rows(
+            sqlx::query(LIST_ADMIN_WALLETS_SQL)
+                .bind(query.status.as_deref())
+                .bind(query.owner_type.as_deref())
+                .bind(as_i64(query.offset, "wallet offset")?)
+                .bind(as_i64(query.limit, "wallet limit")?)
+                .fetch(&self.pool),
+            map_admin_wallet_list_item_row,
+        )
+        .await?;
         Ok(StoredAdminWalletListPage { items, total })
     }
 
@@ -714,19 +700,17 @@ impl WalletReadRepository for SqlxWalletRepository {
                 .await
                 .map_postgres_err()?,
         )?;
-        let rows = sqlx::query(LIST_ADMIN_WALLET_LEDGER_SQL)
-            .bind(query.category.as_deref())
-            .bind(query.reason_code.as_deref())
-            .bind(query.owner_type.as_deref())
-            .bind(as_i64(query.offset, "wallet ledger offset")?)
-            .bind(as_i64(query.limit, "wallet ledger limit")?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_admin_wallet_ledger_item_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let items = collect_query_rows(
+            sqlx::query(LIST_ADMIN_WALLET_LEDGER_SQL)
+                .bind(query.category.as_deref())
+                .bind(query.reason_code.as_deref())
+                .bind(query.owner_type.as_deref())
+                .bind(as_i64(query.offset, "wallet ledger offset")?)
+                .bind(as_i64(query.limit, "wallet ledger limit")?)
+                .fetch(&self.pool),
+            map_admin_wallet_ledger_item_row,
+        )
+        .await?;
         Ok(StoredAdminWalletLedgerPage { items, total })
     }
 
@@ -741,17 +725,15 @@ impl WalletReadRepository for SqlxWalletRepository {
                 .await
                 .map_postgres_err()?,
         )?;
-        let rows = sqlx::query(LIST_ADMIN_WALLET_REFUND_REQUESTS_SQL)
-            .bind(query.status.as_deref())
-            .bind(as_i64(query.offset, "wallet refund request offset")?)
-            .bind(as_i64(query.limit, "wallet refund request limit")?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_admin_wallet_refund_request_item_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let items = collect_query_rows(
+            sqlx::query(LIST_ADMIN_WALLET_REFUND_REQUESTS_SQL)
+                .bind(query.status.as_deref())
+                .bind(as_i64(query.offset, "wallet refund request offset")?)
+                .bind(as_i64(query.limit, "wallet refund request limit")?)
+                .fetch(&self.pool),
+            map_admin_wallet_refund_request_item_row,
+        )
+        .await?;
         Ok(StoredAdminWalletRefundRequestPage { items, total })
     }
 
@@ -768,17 +750,15 @@ impl WalletReadRepository for SqlxWalletRepository {
                 .await
                 .map_postgres_err()?,
         )?;
-        let rows = sqlx::query(LIST_ADMIN_WALLET_TRANSACTIONS_SQL)
-            .bind(wallet_id)
-            .bind(as_i64(offset, "wallet transaction offset")?)
-            .bind(as_i64(limit, "wallet transaction limit")?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_admin_wallet_transaction_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let items = collect_query_rows(
+            sqlx::query(LIST_ADMIN_WALLET_TRANSACTIONS_SQL)
+                .bind(wallet_id)
+                .bind(as_i64(offset, "wallet transaction offset")?)
+                .bind(as_i64(limit, "wallet transaction limit")?)
+                .fetch(&self.pool),
+            map_admin_wallet_transaction_row,
+        )
+        .await?;
         Ok(StoredAdminWalletTransactionPage { items, total })
     }
 
@@ -810,17 +790,15 @@ impl WalletReadRepository for SqlxWalletRepository {
                 .await
                 .map_postgres_err()?,
         )?;
-        let rows = sqlx::query(LIST_WALLET_DAILY_USAGE_HISTORY_SQL)
-            .bind(wallet_id)
-            .bind(billing_timezone)
-            .bind(as_i64(limit, "wallet daily usage history limit")?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_wallet_daily_usage_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let items = collect_query_rows(
+            sqlx::query(LIST_WALLET_DAILY_USAGE_HISTORY_SQL)
+                .bind(wallet_id)
+                .bind(billing_timezone)
+                .bind(as_i64(limit, "wallet daily usage history limit")?)
+                .fetch(&self.pool),
+            map_wallet_daily_usage_row,
+        )
+        .await?;
         Ok(StoredWalletDailyUsageLedgerPage { items, total })
     }
 
@@ -837,17 +815,15 @@ impl WalletReadRepository for SqlxWalletRepository {
                 .await
                 .map_postgres_err()?,
         )?;
-        let rows = sqlx::query(LIST_ADMIN_WALLET_REFUNDS_SQL)
-            .bind(wallet_id)
-            .bind(as_i64(offset, "wallet refund offset")?)
-            .bind(as_i64(limit, "wallet refund limit")?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_admin_wallet_refund_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let items = collect_query_rows(
+            sqlx::query(LIST_ADMIN_WALLET_REFUNDS_SQL)
+                .bind(wallet_id)
+                .bind(as_i64(offset, "wallet refund offset")?)
+                .bind(as_i64(limit, "wallet refund limit")?)
+                .fetch(&self.pool),
+            map_admin_wallet_refund_row,
+        )
+        .await?;
         Ok(StoredAdminWalletRefundPage { items, total })
     }
 
@@ -863,18 +839,16 @@ impl WalletReadRepository for SqlxWalletRepository {
                 .await
                 .map_postgres_err()?,
         )?;
-        let rows = sqlx::query(LIST_ADMIN_PAYMENT_ORDERS_SQL)
-            .bind(query.payment_method.as_deref())
-            .bind(query.status.as_deref())
-            .bind(as_i64(query.offset, "payment order offset")?)
-            .bind(as_i64(query.limit, "payment order limit")?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_admin_payment_order_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let items = collect_query_rows(
+            sqlx::query(LIST_ADMIN_PAYMENT_ORDERS_SQL)
+                .bind(query.payment_method.as_deref())
+                .bind(query.status.as_deref())
+                .bind(as_i64(query.offset, "payment order offset")?)
+                .bind(as_i64(query.limit, "payment order limit")?)
+                .fetch(&self.pool),
+            map_admin_payment_order_row,
+        )
+        .await?;
         Ok(StoredAdminPaymentOrderPage { items, total })
     }
 
@@ -903,17 +877,15 @@ impl WalletReadRepository for SqlxWalletRepository {
                 .await
                 .map_postgres_err()?,
         )?;
-        let rows = sqlx::query(LIST_WALLET_PAYMENT_ORDERS_BY_USER_SQL)
-            .bind(user_id)
-            .bind(as_i64(offset, "wallet payment order offset")?)
-            .bind(as_i64(limit, "wallet payment order limit")?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_admin_payment_order_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let items = collect_query_rows(
+            sqlx::query(LIST_WALLET_PAYMENT_ORDERS_BY_USER_SQL)
+                .bind(user_id)
+                .bind(as_i64(offset, "wallet payment order offset")?)
+                .bind(as_i64(limit, "wallet payment order limit")?)
+                .fetch(&self.pool),
+            map_admin_payment_order_row,
+        )
+        .await?;
         Ok(StoredAdminPaymentOrderPage { items, total })
     }
 
@@ -958,17 +930,15 @@ impl WalletReadRepository for SqlxWalletRepository {
                 .await
                 .map_postgres_err()?,
         )?;
-        let rows = sqlx::query(LIST_ADMIN_PAYMENT_CALLBACKS_SQL)
-            .bind(payment_method)
-            .bind(as_i64(offset, "payment callback offset")?)
-            .bind(as_i64(limit, "payment callback limit")?)
-            .fetch_all(&self.pool)
-            .await
-            .map_postgres_err()?;
-        let items = rows
-            .iter()
-            .map(map_admin_payment_callback_row)
-            .collect::<Result<Vec<_>, _>>()?;
+        let items = collect_query_rows(
+            sqlx::query(LIST_ADMIN_PAYMENT_CALLBACKS_SQL)
+                .bind(payment_method)
+                .bind(as_i64(offset, "payment callback offset")?)
+                .bind(as_i64(limit, "payment callback limit")?)
+                .fetch(&self.pool),
+            map_admin_payment_callback_row,
+        )
+        .await?;
         Ok(StoredAdminPaymentCallbackPage { items, total })
     }
 }
@@ -3554,6 +3524,20 @@ where
 fn read_count(row: PgRow) -> Result<u64, DataLayerError> {
     let total = row.try_get::<i64, _>("total").map_postgres_err()?;
     Ok(total.max(0) as u64)
+}
+
+async fn collect_query_rows<T, S>(
+    mut rows: S,
+    map_row: fn(&PgRow) -> Result<T, DataLayerError>,
+) -> Result<Vec<T>, DataLayerError>
+where
+    S: TryStream<Ok = PgRow, Error = sqlx::Error> + Unpin,
+{
+    let mut items = Vec::new();
+    while let Some(row) = rows.try_next().await.map_postgres_err()? {
+        items.push(map_row(&row)?);
+    }
+    Ok(items)
 }
 
 fn map_admin_wallet_list_item_row(


### PR DESCRIPTION
- 为 provider catalog key 和 video task 列表增加 summary/page 查询与排序能力，减少列表场景读取重字段
- 将多处 SQL 结果读取改为流式收集，降低 `fetch_all` 的内存占用
- 把日/小时统计、钱包日用量等维护任务改为数据库侧 `CTE + upsert` 聚合
- 修复视频任务轮询更新时从本地 snapshot 回填稀疏字段，避免 `prompt` 和请求体信息丢失