### PR TITLE
fix(mapping): 对齐全局模型映射的正则匹配行为与范围

### DIFF
--- a/apps/aether-gateway/src/handlers/admin/model/routing.rs
+++ b/apps/aether-gateway/src/handlers/admin/model/routing.rs
@@ -7,7 +7,9 @@ use aether_data_contracts::repository::global_models::{
 use aether_data_contracts::repository::provider_catalog::{
     StoredProviderCatalogEndpoint, StoredProviderCatalogKey,
 };
-use aether_scheduler_core::{is_provider_key_circuit_open, provider_key_health_score};
+use aether_scheduler_core::{
+    is_provider_key_circuit_open, matches_model_mapping, provider_key_health_score,
+};
 use serde_json::json;
 use std::collections::BTreeMap;
 use uuid::Uuid;
@@ -121,6 +123,13 @@ pub(crate) async fn build_admin_global_model_routing_payload(
                 .unwrap_or_default()
                 .into_iter()
                 .filter(|key| provider_catalog_key_supports_format(key, &endpoint.api_format))
+                .filter(|key| {
+                    key_allowed_models_match_global_model_for_routing(
+                        key.allowed_models.as_ref(),
+                        &global_model.name,
+                        &global_model_mappings,
+                    )
+                })
                 .collect::<Vec<_>>();
             endpoint_keys.sort_by(|left, right| {
                 left.internal_priority
@@ -170,14 +179,6 @@ pub(crate) async fn build_admin_global_model_routing_payload(
                         "circuit_breaker_formats": circuit_breaker_formats,
                         "next_probe_at": next_probe_at,
                     });
-                    all_keys_whitelist.push(json!({
-                        "key_id": &key.id,
-                        "key_name": &key.name,
-                        "masked_key": state.masked_catalog_api_key(key),
-                        "provider_id": &provider.id,
-                        "provider_name": &provider.name,
-                        "allowed_models": json_string_list(key.allowed_models.as_ref()),
-                    }));
                     payload
                 })
                 .collect::<Vec<_>>();
@@ -218,6 +219,53 @@ pub(crate) async fn build_admin_global_model_routing_payload(
             "active_endpoints": active_endpoints,
         }));
     }
+
+    // 与 Python 逻辑对齐：供前端实时匹配的白名单数据来自“全站活跃 Provider 的活跃 Key”
+    // （仅保留配置了非空 allowed_models 的 Key），而不是仅当前 GlobalModel 关联 Provider。
+    let active_providers = state
+        .list_provider_catalog_providers(true)
+        .await
+        .ok()
+        .unwrap_or_default();
+    let active_provider_ids = active_providers
+        .iter()
+        .map(|provider| provider.id.clone())
+        .collect::<Vec<_>>();
+    let active_provider_name_by_id = active_providers
+        .into_iter()
+        .map(|provider| (provider.id, provider.name))
+        .collect::<BTreeMap<_, _>>();
+    let active_keys = if active_provider_ids.is_empty() {
+        Vec::new()
+    } else {
+        state
+            .list_provider_catalog_keys_by_provider_ids(&active_provider_ids)
+            .await
+            .ok()
+            .unwrap_or_default()
+    };
+    for key in active_keys {
+        if !key.is_active {
+            continue;
+        }
+        let allowed_models = json_string_list(key.allowed_models.as_ref());
+        if allowed_models.is_empty() {
+            continue;
+        }
+        let provider_name = active_provider_name_by_id
+            .get(&key.provider_id)
+            .cloned()
+            .unwrap_or_default();
+        all_keys_whitelist.push(json!({
+            "key_id": key.id,
+            "key_name": key.name,
+            "masked_key": state.masked_catalog_api_key(&key),
+            "provider_id": key.provider_id,
+            "provider_name": provider_name,
+            "allowed_models": allowed_models,
+        }));
+    }
+
     providers_payload.sort_by(|left, right| {
         left.get("provider_priority")
             .and_then(serde_json::Value::as_i64)
@@ -255,6 +303,35 @@ pub(crate) async fn build_admin_global_model_routing_payload(
         "keep_priority_on_conversion": keep_priority_on_conversion,
         "all_keys_whitelist": all_keys_whitelist,
     }))
+}
+
+fn key_allowed_models_match_global_model_for_routing(
+    raw_allowed_models: Option<&serde_json::Value>,
+    global_model_name: &str,
+    global_model_mappings: &[String],
+) -> bool {
+    // 兼容 Python 预览逻辑：None/[] 视为“不限制”，在链路预览中保留该 Key。
+    let allowed_models = json_string_list(raw_allowed_models);
+    if raw_allowed_models.is_none() || allowed_models.is_empty() {
+        return true;
+    }
+
+    if allowed_models
+        .iter()
+        .any(|value| value == global_model_name)
+    {
+        return true;
+    }
+
+    for allowed_model in &allowed_models {
+        for pattern in global_model_mappings {
+            if matches_model_mapping(pattern, allowed_model) {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 pub(crate) async fn build_admin_assign_global_model_to_providers_payload(

--- a/apps/aether-gateway/src/handlers/admin/provider/delete_task.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/delete_task.rs
@@ -7,11 +7,20 @@ use crate::handlers::admin::shared::{decrypt_catalog_secret_with_fallbacks, json
 use crate::handlers::public::matches_model_mapping_for_models;
 use crate::{GatewayError, LocalProviderDeleteTaskState};
 use aether_data_contracts::repository::global_models::{
-    AdminProviderModelListQuery, PublicGlobalModelQuery, StoredPublicGlobalModel,
+    AdminGlobalModelListQuery, AdminProviderModelListQuery, PublicGlobalModelQuery,
 };
 use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogKey;
 use serde_json::json;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone)]
+struct MappingPreviewGlobalModel {
+    id: String,
+    name: String,
+    display_name: String,
+    is_active: bool,
+    mappings: Vec<String>,
+}
 
 pub(crate) async fn run_admin_provider_delete_task(
     state: &AdminAppState<'_>,
@@ -141,10 +150,10 @@ pub(crate) async fn run_admin_provider_delete_task(
     Ok(task)
 }
 
-pub(crate) fn public_global_model_mapping_patterns(model: &StoredPublicGlobalModel) -> Vec<String> {
-    model
-        .config
-        .as_ref()
+pub(crate) fn global_model_mapping_patterns_from_config(
+    config: Option<&serde_json::Value>,
+) -> Vec<String> {
+    config
         .and_then(serde_json::Value::as_object)
         .and_then(|config| config.get("model_mappings"))
         .and_then(serde_json::Value::as_array)
@@ -211,8 +220,8 @@ pub(crate) async fn build_admin_provider_mapping_preview_payload(
         keys.truncate(ADMIN_PROVIDER_MAPPING_PREVIEW_MAX_KEYS);
     }
 
-    let public_models = app
-        .list_public_global_models(&PublicGlobalModelQuery {
+    let admin_models = state
+        .list_admin_global_models(&AdminGlobalModelListQuery {
             offset: 0,
             limit: ADMIN_PROVIDER_MAPPING_PREVIEW_FETCH_LIMIT,
             is_active: None,
@@ -221,19 +230,56 @@ pub(crate) async fn build_admin_provider_mapping_preview_payload(
         .await
         .ok()
         .unwrap_or_else(|| {
-            aether_data_contracts::repository::global_models::StoredPublicGlobalModelPage {
+            aether_data_contracts::repository::global_models::StoredAdminGlobalModelPage {
                 items: Vec::new(),
                 total: 0,
             }
         })
         .items;
-    let mut models_with_mappings = public_models
+    let mut models_with_mappings = admin_models
         .into_iter()
         .filter_map(|model| {
-            let mappings = public_global_model_mapping_patterns(&model);
-            (!mappings.is_empty()).then_some((model, mappings))
+            let mappings = global_model_mapping_patterns_from_config(model.config.as_ref());
+            (!mappings.is_empty()).then_some(MappingPreviewGlobalModel {
+                id: model.id,
+                name: model.name,
+                display_name: model.display_name,
+                is_active: model.is_active,
+                mappings,
+            })
         })
         .collect::<Vec<_>>();
+    if models_with_mappings.is_empty() {
+        let public_models = app
+            .list_public_global_models(&PublicGlobalModelQuery {
+                offset: 0,
+                limit: ADMIN_PROVIDER_MAPPING_PREVIEW_FETCH_LIMIT,
+                is_active: None,
+                search: None,
+            })
+            .await
+            .ok()
+            .unwrap_or_else(|| {
+                aether_data_contracts::repository::global_models::StoredPublicGlobalModelPage {
+                    items: Vec::new(),
+                    total: 0,
+                }
+            })
+            .items;
+        models_with_mappings = public_models
+            .into_iter()
+            .filter_map(|model| {
+                let mappings = global_model_mapping_patterns_from_config(model.config.as_ref());
+                (!mappings.is_empty()).then_some(MappingPreviewGlobalModel {
+                    id: model.id,
+                    name: model.name.clone(),
+                    display_name: model.display_name.unwrap_or(model.name),
+                    is_active: model.is_active,
+                    mappings,
+                })
+            })
+            .collect::<Vec<_>>();
+    }
     let total_models_with_mappings = models_with_mappings.len();
     let truncated_models =
         total_models_with_mappings.saturating_sub(ADMIN_PROVIDER_MAPPING_PREVIEW_MAX_MODELS);
@@ -263,10 +309,10 @@ pub(crate) async fn build_admin_provider_mapping_preview_payload(
         }
 
         let mut matching_global_models = Vec::new();
-        for (global_model, mappings) in &models_with_mappings {
+        for global_model in &models_with_mappings {
             let mut matched_models = Vec::new();
             for allowed_model in &allowed_models {
-                for mapping_pattern in mappings {
+                for mapping_pattern in &global_model.mappings {
                     if matches_model_mapping_for_models(mapping_pattern, allowed_model) {
                         matched_models.push(json!({
                             "allowed_model": allowed_model,
@@ -281,10 +327,7 @@ pub(crate) async fn build_admin_provider_mapping_preview_payload(
                 matching_global_models.push(json!({
                     "global_model_id": global_model.id,
                     "global_model_name": global_model.name,
-                    "display_name": global_model
-                        .display_name
-                        .clone()
-                        .unwrap_or_else(|| global_model.name.clone()),
+                    "display_name": global_model.display_name,
                     "is_active": global_model.is_active,
                     "matched_models": matched_models,
                 }));

--- a/apps/aether-gateway/src/handlers/public/support/models/shared.rs
+++ b/apps/aether-gateway/src/handlers/public/support/models/shared.rs
@@ -1,7 +1,7 @@
 use aether_data_contracts::repository::candidate_selection::{
     StoredMinimalCandidateSelectionRow, StoredProviderModelMapping,
 };
-use regex::Regex;
+use aether_scheduler_core::matches_model_mapping;
 
 use super::GatewayPublicRequestContext;
 
@@ -103,10 +103,7 @@ fn candidate_model_names_for_models(
 }
 
 pub(crate) fn matches_model_mapping_for_models(pattern: &str, model_name: &str) -> bool {
-    let Ok(compiled) = Regex::new(&format!("^(?:{pattern})$")) else {
-        return false;
-    };
-    compiled.is_match(model_name)
+    matches_model_mapping(pattern, model_name)
 }
 
 fn row_exposes_global_model_for_models(

--- a/apps/aether-gateway/src/tests/control/admin/models/global.rs
+++ b/apps/aether-gateway/src/tests/control/admin/models/global.rs
@@ -619,8 +619,16 @@ async fn gateway_handles_admin_global_model_routing_locally_with_trusted_admin_p
         None,
         None,
     );
+    let unlinked_provider = sample_provider("provider-unlinked", "shadow", 30).with_billing_fields(
+        Some("quota".to_string()),
+        Some(30.0),
+        Some(6.0),
+        None,
+        None,
+        None,
+    );
     let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
-        vec![openai_provider, alt_provider],
+        vec![openai_provider, alt_provider, unlinked_provider],
         vec![
             sample_endpoint(
                 "endpoint-openai-chat",
@@ -633,6 +641,12 @@ async fn gateway_handles_admin_global_model_routing_locally_with_trusted_admin_p
                 "provider-alt",
                 "openai:chat",
                 "https://api.alt.example",
+            ),
+            sample_endpoint(
+                "endpoint-unlinked-chat",
+                "provider-unlinked",
+                "openai:chat",
+                "https://api.shadow.example",
             ),
         ],
         {
@@ -668,7 +682,17 @@ async fn gateway_handles_admin_global_model_routing_locally_with_trusted_admin_p
             mapped_key.allowed_models = Some(json!(["gpt-5-upstream"]));
             mapped_key.rpm_limit = Some(120);
 
-            vec![primary_key, mapped_key]
+            let mut unlinked_key = sample_key(
+                "key-unlinked-routing",
+                "provider-unlinked",
+                "openai:chat",
+                "sk-unlinked-routing-9999",
+            );
+            unlinked_key.name = "unlinked".to_string();
+            unlinked_key.internal_priority = 40;
+            unlinked_key.allowed_models = Some(json!(["gpt-5-upstream-shadow"]));
+
+            vec![primary_key, mapped_key, unlinked_key]
         },
     ));
     let global_model_repository = Arc::new(
@@ -774,13 +798,16 @@ async fn gateway_handles_admin_global_model_routing_locally_with_trusted_admin_p
     let whitelist = payload["all_keys_whitelist"]
         .as_array()
         .expect("whitelist array");
-    assert_eq!(whitelist.len(), 2);
+    assert_eq!(whitelist.len(), 3);
     assert!(whitelist
         .iter()
         .any(|item| item["key_id"] == "key-openai-routing"));
     assert!(whitelist
         .iter()
         .any(|item| item["key_id"] == "key-alt-routing"));
+    assert!(whitelist
+        .iter()
+        .any(|item| item["key_id"] == "key-unlinked-routing"));
     assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
 
     gateway_handle.abort();

--- a/crates/aether-scheduler-core/src/model.rs
+++ b/crates/aether-scheduler-core/src/model.rs
@@ -4,7 +4,7 @@ use aether_data_contracts::repository::candidate_selection::{
     StoredMinimalCandidateSelectionRow, StoredProviderModelMapping,
 };
 use aether_data_contracts::DataLayerError;
-use regex::Regex;
+use regex::RegexBuilder;
 
 pub fn resolve_requested_global_model_name(
     rows: &[StoredMinimalCandidateSelectionRow],
@@ -201,7 +201,15 @@ fn capabilities_support_required_capability(
 }
 
 pub fn matches_model_mapping(pattern: &str, model_name: &str) -> bool {
-    let Ok(compiled) = Regex::new(&format!("^(?:{pattern})$")) else {
+    if pattern.eq_ignore_ascii_case(model_name) {
+        return true;
+    }
+
+    let regex_pattern = format!("^(?:{pattern})$");
+    let Ok(compiled) = RegexBuilder::new(&regex_pattern)
+        .case_insensitive(true)
+        .build()
+    else {
         return false;
     };
     compiled.is_match(model_name)
@@ -252,4 +260,26 @@ pub fn extract_global_priority_for_format(
 
 pub fn normalize_api_format(value: &str) -> String {
     value.trim().to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::matches_model_mapping;
+
+    #[test]
+    fn model_mapping_match_is_case_insensitive() {
+        assert!(matches_model_mapping("gpt-4o", "GPT-4O"));
+        assert!(matches_model_mapping("gpt-5(?:\\.\\d+)?", "GPT-5.1"));
+    }
+
+    #[test]
+    fn model_mapping_match_is_anchored_to_full_text() {
+        assert!(matches_model_mapping("gpt-4o", "gpt-4o"));
+        assert!(!matches_model_mapping("gpt-4o", "gpt-4o-mini"));
+    }
+
+    #[test]
+    fn invalid_model_mapping_pattern_returns_false() {
+        assert!(!matches_model_mapping("([a-z", "gpt-4o"));
+    }
 }


### PR DESCRIPTION
- scheduler_core: `matches_model_mapping` 改为大小写不敏感且整串匹配，并补充单测
- global model routing 预览:
  - Key 过滤增加与 Python 一致的 `allowed_models + model_mappings` 校验
  - `all_keys_whitelist` 改为收集全站活跃 Provider 的活跃 Key 白名单
- provider mapping-preview:
  - 优先使用 admin 全量 GlobalModel（含非激活）参与映射
  - admin 数据为空时回退 public 模型，保持兼容
- public models 匹配逻辑统一复用 scheduler_core 实现，避免行为分叉
- 更新网关测试，覆盖未关联 Provider 的 Key 也进入 whitelist 的场景