### PR TITLE
fix(kiro,pool,model): 对齐 Kiro 管理链路并修复全局模型删除行为

### DIFF
--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/import.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/import.rs
@@ -94,6 +94,12 @@ pub(super) async fn handle_admin_provider_oauth_import_refresh_token(
             "该 Provider 不是固定类型，无法使用 provider-oauth",
         ));
     }
+    if provider_type == "kiro" {
+        return Ok(build_internal_control_error_response(
+            http::StatusCode::BAD_REQUEST,
+            "Kiro 不支持单条 Refresh Token 导入，请使用批量导入或设备授权。",
+        ));
+    }
     let Some(template) = admin_provider_oauth_template(&provider_type) else {
         return Ok(build_admin_provider_oauth_backend_unavailable_response());
     };

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/provisioning.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/provisioning.rs
@@ -83,6 +83,15 @@ pub(crate) async fn create_provider_oauth_catalog_key(
     proxy: Option<serde_json::Value>,
     expires_at_unix_secs: Option<u64>,
 ) -> Result<Option<StoredProviderCatalogKey>, GatewayError> {
+    let auth_type = if auth_config
+        .get("provider_type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|value| value.eq_ignore_ascii_case("kiro"))
+    {
+        "bearer"
+    } else {
+        "oauth"
+    };
     let Some(encrypted_api_key) = state.encrypt_catalog_secret_with_fallbacks(access_token) else {
         return Ok(None);
     };
@@ -102,7 +111,7 @@ pub(crate) async fn create_provider_oauth_catalog_key(
         Uuid::new_v4().to_string(),
         provider_id.to_string(),
         name.to_string(),
-        "oauth".to_string(),
+        auth_type.to_string(),
         None,
         true,
     )
@@ -157,6 +166,13 @@ pub(crate) async fn update_existing_provider_oauth_catalog_key(
         .map(|duration| duration.as_secs())
         .unwrap_or(0);
     let mut updated = existing_key.clone();
+    if auth_config
+        .get("provider_type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|value| value.eq_ignore_ascii_case("kiro"))
+    {
+        updated.auth_type = "bearer".to_string();
+    }
     updated.encrypted_api_key = encrypted_api_key;
     updated.encrypted_auth_config = Some(encrypted_auth_config);
     updated.is_active = true;

--- a/apps/aether-gateway/src/handlers/admin/provider/pool/config.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/pool/config.rs
@@ -53,6 +53,7 @@ pub(crate) fn admin_provider_pool_config(
     let Some(pool_advanced) = raw_pool_advanced.as_object() else {
         return Some(AdminProviderPoolConfig {
             lru_enabled: false,
+            skip_exhausted_accounts: false,
             cost_window_seconds: 18_000,
             cost_limit_per_key_tokens: None,
         });
@@ -60,6 +61,10 @@ pub(crate) fn admin_provider_pool_config(
 
     Some(AdminProviderPoolConfig {
         lru_enabled: admin_provider_pool_lru_enabled(pool_advanced),
+        skip_exhausted_accounts: pool_advanced
+            .get("skip_exhausted_accounts")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
         cost_window_seconds: pool_advanced
             .get("cost_window_seconds")
             .and_then(json_u64)
@@ -69,4 +74,58 @@ pub(crate) fn admin_provider_pool_config(
             .get("cost_limit_per_key_tokens")
             .and_then(json_u64),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::admin_provider_pool_config;
+    use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogProvider;
+    use serde_json::json;
+
+    fn sample_provider(config: serde_json::Value) -> StoredProviderCatalogProvider {
+        StoredProviderCatalogProvider::new(
+            "provider-1".to_string(),
+            "provider-1".to_string(),
+            Some("https://example.com".to_string()),
+            "codex".to_string(),
+        )
+        .expect("provider should build")
+        .with_transport_fields(
+            true,
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(config),
+        )
+    }
+
+    #[test]
+    fn defaults_skip_exhausted_accounts_to_false() {
+        let provider = sample_provider(json!({ "pool_advanced": {} }));
+        let config = admin_provider_pool_config(&provider).expect("pool config should exist");
+
+        assert!(!config.skip_exhausted_accounts);
+    }
+
+    #[test]
+    fn parses_skip_exhausted_accounts_from_pool_advanced() {
+        let provider = sample_provider(json!({
+            "pool_advanced": {
+                "skip_exhausted_accounts": true,
+                "lru_enabled": true,
+                "cost_window_seconds": 7200,
+                "cost_limit_per_key_tokens": 12000
+            }
+        }));
+        let config = admin_provider_pool_config(&provider).expect("pool config should exist");
+
+        assert!(config.skip_exhausted_accounts);
+        assert!(config.lru_enabled);
+        assert_eq!(config.cost_window_seconds, 7200);
+        assert_eq!(config.cost_limit_per_key_tokens, Some(12_000));
+    }
 }

--- a/apps/aether-gateway/src/handlers/admin/provider/pool_admin/payloads.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/pool_admin/payloads.rs
@@ -3,6 +3,7 @@ use crate::handlers::admin::provider::shared::support::{
 };
 use crate::handlers::admin::request::AdminAppState;
 use crate::handlers::admin::shared::{provider_key_status_snapshot_payload, unix_secs_to_rfc3339};
+use aether_admin::provider::pool as admin_provider_pool_pure;
 use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogKey;
 use serde_json::json;
 
@@ -551,6 +552,7 @@ fn admin_pool_scheduling_payload(
     cooldown_ttl_seconds: Option<u64>,
     health_score: f64,
     circuit_breaker_open: bool,
+    account_quota_exhausted: bool,
 ) -> (String, String, String, Vec<serde_json::Value>) {
     if !key.is_active {
         return (
@@ -562,6 +564,21 @@ fn admin_pool_scheduling_payload(
                 "label": "已禁用",
                 "blocking": true,
                 "source": "manual",
+                "ttl_seconds": serde_json::Value::Null,
+                "detail": serde_json::Value::Null,
+            })],
+        );
+    }
+    if account_quota_exhausted {
+        return (
+            "blocked".to_string(),
+            "account_quota_exhausted".to_string(),
+            "额度耗尽".to_string(),
+            vec![json!({
+                "code": "account_quota_exhausted",
+                "label": "额度耗尽",
+                "blocking": true,
+                "source": "quota",
                 "ttl_seconds": serde_json::Value::Null,
                 "detail": serde_json::Value::Null,
             })],
@@ -632,6 +649,8 @@ pub(super) fn build_admin_pool_key_payload(
         .and_then(|_| runtime.cooldown_ttl_by_key.get(&key.id).copied());
     let health_score = admin_pool_health_score(key);
     let circuit_breaker_open = admin_pool_circuit_breaker_open(key);
+    let account_quota_exhausted = pool_config.is_some_and(|config| config.skip_exhausted_accounts)
+        && admin_provider_pool_pure::admin_pool_key_account_quota_exhausted(key, provider_type);
     let (scheduling_status, scheduling_reason, scheduling_label, scheduling_reasons) =
         admin_pool_scheduling_payload(
             key,
@@ -639,6 +658,7 @@ pub(super) fn build_admin_pool_key_payload(
             cooldown_ttl_seconds,
             health_score,
             circuit_breaker_open,
+            account_quota_exhausted,
         );
     let auth_config = state.parse_catalog_auth_config_json(key);
     let oauth_expires_at = admin_pool_derive_oauth_expires_at(key, auth_config.as_ref());

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
@@ -1,17 +1,29 @@
 use super::payload::{
     provider_query_extract_api_key_id, provider_query_extract_force_refresh,
-    provider_query_extract_provider_id,
+    provider_query_extract_model, provider_query_extract_provider_id,
+    provider_query_extract_request_id,
 };
 use super::response::{
     build_admin_provider_query_bad_request_response, build_admin_provider_query_not_found_response,
-    ADMIN_PROVIDER_QUERY_API_KEY_NOT_FOUND_DETAIL, ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
+    ADMIN_PROVIDER_QUERY_API_KEY_NOT_FOUND_DETAIL, ADMIN_PROVIDER_QUERY_MODEL_REQUIRED_DETAIL,
+    ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL, ADMIN_PROVIDER_QUERY_NO_LOCAL_MODELS_DETAIL,
     ADMIN_PROVIDER_QUERY_PROVIDER_ID_REQUIRED_DETAIL,
     ADMIN_PROVIDER_QUERY_PROVIDER_NOT_FOUND_DETAIL,
 };
+use crate::ai_pipeline::{maybe_build_sync_finalize_outcome, GatewayControlDecision};
 use crate::execution_runtime;
 use crate::handlers::admin::request::AdminAppState;
 use crate::model_fetch::ModelFetchRuntimeState;
+use crate::provider_transport::kiro::{
+    build_kiro_generate_assistant_response_url, build_kiro_provider_headers,
+    build_kiro_provider_request_body, supports_local_kiro_request_transport_with_network,
+    KiroProviderHeadersInput, KIRO_ENVELOPE_NAME,
+};
+use crate::usage::GatewaySyncReportRequest;
 use crate::{AppState, GatewayError};
+use aether_admin::provider::pool as admin_provider_pool_pure;
+use aether_contracts::{ExecutionPlan, RequestBody};
+use aether_data_contracts::repository::global_models::AdminProviderModelListQuery;
 use aether_data_contracts::repository::provider_catalog::{
     StoredProviderCatalogEndpoint, StoredProviderCatalogKey, StoredProviderCatalogProvider,
 };
@@ -19,9 +31,16 @@ use aether_model_fetch::{
     aggregate_models_for_cache, fetch_models_from_transports, json_string_list,
     preset_models_for_provider, selected_models_fetch_endpoints,
 };
-use axum::{body::Body, http::Response, response::IntoResponse, Json};
+use axum::{
+    body::{to_bytes, Body},
+    http::{HeaderMap, HeaderName, HeaderValue},
+    response::{IntoResponse, Response},
+    Json,
+};
+use base64::Engine as _;
 use serde_json::{json, Value};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+use uuid::Uuid;
 
 pub(crate) const ADMIN_PROVIDER_QUERY_LOCAL_TEST_MODEL_MESSAGE: &str =
     "Rust local provider-query model test is not configured";
@@ -32,7 +51,10 @@ const ADMIN_PROVIDER_QUERY_NO_ACTIVE_ENDPOINT_DETAIL: &str =
 const ADMIN_PROVIDER_QUERY_NO_MODELS_FROM_ENDPOINT_DETAIL: &str =
     "No models returned from any endpoint";
 const ADMIN_PROVIDER_QUERY_NO_MODELS_FROM_KEY_DETAIL: &str = "No models returned from any key";
+const ADMIN_PROVIDER_QUERY_NO_ACTIVE_TEST_CANDIDATE_DETAIL: &str =
+    "No active endpoint or API key found";
 const ANTIGRAVITY_PROVIDER_CACHE_KEY_PREFIX: &str = "upstream_models_provider:";
+const DEFAULT_PROVIDER_QUERY_TEST_MESSAGE: &str = "Hello! This is a test message.";
 
 #[derive(Debug)]
 struct ProviderQueryKeyFetchResult {
@@ -42,12 +64,800 @@ struct ProviderQueryKeyFetchResult {
     has_success: bool,
 }
 
+#[derive(Debug, Clone)]
+struct ProviderQueryTestCandidate {
+    endpoint: StoredProviderCatalogEndpoint,
+    key: StoredProviderCatalogKey,
+    effective_model: String,
+}
+
+#[derive(Debug, Clone)]
+struct ProviderQueryTestAttempt {
+    candidate_index: usize,
+    endpoint_api_format: String,
+    endpoint_base_url: String,
+    key_name: String,
+    key_id: String,
+    auth_type: String,
+    effective_model: String,
+    status: &'static str,
+    skip_reason: Option<String>,
+    error_message: Option<String>,
+    status_code: Option<u16>,
+    latency_ms: Option<u64>,
+    request_url: Option<String>,
+    request_headers: Option<BTreeMap<String, String>>,
+    request_body: Option<Value>,
+    response_headers: Option<BTreeMap<String, String>>,
+    response_body: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+struct ProviderQueryExecutionOutcome {
+    status: &'static str,
+    error_message: Option<String>,
+    status_code: Option<u16>,
+    latency_ms: Option<u64>,
+    request_url: String,
+    request_headers: BTreeMap<String, String>,
+    request_body: Value,
+    response_headers: BTreeMap<String, String>,
+    response_body: Option<Value>,
+}
+
 fn provider_query_provider_payload(provider: &StoredProviderCatalogProvider) -> Value {
     json!({
         "id": provider.id.clone(),
         "name": provider.name.clone(),
         "display_name": provider.name.clone(),
     })
+}
+
+fn provider_query_test_mode(payload: &Value) -> &str {
+    payload
+        .get("mode")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("global")
+}
+
+fn provider_query_extract_endpoint_id(payload: &Value) -> Option<String> {
+    payload
+        .get("endpoint_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn provider_query_extract_api_format(payload: &Value) -> Option<String> {
+    payload
+        .get("api_format")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn provider_query_extract_message(payload: &Value) -> Option<String> {
+    payload
+        .get("message")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn provider_query_extract_request_body(payload: &Value) -> Option<Value> {
+    payload
+        .get("request_body")
+        .filter(|value| value.is_object())
+        .cloned()
+}
+
+fn provider_query_extract_request_headers(payload: &Value) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    let Some(values) = payload.get("request_headers").and_then(Value::as_object) else {
+        return headers;
+    };
+    for (key, value) in values {
+        let key = key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        let Some(value) = (match value {
+            Value::String(value) => Some(value.trim().to_string()),
+            Value::Bool(value) => Some(value.to_string()),
+            Value::Number(value) => Some(value.to_string()),
+            other => serde_json::to_string(other).ok(),
+        }) else {
+            continue;
+        };
+        if value.is_empty() {
+            continue;
+        }
+        let Ok(name) = HeaderName::from_bytes(key.as_bytes()) else {
+            continue;
+        };
+        let Ok(value) = HeaderValue::from_str(&value) else {
+            continue;
+        };
+        headers.insert(name, value);
+    }
+    headers
+}
+
+fn provider_query_build_test_request_body(payload: &Value, model: &str) -> Value {
+    if let Some(mut body) = provider_query_extract_request_body(payload) {
+        if let Some(object) = body.as_object_mut() {
+            object.insert("model".to_string(), Value::String(model.to_string()));
+        }
+        return body;
+    }
+
+    json!({
+        "model": model,
+        "messages": [{
+            "role": "user",
+            "content": provider_query_extract_message(payload)
+                .unwrap_or_else(|| DEFAULT_PROVIDER_QUERY_TEST_MESSAGE.to_string())
+        }],
+        "max_tokens": 30,
+        "temperature": 0.7,
+        "stream": true,
+    })
+}
+
+fn provider_query_select_kiro_endpoint<'a>(
+    endpoints: &'a [StoredProviderCatalogEndpoint],
+    endpoint_id: Option<&str>,
+    api_format: Option<&str>,
+) -> Result<Option<&'a StoredProviderCatalogEndpoint>, &'static str> {
+    if let Some(endpoint_id) = endpoint_id {
+        let endpoint = endpoints.iter().find(|endpoint| endpoint.id == endpoint_id);
+        return endpoint
+            .ok_or("Endpoint not found")
+            .map(|endpoint| Some(endpoint));
+    }
+
+    if let Some(api_format) = api_format {
+        let endpoint = endpoints.iter().find(|endpoint| {
+            endpoint.is_active && endpoint.api_format.trim().eq_ignore_ascii_case(api_format)
+        });
+        return Ok(endpoint);
+    }
+
+    Ok(endpoints.iter().find(|endpoint| endpoint.is_active))
+}
+
+fn provider_query_key_supports_endpoint(
+    key: &StoredProviderCatalogKey,
+    endpoint_api_format: &str,
+) -> bool {
+    let formats = json_string_list(key.api_formats.as_ref());
+    formats.is_empty()
+        || formats
+            .iter()
+            .any(|value| value.eq_ignore_ascii_case(endpoint_api_format))
+}
+
+fn provider_query_test_key_sort_key(
+    provider_type: &str,
+    key: &StoredProviderCatalogKey,
+    endpoint_api_format: &str,
+) -> (u8, u8, i32, u64, i32) {
+    let quota_exhausted =
+        admin_provider_pool_pure::admin_pool_key_account_quota_exhausted(key, provider_type);
+    let circuit_open = key
+        .circuit_breaker_by_format
+        .as_ref()
+        .and_then(Value::as_object)
+        .and_then(|value| value.get(endpoint_api_format))
+        .and_then(Value::as_object)
+        .and_then(|value| value.get("open"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let health_score = key
+        .health_by_format
+        .as_ref()
+        .and_then(Value::as_object)
+        .and_then(|value| value.get(endpoint_api_format))
+        .and_then(Value::as_object)
+        .and_then(|value| value.get("health_score"))
+        .and_then(Value::as_f64)
+        .unwrap_or(1.0);
+    let consecutive_failures = key
+        .health_by_format
+        .as_ref()
+        .and_then(Value::as_object)
+        .and_then(|value| value.get(endpoint_api_format))
+        .and_then(Value::as_object)
+        .and_then(|value| value.get("consecutive_failures"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let normalized_health = (health_score.clamp(0.0, 1.0) * 1000.0).round() as i32;
+
+    (
+        if quota_exhausted { 1 } else { 0 },
+        if circuit_open { 1 } else { 0 },
+        -normalized_health,
+        consecutive_failures,
+        key.internal_priority,
+    )
+}
+
+async fn provider_query_resolve_global_effective_model(
+    state: &AdminAppState<'_>,
+    provider_id: &str,
+    requested_model: &str,
+) -> Result<String, GatewayError> {
+    let models = state
+        .list_admin_provider_models(&AdminProviderModelListQuery {
+            provider_id: provider_id.to_string(),
+            is_active: Some(true),
+            offset: 0,
+            limit: 1024,
+        })
+        .await
+        .unwrap_or_default();
+
+    Ok(models
+        .into_iter()
+        .find(|model| {
+            model.is_available
+                && model
+                    .global_model_name
+                    .as_deref()
+                    .is_some_and(|value| value.eq_ignore_ascii_case(requested_model))
+        })
+        .map(|model| model.provider_model_name)
+        .unwrap_or_else(|| requested_model.to_string()))
+}
+
+async fn provider_query_build_kiro_test_candidates(
+    state: &AdminAppState<'_>,
+    provider: &StoredProviderCatalogProvider,
+    payload: &Value,
+) -> Result<Vec<ProviderQueryTestCandidate>, Response<Body>> {
+    let provider_ids = vec![provider.id.clone()];
+    let endpoints = state
+        .app()
+        .list_provider_catalog_endpoints_by_provider_ids(&provider_ids)
+        .await
+        .map_err(|_| {
+            build_admin_provider_query_bad_request_response(
+                ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
+            )
+        })?;
+    let endpoint = match provider_query_select_kiro_endpoint(
+        &endpoints,
+        provider_query_extract_endpoint_id(payload).as_deref(),
+        provider_query_extract_api_format(payload).as_deref(),
+    ) {
+        Ok(Some(endpoint)) => endpoint.clone(),
+        Ok(None) => {
+            return Err(build_admin_provider_query_not_found_response(
+                ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
+            ));
+        }
+        Err("Endpoint not found") => {
+            return Err(build_admin_provider_query_not_found_response(
+                ADMIN_PROVIDER_QUERY_API_KEY_NOT_FOUND_DETAIL,
+            ));
+        }
+        Err(_) => {
+            return Err(build_admin_provider_query_not_found_response(
+                ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
+            ));
+        }
+    };
+
+    let all_keys = state
+        .app()
+        .list_provider_catalog_keys_by_provider_ids(&provider_ids)
+        .await
+        .map_err(|_| {
+            build_admin_provider_query_bad_request_response(
+                ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
+            )
+        })?;
+
+    let selected_key_id = provider_query_extract_api_key_id(payload);
+    if let Some(api_key_id) = selected_key_id.as_deref() {
+        let Some(key) = all_keys.iter().find(|key| key.id == api_key_id) else {
+            return Err(build_admin_provider_query_not_found_response(
+                ADMIN_PROVIDER_QUERY_API_KEY_NOT_FOUND_DETAIL,
+            ));
+        };
+        if !key.is_active || !provider_query_key_supports_endpoint(key, &endpoint.api_format) {
+            return Err(build_admin_provider_query_not_found_response(
+                ADMIN_PROVIDER_QUERY_NO_ACTIVE_TEST_CANDIDATE_DETAIL,
+            ));
+        }
+    }
+
+    let requested_model = provider_query_extract_model(payload).ok_or_else(|| {
+        build_admin_provider_query_bad_request_response(ADMIN_PROVIDER_QUERY_MODEL_REQUIRED_DETAIL)
+    })?;
+    let effective_model = if provider_query_test_mode(payload).eq_ignore_ascii_case("direct") {
+        requested_model.clone()
+    } else {
+        provider_query_resolve_global_effective_model(state, &provider.id, &requested_model)
+            .await
+            .unwrap_or(requested_model.clone())
+    };
+
+    let mut keys = all_keys
+        .into_iter()
+        .filter(|key| key.is_active)
+        .filter(|key| {
+            selected_key_id
+                .as_deref()
+                .is_none_or(|value| value == key.id.as_str())
+        })
+        .filter(|key| provider_query_key_supports_endpoint(key, &endpoint.api_format))
+        .collect::<Vec<_>>();
+    keys.sort_by_key(|key| {
+        provider_query_test_key_sort_key(provider.provider_type.as_str(), key, &endpoint.api_format)
+    });
+
+    let candidates = keys
+        .into_iter()
+        .map(|key| ProviderQueryTestCandidate {
+            endpoint: endpoint.clone(),
+            key,
+            effective_model: effective_model.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    if candidates.is_empty() {
+        return Err(build_admin_provider_query_not_found_response(
+            ADMIN_PROVIDER_QUERY_NO_ACTIVE_TEST_CANDIDATE_DETAIL,
+        ));
+    }
+
+    Ok(candidates)
+}
+
+fn provider_query_decode_execution_body(
+    result: &aether_contracts::ExecutionResult,
+) -> Option<Vec<u8>> {
+    result
+        .body
+        .as_ref()
+        .and_then(|body| body.body_bytes_b64.as_deref())
+        .and_then(|value| base64::engine::general_purpose::STANDARD.decode(value).ok())
+}
+
+fn provider_query_extract_error_message(
+    result: &aether_contracts::ExecutionResult,
+) -> Option<String> {
+    result
+        .body
+        .as_ref()
+        .and_then(|body| body.json_body.as_ref())
+        .and_then(Value::as_object)
+        .and_then(|value| {
+            value
+                .get("error")
+                .and_then(Value::as_object)
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+                .or_else(|| value.get("message").and_then(Value::as_str))
+        })
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            provider_query_decode_execution_body(result)
+                .and_then(|bytes| String::from_utf8(bytes).ok())
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+        .or_else(|| {
+            result
+                .error
+                .as_ref()
+                .map(|error| error.message.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+}
+
+async fn provider_query_finalize_kiro_result(
+    route_path: &str,
+    trace_id: &str,
+    requested_model: &str,
+    endpoint_api_format: &str,
+    effective_model: &str,
+    original_request_body: &Value,
+    result: &aether_contracts::ExecutionResult,
+) -> Result<Option<Value>, GatewayError> {
+    let decision = GatewayControlDecision::synthetic(
+        route_path,
+        Some("admin_proxy".to_string()),
+        Some("provider_query_manage".to_string()),
+        Some("test_model_failover".to_string()),
+        Some(endpoint_api_format.to_string()),
+    );
+    let payload = GatewaySyncReportRequest {
+        trace_id: trace_id.to_string(),
+        report_kind: "claude_cli_sync_finalize".to_string(),
+        report_context: Some(json!({
+            "client_api_format": endpoint_api_format,
+            "provider_api_format": endpoint_api_format,
+            "model": requested_model,
+            "mapped_model": effective_model,
+            "needs_conversion": false,
+            "has_envelope": true,
+            "envelope_name": KIRO_ENVELOPE_NAME,
+            "original_request_body": original_request_body,
+        })),
+        status_code: result.status_code,
+        headers: result.headers.clone(),
+        body_json: result.body.as_ref().and_then(|body| body.json_body.clone()),
+        client_body_json: None,
+        body_base64: result
+            .body
+            .as_ref()
+            .and_then(|body| body.body_bytes_b64.clone()),
+        telemetry: result.telemetry.clone(),
+    };
+
+    let Some(outcome) = maybe_build_sync_finalize_outcome(trace_id, &decision, &payload)? else {
+        return Ok(None);
+    };
+    let bytes = to_bytes(outcome.response.into_body(), usize::MAX)
+        .await
+        .map_err(|err| GatewayError::Internal(err.to_string()))?;
+    serde_json::from_slice::<Value>(&bytes)
+        .map(Some)
+        .map_err(|err| GatewayError::Internal(err.to_string()))
+}
+
+async fn provider_query_execute_kiro_test_candidate(
+    state: &AdminAppState<'_>,
+    provider: &StoredProviderCatalogProvider,
+    candidate: &ProviderQueryTestCandidate,
+    payload: &Value,
+    route_path: &str,
+    trace_id: &str,
+    requested_model: &str,
+) -> Result<ProviderQueryExecutionOutcome, GatewayError> {
+    let Some(transport) = state
+        .read_provider_transport_snapshot(&provider.id, &candidate.endpoint.id, &candidate.key.id)
+        .await?
+    else {
+        return Ok(ProviderQueryExecutionOutcome {
+            status: "skipped",
+            error_message: None,
+            status_code: None,
+            latency_ms: None,
+            request_url: String::new(),
+            request_headers: BTreeMap::new(),
+            request_body: Value::Null,
+            response_headers: BTreeMap::new(),
+            response_body: None,
+        });
+    };
+
+    if !supports_local_kiro_request_transport_with_network(&transport) {
+        return Ok(ProviderQueryExecutionOutcome {
+            status: "skipped",
+            error_message: None,
+            status_code: None,
+            latency_ms: None,
+            request_url: String::new(),
+            request_headers: BTreeMap::new(),
+            request_body: Value::Null,
+            response_headers: BTreeMap::new(),
+            response_body: None,
+        });
+    }
+
+    let Some(kiro_auth) = state
+        .resolve_local_oauth_kiro_request_auth(&transport)
+        .await?
+    else {
+        return Ok(ProviderQueryExecutionOutcome {
+            status: "failed",
+            error_message: Some("oauth auth failed".to_string()),
+            status_code: None,
+            latency_ms: None,
+            request_url: String::new(),
+            request_headers: BTreeMap::new(),
+            request_body: Value::Null,
+            response_headers: BTreeMap::new(),
+            response_body: None,
+        });
+    };
+
+    let request_body = provider_query_build_test_request_body(payload, &candidate.effective_model);
+    let provider_request_body = match build_kiro_provider_request_body(
+        &request_body,
+        &candidate.effective_model,
+        &kiro_auth.auth_config,
+        transport.endpoint.body_rules.as_ref(),
+    ) {
+        Some(body) => body,
+        None => {
+            return Ok(ProviderQueryExecutionOutcome {
+                status: "failed",
+                error_message: Some("provider request body build failed".to_string()),
+                status_code: None,
+                latency_ms: None,
+                request_url: String::new(),
+                request_headers: BTreeMap::new(),
+                request_body,
+                response_headers: BTreeMap::new(),
+                response_body: None,
+            });
+        }
+    };
+
+    let mut synthetic_request = http::Request::builder()
+        .uri(route_path)
+        .body(())
+        .map_err(|err| GatewayError::Internal(err.to_string()))?;
+    *synthetic_request.headers_mut() = provider_query_extract_request_headers(payload);
+    let (parts, _) = synthetic_request.into_parts();
+
+    let request_url = build_kiro_generate_assistant_response_url(
+        &transport.endpoint.base_url,
+        parts.uri.query(),
+        Some(kiro_auth.auth_config.effective_api_region()),
+    )
+    .ok_or_else(|| GatewayError::Internal("kiro request url is unavailable".to_string()))?;
+    let request_headers = build_kiro_provider_headers(KiroProviderHeadersInput {
+        headers: &parts.headers,
+        provider_request_body: &provider_request_body,
+        original_request_body: &request_body,
+        header_rules: transport.endpoint.header_rules.as_ref(),
+        auth_header: &kiro_auth.name,
+        auth_value: &kiro_auth.value,
+        auth_config: &kiro_auth.auth_config,
+        machine_id: kiro_auth.machine_id.as_str(),
+    })
+    .ok_or_else(|| GatewayError::Internal("kiro request headers are unavailable".to_string()))?;
+
+    let plan = ExecutionPlan {
+        request_id: trace_id.to_string(),
+        candidate_id: Some(format!("provider-query-{}", candidate.key.id)),
+        provider_name: Some(provider.name.clone()),
+        provider_id: provider.id.clone(),
+        endpoint_id: candidate.endpoint.id.clone(),
+        key_id: candidate.key.id.clone(),
+        method: "POST".to_string(),
+        url: request_url.clone(),
+        headers: request_headers.clone(),
+        content_type: Some("application/json".to_string()),
+        content_encoding: None,
+        body: RequestBody::from_json(provider_request_body.clone()),
+        stream: true,
+        client_api_format: candidate.endpoint.api_format.clone(),
+        provider_api_format: candidate.endpoint.api_format.clone(),
+        model_name: Some(candidate.effective_model.clone()),
+        proxy: state
+            .resolve_transport_proxy_snapshot_with_tunnel_affinity(&transport)
+            .await,
+        tls_profile: state.resolve_transport_tls_profile(&transport),
+        timeouts: state.resolve_transport_execution_timeouts(&transport),
+    };
+
+    let result = state
+        .execute_execution_runtime_sync_plan(Some(trace_id), &plan)
+        .await?;
+    let response_body = if result.status_code < 400 {
+        provider_query_finalize_kiro_result(
+            route_path,
+            trace_id,
+            requested_model,
+            candidate.endpoint.api_format.as_str(),
+            candidate.effective_model.as_str(),
+            &request_body,
+            &result,
+        )
+        .await?
+    } else {
+        result.body.as_ref().and_then(|body| body.json_body.clone())
+    };
+    let error_message = if result.status_code >= 400 {
+        provider_query_extract_error_message(&result)
+    } else if response_body.is_none()
+        && provider_query_decode_execution_body(&result)
+            .is_some_and(|body| crate::ai_pipeline::stream_body_contains_error_event(&body))
+    {
+        Some("Kiro upstream returned embedded stream error".to_string())
+    } else {
+        None
+    };
+
+    Ok(ProviderQueryExecutionOutcome {
+        status: if error_message.is_some() {
+            "failed"
+        } else {
+            "success"
+        },
+        error_message,
+        status_code: Some(result.status_code),
+        latency_ms: result.telemetry.as_ref().and_then(|value| value.elapsed_ms),
+        request_url,
+        request_headers,
+        request_body: provider_request_body,
+        response_headers: result.headers,
+        response_body,
+    })
+}
+
+fn provider_query_test_attempt_payload(
+    candidate_index: usize,
+    candidate: &ProviderQueryTestCandidate,
+    execution: &ProviderQueryExecutionOutcome,
+) -> Value {
+    json!({
+        "candidate_index": candidate_index,
+        "retry_index": 0,
+        "endpoint_api_format": candidate.endpoint.api_format,
+        "endpoint_base_url": candidate.endpoint.base_url,
+        "key_name": provider_query_key_display_name(&candidate.key),
+        "key_id": candidate.key.id,
+        "auth_type": candidate.key.auth_type,
+        "effective_model": candidate.effective_model,
+        "status": execution.status,
+        "skip_reason": Value::Null,
+        "error_message": execution.error_message,
+        "status_code": execution.status_code,
+        "latency_ms": execution.latency_ms,
+        "request_url": execution.request_url,
+        "request_headers": execution.request_headers,
+        "request_body": execution.request_body,
+        "response_headers": execution.response_headers,
+        "response_body": execution.response_body,
+    })
+}
+
+async fn build_admin_provider_query_kiro_failover_response(
+    state: &AdminAppState<'_>,
+    payload: &Value,
+    route_path: &str,
+) -> Result<Response<Body>, GatewayError> {
+    let Some(provider_id) = provider_query_extract_provider_id(payload) else {
+        return Ok(build_admin_provider_query_bad_request_response(
+            ADMIN_PROVIDER_QUERY_PROVIDER_ID_REQUIRED_DETAIL,
+        ));
+    };
+    let requested_model = match provider_query_extract_model(payload) {
+        Some(model) => model,
+        None => {
+            return Ok(build_admin_provider_query_bad_request_response(
+                ADMIN_PROVIDER_QUERY_MODEL_REQUIRED_DETAIL,
+            ));
+        }
+    };
+    let Some(provider) = state
+        .app()
+        .read_provider_catalog_providers_by_ids(std::slice::from_ref(&provider_id))
+        .await?
+        .into_iter()
+        .find(|item| item.id == provider_id)
+    else {
+        return Ok(build_admin_provider_query_not_found_response(
+            ADMIN_PROVIDER_QUERY_PROVIDER_NOT_FOUND_DETAIL,
+        ));
+    };
+    if !provider.provider_type.trim().eq_ignore_ascii_case("kiro") {
+        return Ok(build_admin_provider_query_test_model_failover_response(
+            provider_id,
+            super::payload::provider_query_extract_failover_models(payload),
+        ));
+    }
+
+    let candidates =
+        match provider_query_build_kiro_test_candidates(state, &provider, payload).await {
+            Ok(candidates) => candidates,
+            Err(response) => return Ok(response),
+        };
+    let trace_id = provider_query_extract_request_id(payload)
+        .unwrap_or_else(|| format!("provider-query-test-{}", Uuid::new_v4().simple()));
+    let mut attempts = Vec::new();
+    let mut total_attempts = 0usize;
+    let mut success_body = None;
+
+    for (candidate_index, candidate) in candidates.iter().enumerate() {
+        let execution = provider_query_execute_kiro_test_candidate(
+            state,
+            &provider,
+            candidate,
+            payload,
+            route_path,
+            &trace_id,
+            &requested_model,
+        )
+        .await?;
+        if execution.status != "skipped" {
+            total_attempts += 1;
+        }
+        let is_success = execution.status == "success";
+        let response_body = execution.response_body.clone();
+        attempts.push(provider_query_test_attempt_payload(
+            candidate_index,
+            candidate,
+            &execution,
+        ));
+        if is_success {
+            success_body = response_body;
+            break;
+        }
+    }
+
+    let success = success_body.is_some();
+    let error = if success {
+        Value::Null
+    } else {
+        attempts
+            .iter()
+            .rev()
+            .find_map(|attempt| {
+                attempt
+                    .get("error_message")
+                    .cloned()
+                    .filter(|value| !value.is_null())
+            })
+            .unwrap_or_else(|| json!(ADMIN_PROVIDER_QUERY_NO_LOCAL_MODELS_DETAIL))
+    };
+
+    Ok(Json(json!({
+        "success": success,
+        "model": requested_model,
+        "provider": provider_query_provider_payload(&provider),
+        "attempts": attempts,
+        "total_candidates": candidates.len(),
+        "total_attempts": total_attempts,
+        "data": success_body.as_ref().map(|body| json!({
+            "stream": true,
+            "response": body,
+        })),
+        "error": error,
+    }))
+    .into_response())
+}
+
+pub(crate) async fn build_admin_provider_query_test_model_local_response(
+    state: &AdminAppState<'_>,
+    payload: &Value,
+) -> Result<Response<Body>, GatewayError> {
+    let response = build_admin_provider_query_kiro_failover_response(
+        state,
+        payload,
+        "/api/admin/provider-query/test-model",
+    )
+    .await?;
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .map_err(|err| GatewayError::Internal(err.to_string()))?;
+    let parsed: Value =
+        serde_json::from_slice(&body).map_err(|err| GatewayError::Internal(err.to_string()))?;
+
+    Ok(Json(json!({
+        "success": parsed.get("success").cloned().unwrap_or(Value::Bool(false)),
+        "error": parsed.get("error").cloned().unwrap_or(Value::Null),
+        "data": parsed.get("data").cloned().unwrap_or(Value::Null),
+        "provider": parsed.get("provider").cloned().unwrap_or(Value::Null),
+        "model": parsed.get("model").cloned().unwrap_or(Value::Null),
+    }))
+    .into_response())
+}
+
+pub(crate) async fn build_admin_provider_query_test_model_failover_local_response(
+    state: &AdminAppState<'_>,
+    payload: &Value,
+) -> Result<Response<Body>, GatewayError> {
+    build_admin_provider_query_kiro_failover_response(
+        state,
+        payload,
+        "/api/admin/provider-query/test-model-failover",
+    )
+    .await
 }
 
 fn provider_query_key_display_name(key: &StoredProviderCatalogKey) -> String {

--- a/apps/aether-gateway/src/handlers/admin/provider/shared/support.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/shared/support.rs
@@ -13,6 +13,7 @@ pub(crate) const ADMIN_PROVIDER_OAUTH_DATA_UNAVAILABLE_DETAIL: &str =
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct AdminProviderPoolConfig {
     pub(crate) lru_enabled: bool,
+    pub(crate) skip_exhausted_accounts: bool,
     pub(crate) cost_window_seconds: u64,
     pub(crate) cost_limit_per_key_tokens: Option<u64>,
 }

--- a/apps/aether-gateway/src/handlers/admin/provider/write/normalize.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/write/normalize.rs
@@ -13,8 +13,8 @@ pub(crate) fn normalize_provider_type_input(value: &str) -> Result<String, Strin
 pub(crate) fn normalize_auth_type(value: Option<&str>) -> Result<String, String> {
     let auth_type = value.unwrap_or("api_key").trim().to_ascii_lowercase();
     match auth_type.as_str() {
-        "api_key" | "service_account" | "oauth" => Ok(auth_type),
-        _ => Err("auth_type 仅支持 api_key / service_account / oauth".to_string()),
+        "api_key" | "service_account" | "oauth" | "bearer" => Ok(auth_type),
+        _ => Err("auth_type 仅支持 api_key / service_account / oauth / bearer".to_string()),
     }
 }
 
@@ -63,7 +63,7 @@ pub(crate) fn validate_vertex_api_formats(
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_pool_advanced_config;
+    use super::{normalize_auth_type, normalize_pool_advanced_config};
     use serde_json::json;
 
     #[test]
@@ -83,6 +83,14 @@ mod tests {
         assert_eq!(
             normalize_pool_advanced_config(Some(json!(false))).unwrap_err(),
             "pool_advanced 必须是 JSON 对象"
+        );
+    }
+
+    #[test]
+    fn normalize_auth_type_supports_bearer() {
+        assert_eq!(
+            normalize_auth_type(Some("bearer")).expect("bearer should normalize"),
+            "bearer"
         );
     }
 }

--- a/apps/aether-gateway/src/handlers/admin/request/provider/routes/query.rs
+++ b/apps/aether-gateway/src/handlers/admin/request/provider/routes/query.rs
@@ -1,7 +1,9 @@
 use crate::handlers::admin::provider::query::{
     models::{
         build_admin_provider_query_models_response,
+        build_admin_provider_query_test_model_failover_local_response,
         build_admin_provider_query_test_model_failover_response,
+        build_admin_provider_query_test_model_local_response,
         build_admin_provider_query_test_model_response,
     },
     payload::{
@@ -78,10 +80,25 @@ impl<'a> AdminAppState<'a> {
                         ADMIN_PROVIDER_QUERY_MODEL_REQUIRED_DETAIL,
                     )));
                 };
-                Ok(Some(build_admin_provider_query_test_model_response(
-                    provider_id,
-                    model,
-                )))
+                let provider_type = self
+                    .app()
+                    .read_provider_catalog_providers_by_ids(std::slice::from_ref(&provider_id))
+                    .await?
+                    .into_iter()
+                    .find(|provider| provider.id == provider_id)
+                    .map(|provider| provider.provider_type)
+                    .unwrap_or_default();
+                if provider_type.trim().eq_ignore_ascii_case("kiro") {
+                    Ok(Some(
+                        build_admin_provider_query_test_model_local_response(self, &payload)
+                            .await?,
+                    ))
+                } else {
+                    Ok(Some(build_admin_provider_query_test_model_response(
+                        provider_id,
+                        model,
+                    )))
+                }
             }
             "test_model_failover" => {
                 let Some(provider_id) = provider_query_extract_provider_id(&payload) else {
@@ -107,12 +124,29 @@ impl<'a> AdminAppState<'a> {
                         ADMIN_PROVIDER_QUERY_FAILOVER_MODELS_REQUIRED_DETAIL,
                     )));
                 }
-                Ok(Some(
-                    build_admin_provider_query_test_model_failover_response(
-                        provider_id,
-                        failover_models,
-                    ),
-                ))
+                let provider_type = self
+                    .app()
+                    .read_provider_catalog_providers_by_ids(std::slice::from_ref(&provider_id))
+                    .await?
+                    .into_iter()
+                    .find(|provider| provider.id == provider_id)
+                    .map(|provider| provider.provider_type)
+                    .unwrap_or_default();
+                if provider_type.trim().eq_ignore_ascii_case("kiro") {
+                    Ok(Some(
+                        build_admin_provider_query_test_model_failover_local_response(
+                            self, &payload,
+                        )
+                        .await?,
+                    ))
+                } else {
+                    Ok(Some(
+                        build_admin_provider_query_test_model_failover_response(
+                            provider_id,
+                            failover_models,
+                        ),
+                    ))
+                }
             }
             _ => Ok(Some(
                 build_admin_provider_query_models_response(self, &payload).await?,

--- a/apps/aether-gateway/src/scheduler/candidate/runtime.rs
+++ b/apps/aether-gateway/src/scheduler/candidate/runtime.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use aether_admin::provider::pool as admin_provider_pool_pure;
 use aether_data_contracts::repository::candidates::StoredRequestCandidate;
 use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogKey;
 use aether_scheduler_core::{
@@ -20,6 +21,7 @@ pub(super) struct CandidateRuntimeSelectionSnapshot {
     pub(super) provider_concurrent_limits: BTreeMap<String, usize>,
     pub(super) provider_key_rpm_states: BTreeMap<String, StoredProviderCatalogKey>,
     provider_quota_blocks_requests: BTreeMap<String, bool>,
+    key_account_quota_exhausted: BTreeMap<String, bool>,
     provider_key_rpm_reset_ats: BTreeMap<String, Option<u64>>,
 }
 
@@ -30,7 +32,14 @@ pub(super) async fn read_candidate_runtime_selection_snapshot(
 ) -> Result<CandidateRuntimeSelectionSnapshot, GatewayError> {
     let recent_candidates = state.read_recent_request_candidates(128).await?;
     let provider_concurrent_limits = read_provider_concurrent_limits(state, candidates).await?;
+    let provider_skip_exhausted_accounts =
+        read_provider_skip_exhausted_account_map(state, candidates).await?;
     let provider_key_rpm_states = read_provider_key_rpm_states(state, candidates).await?;
+    let key_account_quota_exhausted = read_key_account_quota_exhaustion_map(
+        candidates,
+        &provider_key_rpm_states,
+        &provider_skip_exhausted_accounts,
+    );
     let provider_quota_blocks_requests =
         read_provider_quota_block_map(state, candidates, now_unix_secs).await?;
     let provider_key_rpm_reset_ats =
@@ -41,6 +50,7 @@ pub(super) async fn read_candidate_runtime_selection_snapshot(
         provider_concurrent_limits,
         provider_key_rpm_states,
         provider_quota_blocks_requests,
+        key_account_quota_exhausted,
         provider_key_rpm_reset_ats,
     })
 }
@@ -89,6 +99,11 @@ pub(super) fn is_candidate_selectable(
             .get(candidate.provider_id.as_str())
             .copied()
             .unwrap_or(false),
+        account_quota_exhausted: snapshot
+            .key_account_quota_exhausted
+            .get(candidate.key_id.as_str())
+            .copied()
+            .unwrap_or(false),
         rpm_reset_at: snapshot
             .provider_key_rpm_reset_ats
             .get(candidate.key_id.as_str())
@@ -122,6 +137,11 @@ pub(super) fn current_candidate_runtime_skip_reason(
         now_unix_secs,
         cached_affinity_target,
         provider_quota_blocks_requests,
+        account_quota_exhausted: snapshot
+            .key_account_quota_exhausted
+            .get(candidate.key_id.as_str())
+            .copied()
+            .unwrap_or(false),
         rpm_reset_at,
     })
 }
@@ -190,6 +210,64 @@ async fn read_provider_quota_block_map(
     }
 
     Ok(quota_blocks)
+}
+
+async fn read_provider_skip_exhausted_account_map(
+    state: &(impl SchedulerRuntimeState + ?Sized),
+    candidates: &[SchedulerMinimalCandidateSelectionCandidate],
+) -> Result<BTreeMap<String, bool>, GatewayError> {
+    let provider_ids = candidates
+        .iter()
+        .map(|candidate| candidate.provider_id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if provider_ids.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let providers = state
+        .read_provider_catalog_providers_by_ids(&provider_ids)
+        .await?;
+    Ok(providers
+        .into_iter()
+        .map(|provider| {
+            let skip_exhausted_accounts = provider
+                .config
+                .as_ref()
+                .and_then(|value| value.get("pool_advanced"))
+                .and_then(serde_json::Value::as_object)
+                .and_then(|value| value.get("skip_exhausted_accounts"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            (provider.id, skip_exhausted_accounts)
+        })
+        .collect())
+}
+
+fn read_key_account_quota_exhaustion_map(
+    candidates: &[SchedulerMinimalCandidateSelectionCandidate],
+    provider_key_rpm_states: &BTreeMap<String, StoredProviderCatalogKey>,
+    provider_skip_exhausted_accounts: &BTreeMap<String, bool>,
+) -> BTreeMap<String, bool> {
+    candidates
+        .iter()
+        .map(|candidate| {
+            let exhausted = provider_skip_exhausted_accounts
+                .get(candidate.provider_id.as_str())
+                .copied()
+                .unwrap_or(false)
+                && provider_key_rpm_states
+                    .get(candidate.key_id.as_str())
+                    .is_some_and(|key| {
+                        admin_provider_pool_pure::admin_pool_key_account_quota_exhausted(
+                            key,
+                            candidate.provider_type.as_str(),
+                        )
+                    });
+            (candidate.key_id.clone(), exhausted)
+        })
+        .collect()
 }
 
 fn read_provider_key_rpm_reset_at_map(

--- a/apps/aether-gateway/src/scheduler/candidate/tests/selection.rs
+++ b/apps/aether-gateway/src/scheduler/candidate/tests/selection.rs
@@ -1141,6 +1141,253 @@ async fn exposes_runtime_skipped_candidates_with_skip_reasons() {
 }
 
 #[tokio::test]
+async fn skips_codex_candidate_when_account_quota_is_exhausted_and_pool_flag_enabled() {
+    let mut first = sample_row();
+    first.provider_id = "provider-codex".to_string();
+    first.provider_name = "codex".to_string();
+    first.provider_type = "codex".to_string();
+    first.endpoint_id = "endpoint-codex".to_string();
+    first.endpoint_api_format = "openai:cli".to_string();
+    first.key_id = "key-codex".to_string();
+    first.key_name = "codex-exhausted".to_string();
+    first.key_auth_type = "oauth".to_string();
+    first.key_api_formats = Some(vec!["openai:cli".to_string()]);
+    first.key_global_priority_by_format = Some(serde_json::json!({"openai:cli": 1}));
+
+    let mut second = sample_row();
+    second.provider_id = "provider-openai".to_string();
+    second.provider_name = "openai".to_string();
+    second.endpoint_id = "endpoint-openai".to_string();
+    second.endpoint_api_format = "openai:cli".to_string();
+    second.key_id = "key-openai".to_string();
+    second.key_name = "fallback".to_string();
+    second.key_api_formats = Some(vec!["openai:cli".to_string()]);
+    second.key_global_priority_by_format = Some(serde_json::json!({"openai:cli": 2}));
+
+    let candidates = Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed(vec![
+        first, second,
+    ]));
+    let mut codex_provider = sample_provider("provider-codex", None);
+    codex_provider.provider_type = "codex".to_string();
+    codex_provider.config = Some(serde_json::json!({
+        "pool_advanced": {
+            "skip_exhausted_accounts": true
+        }
+    }));
+    let provider_catalog = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![codex_provider, sample_provider("provider-openai", None)],
+        Vec::new(),
+        vec![
+            {
+                let mut key = sample_key("key-codex", "provider-codex", Some(10));
+                key.auth_type = "oauth".to_string();
+                key.upstream_metadata = Some(serde_json::json!({
+                    "codex": {
+                        "secondary_used_percent": 100.0
+                    }
+                }));
+                key
+            },
+            sample_key("key-openai", "provider-openai", Some(10)),
+        ],
+    ));
+    let quotas = Arc::new(InMemoryProviderQuotaRepository::seed(vec![]));
+    let request_candidates = Arc::new(InMemoryRequestCandidateRepository::seed(vec![]));
+    let state = AppState::new()
+        .expect("state should build")
+        .with_data_state_for_tests(
+            GatewayDataState::with_candidate_selection_provider_catalog_quota_and_request_candidates_for_tests(
+                candidates,
+                provider_catalog,
+                quotas,
+                request_candidates,
+            ),
+        );
+
+    let (selected, skipped) = collect_selectable_candidates_with_skip_reasons(
+        state.data.as_ref(),
+        &state,
+        "openai:cli",
+        "gpt-4.1",
+        false,
+        None,
+        100,
+    )
+    .await
+    .expect("selection should succeed");
+
+    assert_eq!(selected.len(), 1);
+    assert_eq!(selected[0].provider_id, "provider-openai");
+    assert_eq!(skipped.len(), 1);
+    assert_eq!(skipped[0].candidate.provider_id, "provider-codex");
+    assert_eq!(skipped[0].skip_reason, "account_quota_exhausted");
+}
+
+#[tokio::test]
+async fn keeps_codex_candidate_selectable_when_exhausted_account_flag_is_disabled() {
+    let mut first = sample_row();
+    first.provider_id = "provider-codex".to_string();
+    first.provider_name = "codex".to_string();
+    first.provider_type = "codex".to_string();
+    first.endpoint_id = "endpoint-codex".to_string();
+    first.endpoint_api_format = "openai:cli".to_string();
+    first.key_id = "key-codex".to_string();
+    first.key_name = "codex-exhausted".to_string();
+    first.key_auth_type = "oauth".to_string();
+    first.key_api_formats = Some(vec!["openai:cli".to_string()]);
+    first.key_global_priority_by_format = Some(serde_json::json!({"openai:cli": 1}));
+
+    let mut second = sample_row();
+    second.provider_id = "provider-openai".to_string();
+    second.provider_name = "openai".to_string();
+    second.endpoint_id = "endpoint-openai".to_string();
+    second.endpoint_api_format = "openai:cli".to_string();
+    second.key_id = "key-openai".to_string();
+    second.key_name = "fallback".to_string();
+    second.key_api_formats = Some(vec!["openai:cli".to_string()]);
+    second.key_global_priority_by_format = Some(serde_json::json!({"openai:cli": 2}));
+
+    let candidates = Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed(vec![
+        first, second,
+    ]));
+    let mut codex_provider = sample_provider("provider-codex", None);
+    codex_provider.provider_type = "codex".to_string();
+    codex_provider.config = Some(serde_json::json!({
+        "pool_advanced": {}
+    }));
+    let provider_catalog = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![codex_provider, sample_provider("provider-openai", None)],
+        Vec::new(),
+        vec![
+            {
+                let mut key = sample_key("key-codex", "provider-codex", Some(10));
+                key.auth_type = "oauth".to_string();
+                key.upstream_metadata = Some(serde_json::json!({
+                    "codex": {
+                        "secondary_used_percent": 100.0
+                    }
+                }));
+                key
+            },
+            sample_key("key-openai", "provider-openai", Some(10)),
+        ],
+    ));
+    let quotas = Arc::new(InMemoryProviderQuotaRepository::seed(vec![]));
+    let request_candidates = Arc::new(InMemoryRequestCandidateRepository::seed(vec![]));
+    let state = AppState::new()
+        .expect("state should build")
+        .with_data_state_for_tests(
+            GatewayDataState::with_candidate_selection_provider_catalog_quota_and_request_candidates_for_tests(
+                candidates,
+                provider_catalog,
+                quotas,
+                request_candidates,
+            ),
+        );
+
+    let (selected, skipped) = collect_selectable_candidates_with_skip_reasons(
+        state.data.as_ref(),
+        &state,
+        "openai:cli",
+        "gpt-4.1",
+        false,
+        None,
+        100,
+    )
+    .await
+    .expect("selection should succeed");
+
+    assert_eq!(selected.len(), 2);
+    assert!(selected
+        .iter()
+        .any(|candidate| candidate.provider_id == "provider-codex"));
+    assert!(skipped.is_empty());
+}
+
+#[tokio::test]
+async fn skips_kiro_candidate_when_account_quota_is_exhausted_and_pool_flag_enabled() {
+    let mut first = sample_row();
+    first.provider_id = "provider-kiro".to_string();
+    first.provider_name = "kiro".to_string();
+    first.provider_type = "kiro".to_string();
+    first.endpoint_id = "endpoint-kiro".to_string();
+    first.endpoint_api_format = "claude:cli".to_string();
+    first.key_id = "key-kiro".to_string();
+    first.key_name = "kiro-exhausted".to_string();
+    first.key_auth_type = "oauth".to_string();
+    first.key_api_formats = Some(vec!["claude:cli".to_string()]);
+    first.key_global_priority_by_format = Some(serde_json::json!({"claude:cli": 1}));
+
+    let mut second = sample_row();
+    second.provider_id = "provider-openai".to_string();
+    second.provider_name = "openai".to_string();
+    second.endpoint_id = "endpoint-openai".to_string();
+    second.endpoint_api_format = "claude:cli".to_string();
+    second.key_id = "key-openai".to_string();
+    second.key_name = "fallback".to_string();
+    second.key_api_formats = Some(vec!["claude:cli".to_string()]);
+    second.key_global_priority_by_format = Some(serde_json::json!({"claude:cli": 2}));
+
+    let candidates = Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed(vec![
+        first, second,
+    ]));
+    let mut kiro_provider = sample_provider("provider-kiro", None);
+    kiro_provider.provider_type = "kiro".to_string();
+    kiro_provider.config = Some(serde_json::json!({
+        "pool_advanced": {
+            "skip_exhausted_accounts": true
+        }
+    }));
+    let provider_catalog = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![kiro_provider, sample_provider("provider-openai", None)],
+        Vec::new(),
+        vec![
+            {
+                let mut key = sample_key("key-kiro", "provider-kiro", Some(10));
+                key.auth_type = "oauth".to_string();
+                key.upstream_metadata = Some(serde_json::json!({
+                    "kiro": {
+                        "remaining": 0
+                    }
+                }));
+                key
+            },
+            sample_key("key-openai", "provider-openai", Some(10)),
+        ],
+    ));
+    let quotas = Arc::new(InMemoryProviderQuotaRepository::seed(vec![]));
+    let request_candidates = Arc::new(InMemoryRequestCandidateRepository::seed(vec![]));
+    let state = AppState::new()
+        .expect("state should build")
+        .with_data_state_for_tests(
+            GatewayDataState::with_candidate_selection_provider_catalog_quota_and_request_candidates_for_tests(
+                candidates,
+                provider_catalog,
+                quotas,
+                request_candidates,
+            ),
+        );
+
+    let (selected, skipped) = collect_selectable_candidates_with_skip_reasons(
+        state.data.as_ref(),
+        &state,
+        "claude:cli",
+        "gpt-4.1",
+        false,
+        None,
+        100,
+    )
+    .await
+    .expect("selection should succeed");
+
+    assert_eq!(selected.len(), 1);
+    assert_eq!(selected[0].provider_id, "provider-openai");
+    assert_eq!(skipped.len(), 1);
+    assert_eq!(skipped[0].candidate.provider_id, "provider-kiro");
+    assert_eq!(skipped[0].skip_reason, "account_quota_exhausted");
+}
+
+#[tokio::test]
 async fn same_priority_candidates_prefer_healthier_provider_key_before_id_order() {
     let mut first = sample_row();
     first.provider_id = "provider-a".to_string();

--- a/apps/aether-gateway/src/tests/control/admin/models/global.rs
+++ b/apps/aether-gateway/src/tests/control/admin/models/global.rs
@@ -1028,6 +1028,82 @@ async fn gateway_batch_deletes_admin_global_models_locally_with_trusted_admin_pr
 }
 
 #[tokio::test]
+async fn gateway_deletes_admin_global_model_with_bound_provider_models_locally() {
+    let upstream_hits = Arc::new(Mutex::new(0usize));
+    let upstream_hits_clone = Arc::clone(&upstream_hits);
+    let upstream = Router::new().route(
+        "/api/admin/models/global/global-gpt-5",
+        any(move |_request: Request| {
+            let upstream_hits_inner = Arc::clone(&upstream_hits_clone);
+            async move {
+                *upstream_hits_inner.lock().expect("mutex should lock") += 1;
+                (StatusCode::OK, Body::from("unexpected upstream hit"))
+            }
+        }),
+    );
+
+    let global_model_repository = Arc::new(
+        InMemoryGlobalModelReadRepository::seed(Vec::new())
+            .with_admin_global_models(vec![sample_admin_global_model(
+                "global-gpt-5",
+                "gpt-5",
+                "GPT 5",
+            )])
+            .with_admin_provider_models(vec![sample_admin_provider_model(
+                "model-openai-gpt5",
+                "provider-openai",
+                "global-gpt-5",
+                "gpt-5-upstream",
+            )]),
+    );
+
+    let (upstream_url, upstream_handle) = start_server(upstream).await;
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(
+                GatewayDataState::disabled()
+                    .with_global_model_repository_for_tests(global_model_repository.clone()),
+            ),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .delete(format!(
+            "{gateway_url}/api/admin/models/global/global-gpt-5"
+        ))
+        .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    let deleted = global_model_repository
+        .get_admin_global_model_by_id("global-gpt-5")
+        .await
+        .expect("model lookup should succeed");
+    assert!(deleted.is_none());
+    let provider_models = global_model_repository
+        .list_admin_provider_models(&AdminProviderModelListQuery {
+            provider_id: "provider-openai".to_string(),
+            is_active: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("provider models should read");
+    assert!(provider_models.is_empty());
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_assigns_admin_global_model_to_providers_locally_with_trusted_admin_principal() {
     let upstream_hits = Arc::new(Mutex::new(0usize));
     let upstream_hits_clone = Arc::clone(&upstream_hits);

--- a/apps/aether-gateway/src/tests/control/admin/oauth.rs
+++ b/apps/aether-gateway/src/tests/control/admin/oauth.rs
@@ -1793,6 +1793,51 @@ async fn gateway_imports_admin_provider_oauth_refresh_token_locally_with_trusted
 }
 
 #[tokio::test]
+async fn gateway_rejects_kiro_single_refresh_token_import_with_clear_error() {
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![{
+            let mut provider = sample_provider("provider-kiro", "kiro", 10);
+            provider.provider_type = "kiro".to_string();
+            provider
+        }],
+        vec![sample_endpoint(
+            "endpoint-kiro-chat",
+            "provider-kiro",
+            "kiro:generateAssistantResponse",
+            "https://service.kiro.dev",
+        )],
+        Vec::new(),
+    ));
+    let state = AppState::new()
+        .expect("gateway should build")
+        .with_data_state_for_tests(GatewayDataState::with_provider_catalog_reader_for_tests(
+            provider_catalog_repository,
+        ));
+
+    let response = local_admin_provider_oauth_response(
+        &state,
+        http::Method::POST,
+        "/api/admin/provider-oauth/providers/provider-kiro/import-refresh-token",
+        Some(json!({
+            "refresh_token": "kiro-refresh-token"
+        })),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let payload: serde_json::Value = serde_json::from_slice(
+        &to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should read"),
+    )
+    .expect("json body should parse");
+    assert_eq!(
+        payload["detail"],
+        json!("Kiro 不支持单条 Refresh Token 导入，请使用批量导入或设备授权。")
+    );
+}
+
+#[tokio::test]
 async fn gateway_imports_admin_provider_oauth_refresh_token_via_execution_runtime_proxy_node() {
     let execution_plans = Arc::new(Mutex::new(Vec::<ExecutionPlan>::new()));
     let execution_plans_clone = Arc::clone(&execution_plans);

--- a/apps/aether-gateway/src/tests/control/admin/pool.rs
+++ b/apps/aether-gateway/src/tests/control/admin/pool.rs
@@ -1110,6 +1110,162 @@ async fn gateway_formats_codex_quota_countdown_from_reset_after_seconds() {
 }
 
 #[tokio::test]
+async fn gateway_marks_exhausted_codex_pool_key_as_blocked_when_flag_enabled() {
+    let mut provider = sample_provider("provider-codex", "codex", 10).with_transport_fields(
+        true,
+        false,
+        true,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(json!({
+            "pool_advanced": {
+                "enabled": true,
+                "skip_exhausted_accounts": true
+            }
+        })),
+    );
+    provider.provider_type = "codex".to_string();
+
+    let mut key = sample_key(
+        "key-codex-exhausted",
+        "provider-codex",
+        "openai:cli",
+        "oauth-placeholder",
+    );
+    key.name = "codex exhausted".to_string();
+    key.auth_type = "oauth".to_string();
+    key.upstream_metadata = Some(json!({
+        "codex": {
+            "secondary_used_percent": 100.0,
+            "plan_type": "plus"
+        }
+    }));
+
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        Vec::new(),
+        vec![key],
+    ));
+    let state = AppState::new()
+        .expect("gateway should build")
+        .with_data_state_for_tests(GatewayDataState::with_provider_catalog_reader_for_tests(
+            provider_catalog_repository,
+        ));
+
+    let response = local_admin_pool_response(
+        &state,
+        http::Method::GET,
+        "/api/admin/pool/provider-codex/keys?page=1&page_size=50&status=all",
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = serde_json::from_slice(
+        &to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should read"),
+    )
+    .expect("json body should parse");
+    let keys = payload["keys"].as_array().expect("keys should be array");
+
+    assert_eq!(keys[0]["scheduling_status"], json!("blocked"));
+    assert_eq!(
+        keys[0]["scheduling_reason"],
+        json!("account_quota_exhausted")
+    );
+    assert_eq!(keys[0]["scheduling_label"], json!("额度耗尽"));
+    assert_eq!(
+        keys[0]["scheduling_reasons"][0],
+        json!({
+            "code": "account_quota_exhausted",
+            "label": "额度耗尽",
+            "blocking": true,
+            "source": "quota",
+            "ttl_seconds": serde_json::Value::Null,
+            "detail": serde_json::Value::Null,
+        })
+    );
+    assert_eq!(keys[0]["account_quota"], json!("5H剩余 0.0%"));
+}
+
+#[tokio::test]
+async fn gateway_marks_exhausted_kiro_pool_key_as_blocked_when_flag_enabled() {
+    let mut provider = sample_provider("provider-kiro", "kiro", 10).with_transport_fields(
+        true,
+        false,
+        true,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(json!({
+            "pool_advanced": {
+                "enabled": true,
+                "skip_exhausted_accounts": true
+            }
+        })),
+    );
+    provider.provider_type = "kiro".to_string();
+
+    let mut key = sample_key(
+        "key-kiro-exhausted",
+        "provider-kiro",
+        "claude:cli",
+        "oauth-placeholder",
+    );
+    key.name = "kiro exhausted".to_string();
+    key.auth_type = "oauth".to_string();
+    key.upstream_metadata = Some(json!({
+        "kiro": {
+            "remaining": 0.0,
+            "usage_limit": 100.0,
+            "current_usage": 100.0
+        }
+    }));
+
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        Vec::new(),
+        vec![key],
+    ));
+    let state = AppState::new()
+        .expect("gateway should build")
+        .with_data_state_for_tests(GatewayDataState::with_provider_catalog_reader_for_tests(
+            provider_catalog_repository,
+        ));
+
+    let response = local_admin_pool_response(
+        &state,
+        http::Method::GET,
+        "/api/admin/pool/provider-kiro/keys?page=1&page_size=50&status=all",
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = serde_json::from_slice(
+        &to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body should read"),
+    )
+    .expect("json body should parse");
+    let keys = payload["keys"].as_array().expect("keys should be array");
+
+    assert_eq!(keys[0]["scheduling_status"], json!("blocked"));
+    assert_eq!(
+        keys[0]["scheduling_reason"],
+        json!("account_quota_exhausted")
+    );
+    assert_eq!(keys[0]["scheduling_label"], json!("额度耗尽"));
+    assert_eq!(keys[0]["account_quota"], json!("剩余 0/100"));
+}
+
+#[tokio::test]
 async fn gateway_codex_quota_resets_to_full_after_countdown_elapsed() {
     let mut provider = sample_provider("provider-codex", "codex", 10).with_transport_fields(
         true,

--- a/apps/aether-gateway/src/tests/control/admin/provider_query.rs
+++ b/apps/aether-gateway/src/tests/control/admin/provider_query.rs
@@ -7,6 +7,7 @@ use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogEn
 use axum::body::Body;
 use axum::routing::any;
 use axum::{extract::Request, Json, Router};
+use base64::Engine as _;
 use http::StatusCode;
 use serde_json::json;
 
@@ -19,6 +20,56 @@ use crate::constants::{
     TRUSTED_ADMIN_USER_ROLE_HEADER,
 };
 use crate::data::GatewayDataState;
+
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc = 0xffff_ffffu32;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            let mask = if crc & 1 == 1 { 0xedb8_8320 } else { 0 };
+            crc = (crc >> 1) ^ mask;
+        }
+    }
+    !crc
+}
+
+fn encode_string_header(name: &str, value: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push(name.len() as u8);
+    out.extend_from_slice(name.as_bytes());
+    out.push(7);
+    out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+    out.extend_from_slice(value.as_bytes());
+    out
+}
+
+fn encode_frame(headers: Vec<u8>, payload: Vec<u8>) -> Vec<u8> {
+    let total_len = 12 + headers.len() + payload.len() + 4;
+    let header_len = headers.len();
+    let mut out = Vec::with_capacity(total_len);
+    out.extend_from_slice(&(total_len as u32).to_be_bytes());
+    out.extend_from_slice(&(header_len as u32).to_be_bytes());
+    let prelude_crc = crc32(&out[..8]);
+    out.extend_from_slice(&prelude_crc.to_be_bytes());
+    out.extend_from_slice(&headers);
+    out.extend_from_slice(&payload);
+    let message_crc = crc32(&out);
+    out.extend_from_slice(&message_crc.to_be_bytes());
+    out
+}
+
+fn encode_kiro_event_frame(event_type: &str, payload: serde_json::Value) -> Vec<u8> {
+    let mut headers = encode_string_header(":message-type", "event");
+    headers.extend_from_slice(&encode_string_header(":event-type", event_type));
+    let payload = serde_json::to_vec(&payload).expect("payload should encode");
+    encode_frame(headers, payload)
+}
+
+fn encode_kiro_exception_frame(exception_type: &str) -> Vec<u8> {
+    let mut headers = encode_string_header(":message-type", "exception");
+    headers.extend_from_slice(&encode_string_header(":exception-type", exception_type));
+    encode_frame(headers, Vec::new())
+}
 
 async fn assert_admin_provider_query_route(
     path: &str,
@@ -674,6 +725,277 @@ async fn gateway_handles_admin_provider_query_test_model_failover_locally_with_t
         },
     )
     .await;
+}
+
+#[tokio::test]
+async fn gateway_handles_admin_provider_query_test_model_for_kiro_locally() {
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |Json(plan): Json<ExecutionPlan>| async move {
+            assert_eq!(plan.provider_id, "provider-kiro");
+            assert_eq!(plan.endpoint_id, "endpoint-kiro-cli");
+            assert_eq!(plan.key_id, "key-kiro-primary");
+            assert_eq!(plan.provider_api_format, "claude:cli");
+            assert_eq!(plan.model_name.as_deref(), Some("claude-sonnet-4-upstream"));
+            Json(json!({
+                "request_id": plan.request_id,
+                "candidate_id": plan.candidate_id,
+                "status_code": 200,
+                "headers": {
+                    "content-type": "application/vnd.amazon.eventstream"
+                },
+                "body": {
+                    "body_bytes_b64": base64::engine::general_purpose::STANDARD.encode(
+                        [
+                            encode_kiro_event_frame("assistantResponseEvent", json!({"content": "Hello from Kiro"})),
+                            encode_kiro_exception_frame("ContentLengthExceededException"),
+                        ]
+                        .concat()
+                    )
+                },
+                "telemetry": {
+                    "elapsed_ms": 42
+                }
+            }))
+        }),
+    );
+
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let mut provider = sample_provider("provider-kiro", "Kiro", 10);
+    provider.provider_type = "kiro".to_string();
+    let mut key = sample_key(
+        "key-kiro-primary",
+        "provider-kiro",
+        "claude:cli",
+        "__placeholder__",
+    );
+    key.auth_type = "oauth".to_string();
+    key.encrypted_auth_config = Some(
+        aether_crypto::encrypt_python_fernet_plaintext(
+            DEVELOPMENT_ENCRYPTION_KEY,
+            r#"{
+                "provider_type":"kiro",
+                "auth_method":"idc",
+                "access_token":"cached-kiro-token",
+                "refresh_token":"rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+                "machine_id":"123e4567-e89b-12d3-a456-426614174000",
+                "api_region":"us-east-1",
+                "client_id":"client-id",
+                "client_secret":"client-secret"
+            }"#,
+        )
+        .expect("auth config should encrypt"),
+    );
+
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![StoredProviderCatalogEndpoint::new(
+            "endpoint-kiro-cli".to_string(),
+            "provider-kiro".to_string(),
+            "claude:cli".to_string(),
+            Some("claude".to_string()),
+            Some("cli".to_string()),
+            true,
+        )
+        .expect("endpoint should build")
+        .with_transport_fields(
+            "https://q.{region}.amazonaws.com".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("endpoint transport should build")],
+        vec![key],
+    ));
+
+    let gateway = build_router_with_state(
+        build_state_with_execution_runtime_override(execution_runtime_url)
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/api/admin/provider-query/test-model"))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-kiro",
+            "model_name": "claude-sonnet-4-upstream",
+            "api_format": "claude:cli"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(payload["provider"]["id"], json!("provider-kiro"));
+    assert_eq!(payload["model"], json!("claude-sonnet-4-upstream"));
+    assert_eq!(
+        payload["data"]["response"]["content"][0]["text"],
+        json!("Hello from Kiro")
+    );
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_handles_admin_provider_query_test_model_failover_for_kiro_locally() {
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |Json(plan): Json<ExecutionPlan>| async move {
+            let payload = if plan.key_id == "key-kiro-first" {
+                json!({
+                    "request_id": plan.request_id,
+                    "candidate_id": plan.candidate_id,
+                    "status_code": 429,
+                    "headers": {
+                        "content-type": "application/json"
+                    },
+                    "body": {
+                        "json_body": {
+                            "message": "too many requests"
+                        }
+                    },
+                    "telemetry": {
+                        "elapsed_ms": 11
+                    }
+                })
+            } else {
+                json!({
+                    "request_id": plan.request_id,
+                    "candidate_id": plan.candidate_id,
+                    "status_code": 200,
+                    "headers": {
+                        "content-type": "application/vnd.amazon.eventstream"
+                    },
+                    "body": {
+                        "body_bytes_b64": base64::engine::general_purpose::STANDARD.encode(
+                            [
+                                encode_kiro_event_frame("assistantResponseEvent", json!({"content": "Recovered from failover"})),
+                                encode_kiro_exception_frame("ContentLengthExceededException"),
+                            ]
+                            .concat()
+                        )
+                    },
+                    "telemetry": {
+                        "elapsed_ms": 27
+                    }
+                })
+            };
+            Json(payload)
+        }),
+    );
+
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let mut provider = sample_provider("provider-kiro", "Kiro", 10);
+    provider.provider_type = "kiro".to_string();
+    let build_key = |id: &str| {
+        let mut key = sample_key(id, "provider-kiro", "claude:cli", "__placeholder__");
+        key.auth_type = "oauth".to_string();
+        key.encrypted_auth_config = Some(
+            aether_crypto::encrypt_python_fernet_plaintext(
+                DEVELOPMENT_ENCRYPTION_KEY,
+                r#"{
+                    "provider_type":"kiro",
+                    "auth_method":"idc",
+                    "access_token":"cached-kiro-token",
+                    "refresh_token":"rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+                    "machine_id":"123e4567-e89b-12d3-a456-426614174000",
+                    "api_region":"us-east-1",
+                    "client_id":"client-id",
+                    "client_secret":"client-secret"
+                }"#,
+            )
+            .expect("auth config should encrypt"),
+        );
+        key
+    };
+
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![StoredProviderCatalogEndpoint::new(
+            "endpoint-kiro-cli".to_string(),
+            "provider-kiro".to_string(),
+            "claude:cli".to_string(),
+            Some("claude".to_string()),
+            Some("cli".to_string()),
+            true,
+        )
+        .expect("endpoint should build")
+        .with_transport_fields(
+            "https://q.{region}.amazonaws.com".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("endpoint transport should build")],
+        vec![build_key("key-kiro-first"), build_key("key-kiro-second")],
+    ));
+
+    let gateway = build_router_with_state(
+        build_state_with_execution_runtime_override(execution_runtime_url)
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{gateway_url}/api/admin/provider-query/test-model-failover"
+        ))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-kiro",
+            "mode": "direct",
+            "model_name": "claude-sonnet-4-upstream",
+            "failover_models": ["claude-sonnet-4-upstream"],
+            "api_format": "claude:cli",
+            "request_id": "provider-test-kiro"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(payload["total_candidates"], json!(2));
+    assert_eq!(payload["total_attempts"], json!(2));
+    let attempts = payload["attempts"]
+        .as_array()
+        .expect("attempts should be an array");
+    assert_eq!(attempts.len(), 2);
+    assert_eq!(attempts[0]["status"], json!("failed"));
+    assert_eq!(attempts[0]["status_code"], json!(429));
+    assert_eq!(attempts[1]["status"], json!("success"));
+    assert_eq!(
+        payload["data"]["response"]["content"][0]["text"],
+        json!("Recovered from failover")
+    );
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
 }
 
 #[tokio::test]

--- a/crates/aether-admin/src/provider/pool.rs
+++ b/crates/aether-admin/src/provider/pool.rs
@@ -90,6 +90,81 @@ fn admin_pool_reason_indicates_ban(reason: &str) -> bool {
         .any(|hint| normalized.contains(hint))
 }
 
+fn admin_pool_metadata_bucket<'a>(
+    upstream_metadata: Option<&'a Value>,
+    provider_type: &str,
+) -> Option<&'a serde_json::Map<String, Value>> {
+    upstream_metadata
+        .and_then(Value::as_object)
+        .and_then(|metadata| metadata.get(&provider_type.trim().to_ascii_lowercase()))
+        .and_then(Value::as_object)
+}
+
+fn admin_pool_json_bool(value: Option<&Value>) -> Option<bool> {
+    match value {
+        Some(Value::Bool(value)) => Some(*value),
+        Some(Value::String(value)) => match value.trim().to_ascii_lowercase().as_str() {
+            "true" | "1" => Some(true),
+            "false" | "0" => Some(false),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn admin_pool_json_f64(value: Option<&Value>) -> Option<f64> {
+    match value {
+        Some(Value::Number(number)) => number.as_f64(),
+        Some(Value::String(value)) => value.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+    .filter(|value| value.is_finite())
+}
+
+pub fn admin_pool_key_account_quota_exhausted(
+    key: &StoredProviderCatalogKey,
+    provider_type: &str,
+) -> bool {
+    let provider_type = provider_type.trim().to_ascii_lowercase();
+    let Some(bucket) = admin_pool_metadata_bucket(key.upstream_metadata.as_ref(), &provider_type)
+    else {
+        return false;
+    };
+
+    match provider_type.as_str() {
+        "codex" => {
+            if admin_pool_json_bool(bucket.get("credits_unlimited")) == Some(true) {
+                return false;
+            }
+            if admin_pool_json_bool(bucket.get("has_credits")) == Some(false) {
+                return true;
+            }
+            admin_pool_json_f64(bucket.get("primary_used_percent"))
+                .is_some_and(|value| value >= 100.0)
+                || admin_pool_json_f64(bucket.get("secondary_used_percent"))
+                    .is_some_and(|value| value >= 100.0)
+        }
+        "kiro" => {
+            if admin_pool_json_f64(bucket.get("remaining")).is_some_and(|value| value <= 0.0) {
+                return true;
+            }
+            if admin_pool_json_f64(bucket.get("usage_percentage"))
+                .is_some_and(|value| value >= 100.0)
+            {
+                return true;
+            }
+            match (
+                admin_pool_json_f64(bucket.get("usage_limit")),
+                admin_pool_json_f64(bucket.get("current_usage")),
+            ) {
+                (Some(limit), Some(current)) if limit > 0.0 => current >= limit,
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
 fn admin_pool_has_proxy(key: &StoredProviderCatalogKey) -> bool {
     match key.proxy.as_ref() {
         Some(Value::Object(values)) => !values.is_empty(),
@@ -523,6 +598,102 @@ pub fn build_admin_pool_selection_payload(keys: &[StoredProviderCatalogKey]) -> 
         "total": items.len(),
         "items": items,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::admin_pool_key_account_quota_exhausted;
+    use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogKey;
+    use serde_json::json;
+
+    fn sample_key(upstream_metadata: Option<serde_json::Value>) -> StoredProviderCatalogKey {
+        let mut key = StoredProviderCatalogKey::new(
+            "key-1".to_string(),
+            "provider-1".to_string(),
+            "key-1".to_string(),
+            "oauth".to_string(),
+            None,
+            true,
+        )
+        .expect("key should build");
+        key.upstream_metadata = upstream_metadata;
+        key
+    }
+
+    #[test]
+    fn detects_codex_exhaustion_from_metadata() {
+        assert!(admin_pool_key_account_quota_exhausted(
+            &sample_key(Some(json!({
+                "codex": {
+                    "has_credits": false,
+                    "credits_unlimited": false
+                }
+            }))),
+            "codex",
+        ));
+        assert!(admin_pool_key_account_quota_exhausted(
+            &sample_key(Some(json!({
+                "codex": {
+                    "primary_used_percent": 100.0
+                }
+            }))),
+            "codex",
+        ));
+        assert!(admin_pool_key_account_quota_exhausted(
+            &sample_key(Some(json!({
+                "codex": {
+                    "secondary_used_percent": 100.0
+                }
+            }))),
+            "codex",
+        ));
+        assert!(!admin_pool_key_account_quota_exhausted(
+            &sample_key(Some(json!({
+                "codex": {
+                    "has_credits": false,
+                    "credits_unlimited": true
+                }
+            }))),
+            "codex",
+        ));
+        assert!(!admin_pool_key_account_quota_exhausted(
+            &sample_key(None),
+            "codex",
+        ));
+    }
+
+    #[test]
+    fn detects_kiro_exhaustion_from_metadata() {
+        assert!(admin_pool_key_account_quota_exhausted(
+            &sample_key(Some(json!({
+                "kiro": {
+                    "remaining": 0
+                }
+            }))),
+            "kiro",
+        ));
+        assert!(admin_pool_key_account_quota_exhausted(
+            &sample_key(Some(json!({
+                "kiro": {
+                    "usage_percentage": 100.0
+                }
+            }))),
+            "kiro",
+        ));
+        assert!(admin_pool_key_account_quota_exhausted(
+            &sample_key(Some(json!({
+                "kiro": {
+                    "usage_limit": 100.0,
+                    "current_usage": 100.0
+                }
+            }))),
+            "kiro",
+        ));
+        assert!(!admin_pool_key_account_quota_exhausted(
+            &sample_key(None),
+            "kiro",
+        ));
+    }
 }
 
 pub fn build_admin_pool_key_payload(

--- a/crates/aether-data/src/repository/global_models/sql.rs
+++ b/crates/aether-data/src/repository/global_models/sql.rs
@@ -717,6 +717,19 @@ RETURNING id
         &self,
         global_model_id: &str,
     ) -> Result<bool, DataLayerError> {
+        let mut tx = self.pool.begin().await.map_postgres_err()?;
+
+        sqlx::query(
+            r#"
+DELETE FROM models
+WHERE global_model_id = $1
+            "#,
+        )
+        .bind(global_model_id)
+        .execute(&mut *tx)
+        .await
+        .map_postgres_err()?;
+
         let deleted = sqlx::query(
             r#"
 DELETE FROM global_models
@@ -725,9 +738,11 @@ RETURNING id
             "#,
         )
         .bind(global_model_id)
-        .fetch_optional(&self.pool)
+        .fetch_optional(&mut *tx)
         .await
         .map_postgres_err()?;
+
+        tx.commit().await.map_postgres_err()?;
 
         Ok(deleted.is_some())
     }

--- a/crates/aether-provider-transport/src/kiro/auth.rs
+++ b/crates/aether-provider-transport/src/kiro/auth.rs
@@ -53,12 +53,7 @@ pub fn resolve_local_kiro_bearer_auth(
     if transport.key.decrypted_auth_config.is_some() {
         return None;
     }
-    if !transport
-        .key
-        .auth_type
-        .trim()
-        .eq_ignore_ascii_case("bearer")
-    {
+    if !kiro_auth_type_supported(transport.key.auth_type.as_str()) {
         return None;
     }
 
@@ -90,12 +85,7 @@ pub fn resolve_local_kiro_request_auth(
     {
         return None;
     }
-    if !transport
-        .key
-        .auth_type
-        .trim()
-        .eq_ignore_ascii_case("bearer")
-    {
+    if !kiro_auth_type_supported(transport.key.auth_type.as_str()) {
         return None;
     }
 
@@ -137,13 +127,16 @@ pub fn supports_local_kiro_request_auth_resolution(
                     .provider_type
                     .trim()
                     .eq_ignore_ascii_case(PROVIDER_TYPE)
-                    && transport
-                        .key
-                        .auth_type
-                        .trim()
-                        .eq_ignore_ascii_case("bearer")
+                    && kiro_auth_type_supported(transport.key.auth_type.as_str())
                     && auth_config.can_refresh_access_token()
             })
+}
+
+fn kiro_auth_type_supported(auth_type: &str) -> bool {
+    matches!(
+        auth_type.trim().to_ascii_lowercase().as_str(),
+        "bearer" | "oauth"
+    )
 }
 
 #[cfg(test)]
@@ -233,6 +226,27 @@ mod tests {
         let mut transport = sample_transport();
         transport.key.auth_type = "api_key".to_string();
         assert!(resolve_local_kiro_bearer_auth(&transport).is_none());
+    }
+
+    #[test]
+    fn resolves_request_auth_when_legacy_oauth_auth_type_is_used() {
+        let mut transport = sample_transport();
+        transport.key.auth_type = "oauth".to_string();
+        transport.key.decrypted_api_key = "__placeholder__".to_string();
+        transport.key.decrypted_auth_config = Some(
+            r#"{
+                "access_token":"cached-token",
+                "refresh_token":"rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+                "machine_id":"123e4567-e89b-12d3-a456-426614174000",
+                "api_region":"us-west-2"
+            }"#
+            .to_string(),
+        );
+
+        let auth = resolve_local_kiro_request_auth(&transport)
+            .expect("request auth should resolve from legacy oauth auth_type");
+        assert_eq!(auth.value, "Bearer cached-token");
+        assert!(supports_local_kiro_request_auth_resolution(&transport));
     }
 
     #[test]

--- a/crates/aether-scheduler-core/src/candidate.rs
+++ b/crates/aether-scheduler-core/src/candidate.rs
@@ -370,6 +370,7 @@ pub struct CandidateRuntimeSelectabilityInput<'a> {
     pub now_unix_secs: u64,
     pub cached_affinity_target: Option<&'a crate::SchedulerAffinityTarget>,
     pub provider_quota_blocks_requests: bool,
+    pub account_quota_exhausted: bool,
     pub rpm_reset_at: Option<u64>,
 }
 
@@ -390,11 +391,15 @@ pub fn candidate_runtime_skip_reason_with_state(
         now_unix_secs,
         cached_affinity_target,
         provider_quota_blocks_requests,
+        account_quota_exhausted,
         rpm_reset_at,
     } = input;
 
     if provider_quota_blocks_requests {
         return Some("provider_quota_blocked");
+    }
+    if account_quota_exhausted {
+        return Some("account_quota_exhausted");
     }
     if crate::is_candidate_in_recent_failure_cooldown(
         recent_candidates,
@@ -808,6 +813,7 @@ mod tests {
                 now_unix_secs: 100,
                 cached_affinity_target: None,
                 provider_quota_blocks_requests: false,
+                account_quota_exhausted: false,
                 rpm_reset_at: None,
             },
         ));
@@ -826,6 +832,7 @@ mod tests {
                 now_unix_secs: 100,
                 cached_affinity_target: None,
                 provider_quota_blocks_requests: false,
+                account_quota_exhausted: false,
                 rpm_reset_at: None,
             },
         ));
@@ -838,6 +845,24 @@ mod tests {
                 now_unix_secs: 100,
                 cached_affinity_target: None,
                 provider_quota_blocks_requests: true,
+                account_quota_exhausted: false,
+                rpm_reset_at: None,
+            },
+        ));
+    }
+
+    #[test]
+    fn candidate_selectability_rejects_exhausted_account_quota() {
+        assert!(!candidate_is_selectable_with_runtime_state(
+            CandidateRuntimeSelectabilityInput {
+                candidate: &sample_candidate("1", None),
+                recent_candidates: &[],
+                provider_concurrent_limits: &BTreeMap::new(),
+                provider_key_rpm_states: &BTreeMap::new(),
+                now_unix_secs: 100,
+                cached_affinity_target: None,
+                provider_quota_blocks_requests: false,
+                account_quota_exhausted: true,
                 rpm_reset_at: None,
             },
         ));

--- a/frontend/src/api/endpoints/keys.ts
+++ b/frontend/src/api/endpoints/keys.ts
@@ -60,7 +60,7 @@ export async function getModelCapabilities(modelName: string): Promise<ModelCapa
  * 获取完整的 API Key（用于查看和复制）
  */
 export interface RevealKeyResult {
-  auth_type: 'api_key' | 'service_account' | 'oauth'
+  auth_type: 'api_key' | 'service_account' | 'oauth' | 'bearer'
   api_key?: string
   refresh_token?: string
   auth_config?: string | Record<string, unknown>
@@ -165,7 +165,7 @@ export async function updateProviderKey(
   data: Partial<{
     api_formats: string[]  // 支持的 API 格式列表
     api_key: string
-    auth_type: 'api_key' | 'service_account' | 'oauth'  // 认证类型
+    auth_type: 'api_key' | 'service_account' | 'oauth' | 'bearer'  // 认证类型
     auth_config: Record<string, unknown>  // 认证配置（Vertex AI Service Account JSON）
     name: string
     rate_multipliers: Record<string, number> | null  // 按 API 格式的成本倍率

--- a/frontend/src/api/endpoints/types/provider.ts
+++ b/frontend/src/api/endpoints/types/provider.ts
@@ -229,7 +229,7 @@ export interface EndpointAPIKey {
   api_formats: string[]  // 支持的 endpoint signature 列表（如 "openai:chat"）
   api_key_masked: string
   api_key_plain?: string | null
-  auth_type: 'api_key' | 'service_account' | 'oauth'  // 认证类型（必返回）
+  auth_type: 'api_key' | 'service_account' | 'oauth' | 'bearer'  // 认证类型（必返回）
   name: string  // 密钥名称（必填，用于识别）
   rate_multipliers?: Record<string, number> | null  // 按 endpoint signature 的成本倍率
   internal_priority: number  // Key 内部优先级

--- a/frontend/src/api/endpoints/types/provider.ts
+++ b/frontend/src/api/endpoints/types/provider.ts
@@ -492,6 +492,7 @@ export interface PoolAdvancedConfig {
   global_priority?: number | null
   sticky_session_ttl_seconds?: number | null
   load_threshold_percent?: number | null
+  skip_exhausted_accounts?: boolean | null
   // 旧字段（兼容读取）
   lru_enabled?: boolean
   scheduling_mode?: 'lru' | 'multi_score' | null

--- a/frontend/src/features/pool/components/PoolAccountBatchDialog.vue
+++ b/frontend/src/features/pool/components/PoolAccountBatchDialog.vue
@@ -454,7 +454,7 @@ function downloadJsonFile(data: unknown, filename: string): void {
 
 function normalizeAuthTypeLabel(authType: string): string {
   const text = normalizeText(authType)
-  if (text === 'oauth') return 'OAuth'
+  if (text === 'oauth' || text === 'bearer') return 'OAuth'
   if (text === 'service_account') return 'Service'
   return 'API Key'
 }

--- a/frontend/src/features/pool/components/PoolAdvancedDialog.vue
+++ b/frontend/src/features/pool/components/PoolAdvancedDialog.vue
@@ -467,6 +467,7 @@ const form = ref({
   probing_enabled: false,
   probing_interval_minutes: null as number | null | undefined,
   auto_remove_banned_keys: false,
+  skip_exhausted_accounts: false,
 })
 
 interface ClaudeFormState {
@@ -503,6 +504,8 @@ function getHealthToggleValue(key: PoolHealthToggleKey): boolean {
       return form.value.probing_enabled
     case 'auto_remove_banned_keys':
       return form.value.auto_remove_banned_keys
+    case 'skip_exhausted_accounts':
+      return form.value.skip_exhausted_accounts
   }
 }
 
@@ -516,6 +519,9 @@ function updateHealthToggleValue(key: PoolHealthToggleKey, value: boolean): void
       return
     case 'auto_remove_banned_keys':
       form.value.auto_remove_banned_keys = value
+      return
+    case 'skip_exhausted_accounts':
+      form.value.skip_exhausted_accounts = value
   }
 }
 
@@ -536,6 +542,7 @@ watch(() => props.modelValue, (open) => {
     probing_enabled: cfg?.probing_enabled ?? false,
     probing_interval_minutes: cfg?.probing_interval_minutes ?? null,
     auto_remove_banned_keys: cfg?.auto_remove_banned_keys ?? false,
+    skip_exhausted_accounts: cfg?.skip_exhausted_accounts ?? false,
   }
 
   const cc = props.currentClaudeConfig
@@ -570,6 +577,7 @@ async function handleSave() {
         ? (form.value.probing_interval_minutes ?? undefined)
         : undefined,
       auto_remove_banned_keys: form.value.auto_remove_banned_keys,
+      skip_exhausted_accounts: form.value.skip_exhausted_accounts,
     }
 
     const payload: Parameters<typeof updateProvider>[1] = {

--- a/frontend/src/features/pool/utils/__tests__/poolAdvancedDialog.spec.ts
+++ b/frontend/src/features/pool/utils/__tests__/poolAdvancedDialog.spec.ts
@@ -13,6 +13,7 @@ describe('poolAdvancedDialog', () => {
       'health_policy_enabled',
       'probing_enabled',
       'auto_remove_banned_keys',
+      'skip_exhausted_accounts',
     ])
   })
 
@@ -32,6 +33,11 @@ describe('poolAdvancedDialog', () => {
         key: 'auto_remove_banned_keys',
         label: '异常自动清除',
         description: '仅在检测到不可恢复的账号异常时自动从号池移除，不处理纯 Token 失效。',
+      },
+      {
+        key: 'skip_exhausted_accounts',
+        label: '跳过额度耗尽账号',
+        description: '当 Codex / Kiro 账号额度已耗尽时，直接标记为不可调度并在请求侧跳过。',
       },
     ])
   })

--- a/frontend/src/features/pool/utils/poolAdvancedDialog.ts
+++ b/frontend/src/features/pool/utils/poolAdvancedDialog.ts
@@ -2,6 +2,7 @@ export type PoolHealthToggleKey =
   | 'health_policy_enabled'
   | 'probing_enabled'
   | 'auto_remove_banned_keys'
+  | 'skip_exhausted_accounts'
 
 export interface PoolHealthToggleCard {
   key: PoolHealthToggleKey
@@ -39,6 +40,11 @@ export function buildPoolHealthToggleCards(): PoolHealthToggleCard[] {
       key: 'auto_remove_banned_keys',
       label: '异常自动清除',
       description: '仅在检测到不可恢复的账号异常时自动从号池移除，不处理纯 Token 失效。',
+    },
+    {
+      key: 'skip_exhausted_accounts',
+      label: '跳过额度耗尽账号',
+      description: '当 Codex / Kiro 账号额度已耗尽时，直接标记为不可调度并在请求侧跳过。',
     },
   ]
 }

--- a/frontend/src/features/providers/components/OAuthAccountDialog.vue
+++ b/frontend/src/features/providers/components/OAuthAccountDialog.vue
@@ -939,8 +939,8 @@ async function handleImport() {
   let keepImporting = false
   try {
     const proxyNodeId = selectedProxyNodeId.value || undefined
-    // 检测是否为批量导入
-    if (isBatchImport(inputText)) {
+    // Kiro 的单条 JSON 凭据也必须走 batch-import 路径，后端需要完整 auth_config。
+    if (isKiroProvider.value || isBatchImport(inputText)) {
       const task = await startBatchImportOAuthTask(props.providerId, inputText, proxyNodeId)
       importTask.value = {
         task_id: task.task_id,

--- a/frontend/src/features/providers/components/provider-tabs/ModelTestDialog.vue
+++ b/frontend/src/features/providers/components/provider-tabs/ModelTestDialog.vue
@@ -715,7 +715,7 @@ const requestBodyDraft = computed(() => props.requestBodyDraft ?? '')
 const traceCandidates = computed(() => props.trace?.candidates ?? [])
 const showSetup = computed(() => props.open && !props.testing && !props.result)
 const showResult = computed(() => !!props.result)
-const showTraceTimeline = computed(() => Boolean(props.requestId))
+const showTraceTimeline = computed(() => Boolean(props.requestId) && traceCandidates.value.length > 0)
 const isDark = computed(() => typeof document !== 'undefined' && document.documentElement.classList.contains('dark'))
 const { copyToClipboard } = useClipboard()
 

--- a/frontend/src/views/admin/PoolManagement.vue
+++ b/frontend/src/views/admin/PoolManagement.vue
@@ -1837,7 +1837,7 @@ watch(searchQuery, () => {
 })
 
 function normalizeAuthTypeForEdit(authType: string): EndpointAPIKey['auth_type'] {
-  if (authType === 'oauth' || authType === 'service_account') return authType
+  if (authType === 'oauth' || authType === 'service_account' || authType === 'bearer') return authType
   return 'api_key'
 }
 


### PR DESCRIPTION
## 变更概述

本 PR 主要修复了 Rust 分支里几处与现有 Python 行为不一致的问题，重点包括：

1. 号池高级设置新增“跳过额度耗尽账号”开关，并补齐后端实际跳过逻辑
2. 修复 Kiro OAuth 导入、账号启停、provider-query 模型测试与结果展示链路
3. 修复已绑定 Provider 的 GlobalModel 在 Rust SQL 数据层下无法正常删除的问题

## 详细改动

### 1. 号池支持跳过额度耗尽账号

- 在 `pool_advanced` 中新增 `skip_exhausted_accounts` 开关
- 前端高级设置页新增对应开关，默认关闭，兼容旧配置
- 对 `Codex / Kiro` 增加额度耗尽判定逻辑
- 请求侧调度新增 `account_quota_exhausted` skip reason
- 号池管理页中，额度耗尽账号会显示为 `blocked / 额度耗尽`

### 2. Kiro 管理与测试链路对齐 Rust 行为

- 修复 Kiro 单条 JSON 导入误走 `import-refresh-token` 的前端分流问题
- 对误用的单条导入路径返回更明确的错误提示
- 为 Kiro 补齐 `bearer` 认证类型兼容
- 放开账号启用/禁用等 Key 更新操作对 `bearer` 的校验
- 实现 Kiro `provider-query/test-model` 与 `test-model-failover` 的 Rust 本地执行链
- 对 provider-query 结果弹窗做兜底修复：
  - 无 trace 数据时不再只显示“暂无追踪数据”
  - 会回退展示真实 `attempts`、请求头/体、响应头/体

### 3. 全局模型删除逻辑与 Python 保持一致

- 删除 GlobalModel 时，先在事务内删除关联的 Provider Model
- 再删除 GlobalModel 本身
- 修复 Rust SQL 仓库下因外键约束导致“已绑定 Provider 的模型无法删除”的问题
- 行为与 Python 主线版本对齐

## 兼容性说明

- `skip_exhausted_accounts` 默认关闭，不影响现有 Provider 配置
- Kiro 现有历史数据中若 `auth_type` 为 `oauth`，现在也能兼容本地请求链路
- 新导入的 Kiro Key 会更贴近 Rust 本地链路地使用 `bearer`

## 测试

已补充并通过相关定向测试，包括：

- pool advanced 新开关前端测试
- Codex / Kiro 额度耗尽判定测试
- 请求侧 `account_quota_exhausted` 跳过测试
- Kiro batch import / batch import task 测试
- Kiro provider-query model test / failover 测试
- GlobalModel 删除已绑定 Provider Model 的回归测试

## 影响范围

- 号池调度
- Kiro OAuth 管理
- Kiro provider-query 模型测试
- GlobalModel 删除流程
