### PR TITLE
fix(oauth): 对齐 OpenAI 回调 state 解析与提交流程

### DIFF
--- a/crates/aether-admin/src/provider/state.rs
+++ b/crates/aether-admin/src/provider/state.rs
@@ -40,22 +40,26 @@ pub fn parse_provider_oauth_callback_params(callback_url: &str) -> BTreeMap<Stri
     let Ok(url) = Url::parse(callback_url.trim()) else {
         return merged;
     };
-    for (key, value) in url.query_pairs() {
+    for (key, value) in form_urlencoded::parse(url.query().unwrap_or_default().as_bytes()) {
         merged.insert(key.into_owned(), value.into_owned());
     }
     if let Some(fragment) = url.fragment() {
-        for (key, value) in form_urlencoded::parse(fragment.as_bytes()) {
-            merged
-                .entry(key.into_owned())
-                .or_insert_with(|| value.into_owned());
+        for (key, value) in form_urlencoded::parse(fragment.trim_start_matches('#').as_bytes()) {
+            merged.insert(key.into_owned(), value.into_owned());
         }
     }
     if let Some(code) = merged.get("code").cloned() {
-        if let Some((code_part, state_part)) = code.split_once("#state=") {
+        if let Some((code_part, state_part)) = code.split_once('#') {
             merged.insert("code".to_string(), code_part.to_string());
-            merged
-                .entry("state".to_string())
-                .or_insert_with(|| state_part.to_string());
+            if !merged.contains_key("state") && !state_part.is_empty() {
+                let normalized_state = state_part
+                    .strip_prefix("state=")
+                    .unwrap_or(state_part)
+                    .trim();
+                if !normalized_state.is_empty() {
+                    merged.insert("state".to_string(), normalized_state.to_string());
+                }
+            }
         }
     }
     merged
@@ -268,6 +272,51 @@ pub fn enrich_admin_provider_oauth_auth_config(
                 "organizations",
             ],
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_provider_oauth_callback_params;
+
+    #[test]
+    fn parse_provider_oauth_callback_params_reads_openai_query_state() {
+        let params = parse_provider_oauth_callback_params(
+            "http://localhost:1455/auth/callback?code=ac_test123&scope=openid+email+profile+offline_access&state=4a138f8c65814df691b1a567fd425fb3d7010e86df9b4eb48dcadd94de233d93",
+        );
+
+        assert_eq!(params.get("code").map(String::as_str), Some("ac_test123"));
+        assert_eq!(
+            params.get("scope").map(String::as_str),
+            Some("openid email profile offline_access")
+        );
+        assert_eq!(
+            params.get("state").map(String::as_str),
+            Some("4a138f8c65814df691b1a567fd425fb3d7010e86df9b4eb48dcadd94de233d93")
+        );
+    }
+
+    #[test]
+    fn parse_provider_oauth_callback_params_prefers_fragment_values_like_python() {
+        let params = parse_provider_oauth_callback_params(
+            "http://localhost:1455/auth/callback?code=query-code&state=stale#code=fragment-code&state=fresh-state",
+        );
+
+        assert_eq!(
+            params.get("code").map(String::as_str),
+            Some("fragment-code")
+        );
+        assert_eq!(params.get("state").map(String::as_str), Some("fresh-state"));
+    }
+
+    #[test]
+    fn parse_provider_oauth_callback_params_extracts_state_from_code_suffix() {
+        let params = parse_provider_oauth_callback_params(
+            "http://localhost:1455/auth/callback?code=code-value%23state%3Dnonce-value",
+        );
+
+        assert_eq!(params.get("code").map(String::as_str), Some("code-value"));
+        assert_eq!(params.get("state").map(String::as_str), Some("nonce-value"));
     }
 }
 

--- a/frontend/src/features/providers/components/OAuthAccountDialog.vue
+++ b/frontend/src/features/providers/components/OAuthAccountDialog.vue
@@ -613,6 +613,7 @@ function createInitialOAuthState(): OAuthState {
 }
 
 const oauth = ref<OAuthState>(createInitialOAuthState())
+let oauthInitRequestId = 0
 
 // 设备授权状态
 type DeviceAuthType = 'builder_id' | 'identity_center'
@@ -787,6 +788,7 @@ function resetDevice() {
 }
 
 function resetForm() {
+  oauthInitRequestId += 1
   oauth.value = createInitialOAuthState()
   stopImportPolling()
   stopDevicePolling()
@@ -830,25 +832,31 @@ function openAuthorizationUrl() {
 async function initOAuth() {
   if (!props.providerId) return
   if (isKiroProvider.value) return
+  if (oauth.value.starting) return
 
-
+  const requestId = ++oauthInitRequestId
   oauth.value.starting = true
   try {
     const resp = await startProviderLevelOAuth(props.providerId)
+    if (requestId !== oauthInitRequestId) return
     oauth.value.authorization_url = resp.authorization_url
     oauth.value.redirect_uri = resp.redirect_uri
     oauth.value.instructions = resp.instructions
     oauth.value.provider_type = resp.provider_type
   } catch (err: unknown) {
+    if (requestId !== oauthInitRequestId) return
     const errorMessage = parseApiError(err, '初始化授权失败')
     showError(errorMessage, '错误')
     mode.value = 'import'
   } finally {
-    oauth.value.starting = false
+    if (requestId === oauthInitRequestId) {
+      oauth.value.starting = false
+    }
   }
 }
 
 async function handleCompleteOAuth() {
+  if (oauth.value.completing) return
   if (!canCompleteOAuth.value || !props.providerId) return
   oauth.value.completing = true
   try {


### PR DESCRIPTION
问题: OpenAI 网页 OAuth 回调在 provider-level 授权流程中会出现 state 无效或已过期。Rust 侧 callback 参数解析比旧 Python 实现更严格，无法完整兼容 query/fragment 以及 code 内嵌 state 的历史形态；前端弹窗也缺少初始化与验证阶段的并发保护，容易放大 state 一次性消费后的失败体验。

修复: 将 provider OAuth callback 参数解析逻辑对齐到 Python 版本，补充 OpenAI query state、fragment 覆盖和 code#state 兼容测试；同时为 OAuthAccountDialog 增加初始化请求代次和验证幂等保护，避免重复初始化或重复提交导致的竞态。