### PR TITLE
Fix/provider query non kiro tests

### DIFF
--- a/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
@@ -12,7 +12,7 @@ use super::response::{
 };
 use crate::ai_pipeline::{maybe_build_sync_finalize_outcome, GatewayControlDecision};
 use crate::execution_runtime;
-use crate::handlers::admin::request::AdminAppState;
+use crate::handlers::admin::request::{AdminAppState, AdminGatewayProviderTransportSnapshot};
 use crate::model_fetch::ModelFetchRuntimeState;
 use crate::provider_transport::kiro::{
     build_kiro_generate_assistant_response_url, build_kiro_provider_headers,
@@ -242,6 +242,73 @@ fn provider_query_key_supports_endpoint(
             .any(|value| value.eq_ignore_ascii_case(endpoint_api_format))
 }
 
+fn provider_query_transport_supports_standard_test_execution(
+    state: &AdminAppState<'_>,
+    transport: &AdminGatewayProviderTransportSnapshot,
+    api_format: &str,
+) -> bool {
+    match api_format {
+        "openai:chat" => {
+            crate::provider_transport::policy::supports_local_openai_chat_transport(transport)
+        }
+        "claude:chat" => {
+            crate::provider_transport::policy::supports_local_standard_transport_with_network(
+                transport, api_format,
+            )
+        }
+        "gemini:chat" => state.supports_local_gemini_transport_with_network(transport, api_format),
+        _ => false,
+    }
+}
+
+async fn provider_query_select_preferred_non_kiro_endpoint(
+    state: &AdminAppState<'_>,
+    provider: &StoredProviderCatalogProvider,
+    endpoints: &[StoredProviderCatalogEndpoint],
+    keys: &[StoredProviderCatalogKey],
+    selected_key_id: Option<&str>,
+) -> Option<StoredProviderCatalogEndpoint> {
+    for endpoint in endpoints.iter().filter(|endpoint| endpoint.is_active) {
+        if !provider_query_supports_standard_test_api_format(&endpoint.api_format) {
+            continue;
+        }
+        for key in keys {
+            if !key.is_active
+                || selected_key_id.is_some_and(|value| value != key.id.as_str())
+                || !provider_query_key_supports_endpoint(key, &endpoint.api_format)
+            {
+                continue;
+            }
+            let Ok(Some(transport)) = state
+                .read_provider_transport_snapshot(&provider.id, &endpoint.id, &key.id)
+                .await
+            else {
+                continue;
+            };
+            if provider_query_transport_supports_standard_test_execution(
+                state,
+                &transport,
+                endpoint.api_format.as_str(),
+            ) {
+                return Some(endpoint.clone());
+            }
+        }
+    }
+
+    endpoints
+        .iter()
+        .find(|endpoint| {
+            endpoint.is_active
+                && keys.iter().any(|key| {
+                    key.is_active
+                        && selected_key_id.is_none_or(|value| value == key.id.as_str())
+                        && provider_query_key_supports_endpoint(key, &endpoint.api_format)
+                })
+        })
+        .or_else(|| endpoints.iter().find(|endpoint| endpoint.is_active))
+        .cloned()
+}
+
 fn provider_query_test_key_sort_key(
     provider_type: &str,
     key: &StoredProviderCatalogKey,
@@ -347,38 +414,19 @@ async fn provider_query_build_kiro_test_candidates(
         && requested_api_format.is_none()
         && !provider.provider_type.trim().eq_ignore_ascii_case("kiro")
     {
-        endpoints
-            .iter()
-            .find(|endpoint| {
-                endpoint.is_active
-                    && provider_query_supports_standard_test_api_format(&endpoint.api_format)
-                    && all_keys.iter().any(|key| {
-                        key.is_active
-                            && selected_key_id
-                                .as_deref()
-                                .is_none_or(|value| value == key.id.as_str())
-                            && provider_query_key_supports_endpoint(key, &endpoint.api_format)
-                    })
-            })
-            .or_else(|| {
-                endpoints.iter().find(|endpoint| {
-                    endpoint.is_active
-                        && all_keys.iter().any(|key| {
-                            key.is_active
-                                && selected_key_id
-                                    .as_deref()
-                                    .is_none_or(|value| value == key.id.as_str())
-                                && provider_query_key_supports_endpoint(key, &endpoint.api_format)
-                        })
-                })
-            })
-            .or_else(|| endpoints.iter().find(|endpoint| endpoint.is_active))
-            .cloned()
-            .ok_or_else(|| {
-                build_admin_provider_query_not_found_response(
-                    ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
-                )
-            })?
+        provider_query_select_preferred_non_kiro_endpoint(
+            state,
+            provider,
+            &endpoints,
+            &all_keys,
+            selected_key_id.as_deref(),
+        )
+        .await
+        .ok_or_else(|| {
+            build_admin_provider_query_not_found_response(
+                ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
+            )
+        })?
     } else {
         match provider_query_select_kiro_endpoint(
             &endpoints,
@@ -764,6 +812,23 @@ async fn provider_query_execute_standard_test_candidate(
             response_body: None,
         });
     };
+    if !provider_query_transport_supports_standard_test_execution(
+        state,
+        &transport,
+        candidate.endpoint.api_format.as_str(),
+    ) {
+        return Ok(ProviderQueryExecutionOutcome {
+            status: "skipped",
+            error_message: None,
+            status_code: None,
+            latency_ms: None,
+            request_url: String::new(),
+            request_headers: BTreeMap::new(),
+            request_body: Value::Null,
+            response_headers: BTreeMap::new(),
+            response_body: None,
+        });
+    }
 
     let original_request_body =
         provider_query_build_test_request_body(payload, &candidate.effective_model);
@@ -961,11 +1026,12 @@ async fn provider_query_execute_standard_test_candidate(
             &BTreeMap::new(),
             Some("application/json"),
         ),
-        _ => state.build_passthrough_headers_with_auth(
+        _ => crate::provider_transport::auth::build_openai_passthrough_headers(
             &parts.headers,
             &auth_header,
             &auth_value,
             &BTreeMap::new(),
+            Some("application/json"),
         ),
     };
     if !state.apply_local_header_rules(
@@ -1124,11 +1190,30 @@ async fn build_admin_provider_query_kiro_failover_response(
             Err(response) => return Ok(response),
         }
     }
-    if !is_kiro
-        && candidates.iter().all(|candidate| {
-            !provider_query_supports_standard_test_api_format(&candidate.endpoint.api_format)
-        })
-    {
+    if !is_kiro {
+        let mut supported_candidates = Vec::new();
+        for candidate in candidates {
+            let Some(transport) = state
+                .read_provider_transport_snapshot(
+                    &provider.id,
+                    &candidate.endpoint.id,
+                    &candidate.key.id,
+                )
+                .await?
+            else {
+                continue;
+            };
+            if provider_query_transport_supports_standard_test_execution(
+                state,
+                &transport,
+                candidate.endpoint.api_format.as_str(),
+            ) {
+                supported_candidates.push(candidate);
+            }
+        }
+        candidates = supported_candidates;
+    }
+    if !is_kiro && candidates.is_empty() {
         return Ok(build_admin_provider_query_test_model_failover_response(
             provider_id,
             requested_models,

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
@@ -360,6 +360,18 @@ async fn provider_query_build_kiro_test_candidates(
                             && provider_query_key_supports_endpoint(key, &endpoint.api_format)
                     })
             })
+            .or_else(|| {
+                endpoints.iter().find(|endpoint| {
+                    endpoint.is_active
+                        && all_keys.iter().any(|key| {
+                            key.is_active
+                                && selected_key_id
+                                    .as_deref()
+                                    .is_none_or(|value| value == key.id.as_str())
+                                && provider_query_key_supports_endpoint(key, &endpoint.api_format)
+                        })
+                })
+            })
             .or_else(|| endpoints.iter().find(|endpoint| endpoint.is_active))
             .cloned()
             .ok_or_else(|| {

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
@@ -33,7 +33,7 @@ use aether_model_fetch::{
 };
 use axum::{
     body::{to_bytes, Body},
-    http::{HeaderMap, HeaderName, HeaderValue},
+    http::{self, HeaderMap, HeaderName, HeaderValue},
     response::{IntoResponse, Response},
     Json,
 };
@@ -689,6 +689,310 @@ async fn provider_query_execute_kiro_test_candidate(
     })
 }
 
+async fn provider_query_execute_standard_test_candidate(
+    state: &AdminAppState<'_>,
+    provider: &StoredProviderCatalogProvider,
+    candidate: &ProviderQueryTestCandidate,
+    payload: &Value,
+    route_path: &str,
+    trace_id: &str,
+) -> Result<ProviderQueryExecutionOutcome, GatewayError> {
+    let Some(transport) = state
+        .read_provider_transport_snapshot(&provider.id, &candidate.endpoint.id, &candidate.key.id)
+        .await?
+    else {
+        return Ok(ProviderQueryExecutionOutcome {
+            status: "skipped",
+            error_message: None,
+            status_code: None,
+            latency_ms: None,
+            request_url: String::new(),
+            request_headers: BTreeMap::new(),
+            request_body: Value::Null,
+            response_headers: BTreeMap::new(),
+            response_body: None,
+        });
+    };
+
+    let original_request_body =
+        provider_query_build_test_request_body(payload, &candidate.effective_model);
+    let mut request_body = original_request_body.clone();
+    if let Some(object) = request_body.as_object_mut() {
+        object.insert("stream".to_string(), Value::Bool(false));
+    }
+
+    let provider_api_format = candidate.endpoint.api_format.as_str();
+    let provider_request_body = match provider_api_format {
+        "openai:chat" => {
+            let Some(mut provider_request_body) =
+                crate::ai_pipeline::build_local_openai_chat_request_body(
+                    &request_body,
+                    &candidate.effective_model,
+                    false,
+                )
+            else {
+                return Ok(ProviderQueryExecutionOutcome {
+                    status: "skipped",
+                    error_message: None,
+                    status_code: None,
+                    latency_ms: None,
+                    request_url: String::new(),
+                    request_headers: BTreeMap::new(),
+                    request_body,
+                    response_headers: BTreeMap::new(),
+                    response_body: None,
+                });
+            };
+            if !crate::provider_transport::apply_local_body_rules(
+                &mut provider_request_body,
+                transport.endpoint.body_rules.as_ref(),
+                Some(&request_body),
+            ) {
+                None
+            } else {
+                Some(provider_request_body)
+            }
+        }
+        "claude:chat" | "gemini:chat" => {
+            let Some(mut provider_request_body) =
+                crate::ai_pipeline::build_cross_format_openai_chat_request_body(
+                    &request_body,
+                    &candidate.effective_model,
+                    provider_api_format,
+                    false,
+                )
+            else {
+                return Ok(ProviderQueryExecutionOutcome {
+                    status: "skipped",
+                    error_message: None,
+                    status_code: None,
+                    latency_ms: None,
+                    request_url: String::new(),
+                    request_headers: BTreeMap::new(),
+                    request_body,
+                    response_headers: BTreeMap::new(),
+                    response_body: None,
+                });
+            };
+            if !crate::provider_transport::apply_local_body_rules(
+                &mut provider_request_body,
+                transport.endpoint.body_rules.as_ref(),
+                Some(&request_body),
+            ) {
+                None
+            } else {
+                Some(provider_request_body)
+            }
+        }
+        _ => None,
+    };
+    let Some(provider_request_body) = provider_request_body else {
+        return Ok(ProviderQueryExecutionOutcome {
+            status: "skipped",
+            error_message: None,
+            status_code: None,
+            latency_ms: None,
+            request_url: String::new(),
+            request_headers: BTreeMap::new(),
+            request_body,
+            response_headers: BTreeMap::new(),
+            response_body: None,
+        });
+    };
+
+    let oauth_auth = match provider_api_format {
+        "openai:chat" | "claude:chat" => state.resolve_local_oauth_header_auth(&transport).await?,
+        _ => None,
+    };
+    let auth = match provider_api_format {
+        "openai:chat" => {
+            crate::provider_transport::auth::resolve_local_openai_bearer_auth(&transport)
+                .or(oauth_auth)
+        }
+        "claude:chat" => {
+            crate::provider_transport::auth::resolve_local_standard_auth(&transport).or(oauth_auth)
+        }
+        "gemini:chat" => state.resolve_local_gemini_auth(&transport),
+        _ => None,
+    };
+    let Some((auth_header, auth_value)) = auth else {
+        return Ok(ProviderQueryExecutionOutcome {
+            status: "skipped",
+            error_message: None,
+            status_code: None,
+            latency_ms: None,
+            request_url: String::new(),
+            request_headers: BTreeMap::new(),
+            request_body: provider_request_body,
+            response_headers: BTreeMap::new(),
+            response_body: None,
+        });
+    };
+
+    let mut synthetic_request = http::Request::builder()
+        .uri(route_path)
+        .body(())
+        .map_err(|err| GatewayError::Internal(err.to_string()))?;
+    *synthetic_request.headers_mut() = provider_query_extract_request_headers(payload);
+    let (parts, _) = synthetic_request.into_parts();
+
+    let request_url = match provider_api_format {
+        "openai:chat" => {
+            let custom_path = transport
+                .endpoint
+                .custom_path
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            match custom_path {
+                Some(path) => state.build_passthrough_path_url(
+                    &transport.endpoint.base_url,
+                    path,
+                    parts.uri.query(),
+                    &[],
+                ),
+                None => Some(
+                    state.build_openai_chat_url(&transport.endpoint.base_url, parts.uri.query()),
+                ),
+            }
+        }
+        "claude:chat" => {
+            let custom_path = transport
+                .endpoint
+                .custom_path
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            match custom_path {
+                Some(path) => state.build_passthrough_path_url(
+                    &transport.endpoint.base_url,
+                    path,
+                    parts.uri.query(),
+                    &[],
+                ),
+                None => Some(
+                    state
+                        .build_claude_messages_url(&transport.endpoint.base_url, parts.uri.query()),
+                ),
+            }
+        }
+        "gemini:chat" => {
+            let custom_path = transport
+                .endpoint
+                .custom_path
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            match custom_path {
+                Some(path) => state.build_passthrough_path_url(
+                    &transport.endpoint.base_url,
+                    path,
+                    parts.uri.query(),
+                    &["key"],
+                ),
+                None => state.build_gemini_content_url(
+                    &transport.endpoint.base_url,
+                    &candidate.effective_model,
+                    false,
+                    parts.uri.query(),
+                ),
+            }
+        }
+        _ => None,
+    }
+    .ok_or_else(|| GatewayError::Internal("provider request url is unavailable".to_string()))?;
+
+    let mut request_headers = match provider_api_format {
+        "claude:chat" => crate::provider_transport::auth::build_claude_passthrough_headers(
+            &parts.headers,
+            &auth_header,
+            &auth_value,
+            &BTreeMap::new(),
+            Some("application/json"),
+        ),
+        _ => state.build_passthrough_headers_with_auth(
+            &parts.headers,
+            &auth_header,
+            &auth_value,
+            &BTreeMap::new(),
+        ),
+    };
+    if !state.apply_local_header_rules(
+        &mut request_headers,
+        transport.endpoint.header_rules.as_ref(),
+        &[auth_header.as_str(), "content-type"],
+        &provider_request_body,
+        Some(&request_body),
+    ) {
+        return Ok(ProviderQueryExecutionOutcome {
+            status: "failed",
+            error_message: Some("provider request headers build failed".to_string()),
+            status_code: None,
+            latency_ms: None,
+            request_url,
+            request_headers,
+            request_body: provider_request_body,
+            response_headers: BTreeMap::new(),
+            response_body: None,
+        });
+    }
+    crate::provider_transport::ensure_upstream_auth_header(
+        &mut request_headers,
+        &auth_header,
+        &auth_value,
+    );
+
+    let plan = ExecutionPlan {
+        request_id: trace_id.to_string(),
+        candidate_id: Some(format!("provider-query-{}", candidate.key.id)),
+        provider_name: Some(provider.name.clone()),
+        provider_id: provider.id.clone(),
+        endpoint_id: candidate.endpoint.id.clone(),
+        key_id: candidate.key.id.clone(),
+        method: "POST".to_string(),
+        url: request_url.clone(),
+        headers: request_headers.clone(),
+        content_type: Some("application/json".to_string()),
+        content_encoding: None,
+        body: RequestBody::from_json(provider_request_body.clone()),
+        stream: false,
+        client_api_format: "openai:chat".to_string(),
+        provider_api_format: candidate.endpoint.api_format.clone(),
+        model_name: Some(candidate.effective_model.clone()),
+        proxy: state
+            .resolve_transport_proxy_snapshot_with_tunnel_affinity(&transport)
+            .await,
+        tls_profile: state.resolve_transport_tls_profile(&transport),
+        timeouts: state.resolve_transport_execution_timeouts(&transport),
+    };
+
+    let result = state
+        .execute_execution_runtime_sync_plan(Some(trace_id), &plan)
+        .await?;
+    let response_body = result.body.as_ref().and_then(|body| body.json_body.clone());
+    let error_message = if result.status_code >= 400 {
+        provider_query_extract_error_message(&result)
+    } else {
+        None
+    };
+
+    Ok(ProviderQueryExecutionOutcome {
+        status: if error_message.is_some() {
+            "failed"
+        } else {
+            "success"
+        },
+        error_message,
+        status_code: Some(result.status_code),
+        latency_ms: result.telemetry.as_ref().and_then(|value| value.elapsed_ms),
+        request_url,
+        request_headers,
+        request_body: provider_request_body,
+        response_headers: result.headers,
+        response_body,
+    })
+}
+
 fn provider_query_test_attempt_payload(
     candidate_index: usize,
     candidate: &ProviderQueryTestCandidate,
@@ -745,10 +1049,12 @@ async fn build_admin_provider_query_kiro_failover_response(
             ADMIN_PROVIDER_QUERY_PROVIDER_NOT_FOUND_DETAIL,
         ));
     };
-    if !provider.provider_type.trim().eq_ignore_ascii_case("kiro") {
+    let failover_models = super::payload::provider_query_extract_failover_models(payload);
+    let is_kiro = provider.provider_type.trim().eq_ignore_ascii_case("kiro");
+    if !is_kiro && failover_models.len() > 1 {
         return Ok(build_admin_provider_query_test_model_failover_response(
             provider_id,
-            super::payload::provider_query_extract_failover_models(payload),
+            failover_models,
         ));
     }
 
@@ -764,16 +1070,23 @@ async fn build_admin_provider_query_kiro_failover_response(
     let mut success_body = None;
 
     for (candidate_index, candidate) in candidates.iter().enumerate() {
-        let execution = provider_query_execute_kiro_test_candidate(
-            state,
-            &provider,
-            candidate,
-            payload,
-            route_path,
-            &trace_id,
-            &requested_model,
-        )
-        .await?;
+        let execution = if is_kiro {
+            provider_query_execute_kiro_test_candidate(
+                state,
+                &provider,
+                candidate,
+                payload,
+                route_path,
+                &trace_id,
+                &requested_model,
+            )
+            .await?
+        } else {
+            provider_query_execute_standard_test_candidate(
+                state, &provider, candidate, payload, route_path, &trace_id,
+            )
+            .await?
+        };
         if execution.status != "skipped" {
             total_attempts += 1;
         }
@@ -814,7 +1127,7 @@ async fn build_admin_provider_query_kiro_failover_response(
         "total_candidates": candidates.len(),
         "total_attempts": total_attempts,
         "data": success_body.as_ref().map(|body| json!({
-            "stream": true,
+            "stream": is_kiro,
             "response": body,
         })),
         "error": error,

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
@@ -319,6 +319,7 @@ async fn provider_query_build_kiro_test_candidates(
     state: &AdminAppState<'_>,
     provider: &StoredProviderCatalogProvider,
     payload: &Value,
+    requested_model_override: Option<&str>,
 ) -> Result<Vec<ProviderQueryTestCandidate>, Response<Body>> {
     let provider_ids = vec![provider.id.clone()];
     let endpoints = state
@@ -377,7 +378,9 @@ async fn provider_query_build_kiro_test_candidates(
         }
     }
 
-    let requested_model = provider_query_extract_model(payload)
+    let requested_model = requested_model_override
+        .map(ToOwned::to_owned)
+        .or_else(|| provider_query_extract_model(payload))
         .or_else(|| {
             super::payload::provider_query_extract_failover_models(payload)
                 .first()
@@ -1026,6 +1029,10 @@ fn provider_query_test_attempt_payload(
     })
 }
 
+fn provider_query_supports_standard_test_api_format(api_format: &str) -> bool {
+    matches!(api_format, "openai:chat" | "claude:chat" | "gemini:chat")
+}
+
 async fn build_admin_provider_query_kiro_failover_response(
     state: &AdminAppState<'_>,
     payload: &Value,
@@ -1049,12 +1056,6 @@ async fn build_admin_provider_query_kiro_failover_response(
     };
     let failover_models = super::payload::provider_query_extract_failover_models(payload);
     let is_kiro = provider.provider_type.trim().eq_ignore_ascii_case("kiro");
-    if !is_kiro && failover_models.len() > 1 {
-        return Ok(build_admin_provider_query_test_model_failover_response(
-            provider_id,
-            failover_models,
-        ));
-    }
     let Some(requested_model) =
         provider_query_extract_model(payload).or_else(|| failover_models.first().cloned())
     else {
@@ -1063,11 +1064,37 @@ async fn build_admin_provider_query_kiro_failover_response(
         ));
     };
 
-    let candidates =
-        match provider_query_build_kiro_test_candidates(state, &provider, payload).await {
-            Ok(candidates) => candidates,
+    let requested_models = if is_kiro {
+        vec![requested_model.clone()]
+    } else if failover_models.is_empty() {
+        vec![requested_model.clone()]
+    } else {
+        failover_models.clone()
+    };
+    let mut candidates = Vec::new();
+    for requested_failover_model in &requested_models {
+        match provider_query_build_kiro_test_candidates(
+            state,
+            &provider,
+            payload,
+            Some(requested_failover_model.as_str()),
+        )
+        .await
+        {
+            Ok(mut built_candidates) => candidates.append(&mut built_candidates),
             Err(response) => return Ok(response),
-        };
+        }
+    }
+    if !is_kiro
+        && candidates.iter().all(|candidate| {
+            !provider_query_supports_standard_test_api_format(&candidate.endpoint.api_format)
+        })
+    {
+        return Ok(build_admin_provider_query_test_model_failover_response(
+            provider_id,
+            requested_models,
+        ));
+    }
     let trace_id = provider_query_extract_request_id(payload)
         .unwrap_or_else(|| format!("provider-query-test-{}", Uuid::new_v4().simple()));
     let mut attempts = Vec::new();

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
@@ -669,7 +669,8 @@ async fn provider_query_execute_kiro_test_candidate(
     } else {
         result.body.as_ref().and_then(|body| body.json_body.clone())
     };
-    let error_message = if result.status_code >= 400 {
+    let did_fail = result.status_code >= 400;
+    let error_message = if did_fail {
         provider_query_extract_error_message(&result)
     } else if response_body.is_none()
         && provider_query_decode_execution_body(&result)
@@ -681,7 +682,7 @@ async fn provider_query_execute_kiro_test_candidate(
     };
 
     Ok(ProviderQueryExecutionOutcome {
-        status: if error_message.is_some() {
+        status: if did_fail || error_message.is_some() {
             "failed"
         } else {
             "success"

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
@@ -331,26 +331,47 @@ async fn provider_query_build_kiro_test_candidates(
                 ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
             )
         })?;
-    let endpoint = match provider_query_select_kiro_endpoint(
-        &endpoints,
-        provider_query_extract_endpoint_id(payload).as_deref(),
-        provider_query_extract_api_format(payload).as_deref(),
-    ) {
-        Ok(Some(endpoint)) => endpoint.clone(),
-        Ok(None) => {
-            return Err(build_admin_provider_query_not_found_response(
-                ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
-            ));
-        }
-        Err("Endpoint not found") => {
-            return Err(build_admin_provider_query_not_found_response(
-                ADMIN_PROVIDER_QUERY_API_KEY_NOT_FOUND_DETAIL,
-            ));
-        }
-        Err(_) => {
-            return Err(build_admin_provider_query_not_found_response(
-                ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
-            ));
+    let requested_endpoint_id = provider_query_extract_endpoint_id(payload);
+    let requested_api_format = provider_query_extract_api_format(payload);
+    let endpoint = if requested_endpoint_id.is_none()
+        && requested_api_format.is_none()
+        && !provider.provider_type.trim().eq_ignore_ascii_case("kiro")
+    {
+        endpoints
+            .iter()
+            .find(|endpoint| {
+                endpoint.is_active
+                    && provider_query_supports_standard_test_api_format(&endpoint.api_format)
+            })
+            .or_else(|| endpoints.iter().find(|endpoint| endpoint.is_active))
+            .cloned()
+            .ok_or_else(|| {
+                build_admin_provider_query_not_found_response(
+                    ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
+                )
+            })?
+    } else {
+        match provider_query_select_kiro_endpoint(
+            &endpoints,
+            requested_endpoint_id.as_deref(),
+            requested_api_format.as_deref(),
+        ) {
+            Ok(Some(endpoint)) => endpoint.clone(),
+            Ok(None) => {
+                return Err(build_admin_provider_query_not_found_response(
+                    ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
+                ));
+            }
+            Err("Endpoint not found") => {
+                return Err(build_admin_provider_query_not_found_response(
+                    ADMIN_PROVIDER_QUERY_API_KEY_NOT_FOUND_DETAIL,
+                ));
+            }
+            Err(_) => {
+                return Err(build_admin_provider_query_not_found_response(
+                    ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
+                ));
+            }
         }
     };
 

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
@@ -377,9 +377,17 @@ async fn provider_query_build_kiro_test_candidates(
         }
     }
 
-    let requested_model = provider_query_extract_model(payload).ok_or_else(|| {
-        build_admin_provider_query_bad_request_response(ADMIN_PROVIDER_QUERY_MODEL_REQUIRED_DETAIL)
-    })?;
+    let requested_model = provider_query_extract_model(payload)
+        .or_else(|| {
+            super::payload::provider_query_extract_failover_models(payload)
+                .first()
+                .cloned()
+        })
+        .ok_or_else(|| {
+            build_admin_provider_query_bad_request_response(
+                ADMIN_PROVIDER_QUERY_MODEL_REQUIRED_DETAIL,
+            )
+        })?;
     let effective_model = if provider_query_test_mode(payload).eq_ignore_ascii_case("direct") {
         requested_model.clone()
     } else {
@@ -970,18 +978,15 @@ async fn provider_query_execute_standard_test_candidate(
         .execute_execution_runtime_sync_plan(Some(trace_id), &plan)
         .await?;
     let response_body = result.body.as_ref().and_then(|body| body.json_body.clone());
-    let error_message = if result.status_code >= 400 {
+    let did_fail = result.status_code >= 400;
+    let error_message = if did_fail {
         provider_query_extract_error_message(&result)
     } else {
         None
     };
 
     Ok(ProviderQueryExecutionOutcome {
-        status: if error_message.is_some() {
-            "failed"
-        } else {
-            "success"
-        },
+        status: if did_fail { "failed" } else { "success" },
         error_message,
         status_code: Some(result.status_code),
         latency_ms: result.telemetry.as_ref().and_then(|value| value.elapsed_ms),
@@ -1030,14 +1035,6 @@ async fn build_admin_provider_query_kiro_failover_response(
             ADMIN_PROVIDER_QUERY_PROVIDER_ID_REQUIRED_DETAIL,
         ));
     };
-    let requested_model = match provider_query_extract_model(payload) {
-        Some(model) => model,
-        None => {
-            return Ok(build_admin_provider_query_bad_request_response(
-                ADMIN_PROVIDER_QUERY_MODEL_REQUIRED_DETAIL,
-            ));
-        }
-    };
     let Some(provider) = state
         .app()
         .read_provider_catalog_providers_by_ids(std::slice::from_ref(&provider_id))
@@ -1057,6 +1054,13 @@ async fn build_admin_provider_query_kiro_failover_response(
             failover_models,
         ));
     }
+    let Some(requested_model) =
+        provider_query_extract_model(payload).or_else(|| failover_models.first().cloned())
+    else {
+        return Ok(build_admin_provider_query_bad_request_response(
+            ADMIN_PROVIDER_QUERY_MODEL_REQUIRED_DETAIL,
+        ));
+    };
 
     let candidates =
         match provider_query_build_kiro_test_candidates(state, &provider, payload).await {
@@ -1145,6 +1149,9 @@ pub(crate) async fn build_admin_provider_query_test_model_local_response(
         "/api/admin/provider-query/test-model",
     )
     .await?;
+    if !response.status().is_success() {
+        return Ok(response);
+    }
     let body = to_bytes(response.into_body(), usize::MAX)
         .await
         .map_err(|err| GatewayError::Internal(err.to_string()))?;

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models.rs
@@ -331,6 +331,16 @@ async fn provider_query_build_kiro_test_candidates(
                 ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
             )
         })?;
+    let all_keys = state
+        .app()
+        .list_provider_catalog_keys_by_provider_ids(&provider_ids)
+        .await
+        .map_err(|_| {
+            build_admin_provider_query_bad_request_response(
+                ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
+            )
+        })?;
+    let selected_key_id = provider_query_extract_api_key_id(payload);
     let requested_endpoint_id = provider_query_extract_endpoint_id(payload);
     let requested_api_format = provider_query_extract_api_format(payload);
     let endpoint = if requested_endpoint_id.is_none()
@@ -342,6 +352,13 @@ async fn provider_query_build_kiro_test_candidates(
             .find(|endpoint| {
                 endpoint.is_active
                     && provider_query_supports_standard_test_api_format(&endpoint.api_format)
+                    && all_keys.iter().any(|key| {
+                        key.is_active
+                            && selected_key_id
+                                .as_deref()
+                                .is_none_or(|value| value == key.id.as_str())
+                            && provider_query_key_supports_endpoint(key, &endpoint.api_format)
+                    })
             })
             .or_else(|| endpoints.iter().find(|endpoint| endpoint.is_active))
             .cloned()
@@ -375,17 +392,6 @@ async fn provider_query_build_kiro_test_candidates(
         }
     };
 
-    let all_keys = state
-        .app()
-        .list_provider_catalog_keys_by_provider_ids(&provider_ids)
-        .await
-        .map_err(|_| {
-            build_admin_provider_query_bad_request_response(
-                ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
-            )
-        })?;
-
-    let selected_key_id = provider_query_extract_api_key_id(payload);
     if let Some(api_key_id) = selected_key_id.as_deref() {
         let Some(key) = all_keys.iter().find(|key| key.id == api_key_id) else {
             return Err(build_admin_provider_query_not_found_response(

--- a/apps/aether-gateway/src/handlers/admin/request/provider/routes/query.rs
+++ b/apps/aether-gateway/src/handlers/admin/request/provider/routes/query.rs
@@ -2,9 +2,7 @@ use crate::handlers::admin::provider::query::{
     models::{
         build_admin_provider_query_models_response,
         build_admin_provider_query_test_model_failover_local_response,
-        build_admin_provider_query_test_model_failover_response,
         build_admin_provider_query_test_model_local_response,
-        build_admin_provider_query_test_model_response,
     },
     payload::{
         parse_admin_provider_query_body, provider_query_extract_failover_models,
@@ -58,7 +56,7 @@ impl<'a> AdminAppState<'a> {
                 build_admin_provider_query_models_response(self, &payload).await?,
             )),
             "test_model" => {
-                let Some(provider_id) = provider_query_extract_provider_id(&payload) else {
+                let Some(_provider_id) = provider_query_extract_provider_id(&payload) else {
                     log_admin_provider_query_validation_failure(
                         request_context,
                         route_kind,
@@ -69,7 +67,7 @@ impl<'a> AdminAppState<'a> {
                         ADMIN_PROVIDER_QUERY_PROVIDER_ID_REQUIRED_DETAIL,
                     )));
                 };
-                let Some(model) = provider_query_extract_model(&payload) else {
+                let Some(_model) = provider_query_extract_model(&payload) else {
                     log_admin_provider_query_validation_failure(
                         request_context,
                         route_kind,
@@ -80,28 +78,12 @@ impl<'a> AdminAppState<'a> {
                         ADMIN_PROVIDER_QUERY_MODEL_REQUIRED_DETAIL,
                     )));
                 };
-                let provider_type = self
-                    .app()
-                    .read_provider_catalog_providers_by_ids(std::slice::from_ref(&provider_id))
-                    .await?
-                    .into_iter()
-                    .find(|provider| provider.id == provider_id)
-                    .map(|provider| provider.provider_type)
-                    .unwrap_or_default();
-                if provider_type.trim().eq_ignore_ascii_case("kiro") {
-                    Ok(Some(
-                        build_admin_provider_query_test_model_local_response(self, &payload)
-                            .await?,
-                    ))
-                } else {
-                    Ok(Some(build_admin_provider_query_test_model_response(
-                        provider_id,
-                        model,
-                    )))
-                }
+                Ok(Some(
+                    build_admin_provider_query_test_model_local_response(self, &payload).await?,
+                ))
             }
             "test_model_failover" => {
-                let Some(provider_id) = provider_query_extract_provider_id(&payload) else {
+                let Some(_provider_id) = provider_query_extract_provider_id(&payload) else {
                     log_admin_provider_query_validation_failure(
                         request_context,
                         route_kind,
@@ -124,29 +106,10 @@ impl<'a> AdminAppState<'a> {
                         ADMIN_PROVIDER_QUERY_FAILOVER_MODELS_REQUIRED_DETAIL,
                     )));
                 }
-                let provider_type = self
-                    .app()
-                    .read_provider_catalog_providers_by_ids(std::slice::from_ref(&provider_id))
-                    .await?
-                    .into_iter()
-                    .find(|provider| provider.id == provider_id)
-                    .map(|provider| provider.provider_type)
-                    .unwrap_or_default();
-                if provider_type.trim().eq_ignore_ascii_case("kiro") {
-                    Ok(Some(
-                        build_admin_provider_query_test_model_failover_local_response(
-                            self, &payload,
-                        )
+                Ok(Some(
+                    build_admin_provider_query_test_model_failover_local_response(self, &payload)
                         .await?,
-                    ))
-                } else {
-                    Ok(Some(
-                        build_admin_provider_query_test_model_failover_response(
-                            provider_id,
-                            failover_models,
-                        ),
-                    ))
-                }
+                ))
             }
             _ => Ok(Some(
                 build_admin_provider_query_models_response(self, &payload).await?,

--- a/apps/aether-gateway/src/tests/control/admin/provider_query.rs
+++ b/apps/aether-gateway/src/tests/control/admin/provider_query.rs
@@ -1554,6 +1554,108 @@ async fn gateway_returns_stub_for_unsupported_non_kiro_test_format() {
 }
 
 #[tokio::test]
+async fn gateway_prefers_supported_non_kiro_endpoint_when_api_format_is_omitted() {
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |Json(plan): Json<ExecutionPlan>| async move {
+            assert_eq!(plan.endpoint_id, "endpoint-openai-chat");
+            assert_eq!(plan.provider_api_format, "openai:chat");
+            Json(json!({
+                "request_id": plan.request_id,
+                "candidate_id": plan.candidate_id,
+                "status_code": 200,
+                "headers": {
+                    "content-type": "application/json"
+                },
+                "body": {
+                    "json_body": {
+                        "id": "chatcmpl-preferred-endpoint",
+                        "choices": [{
+                            "message": {
+                                "role": "assistant",
+                                "content": "Selected supported endpoint"
+                            }
+                        }]
+                    }
+                },
+                "telemetry": {
+                    "elapsed_ms": 10
+                }
+            }))
+        }),
+    );
+
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let mut provider = sample_provider("provider-openai", "OpenAI", 10);
+    provider.provider_type = "openai".to_string();
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![
+            sample_endpoint(
+                "endpoint-openai-cli",
+                "provider-openai",
+                "openai:cli",
+                "https://api.openai.example",
+            ),
+            sample_endpoint(
+                "endpoint-openai-chat",
+                "provider-openai",
+                "openai:chat",
+                "https://api.openai.example",
+            ),
+        ],
+        vec![
+            sample_key(
+                "key-openai-cli",
+                "provider-openai",
+                "openai:cli",
+                "sk-test-cli",
+            ),
+            sample_key(
+                "key-openai-chat",
+                "provider-openai",
+                "openai:chat",
+                "sk-test-chat",
+            ),
+        ],
+    ));
+
+    let gateway = build_router_with_state(
+        build_state_with_execution_runtime_override(execution_runtime_url)
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/api/admin/provider-query/test-model"))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-openai",
+            "model": "gpt-5.4-mini"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(
+        payload["data"]["response"]["choices"][0]["message"]["content"],
+        json!("Selected supported endpoint")
+    );
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_handles_admin_provider_query_test_model_failover_with_single_model_name_alias() {
     let execution_runtime = Router::new().route(
         "/v1/execute/sync",

--- a/apps/aether-gateway/src/tests/control/admin/provider_query.rs
+++ b/apps/aether-gateway/src/tests/control/admin/provider_query.rs
@@ -1239,6 +1239,150 @@ async fn gateway_handles_admin_provider_query_test_model_failover_for_kiro_local
 }
 
 #[tokio::test]
+async fn gateway_retries_kiro_failover_after_http_error_without_message() {
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |Json(plan): Json<ExecutionPlan>| async move {
+            let payload = if plan.key_id == "key-kiro-first" {
+                json!({
+                    "request_id": plan.request_id,
+                    "candidate_id": plan.candidate_id,
+                    "status_code": 500,
+                    "headers": {
+                        "content-type": "application/json"
+                    },
+                    "body": {
+                        "json_body": {}
+                    },
+                    "telemetry": {
+                        "elapsed_ms": 9
+                    }
+                })
+            } else {
+                json!({
+                    "request_id": plan.request_id,
+                    "candidate_id": plan.candidate_id,
+                    "status_code": 200,
+                    "headers": {
+                        "content-type": "application/vnd.amazon.eventstream"
+                    },
+                    "body": {
+                        "body_bytes_b64": base64::engine::general_purpose::STANDARD.encode(
+                            [
+                                encode_kiro_event_frame("assistantResponseEvent", json!({"content": "Recovered from Kiro empty error"})),
+                                encode_kiro_exception_frame("ContentLengthExceededException"),
+                            ]
+                            .concat()
+                        )
+                    },
+                    "telemetry": {
+                        "elapsed_ms": 21
+                    }
+                })
+            };
+            Json(payload)
+        }),
+    );
+
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let mut provider = sample_provider("provider-kiro", "Kiro", 10);
+    provider.provider_type = "kiro".to_string();
+    let build_key = |id: &str| {
+        let mut key = sample_key(id, "provider-kiro", "claude:cli", "__placeholder__");
+        key.auth_type = "oauth".to_string();
+        key.encrypted_auth_config = Some(
+            aether_crypto::encrypt_python_fernet_plaintext(
+                DEVELOPMENT_ENCRYPTION_KEY,
+                r#"{
+                    "provider_type":"kiro",
+                    "auth_method":"idc",
+                    "access_token":"cached-kiro-token",
+                    "refresh_token":"rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+                    "machine_id":"123e4567-e89b-12d3-a456-426614174000",
+                    "api_region":"us-east-1",
+                    "client_id":"client-id",
+                    "client_secret":"client-secret"
+                }"#,
+            )
+            .expect("auth config should encrypt"),
+        );
+        key
+    };
+
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![StoredProviderCatalogEndpoint::new(
+            "endpoint-kiro-cli".to_string(),
+            "provider-kiro".to_string(),
+            "claude:cli".to_string(),
+            Some("claude".to_string()),
+            Some("cli".to_string()),
+            true,
+        )
+        .expect("endpoint should build")
+        .with_transport_fields(
+            "https://q.{region}.amazonaws.com".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("endpoint transport should build")],
+        vec![build_key("key-kiro-first"), build_key("key-kiro-second")],
+    ));
+
+    let gateway = build_router_with_state(
+        build_state_with_execution_runtime_override(execution_runtime_url)
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{gateway_url}/api/admin/provider-query/test-model-failover"
+        ))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-kiro",
+            "mode": "direct",
+            "model_name": "claude-sonnet-4-upstream",
+            "failover_models": ["claude-sonnet-4-upstream"],
+            "api_format": "claude:cli",
+            "request_id": "provider-test-kiro-empty-error"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(payload["total_attempts"], json!(2));
+    let attempts = payload["attempts"]
+        .as_array()
+        .expect("attempts should be an array");
+    assert_eq!(attempts[0]["status"], json!("failed"));
+    assert_eq!(attempts[0]["status_code"], json!(500));
+    assert_eq!(attempts[1]["status"], json!("success"));
+    assert_eq!(
+        payload["data"]["response"]["content"][0]["text"],
+        json!("Recovered from Kiro empty error")
+    );
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_handles_admin_provider_query_test_model_failover_with_single_model_name_alias() {
     let execution_runtime = Router::new().route(
         "/v1/execute/sync",

--- a/apps/aether-gateway/src/tests/control/admin/provider_query.rs
+++ b/apps/aether-gateway/src/tests/control/admin/provider_query.rs
@@ -1656,6 +1656,102 @@ async fn gateway_prefers_supported_non_kiro_endpoint_when_api_format_is_omitted(
 }
 
 #[tokio::test]
+async fn gateway_prefers_supported_non_kiro_endpoint_with_compatible_key_when_api_format_is_omitted(
+) {
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |Json(plan): Json<ExecutionPlan>| async move {
+            assert_eq!(plan.endpoint_id, "endpoint-openai-chat");
+            assert_eq!(plan.provider_api_format, "openai:chat");
+            assert_eq!(plan.key_id, "key-openai-chat");
+            Json(json!({
+                "request_id": plan.request_id,
+                "candidate_id": plan.candidate_id,
+                "status_code": 200,
+                "headers": {
+                    "content-type": "application/json"
+                },
+                "body": {
+                    "json_body": {
+                        "id": "chatcmpl-key-compatible-endpoint",
+                        "choices": [{
+                            "message": {
+                                "role": "assistant",
+                                "content": "Selected endpoint with compatible key"
+                            }
+                        }]
+                    }
+                },
+                "telemetry": {
+                    "elapsed_ms": 11
+                }
+            }))
+        }),
+    );
+
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let mut provider = sample_provider("provider-openai", "OpenAI", 10);
+    provider.provider_type = "openai".to_string();
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![
+            sample_endpoint(
+                "endpoint-gemini-chat",
+                "provider-openai",
+                "gemini:chat",
+                "https://api.gemini.example",
+            ),
+            sample_endpoint(
+                "endpoint-openai-chat",
+                "provider-openai",
+                "openai:chat",
+                "https://api.openai.example",
+            ),
+        ],
+        vec![sample_key(
+            "key-openai-chat",
+            "provider-openai",
+            "openai:chat",
+            "sk-test-chat",
+        )],
+    ));
+
+    let gateway = build_router_with_state(
+        build_state_with_execution_runtime_override(execution_runtime_url)
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/api/admin/provider-query/test-model"))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-openai",
+            "model": "gpt-5.4-mini"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(
+        payload["data"]["response"]["choices"][0]["message"]["content"],
+        json!("Selected endpoint with compatible key")
+    );
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_handles_admin_provider_query_test_model_failover_with_single_model_name_alias() {
     let execution_runtime = Router::new().route(
         "/v1/execute/sync",

--- a/apps/aether-gateway/src/tests/control/admin/provider_query.rs
+++ b/apps/aether-gateway/src/tests/control/admin/provider_query.rs
@@ -1383,6 +1383,177 @@ async fn gateway_retries_kiro_failover_after_http_error_without_message() {
 }
 
 #[tokio::test]
+async fn gateway_handles_non_kiro_multi_model_failover_locally() {
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |Json(plan): Json<ExecutionPlan>| async move {
+            let payload = if plan.model_name.as_deref() == Some("gpt-4.1") {
+                json!({
+                    "request_id": plan.request_id,
+                    "candidate_id": plan.candidate_id,
+                    "status_code": 500,
+                    "headers": {
+                        "content-type": "application/json"
+                    },
+                    "body": {
+                        "json_body": {
+                            "error": {
+                                "message": "primary model failed"
+                            }
+                        }
+                    },
+                    "telemetry": {
+                        "elapsed_ms": 8
+                    }
+                })
+            } else {
+                json!({
+                    "request_id": plan.request_id,
+                    "candidate_id": plan.candidate_id,
+                    "status_code": 200,
+                    "headers": {
+                        "content-type": "application/json"
+                    },
+                    "body": {
+                        "json_body": {
+                            "id": "chatcmpl-multi-model",
+                            "choices": [{
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "Recovered with fallback model"
+                                }
+                            }]
+                        }
+                    },
+                    "telemetry": {
+                        "elapsed_ms": 12
+                    }
+                })
+            };
+            Json(payload)
+        }),
+    );
+
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let mut provider = sample_provider("provider-openai", "OpenAI", 10);
+    provider.provider_type = "openai".to_string();
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![sample_endpoint(
+            "endpoint-openai-chat",
+            "provider-openai",
+            "openai:chat",
+            "https://api.openai.example",
+        )],
+        vec![sample_key(
+            "key-openai-primary",
+            "provider-openai",
+            "openai:chat",
+            "sk-test-primary",
+        )],
+    ));
+
+    let gateway = build_router_with_state(
+        build_state_with_execution_runtime_override(execution_runtime_url)
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{gateway_url}/api/admin/provider-query/test-model-failover"
+        ))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-openai",
+            "failover_models": ["gpt-4.1", "gpt-4o-mini"],
+            "api_format": "openai:chat"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(payload["total_attempts"], json!(2));
+    let attempts = payload["attempts"]
+        .as_array()
+        .expect("attempts should be an array");
+    assert_eq!(attempts[0]["effective_model"], json!("gpt-4.1"));
+    assert_eq!(attempts[1]["effective_model"], json!("gpt-4o-mini"));
+    assert_eq!(
+        payload["data"]["response"]["choices"][0]["message"]["content"],
+        json!("Recovered with fallback model")
+    );
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_returns_stub_for_unsupported_non_kiro_test_format() {
+    let mut provider = sample_provider("provider-openai", "OpenAI", 10);
+    provider.provider_type = "openai".to_string();
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![sample_endpoint(
+            "endpoint-openai-cli",
+            "provider-openai",
+            "openai:cli",
+            "https://api.openai.example",
+        )],
+        vec![sample_key(
+            "key-openai-cli",
+            "provider-openai",
+            "openai:cli",
+            "sk-test-cli",
+        )],
+    ));
+
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/api/admin/provider-query/test-model"))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-openai",
+            "model": "gpt-5.4-mini",
+            "api_format": "openai:cli"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(false));
+    assert_eq!(
+        payload["error"],
+        json!("Rust local provider-query failover simulation is not configured")
+    );
+
+    gateway_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_handles_admin_provider_query_test_model_failover_with_single_model_name_alias() {
     let execution_runtime = Router::new().route(
         "/v1/execute/sync",

--- a/apps/aether-gateway/src/tests/control/admin/provider_query.rs
+++ b/apps/aether-gateway/src/tests/control/admin/provider_query.rs
@@ -705,6 +705,10 @@ async fn gateway_handles_admin_provider_query_test_model_locally_with_trusted_ad
             assert_eq!(plan.model_name.as_deref(), Some("gpt-4.1"));
             assert!(!plan.stream);
             assert_eq!(
+                plan.headers.get("content-type").map(String::as_str),
+                Some("application/json")
+            );
+            assert_eq!(
                 plan.headers.get("authorization").map(String::as_str),
                 Some("Bearer sk-test-primary")
             );
@@ -1554,6 +1558,62 @@ async fn gateway_returns_stub_for_unsupported_non_kiro_test_format() {
 }
 
 #[tokio::test]
+async fn gateway_returns_stub_for_transport_unsupported_non_kiro_provider() {
+    let mut provider = sample_provider("provider-antigravity", "Antigravity", 10);
+    provider.provider_type = "antigravity".to_string();
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![sample_endpoint(
+            "endpoint-antigravity-gemini",
+            "provider-antigravity",
+            "gemini:chat",
+            "https://cloudcode-pa.googleapis.com",
+        )],
+        vec![sample_key(
+            "key-antigravity-gemini",
+            "provider-antigravity",
+            "gemini:chat",
+            "sk-test-antigravity",
+        )],
+    ));
+
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/api/admin/provider-query/test-model"))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-antigravity",
+            "model": "gemini-2.5-pro",
+            "api_format": "gemini:chat"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(false));
+    assert_eq!(
+        payload["error"],
+        json!("Rust local provider-query failover simulation is not configured")
+    );
+
+    gateway_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_prefers_supported_non_kiro_endpoint_when_api_format_is_omitted() {
     let execution_runtime = Router::new().route(
         "/v1/execute/sync",
@@ -1649,6 +1709,106 @@ async fn gateway_prefers_supported_non_kiro_endpoint_when_api_format_is_omitted(
     assert_eq!(
         payload["data"]["response"]["choices"][0]["message"]["content"],
         json!("Selected supported endpoint")
+    );
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_prefers_transport_supported_non_kiro_endpoint_when_api_format_is_omitted() {
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |Json(plan): Json<ExecutionPlan>| async move {
+            assert_eq!(plan.endpoint_id, "endpoint-openai-chat-supported");
+            assert_eq!(plan.provider_api_format, "openai:chat");
+            assert_eq!(
+                plan.headers.get("content-type").map(String::as_str),
+                Some("application/json")
+            );
+            Json(json!({
+                "request_id": plan.request_id,
+                "candidate_id": plan.candidate_id,
+                "status_code": 200,
+                "headers": {
+                    "content-type": "application/json"
+                },
+                "body": {
+                    "json_body": {
+                        "id": "chatcmpl-supported-transport",
+                        "choices": [{
+                            "message": {
+                                "role": "assistant",
+                                "content": "Selected locally supported endpoint"
+                            }
+                        }]
+                    }
+                },
+                "telemetry": {
+                    "elapsed_ms": 12
+                }
+            }))
+        }),
+    );
+
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let mut provider = sample_provider("provider-openai", "OpenAI", 10);
+    provider.provider_type = "openai".to_string();
+    let mut unsupported_endpoint = sample_endpoint(
+        "endpoint-openai-chat-unsupported",
+        "provider-openai",
+        "openai:chat",
+        "https://api.openai.example",
+    );
+    unsupported_endpoint.header_rules = Some(json!({"invalid": true}));
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![
+            unsupported_endpoint,
+            sample_endpoint(
+                "endpoint-openai-chat-supported",
+                "provider-openai",
+                "openai:chat",
+                "https://api.openai.example",
+            ),
+        ],
+        vec![sample_key(
+            "key-openai-chat",
+            "provider-openai",
+            "openai:chat",
+            "sk-test-chat",
+        )],
+    ));
+
+    let gateway = build_router_with_state(
+        build_state_with_execution_runtime_override(execution_runtime_url)
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/api/admin/provider-query/test-model"))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-openai",
+            "model": "gpt-5.4-mini"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(
+        payload["data"]["response"]["choices"][0]["message"]["content"],
+        json!("Selected locally supported endpoint")
     );
 
     gateway_handle.abort();

--- a/apps/aether-gateway/src/tests/control/admin/provider_query.rs
+++ b/apps/aether-gateway/src/tests/control/admin/provider_query.rs
@@ -1752,6 +1752,69 @@ async fn gateway_prefers_supported_non_kiro_endpoint_with_compatible_key_when_ap
 }
 
 #[tokio::test]
+async fn gateway_uses_compatible_unsupported_endpoint_stub_when_api_format_is_omitted() {
+    let mut provider = sample_provider("provider-openai", "OpenAI", 10);
+    provider.provider_type = "openai".to_string();
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![
+            sample_endpoint(
+                "endpoint-openai-chat",
+                "provider-openai",
+                "openai:chat",
+                "https://api.openai.example",
+            ),
+            sample_endpoint(
+                "endpoint-openai-cli",
+                "provider-openai",
+                "openai:cli",
+                "https://api.openai.example",
+            ),
+        ],
+        vec![sample_key(
+            "key-openai-cli",
+            "provider-openai",
+            "openai:cli",
+            "sk-test-cli",
+        )],
+    ));
+
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/api/admin/provider-query/test-model"))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-openai",
+            "model": "gpt-5.4-mini"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(false));
+    assert_eq!(
+        payload["error"],
+        json!("Rust local provider-query failover simulation is not configured")
+    );
+
+    gateway_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_handles_admin_provider_query_test_model_failover_with_single_model_name_alias() {
     let execution_runtime = Router::new().route(
         "/v1/execute/sync",

--- a/apps/aether-gateway/src/tests/control/admin/provider_query.rs
+++ b/apps/aether-gateway/src/tests/control/admin/provider_query.rs
@@ -1307,7 +1307,7 @@ async fn gateway_handles_admin_provider_query_test_model_failover_with_single_mo
         .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
         .json(&json!({
             "provider_id": "provider-openai",
-            "model_name": "gpt-4.1",
+            "failover_models": ["gpt-4.1"],
             "api_format": "openai:chat"
         }))
         .send()
@@ -1326,6 +1326,154 @@ async fn gateway_handles_admin_provider_query_test_model_failover_with_single_mo
 
     gateway_handle.abort();
     execution_runtime_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_retries_non_kiro_failover_after_http_error_without_message() {
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |Json(plan): Json<ExecutionPlan>| async move {
+            let auth = plan
+                .headers
+                .get("authorization")
+                .map(String::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let payload = if auth == "Bearer sk-test-first" {
+                json!({
+                    "request_id": plan.request_id,
+                    "candidate_id": plan.candidate_id,
+                    "status_code": 500,
+                    "headers": {
+                        "content-type": "application/json"
+                    },
+                    "body": {
+                        "json_body": {}
+                    },
+                    "telemetry": {
+                        "elapsed_ms": 7
+                    }
+                })
+            } else {
+                json!({
+                    "request_id": plan.request_id,
+                    "candidate_id": plan.candidate_id,
+                    "status_code": 200,
+                    "headers": {
+                        "content-type": "application/json"
+                    },
+                    "body": {
+                        "json_body": {
+                            "id": "chatcmpl-retry",
+                            "choices": [{
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "Recovered after empty error"
+                                }
+                            }]
+                        }
+                    },
+                    "telemetry": {
+                        "elapsed_ms": 13
+                    }
+                })
+            };
+            Json(payload)
+        }),
+    );
+
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let mut provider = sample_provider("provider-openai", "OpenAI", 10);
+    provider.provider_type = "openai".to_string();
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![sample_endpoint(
+            "endpoint-openai-chat",
+            "provider-openai",
+            "openai:chat",
+            "https://api.openai.example",
+        )],
+        vec![
+            sample_key(
+                "key-openai-first",
+                "provider-openai",
+                "openai:chat",
+                "sk-test-first",
+            ),
+            sample_key(
+                "key-openai-second",
+                "provider-openai",
+                "openai:chat",
+                "sk-test-second",
+            ),
+        ],
+    ));
+
+    let gateway = build_router_with_state(
+        build_state_with_execution_runtime_override(execution_runtime_url)
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{gateway_url}/api/admin/provider-query/test-model-failover"
+        ))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-openai",
+            "failover_models": ["gpt-4.1"],
+            "api_format": "openai:chat"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(payload["total_attempts"], json!(2));
+    let attempts = payload["attempts"]
+        .as_array()
+        .expect("attempts should be an array");
+    assert_eq!(attempts[0]["status"], json!("failed"));
+    assert_eq!(attempts[0]["status_code"], json!(500));
+    assert_eq!(attempts[1]["status"], json!("success"));
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_preserves_non_success_status_for_test_model_local_wrapper() {
+    let gateway = build_router_with_state(AppState::new().expect("gateway should build"));
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/api/admin/provider-query/test-model"))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-does-not-exist",
+            "model": "gpt-4.1"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["detail"], json!("Provider not found"));
+
+    gateway_handle.abort();
 }
 
 #[tokio::test]

--- a/apps/aether-gateway/src/tests/control/admin/provider_query.rs
+++ b/apps/aether-gateway/src/tests/control/admin/provider_query.rs
@@ -12,8 +12,8 @@ use http::StatusCode;
 use serde_json::json;
 
 use super::super::{
-    build_router_with_state, build_state_with_execution_runtime_override, sample_key,
-    sample_provider, start_server, AppState,
+    build_router_with_state, build_state_with_execution_runtime_override, sample_endpoint,
+    sample_key, sample_provider, start_server, AppState,
 };
 use crate::constants::{
     GATEWAY_HEADER, TRUSTED_ADMIN_SESSION_ID_HEADER, TRUSTED_ADMIN_USER_ID_HEADER,
@@ -695,36 +695,276 @@ async fn gateway_handles_admin_provider_query_models_for_fixed_provider_without_
 
 #[tokio::test]
 async fn gateway_handles_admin_provider_query_test_model_locally_with_trusted_admin_principal() {
-    assert_admin_provider_query_route(
-        "/api/admin/provider-query/test-model",
-        json!({ "provider_id": "provider-openai", "model": "gpt-4.1" }),
-        StatusCode::OK,
-        |payload| {
-            assert_eq!(payload["success"], json!(false));
-            assert_eq!(payload["tested"], json!(false));
-            assert!(payload["provider_id"].as_str().is_some());
-        },
-    )
-    .await;
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |Json(plan): Json<ExecutionPlan>| async move {
+            assert_eq!(plan.provider_id, "provider-openai");
+            assert_eq!(plan.endpoint_id, "endpoint-openai-chat");
+            assert_eq!(plan.key_id, "key-openai-primary");
+            assert_eq!(plan.provider_api_format, "openai:chat");
+            assert_eq!(plan.model_name.as_deref(), Some("gpt-4.1"));
+            assert!(!plan.stream);
+            assert_eq!(
+                plan.headers.get("authorization").map(String::as_str),
+                Some("Bearer sk-test-primary")
+            );
+            assert_eq!(
+                plan.body
+                    .json_body
+                    .as_ref()
+                    .and_then(|body| body.get("model")),
+                Some(&json!("gpt-4.1"))
+            );
+            Json(json!({
+                "request_id": plan.request_id,
+                "candidate_id": plan.candidate_id,
+                "status_code": 200,
+                "headers": {
+                    "content-type": "application/json"
+                },
+                "body": {
+                    "json_body": {
+                        "id": "chatcmpl-test-model",
+                        "object": "chat.completion",
+                        "choices": [{
+                            "message": {
+                                "role": "assistant",
+                                "content": "Hello from OpenAI"
+                            }
+                        }]
+                    }
+                },
+                "telemetry": {
+                    "elapsed_ms": 18
+                }
+            }))
+        }),
+    );
+
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let mut provider = sample_provider("provider-openai", "OpenAI", 10);
+    provider.provider_type = "openai".to_string();
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![sample_endpoint(
+            "endpoint-openai-chat",
+            "provider-openai",
+            "openai:chat",
+            "https://api.openai.example",
+        )],
+        vec![sample_key(
+            "key-openai-primary",
+            "provider-openai",
+            "openai:chat",
+            "sk-test-primary",
+        )],
+    ));
+
+    let gateway = build_router_with_state(
+        build_state_with_execution_runtime_override(execution_runtime_url)
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/api/admin/provider-query/test-model"))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-openai",
+            "model": "gpt-4.1",
+            "api_format": "openai:chat"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(payload["provider"]["id"], json!("provider-openai"));
+    assert_eq!(payload["model"], json!("gpt-4.1"));
+    assert_eq!(payload["error"], serde_json::Value::Null);
+    assert_eq!(
+        payload["data"]["response"]["choices"][0]["message"]["content"],
+        json!("Hello from OpenAI")
+    );
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
 }
 
 #[tokio::test]
 async fn gateway_handles_admin_provider_query_test_model_failover_locally_with_trusted_admin_principal(
 ) {
-    assert_admin_provider_query_route(
-        "/api/admin/provider-query/test-model-failover",
-        json!({
-            "provider_id": "provider-openai",
-            "failover_models": ["gpt-4.1", "gpt-4o-mini"]
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |Json(plan): Json<ExecutionPlan>| async move {
+            let auth = plan
+                .headers
+                .get("authorization")
+                .map(String::as_str)
+                .unwrap_or_default()
+                .to_string();
+            assert_eq!(plan.provider_id, "provider-openai");
+            assert_eq!(plan.endpoint_id, "endpoint-openai-chat");
+            assert_eq!(plan.provider_api_format, "openai:chat");
+            assert_eq!(plan.model_name.as_deref(), Some("gpt-4.1"));
+            assert_eq!(
+                plan.headers.get("x-test-header").map(String::as_str),
+                Some("from-admin")
+            );
+            assert_eq!(
+                plan.body
+                    .json_body
+                    .as_ref()
+                    .and_then(|body| body.get("messages"))
+                    .and_then(|messages| messages.as_array())
+                    .and_then(|messages| messages.first())
+                    .and_then(|message| message.get("content")),
+                Some(&json!("custom prompt"))
+            );
+            let payload = if auth == "Bearer sk-test-first" {
+                json!({
+                    "request_id": plan.request_id,
+                    "candidate_id": plan.candidate_id,
+                    "status_code": 429,
+                    "headers": {
+                        "content-type": "application/json"
+                    },
+                    "body": {
+                        "json_body": {
+                            "error": {
+                                "message": "too many requests"
+                            }
+                        }
+                    },
+                    "telemetry": {
+                        "elapsed_ms": 11
+                    }
+                })
+            } else {
+                json!({
+                    "request_id": plan.request_id,
+                    "candidate_id": plan.candidate_id,
+                    "status_code": 200,
+                    "headers": {
+                        "content-type": "application/json"
+                    },
+                    "body": {
+                        "json_body": {
+                            "id": "chatcmpl-failover",
+                            "object": "chat.completion",
+                            "choices": [{
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "Recovered from OpenAI failover"
+                                }
+                            }]
+                        }
+                    },
+                    "telemetry": {
+                        "elapsed_ms": 27
+                    }
+                })
+            };
+            Json(payload)
         }),
-        StatusCode::OK,
-        |payload| {
-            assert_eq!(payload["success"], json!(false));
-            assert_eq!(payload["tested"], json!(false));
-            assert!(payload["provider_id"].as_str().is_some());
-        },
-    )
-    .await;
+    );
+
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let mut provider = sample_provider("provider-openai", "OpenAI", 10);
+    provider.provider_type = "openai".to_string();
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![sample_endpoint(
+            "endpoint-openai-chat",
+            "provider-openai",
+            "openai:chat",
+            "https://api.openai.example",
+        )],
+        vec![
+            sample_key(
+                "key-openai-first",
+                "provider-openai",
+                "openai:chat",
+                "sk-test-first",
+            ),
+            sample_key(
+                "key-openai-second",
+                "provider-openai",
+                "openai:chat",
+                "sk-test-second",
+            ),
+        ],
+    ));
+
+    let gateway = build_router_with_state(
+        build_state_with_execution_runtime_override(execution_runtime_url)
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{gateway_url}/api/admin/provider-query/test-model-failover"
+        ))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-openai",
+            "mode": "direct",
+            "model_name": "gpt-4.1",
+            "failover_models": ["gpt-4.1"],
+            "api_format": "openai:chat",
+            "request_headers": {
+                "x-test-header": "from-admin"
+            },
+            "request_body": {
+                "model": "ignored-model",
+                "messages": [{
+                    "role": "user",
+                    "content": "custom prompt"
+                }]
+            },
+            "request_id": "provider-test-openai"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(payload["total_candidates"], json!(2));
+    assert_eq!(payload["total_attempts"], json!(2));
+    let attempts = payload["attempts"]
+        .as_array()
+        .expect("attempts should be an array");
+    assert_eq!(attempts.len(), 2);
+    assert_eq!(attempts[0]["status"], json!("failed"));
+    assert_eq!(attempts[0]["status_code"], json!(429));
+    assert_eq!(attempts[1]["status"], json!("success"));
+    assert_eq!(attempts[1]["key_id"], json!("key-openai-second"));
+    assert_eq!(attempts[1]["request_body"]["model"], json!("gpt-4.1"));
+    assert_eq!(payload["data"]["stream"], json!(false));
+    assert_eq!(
+        payload["data"]["response"]["choices"][0]["message"]["content"],
+        json!("Recovered from OpenAI failover")
+    );
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
 }
 
 #[tokio::test]
@@ -1000,23 +1240,92 @@ async fn gateway_handles_admin_provider_query_test_model_failover_for_kiro_local
 
 #[tokio::test]
 async fn gateway_handles_admin_provider_query_test_model_failover_with_single_model_name_alias() {
-    assert_admin_provider_query_route(
-        "/api/admin/provider-query/test-model-failover",
-        json!({
-            "provider_id": "provider-openai",
-            "model_name": "gpt-4.1"
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |Json(plan): Json<ExecutionPlan>| async move {
+            assert_eq!(plan.model_name.as_deref(), Some("gpt-4.1"));
+            Json(json!({
+                "request_id": plan.request_id,
+                "candidate_id": plan.candidate_id,
+                "status_code": 200,
+                "headers": {
+                    "content-type": "application/json"
+                },
+                "body": {
+                    "json_body": {
+                        "id": "chatcmpl-alias",
+                        "choices": [{
+                            "message": {
+                                "role": "assistant",
+                                "content": "Alias path succeeded"
+                            }
+                        }]
+                    }
+                },
+                "telemetry": {
+                    "elapsed_ms": 9
+                }
+            }))
         }),
-        StatusCode::OK,
-        |payload| {
-            assert_eq!(payload["success"], json!(false));
-            assert_eq!(payload["tested"], json!(false));
-            assert_eq!(payload["model"], json!("gpt-4.1"));
-            assert_eq!(payload["failover_models"], json!(["gpt-4.1"]));
-            assert_eq!(payload["attempts"], json!([]));
-            assert_eq!(payload["total_attempts"], json!(0));
-        },
-    )
-    .await;
+    );
+
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let mut provider = sample_provider("provider-openai", "OpenAI", 10);
+    provider.provider_type = "openai".to_string();
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![sample_endpoint(
+            "endpoint-openai-chat",
+            "provider-openai",
+            "openai:chat",
+            "https://api.openai.example",
+        )],
+        vec![sample_key(
+            "key-openai-alias",
+            "provider-openai",
+            "openai:chat",
+            "sk-test-alias",
+        )],
+    ));
+
+    let gateway = build_router_with_state(
+        build_state_with_execution_runtime_override(execution_runtime_url)
+            .with_data_state_for_tests(GatewayDataState::with_provider_transport_reader_for_tests(
+                provider_catalog_repository,
+                DEVELOPMENT_ENCRYPTION_KEY.to_string(),
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{gateway_url}/api/admin/provider-query/test-model-failover"
+        ))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "provider_id": "provider-openai",
+            "model_name": "gpt-4.1",
+            "api_format": "openai:chat"
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["success"], json!(true));
+    assert_eq!(payload["model"], json!("gpt-4.1"));
+    assert_eq!(payload["total_attempts"], json!(1));
+    assert_eq!(
+        payload["data"]["response"]["choices"][0]["message"]["content"],
+        json!("Alias path succeeded")
+    );
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 背景

前端“测试模型”当前统一走 `/api/admin/provider-query/test-model-failover`。  
Rust 端此前只有 Kiro 会进入真实本地执行，非 Kiro provider 会直接返回：

`Rust local provider-query failover simulation is not configured`

所以普通 provider 在前端点“测试模型”时会稳定失败。

## 本 PR 做了什么

这个 PR **不改前端 contract**，而是在 Rust admin provider-query 路径上补齐当前前端实际依赖的本地测试能力。

具体包括：

- 为 **非 Kiro provider** 增加本地 provider-query 模型测试执行链路
- 支持非 Kiro 的：
  - 单模型测试
  - 单模型 failover 形态
  - 多模型 failover 候选链路
- 对本地已支持的 chat 格式（`openai:chat` / `claude:chat` / `gemini:chat`）执行真实测试
- 对本地暂不支持的格式，继续显式返回原有 stub，避免误报
- 当未显式传 `api_format` / `endpoint_id` 时，优先选择 **本地可执行且有兼容 key** 的 endpoint，避免结果受 endpoint 顺序影响
- 修正 `/test-model` 包装层吞掉原始 4xx / 404 的问题
- 修正 Kiro / 非 Kiro 在 HTTP >= 400 但响应体没有 `error.message` 时被误判为 success、导致 failover 不继续的问题

## 建议 reviewer 按这个顺序看

### 1. 路由入口
`apps/aether-gateway/src/handlers/admin/request/provider/routes/query.rs`

先看这里，确认这次不是改前端，而是把 `test-model` / `test-model-failover` 统一接入本地 provider-query 处理链路。

### 2. 核心执行逻辑
`apps/aether-gateway/src/handlers/admin/provider/query/models.rs`

重点看这几块：

- candidate / endpoint / key 选择逻辑
- 非 Kiro 本地执行路径
- unsupported format 的 fallback 行为
- HTTP 错误如何转成 failed，并继续 failover

### 3. 回归测试
`apps/aether-gateway/src/tests/control/admin/provider_query.rs`

这里基本覆盖了这次改动的关键场景：

- 非 Kiro 单模型测试
- 非 Kiro 多模型 failover
- 只传 `failover_models` 的 alias 场景
- mixed endpoint / key 选择
- unsupported format 回退 stub
- Kiro / 非 Kiro 在空错误体下的 HTTP retry

## 验证

已执行：

- `cargo check -p aether-gateway`
- `cargo test -p aether-gateway provider_query`