### PR TITLE
fix(aether-crypto): fix provider key decryption for legacy Python Fernet secrets

### DIFF
--- a/crates/aether-crypto/src/python_fernet.rs
+++ b/crates/aether-crypto/src/python_fernet.rs
@@ -3,7 +3,7 @@ use std::sync::{LazyLock, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use aes::cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit};
-use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
+use base64::engine::general_purpose::{STANDARD, URL_SAFE, URL_SAFE_NO_PAD};
 use base64::Engine as _;
 use cbc::{Decryptor, Encryptor};
 use hmac::{Hmac, Mac};
@@ -222,6 +222,7 @@ fn raw_fernet_key(secret: &str) -> [u8; 32] {
 fn decode_direct_fernet_key(secret: &str) -> Result<[u8; 32], PythonFernetError> {
     let decoded = URL_SAFE
         .decode(secret)
+        .or_else(|_| STANDARD.decode(secret))
         .map_err(|_| PythonFernetError::InvalidInnerBase64)?;
     let raw_key: [u8; 32] = decoded
         .as_slice()
@@ -263,6 +264,16 @@ mod tests {
     fn passes_through_existing_fernet_key_secret() {
         let direct_key = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
         assert_eq!(derive_python_fernet_key(direct_key), direct_key);
+    }
+
+    #[test]
+    fn decrypts_legacy_python_ciphertext_with_direct_fernet_key() {
+        let direct_key = "h0Wzfv1ieDOgsmGELpKEV7qH8QpFP+lRnPW4pI0g4/M=";
+        let ciphertext = "Z0FBQUFBQnA1YjlRNXowblFSVWYyVzdOT1VQbXBsQWY3RHF5UTFkaGtwbmsweWkyVTVLdExFSGYwSVE2aUNMOXhzdkNCSTlOUTRlOEFEbFlTN25jc0xFQ2xkWEpQaEkxTzhGMGhrUXFsQnlUN3JRRUdOcndWelU9";
+        let plaintext = decrypt_python_fernet_ciphertext(direct_key, ciphertext)
+            .expect("legacy ciphertext should decrypt");
+
+        assert_eq!(plaintext, "sk-sanitized-regression-token");
     }
 
     #[test]


### PR DESCRIPTION
主要修复ENCRYPTION_KEY带"+"导致的无法正常加解密问题

升级到rust版本，客户端请求或页面复制独立密钥会报以下错误：
```
2026-04-20 12:53:41.368 +08:00 | WARN     | ~::candidate_eligibility - failed to load provider transport while evaluating local candidate eligibility | event_name="candidate_eligibility_transport_load_failed" log_type="event" provider_id="f32fe130-13a0-4323-b326-05f4b2cfbc40" endpoint_id="be203ea4-8dba-4498-8b95-ed49f141c02d" key_id="085f0676-1185-4964-b00d-bbebff1910a9" error="Internal(\"unexpected database value: failed to decrypt provider_api_keys.api_key: invalid Python Fernet token signature\")"
```
修复后单元测试通过
```
cargo test -p aether-crypto -- --nocapture
Finished `test` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running unittests src/lib.rs (target/debug/deps/aether_crypto-eaf26303e6a5dac4)
running 8 tests
test python_fernet::tests::decrypts_legacy_python_ciphertext_with_direct_fernet_key ... ok
test python_fernet::tests::passes_through_existing_fernet_key_secret ... ok
test python_fernet::tests::decrypts_python_compatible_outer_wrapped_ciphertext ... ok
test python_fernet::tests::derives_python_pbkdf2_key_for_development_secret ... ok
test python_fernet::tests::encrypt_and_decrypt_round_trip ... ok
test python_fernet::tests::treats_unpadded_direct_key_like_python_pbkdf2_secret ... ok
test python_fernet::tests::rejects_tampered_signature ... ok
test python_fernet::tests::detects_python_fernet_ciphertext_shape ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.61s
   Doc-tests aether_crypto
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```