### PR TITLE
fix(proxy-nodes): allow management tokens with json null allowed_ips

### DIFF
--- a/apps/aether-gateway/src/handlers/proxy/mod.rs
+++ b/apps/aether-gateway/src/handlers/proxy/mod.rs
@@ -120,6 +120,9 @@ fn remote_ip_allowed(allowed_ips: Option<&serde_json::Value>, remote_ip: std::ne
     let Some(allowed_ips) = allowed_ips else {
         return true;
     };
+    if allowed_ips.is_null() {
+        return true;
+    }
     let Some(items) = allowed_ips.as_array() else {
         return false;
     };

--- a/apps/aether-gateway/src/tests/control/admin/proxy_nodes.rs
+++ b/apps/aether-gateway/src/tests/control/admin/proxy_nodes.rs
@@ -783,8 +783,12 @@ async fn gateway_registers_proxy_node_with_management_token_when_allowed_ips_is_
         .await
         .expect("admin user should be created")
         .expect("admin user should exist");
-    let mut management_token =
-        sample_management_token("token-proxy-register-json-null", &admin_user.id, "proxy-admin", true);
+    let mut management_token = sample_management_token(
+        "token-proxy-register-json-null",
+        &admin_user.id,
+        "proxy-admin",
+        true,
+    );
     management_token.token.allowed_ips = Some(serde_json::Value::Null);
     let management_token_repository =
         Arc::new(InMemoryManagementTokenRepository::seed_with_hashes(
@@ -823,7 +827,10 @@ async fn gateway_registers_proxy_node_with_management_token_when_allowed_ips_is_
         .await
         .expect("json body should parse");
     assert_eq!(register_payload["node"]["name"], "proxy-json-null");
-    assert_eq!(register_payload["node"]["registered_by"], json!(admin_user.id));
+    assert_eq!(
+        register_payload["node"]["registered_by"],
+        json!(admin_user.id)
+    );
 
     gateway_handle.abort();
 }

--- a/apps/aether-gateway/src/tests/control/admin/proxy_nodes.rs
+++ b/apps/aether-gateway/src/tests/control/admin/proxy_nodes.rs
@@ -764,6 +764,71 @@ async fn gateway_registers_and_unregisters_proxy_nodes_locally_with_management_t
 }
 
 #[tokio::test]
+async fn gateway_registers_proxy_node_with_management_token_when_allowed_ips_is_json_null() {
+    let raw_token = "ae_proxy_register_json_null";
+    let proxy_node_repository = Arc::new(InMemoryProxyNodeRepository::default());
+    let state = AppState::new().expect("gateway should build");
+    let admin_user = state
+        .create_local_auth_user_with_settings(
+            Some("proxy-admin@example.com".to_string()),
+            true,
+            "admin".to_string(),
+            "hash".to_string(),
+            "admin".to_string(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("admin user should be created")
+        .expect("admin user should exist");
+    let mut management_token =
+        sample_management_token("token-proxy-register-json-null", &admin_user.id, "proxy-admin", true);
+    management_token.token.allowed_ips = Some(serde_json::Value::Null);
+    let management_token_repository =
+        Arc::new(InMemoryManagementTokenRepository::seed_with_hashes(
+            vec![management_token],
+            vec![(
+                hash_management_token(raw_token),
+                "token-proxy-register-json-null".to_string(),
+            )],
+        ));
+
+    let state = state.with_data_state_for_tests(
+        GatewayDataState::with_management_token_repository_for_tests(management_token_repository)
+            .attach_proxy_node_repository_for_tests(proxy_node_repository),
+    );
+    let gateway = build_router_with_state(state);
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let register_response = reqwest::Client::new()
+        .post(format!("{gateway_url}/api/admin/proxy-nodes/register"))
+        .header(GATEWAY_HEADER, "rust-phase3b")
+        .bearer_auth(raw_token)
+        .json(&json!({
+            "name": "proxy-json-null",
+            "ip": "1.1.1.1",
+            "port": 0,
+            "heartbeat_interval": 30,
+            "tunnel_mode": true
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(register_response.status(), StatusCode::OK);
+    let register_payload: serde_json::Value = register_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(register_payload["node"]["name"], "proxy-json-null");
+    assert_eq!(register_payload["node"]["registered_by"], json!(admin_user.id));
+
+    gateway_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_creates_updates_and_tests_manual_proxy_nodes_locally() {
     let proxy_auths = Arc::new(Mutex::new(Vec::<Option<String>>::new()));
     let proxy_auths_clone = Arc::clone(&proxy_auths);


### PR DESCRIPTION
## 变更说明
  - 修复管理令牌 `allowed_ips = JSON null` 时代理节点注册被错误鉴权拦截的问题
  - 将 JSON `null` 视为“不限制 IP”
  - 补充对应回归测试

  ## 问题原因
  部分管理令牌的 `allowed_ips` 存的是 JSON `null`，而不是 SQL `NULL`。
  网关此前只把 SQL `NULL` 当作“不限制 IP”，导致这类有效的管理员令牌在注册代理节点时错误返回 `401`。