### PR TITLE
fix(oauth): 修复 OAuth 刷新后 Token 有效期不更新问题

### DIFF
--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/refresh/execution.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/refresh/execution.rs
@@ -24,8 +24,8 @@ pub(super) async fn execute_admin_provider_oauth_refresh(
         transport,
     } = request;
 
-    match state.force_local_oauth_refresh_entry(&transport).await {
-        Ok(Some(_)) => {}
+    let refreshed_entry = match state.force_local_oauth_refresh_entry(&transport).await {
+        Ok(Some(entry)) => Some(entry),
         Ok(None) => {
             return Ok(RefreshDispatch::Respond(response::control_error_response(
                 http::StatusCode::BAD_REQUEST,
@@ -75,7 +75,7 @@ pub(super) async fn execute_admin_provider_oauth_refresh(
                 response::oauth_refresh_failed_bad_request_response(&message),
             ));
         }
-    }
+    };
 
     if !helpers::key_is_account_blocked(&key, OAUTH_ACCOUNT_BLOCK_PREFIX) {
         let _ = state
@@ -89,10 +89,25 @@ pub(super) async fn execute_admin_provider_oauth_refresh(
         .into_iter()
         .next()
         .unwrap_or(key);
-    let refreshed_auth_config = helpers::refreshed_auth_config_object(
-        state,
-        refreshed_key.encrypted_auth_config.as_deref(),
-    );
+    let refreshed_auth_config = refreshed_entry
+        .as_ref()
+        .and_then(|entry| entry.metadata.as_ref())
+        .and_then(serde_json::Value::as_object)
+        .cloned()
+        .unwrap_or_else(|| {
+            helpers::refreshed_auth_config_object(
+                state,
+                refreshed_key.encrypted_auth_config.as_deref(),
+            )
+        });
+    let refreshed_expires_at_unix_secs = refreshed_entry
+        .as_ref()
+        .and_then(|entry| entry.expires_at_unix_secs)
+        .or_else(|| {
+            refreshed_auth_config
+                .get("expires_at")
+                .and_then(serde_json::Value::as_u64)
+        });
     let (account_state_recheck_attempted, account_state_recheck_error) = state
         .refresh_provider_oauth_account_state_after_update(&provider, &key_id, None)
         .await?;
@@ -100,6 +115,7 @@ pub(super) async fn execute_admin_provider_oauth_refresh(
     Ok(RefreshDispatch::Continue(RefreshSuccessContext {
         provider_type,
         refreshed_auth_config,
+        refreshed_expires_at_unix_secs,
         account_state_recheck_attempted,
         account_state_recheck_error,
     }))

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/refresh/helpers.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/refresh/helpers.rs
@@ -23,6 +23,7 @@ pub(super) struct RefreshRequestContext {
 pub(super) struct RefreshSuccessContext {
     pub(super) provider_type: String,
     pub(super) refreshed_auth_config: Map<String, Value>,
+    pub(super) refreshed_expires_at_unix_secs: Option<u64>,
     pub(super) account_state_recheck_attempted: bool,
     pub(super) account_state_recheck_error: Option<String>,
 }

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/refresh/response.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/refresh/response.rs
@@ -36,13 +36,14 @@ pub(super) fn oauth_refresh_failed_service_unavailable_response(
 pub(super) fn admin_provider_oauth_refresh_success_response(
     success: RefreshSuccessContext,
 ) -> Response<Body> {
+    let expires_at = success
+        .refreshed_expires_at_unix_secs
+        .map(serde_json::Value::from)
+        .or_else(|| success.refreshed_auth_config.get("expires_at").cloned())
+        .unwrap_or(Value::Null);
     Json(json!({
         "provider_type": success.provider_type,
-        "expires_at": success
-            .refreshed_auth_config
-            .get("expires_at")
-            .cloned()
-            .unwrap_or(Value::Null),
+        "expires_at": expires_at,
         "has_refresh_token": success
             .refreshed_auth_config
             .get("refresh_token")

--- a/apps/aether-gateway/src/handlers/admin/provider/pool_admin/payloads.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/pool_admin/payloads.rs
@@ -121,6 +121,10 @@ fn admin_pool_derive_oauth_expires_at(
         return None;
     }
 
+    if key.expires_at_unix_secs.is_some() {
+        return key.expires_at_unix_secs;
+    }
+
     for field in ["expires_at", "expiresAt", "expiry", "exp"] {
         let expires_at = admin_pool_json_to_u64(auth_config.and_then(|config| config.get(field)));
         if expires_at.is_some() {
@@ -128,7 +132,7 @@ fn admin_pool_derive_oauth_expires_at(
         }
     }
 
-    key.expires_at_unix_secs
+    None
 }
 
 fn admin_pool_derive_oauth_plan_type(

--- a/apps/aether-gateway/src/handlers/shared/catalog.rs
+++ b/apps/aether-gateway/src/handlers/shared/catalog.rs
@@ -1024,6 +1024,10 @@ pub(crate) fn provider_key_status_snapshot_payload(
         .or_else(|| default_provider_key_status_snapshot().as_object().cloned())
         .unwrap_or_default();
     snapshot.insert(
+        "oauth".to_string(),
+        build_provider_key_oauth_status_snapshot(key),
+    );
+    snapshot.insert(
         "account".to_string(),
         build_provider_key_account_status_snapshot(key, provider_type),
     );

--- a/crates/aether-data/src/repository/provider_catalog/sql.rs
+++ b/crates/aether-data/src/repository/provider_catalog/sql.rs
@@ -1366,6 +1366,7 @@ INSERT INTO provider_api_keys (
         .bind(key.is_active)
         .bind(key.created_at_unix_ms.map(|value| value as f64))
         .bind(key.updated_at_unix_secs.map(|value| value as f64))
+        .bind(key.expires_at_unix_secs.map(|value| value as f64))
         .execute(&self.pool)
         .await
         .map_postgres_err()?;
@@ -1735,6 +1736,10 @@ SET
   proxy = $22,
   fingerprint = $23,
   upstream_metadata = $24,
+  expires_at = CASE
+    WHEN $38::double precision IS NULL THEN NULL
+    ELSE TO_TIMESTAMP($38::double precision)
+  END,
   oauth_invalid_at = CASE
     WHEN $25::double precision IS NULL THEN NULL
     ELSE TO_TIMESTAMP($25::double precision)
@@ -1803,6 +1808,7 @@ WHERE id = $1
         .bind(key.last_rpm_peak.map(|value| value as i32))
         .bind(key.is_active)
         .bind(key.updated_at_unix_secs.map(|value| value as f64))
+        .bind(key.expires_at_unix_secs.map(|value| value as f64))
         .execute(&self.pool)
         .await
         .map_postgres_err()?

--- a/frontend/src/features/providers/components/ProviderDetailDrawer.vue
+++ b/frontend/src/features/providers/components/ProviderDetailDrawer.vue
@@ -1703,19 +1703,28 @@ async function handleRefreshOAuth(key: EndpointAPIKey) {
   refreshingOAuthKeyId.value = key.id
   try {
     const result = await refreshProviderOAuth(key.id)
+    const refreshedExpiresAt = typeof result.expires_at === 'number' ? result.expires_at : null
     let refreshedKey: EndpointAPIKey | null = null
     // 更新本地数据
     const keyInList = providerKeys.value.find(k => k.id === key.id)
     if (keyInList) {
-      keyInList.oauth_expires_at = result.expires_at
+      keyInList.oauth_expires_at = refreshedExpiresAt
     }
     // 只重新加载 keys 数据，避免整个表格刷新
     if (props.providerId) {
       const freshKeys = await getProviderKeys(props.providerId).catch(() => null)
       if (freshKeys) {
-        providerKeys.value = freshKeys
-        syncCurrentSelections(endpoints.value, freshKeys)
-        refreshedKey = freshKeys.find(item => item.id === key.id) ?? null
+        const mergedKeys = freshKeys.map((item) => {
+          if (item.id !== key.id) return item
+          if (refreshedExpiresAt == null) return item
+          if (typeof item.oauth_expires_at === 'number' && item.oauth_expires_at >= refreshedExpiresAt) {
+            return item
+          }
+          return { ...item, oauth_expires_at: refreshedExpiresAt }
+        })
+        providerKeys.value = mergedKeys
+        syncCurrentSelections(endpoints.value, mergedKeys)
+        refreshedKey = mergedKeys.find(item => item.id === key.id) ?? null
       }
     }
     const feedback = getOAuthRefreshFeedback({

--- a/frontend/src/views/admin/PoolManagement.vue
+++ b/frontend/src/views/admin/PoolManagement.vue
@@ -2180,11 +2180,22 @@ async function handleRefreshOAuth(key: PoolKeyDetail) {
   refreshingOAuthKeyId.value = key.key_id
   try {
     const result = await refreshProviderOAuth(key.key_id)
+    const refreshedExpiresAt = typeof result.expires_at === 'number' ? result.expires_at : null
     const target = keyPage.value.keys.find(k => k.key_id === key.key_id)
     if (target) {
-      target.oauth_expires_at = result.expires_at ?? null
+      target.oauth_expires_at = refreshedExpiresAt
     }
     await loadKeys()
+    if (refreshedExpiresAt != null) {
+      const reloadedTarget = keyPage.value.keys.find(k => k.key_id === key.key_id)
+      if (
+        reloadedTarget
+        && (typeof reloadedTarget.oauth_expires_at !== 'number'
+          || reloadedTarget.oauth_expires_at < refreshedExpiresAt)
+      ) {
+        reloadedTarget.oauth_expires_at = refreshedExpiresAt
+      }
+    }
     const refreshedKey = keyPage.value.keys.find(k => k.key_id === key.key_id) ?? null
     const feedback = getOAuthRefreshFeedback({
       accountStateRecheckAttempted: result.account_state_recheck_attempted,


### PR DESCRIPTION
- 持久化刷新后的 `expires_at` 到 Provider Key SQL 更新链路
- 手动刷新接口优先返回本次刷新得到的过期时间
- 按当前 Key 字段重建 OAuth 状态快照，避免旧快照覆盖
- 前端刷新后防止旧列表数据回退覆盖新有效期