### PR TITLE
fix(kiro): 修复 Kiro WebSearch MCP 调用

### DIFF
--- a/apps/aether-gateway/src/ai_pipeline_api.rs
+++ b/apps/aether-gateway/src/ai_pipeline_api.rs
@@ -28,7 +28,7 @@ pub(crate) use crate::ai_pipeline::{
 pub(crate) use aether_ai_pipeline::api::{
     build_core_error_body_for_client_format, core_error_background_report_kind,
     core_error_default_client_api_format, core_success_background_report_kind,
-    implicit_sync_finalize_report_kind, is_core_error_finalize_kind,
+    encode_kiro_sse_events, implicit_sync_finalize_report_kind, is_core_error_finalize_kind,
     normalize_provider_private_report_context, normalize_provider_private_response_value,
     provider_private_response_allows_sync_finalize, resolve_claude_stream_spec,
     resolve_claude_sync_spec, resolve_gemini_stream_spec, resolve_gemini_sync_spec,

--- a/apps/aether-gateway/src/execution_runtime/kiro_web_search.rs
+++ b/apps/aether-gateway/src/execution_runtime/kiro_web_search.rs
@@ -1,0 +1,1395 @@
+use std::collections::BTreeMap;
+use std::io::Error as IoError;
+
+use aether_contracts::{
+    ExecutionPlan, ExecutionResult, ExecutionTelemetry, RequestBody, StreamFrame,
+    StreamFramePayload, StreamFrameType,
+};
+use axum::body::Bytes;
+use base64::Engine as _;
+use futures_util::stream::{self, BoxStream};
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+use crate::execution_runtime::ndjson::encode_stream_frame_ndjson;
+use crate::execution_runtime::transport::{
+    DirectSyncExecutionRuntime, ExecutionRuntimeTransportError,
+};
+use crate::AppState;
+
+const WEB_SEARCH_TOOL_NAME: &str = "web_search";
+const WEB_SEARCH_TOOL_TYPE_PREFIX: &str = "web_search";
+const WEB_SEARCH_QUERY_PREFIX: &str = "Perform a web search for the query: ";
+
+pub(crate) struct KiroWebSearchStream {
+    pub(crate) frame_stream: BoxStream<'static, Result<Bytes, IoError>>,
+    pub(crate) report_context: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct KiroWebSearchRequest {
+    query: String,
+    model: String,
+    input_tokens: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct McpRequest {
+    jsonrpc: &'static str,
+    id: String,
+    method: &'static str,
+    params: McpParams,
+}
+
+#[derive(Debug, Serialize)]
+struct McpParams {
+    name: &'static str,
+    arguments: McpArguments,
+}
+
+#[derive(Debug, Serialize)]
+struct McpArguments {
+    query: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct McpResponse {
+    #[serde(default)]
+    error: Option<McpError>,
+    #[serde(default)]
+    result: Option<McpResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct McpError {
+    #[serde(default)]
+    code: Option<i64>,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct McpResult {
+    #[serde(default)]
+    content: Vec<McpContent>,
+    #[serde(default, rename = "isError")]
+    is_error: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct McpContent {
+    #[serde(rename = "type")]
+    content_type: String,
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct WebSearchResults {
+    #[serde(default)]
+    results: Vec<WebSearchResult>,
+    #[serde(default, rename = "totalResults")]
+    total_results: Option<i64>,
+    #[serde(default)]
+    query: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct WebSearchResult {
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    snippet: Option<String>,
+    #[serde(default, rename = "publishedDate")]
+    published_date: Option<Value>,
+}
+
+struct KiroMcpExecution {
+    result: ExecutionResult,
+    url: String,
+    profile_arn_present: bool,
+}
+
+struct KiroMcpRequestContext {
+    headers: BTreeMap<String, String>,
+    profile_arn_present: bool,
+    auth_config: Option<aether_provider_transport::kiro::KiroAuthConfig>,
+}
+
+pub(crate) async fn maybe_execute_kiro_web_search_stream(
+    state: &AppState,
+    plan: &ExecutionPlan,
+    report_context: Option<&Value>,
+) -> Result<Option<KiroWebSearchStream>, ExecutionRuntimeTransportError> {
+    let Some(request) = detect_kiro_web_search_request(plan, report_context) else {
+        return Ok(None);
+    };
+
+    let (tool_use_id, mcp_request) = create_mcp_request(request.query.as_str());
+    let mcp_execution = execute_mcp_request(state, plan, &mcp_request).await?;
+
+    debug!(
+        event_name = "kiro_web_search_mcp_executed",
+        log_type = "debug",
+        request_id = %plan.request_id,
+        candidate_id = ?plan.candidate_id,
+        status_code = mcp_execution.result.status_code,
+        mcp_url = %mcp_execution.url,
+        profile_arn_present = mcp_execution.profile_arn_present,
+        "gateway executed Kiro web_search through MCP endpoint"
+    );
+
+    if !(200..300).contains(&mcp_execution.result.status_code) {
+        return Ok(Some(KiroWebSearchStream {
+            frame_stream: execution_result_frame_stream(&mcp_execution.result),
+            report_context: report_context.cloned(),
+        }));
+    }
+
+    let search_results = parse_mcp_search_results(&mcp_execution.result);
+    let sse_body = build_web_search_sse_body(
+        request.model.as_str(),
+        request.query.as_str(),
+        tool_use_id.as_str(),
+        search_results,
+        request.input_tokens,
+    )
+    .map_err(ExecutionRuntimeTransportError::BodyEncode)?;
+    let mut synthetic_context = synthetic_report_context(report_context, mcp_execution.url);
+    if let Some(context) = synthetic_context.as_mut().and_then(Value::as_object_mut) {
+        context.insert("kiro_web_search_mcp".to_string(), Value::Bool(true));
+    }
+
+    Ok(Some(KiroWebSearchStream {
+        frame_stream: sse_frame_stream(Bytes::from(sse_body)),
+        report_context: synthetic_context,
+    }))
+}
+
+fn execute_result_body_bytes(result: &ExecutionResult) -> Vec<u8> {
+    let Some(body) = result.body.as_ref() else {
+        return Vec::new();
+    };
+    if let Some(json_body) = body.json_body.as_ref() {
+        return serde_json::to_vec(json_body).unwrap_or_default();
+    }
+    body.body_bytes_b64
+        .as_deref()
+        .and_then(|body| base64::engine::general_purpose::STANDARD.decode(body).ok())
+        .unwrap_or_default()
+}
+
+fn execution_result_frame_stream(
+    result: &ExecutionResult,
+) -> BoxStream<'static, Result<Bytes, IoError>> {
+    raw_response_frame_stream(
+        result.status_code,
+        result.headers.clone(),
+        Bytes::from(execute_result_body_bytes(result)),
+        result.telemetry.clone(),
+    )
+}
+
+fn sse_frame_stream(body: Bytes) -> BoxStream<'static, Result<Bytes, IoError>> {
+    raw_response_frame_stream(
+        200,
+        BTreeMap::from([
+            ("cache-control".to_string(), "no-cache".to_string()),
+            ("content-type".to_string(), "text/event-stream".to_string()),
+        ]),
+        body,
+        None,
+    )
+}
+
+fn raw_response_frame_stream(
+    status_code: u16,
+    headers: BTreeMap<String, String>,
+    body: Bytes,
+    telemetry: Option<ExecutionTelemetry>,
+) -> BoxStream<'static, Result<Bytes, IoError>> {
+    let ttfb_ms = telemetry.as_ref().and_then(|value| value.ttfb_ms);
+    let elapsed_ms = telemetry.as_ref().and_then(|value| value.elapsed_ms);
+    let upstream_bytes = body.len() as u64;
+    let mut frames = vec![
+        StreamFrame {
+            frame_type: StreamFrameType::Headers,
+            payload: StreamFramePayload::Headers {
+                status_code,
+                headers,
+            },
+        },
+        StreamFrame {
+            frame_type: StreamFrameType::Telemetry,
+            payload: StreamFramePayload::Telemetry {
+                telemetry: ExecutionTelemetry {
+                    ttfb_ms,
+                    elapsed_ms: ttfb_ms,
+                    upstream_bytes: Some(0),
+                },
+            },
+        },
+    ];
+    if !body.is_empty() {
+        frames.push(StreamFrame {
+            frame_type: StreamFrameType::Data,
+            payload: StreamFramePayload::Data {
+                chunk_b64: Some(base64::engine::general_purpose::STANDARD.encode(body.as_ref())),
+                text: None,
+            },
+        });
+    }
+    frames.push(StreamFrame {
+        frame_type: StreamFrameType::Telemetry,
+        payload: StreamFramePayload::Telemetry {
+            telemetry: ExecutionTelemetry {
+                ttfb_ms,
+                elapsed_ms,
+                upstream_bytes: Some(upstream_bytes),
+            },
+        },
+    });
+    frames.push(StreamFrame::eof());
+
+    stream::iter(
+        frames
+            .into_iter()
+            .map(|frame| encode_stream_frame_ndjson(&frame)),
+    )
+    .boxed()
+}
+
+async fn execute_mcp_request(
+    state: &AppState,
+    plan: &ExecutionPlan,
+    request: &McpRequest,
+) -> Result<KiroMcpExecution, ExecutionRuntimeTransportError> {
+    let mcp_url = aether_provider_transport::kiro::build_kiro_mcp_url_from_resolved_url(&plan.url)
+        .ok_or_else(|| {
+            ExecutionRuntimeTransportError::UpstreamRequest(format!(
+                "failed to build Kiro MCP url from {}",
+                plan.url
+            ))
+        })?;
+    let mut request_context = build_mcp_request_context(state, plan).await;
+    if !request_context.profile_arn_present {
+        if let Some(profile_arn) = discover_kiro_profile_arn(state, plan, &request_context).await? {
+            request_context.headers.insert(
+                aether_provider_transport::kiro::KIRO_PROFILE_ARN_HEADER.to_string(),
+                profile_arn,
+            );
+            request_context.profile_arn_present = true;
+        }
+    }
+    let body_json =
+        serde_json::to_value(request).map_err(ExecutionRuntimeTransportError::BodyEncode)?;
+    let mcp_plan = ExecutionPlan {
+        request_id: plan.request_id.clone(),
+        candidate_id: plan.candidate_id.clone(),
+        provider_name: plan.provider_name.clone(),
+        provider_id: plan.provider_id.clone(),
+        endpoint_id: plan.endpoint_id.clone(),
+        key_id: plan.key_id.clone(),
+        method: "POST".to_string(),
+        url: mcp_url.clone(),
+        headers: request_context.headers,
+        content_type: Some("application/json".to_string()),
+        content_encoding: None,
+        body: RequestBody::from_json(body_json),
+        stream: false,
+        client_api_format: plan.client_api_format.clone(),
+        provider_api_format: plan.provider_api_format.clone(),
+        model_name: plan.model_name.clone(),
+        proxy: plan.proxy.clone(),
+        tls_profile: plan.tls_profile.clone(),
+        timeouts: plan.timeouts.clone(),
+    };
+    let result = DirectSyncExecutionRuntime::new()
+        .execute_sync(&mcp_plan)
+        .await?;
+    Ok(KiroMcpExecution {
+        result,
+        url: mcp_url,
+        profile_arn_present: request_context.profile_arn_present,
+    })
+}
+
+async fn build_mcp_request_context(
+    state: &AppState,
+    plan: &ExecutionPlan,
+) -> KiroMcpRequestContext {
+    let body_profile_arn = profile_arn_from_plan_body(plan);
+    let fallback = || build_mcp_headers_from_plan(&plan.headers, body_profile_arn.as_deref());
+
+    let transport = match state
+        .read_provider_transport_snapshot(&plan.provider_id, &plan.endpoint_id, &plan.key_id)
+        .await
+    {
+        Ok(Some(transport)) => transport,
+        Ok(None) => return fallback(),
+        Err(err) => {
+            warn!(
+                event_name = "kiro_web_search_transport_snapshot_unavailable",
+                log_type = "ops",
+                request_id = %plan.request_id,
+                candidate_id = ?plan.candidate_id,
+                provider_id = %plan.provider_id,
+                endpoint_id = %plan.endpoint_id,
+                key_id = %plan.key_id,
+                error = ?err,
+                "gateway could not read Kiro transport snapshot for web_search MCP"
+            );
+            return fallback();
+        }
+    };
+
+    build_mcp_headers_from_transport(&transport, plan, body_profile_arn.as_deref())
+        .unwrap_or_else(fallback)
+}
+
+fn build_mcp_headers_from_transport(
+    transport: &aether_provider_transport::GatewayProviderTransportSnapshot,
+    plan: &ExecutionPlan,
+    body_profile_arn: Option<&str>,
+) -> Option<KiroMcpRequestContext> {
+    if !transport
+        .provider
+        .provider_type
+        .trim()
+        .eq_ignore_ascii_case(aether_provider_transport::kiro::PROVIDER_TYPE)
+    {
+        return None;
+    }
+
+    let resolved_auth = aether_provider_transport::kiro::resolve_local_kiro_request_auth(transport);
+    let auth_config = resolved_auth
+        .as_ref()
+        .map(|auth| auth.auth_config.clone())
+        .or_else(|| {
+            aether_provider_transport::kiro::KiroAuthConfig::from_raw_json(
+                transport.key.decrypted_auth_config.as_deref(),
+            )
+        })?;
+    let fallback_secret = header_value_case_insensitive(
+        &plan.headers,
+        aether_provider_transport::kiro::KIRO_AUTH_HEADER,
+    )
+    .and_then(stripped_bearer_token)
+    .or_else(|| {
+        transport
+            .key
+            .decrypted_api_key
+            .trim()
+            .strip_prefix("__placeholder__")
+            .map(|_| "")
+            .or_else(|| Some(transport.key.decrypted_api_key.trim()))
+    });
+    let machine_id = resolved_auth
+        .as_ref()
+        .map(|auth| auth.machine_id.clone())
+        .or_else(|| {
+            aether_provider_transport::kiro::generate_machine_id(&auth_config, fallback_secret)
+        })?;
+    let mut headers = aether_provider_transport::kiro::build_mcp_headers(&auth_config, &machine_id);
+    if !headers.contains_key(aether_provider_transport::kiro::KIRO_PROFILE_ARN_HEADER) {
+        if let Some(profile_arn) = body_profile_arn {
+            headers.insert(
+                aether_provider_transport::kiro::KIRO_PROFILE_ARN_HEADER.to_string(),
+                profile_arn.to_string(),
+            );
+        }
+    }
+
+    if let Some(plan_auth_value) = header_value_case_insensitive(
+        &plan.headers,
+        aether_provider_transport::kiro::KIRO_AUTH_HEADER,
+    ) {
+        headers.insert(
+            aether_provider_transport::kiro::KIRO_AUTH_HEADER.to_string(),
+            plan_auth_value.to_string(),
+        );
+    } else if let Some(auth) = resolved_auth {
+        headers.insert(auth.name.to_string(), auth.value);
+    }
+    if header_value_case_insensitive(
+        &plan.headers,
+        aether_provider_transport::kiro::KIRO_TOKEN_TYPE_HEADER,
+    )
+    .is_some_and(|value| value.eq_ignore_ascii_case("API_KEY"))
+    {
+        headers.insert("tokentype".to_string(), "API_KEY".to_string());
+    }
+
+    headers.remove("x-amzn-kiro-agent-mode");
+    headers.remove("content-length");
+    let profile_arn_present = headers.keys().any(|name| {
+        name.eq_ignore_ascii_case(aether_provider_transport::kiro::KIRO_PROFILE_ARN_HEADER)
+    });
+    Some(KiroMcpRequestContext {
+        headers,
+        profile_arn_present,
+        auth_config: Some(auth_config),
+    })
+}
+
+fn profile_arn_from_plan_body(plan: &ExecutionPlan) -> Option<String> {
+    plan.body
+        .json_body
+        .as_ref()
+        .and_then(|body| body.get("profileArn"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn header_value_case_insensitive<'a>(
+    headers: &'a BTreeMap<String, String>,
+    target: &str,
+) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(target))
+        .map(|(_, value)| value.trim())
+        .filter(|value| !value.is_empty())
+}
+
+fn stripped_bearer_token(value: &str) -> Option<&str> {
+    value
+        .trim()
+        .strip_prefix("Bearer ")
+        .or_else(|| value.trim().strip_prefix("bearer "))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+async fn discover_kiro_profile_arn(
+    _state: &AppState,
+    plan: &ExecutionPlan,
+    context: &KiroMcpRequestContext,
+) -> Result<Option<String>, ExecutionRuntimeTransportError> {
+    let Some(auth_config) = context.auth_config.as_ref() else {
+        return Ok(None);
+    };
+    for region in profile_discovery_regions(auth_config) {
+        match discover_kiro_profile_arn_in_region(plan, context, region.as_str()).await? {
+            Some(profile_arn) => {
+                debug!(
+                    event_name = "kiro_web_search_profile_arn_discovered",
+                    log_type = "debug",
+                    request_id = %plan.request_id,
+                    candidate_id = ?plan.candidate_id,
+                    region = region.as_str(),
+                    "gateway discovered Kiro profileArn for web_search MCP"
+                );
+                return Ok(Some(profile_arn));
+            }
+            None => continue,
+        }
+    }
+    warn!(
+        event_name = "kiro_web_search_profile_arn_unavailable",
+        log_type = "ops",
+        request_id = %plan.request_id,
+        candidate_id = ?plan.candidate_id,
+        provider_id = %plan.provider_id,
+        endpoint_id = %plan.endpoint_id,
+        key_id = %plan.key_id,
+        "gateway could not resolve Kiro profileArn before web_search MCP"
+    );
+    Ok(None)
+}
+
+async fn discover_kiro_profile_arn_in_region(
+    plan: &ExecutionPlan,
+    context: &KiroMcpRequestContext,
+    region: &str,
+) -> Result<Option<String>, ExecutionRuntimeTransportError> {
+    let mut next_token: Option<String> = None;
+    for _ in 0..4 {
+        let mut body = serde_json::Map::new();
+        if let Some(token) = next_token.as_deref() {
+            body.insert("nextToken".to_string(), Value::String(token.to_string()));
+        }
+        let list_plan = ExecutionPlan {
+            request_id: plan.request_id.clone(),
+            candidate_id: plan.candidate_id.clone(),
+            provider_name: plan.provider_name.clone(),
+            provider_id: plan.provider_id.clone(),
+            endpoint_id: plan.endpoint_id.clone(),
+            key_id: plan.key_id.clone(),
+            method: "POST".to_string(),
+            url: format!(
+                "{}/ListAvailableProfiles",
+                kiro_runtime_base_url_for_region(region).trim_end_matches('/')
+            ),
+            headers: build_profile_discovery_headers(&context.headers, region),
+            content_type: Some("application/json".to_string()),
+            content_encoding: None,
+            body: RequestBody::from_json(Value::Object(body)),
+            stream: false,
+            client_api_format: plan.client_api_format.clone(),
+            provider_api_format: "kiro:profiles".to_string(),
+            model_name: Some("kiro-list-available-profiles".to_string()),
+            proxy: plan.proxy.clone(),
+            tls_profile: plan.tls_profile.clone(),
+            timeouts: plan.timeouts.clone(),
+        };
+        let result = DirectSyncExecutionRuntime::new()
+            .execute_sync(&list_plan)
+            .await?;
+        if !(200..300).contains(&result.status_code) {
+            debug!(
+                event_name = "kiro_web_search_profile_arn_discovery_status",
+                log_type = "debug",
+                request_id = %plan.request_id,
+                candidate_id = ?plan.candidate_id,
+                region,
+                status_code = result.status_code,
+                "Kiro ListAvailableProfiles did not return success"
+            );
+            return Ok(None);
+        }
+        let Some(body_json) = execution_result_body_json(&result) else {
+            return Ok(None);
+        };
+        if let Some(profile_arn) = first_profile_arn(&body_json) {
+            return Ok(Some(profile_arn));
+        }
+        next_token = body_json
+            .get("nextToken")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        if next_token.is_none() {
+            return Ok(None);
+        }
+    }
+    Ok(None)
+}
+
+fn build_profile_discovery_headers(
+    mcp_headers: &BTreeMap<String, String>,
+    region: &str,
+) -> BTreeMap<String, String> {
+    let mut headers = mcp_headers.clone();
+    remove_header_case_insensitive(
+        &mut headers,
+        aether_provider_transport::kiro::KIRO_PROFILE_ARN_HEADER,
+    );
+    headers.insert("accept".to_string(), "application/json".to_string());
+    headers.insert("content-type".to_string(), "application/json".to_string());
+    headers.insert(
+        "host".to_string(),
+        kiro_runtime_host_for_region(region).to_string(),
+    );
+    headers
+}
+
+fn profile_discovery_regions(
+    auth_config: &aether_provider_transport::kiro::KiroAuthConfig,
+) -> Vec<String> {
+    let mut regions = Vec::new();
+    push_unique_region(&mut regions, auth_config.effective_api_region());
+    push_unique_region(&mut regions, auth_config.effective_auth_region());
+    if auth_config.is_idc_auth() {
+        push_unique_region(&mut regions, "us-east-1");
+        push_unique_region(&mut regions, "eu-central-1");
+    }
+    regions
+}
+
+fn push_unique_region(regions: &mut Vec<String>, region: &str) {
+    let region = region.trim();
+    if region.is_empty() || regions.iter().any(|value| value == region) {
+        return;
+    }
+    regions.push(region.to_string());
+}
+
+fn kiro_runtime_base_url_for_region(region: &str) -> String {
+    format!("https://{}", kiro_runtime_host_for_region(region))
+}
+
+fn kiro_runtime_host_for_region(region: &str) -> String {
+    match region {
+        "us-gov-east-1" | "us-gov-west-1" => format!("q-fips.{region}.amazonaws.com"),
+        "us-iso-east-1" => "q.us-iso-east-1.c2s.ic.gov".to_string(),
+        "us-isob-east-1" => "q.us-isob-east-1.sc2s.sgov.gov".to_string(),
+        "us-isof-south-1" => "q.us-isof-south-1.csp.hci.ic.gov".to_string(),
+        "us-isof-east-1" => "q.us-isof-east-1.csp.hci.ic.gov".to_string(),
+        _ => format!("q.{region}.amazonaws.com"),
+    }
+}
+
+fn first_profile_arn(body: &Value) -> Option<String> {
+    body.get("profiles")?
+        .as_array()?
+        .iter()
+        .find_map(|profile| {
+            profile
+                .get("arn")
+                .or_else(|| profile.get("profileArn"))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        })
+}
+
+fn build_mcp_headers_from_plan(
+    plan_headers: &BTreeMap<String, String>,
+    profile_arn: Option<&str>,
+) -> KiroMcpRequestContext {
+    let mut headers = BTreeMap::new();
+    for (name, value) in plan_headers {
+        let normalized = name.trim().to_ascii_lowercase();
+        if normalized.is_empty()
+            || matches!(
+                normalized.as_str(),
+                "accept" | "content-length" | "connection" | "host" | "x-amzn-kiro-agent-mode"
+            )
+        {
+            continue;
+        }
+        headers.insert(normalized, value.trim().to_string());
+    }
+    remove_header_case_insensitive(
+        &mut headers,
+        aether_provider_transport::kiro::KIRO_PROFILE_ARN_HEADER,
+    );
+    headers.insert("accept".to_string(), "application/json".to_string());
+    headers.insert("content-type".to_string(), "application/json".to_string());
+    if let Some(profile_arn) = profile_arn {
+        headers.insert(
+            aether_provider_transport::kiro::KIRO_PROFILE_ARN_HEADER.to_string(),
+            profile_arn.to_string(),
+        );
+    }
+    let profile_arn_present = headers.keys().any(|name| {
+        name.eq_ignore_ascii_case(aether_provider_transport::kiro::KIRO_PROFILE_ARN_HEADER)
+    });
+    KiroMcpRequestContext {
+        headers,
+        profile_arn_present,
+        auth_config: None,
+    }
+}
+
+fn remove_header_case_insensitive(headers: &mut BTreeMap<String, String>, target: &str) {
+    let matching_keys = headers
+        .keys()
+        .filter(|name| name.eq_ignore_ascii_case(target))
+        .cloned()
+        .collect::<Vec<_>>();
+    for key in matching_keys {
+        headers.remove(&key);
+    }
+}
+
+fn detect_kiro_web_search_request(
+    plan: &ExecutionPlan,
+    report_context: Option<&Value>,
+) -> Option<KiroWebSearchRequest> {
+    if !plan
+        .provider_name
+        .as_deref()
+        .unwrap_or_default()
+        .trim()
+        .eq_ignore_ascii_case("kiro")
+        && !report_context
+            .and_then(|context| context.get("envelope_name"))
+            .and_then(Value::as_str)
+            .is_some_and(|value| {
+                value.eq_ignore_ascii_case(aether_provider_transport::kiro::KIRO_ENVELOPE_NAME)
+            })
+    {
+        return None;
+    }
+    if !plan.stream || !plan.provider_api_format.eq_ignore_ascii_case("claude:cli") {
+        return None;
+    }
+    if report_context
+        .and_then(|context| context.get("client_api_format"))
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.eq_ignore_ascii_case("claude:cli"))
+    {
+        return None;
+    }
+
+    if let Some(original) = report_context
+        .and_then(|context| context.get("original_request_body"))
+        .filter(|body| body.is_object())
+    {
+        if has_only_builtin_web_search_tool(original) {
+            let query = extract_search_query_from_claude_request(original)?;
+            let model = original
+                .get("model")
+                .and_then(Value::as_str)
+                .or(plan.model_name.as_deref())
+                .unwrap_or("claude")
+                .to_string();
+            return Some(KiroWebSearchRequest {
+                query,
+                model,
+                input_tokens: estimate_input_tokens(original),
+            });
+        }
+    }
+
+    detect_kiro_web_search_from_envelope(plan)
+}
+
+fn detect_kiro_web_search_from_envelope(plan: &ExecutionPlan) -> Option<KiroWebSearchRequest> {
+    let body = plan.body.json_body.as_ref()?;
+    let current_message = body
+        .get("conversationState")?
+        .get("currentMessage")?
+        .get("userInputMessage")?;
+    let tools = current_message
+        .get("userInputMessageContext")
+        .and_then(|context| context.get("tools"))
+        .and_then(Value::as_array)?;
+    if tools.len() != 1 {
+        return None;
+    }
+    let spec = tools[0].get("toolSpecification")?;
+    if spec.get("name").and_then(Value::as_str) != Some(WEB_SEARCH_TOOL_NAME) {
+        return None;
+    }
+    let description = spec
+        .get("description")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim();
+    let input_schema = spec.get("inputSchema").and_then(|value| value.get("json"));
+    if !description.is_empty() || !schema_is_empty_object(input_schema) {
+        return None;
+    }
+    let query = current_message
+        .get("content")
+        .and_then(Value::as_str)
+        .and_then(strip_search_query_prefix)?;
+    let model = current_message
+        .get("modelId")
+        .and_then(Value::as_str)
+        .or(plan.model_name.as_deref())
+        .unwrap_or("claude")
+        .to_string();
+    Some(KiroWebSearchRequest {
+        query,
+        model,
+        input_tokens: estimate_input_tokens(body),
+    })
+}
+
+fn schema_is_empty_object(value: Option<&Value>) -> bool {
+    let Some(value) = value else {
+        return true;
+    };
+    value.as_object().is_some_and(|object| {
+        object
+            .get("properties")
+            .is_none_or(|props| props.as_object().is_none_or(serde_json::Map::is_empty))
+    })
+}
+
+fn has_only_builtin_web_search_tool(body: &Value) -> bool {
+    let Some(tools) = body.get("tools").and_then(Value::as_array) else {
+        return false;
+    };
+    if tools.len() != 1 {
+        return false;
+    }
+    let tool = &tools[0];
+    if tool.get("name").and_then(Value::as_str) != Some(WEB_SEARCH_TOOL_NAME) {
+        return false;
+    }
+    tool.get("type")
+        .or_else(|| tool.get("tool_type"))
+        .and_then(Value::as_str)
+        .is_some_and(|value| value.trim().starts_with(WEB_SEARCH_TOOL_TYPE_PREFIX))
+}
+
+fn extract_search_query_from_claude_request(body: &Value) -> Option<String> {
+    let first_message = body.get("messages")?.as_array()?.first()?;
+    let text = extract_text_content(first_message.get("content")?)?;
+    strip_search_query_prefix(text.as_str())
+}
+
+fn extract_text_content(content: &Value) -> Option<String> {
+    match content {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(blocks) => blocks.iter().find_map(|block| {
+            (block.get("type").and_then(Value::as_str) == Some("text"))
+                .then(|| {
+                    block
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned)
+                })
+                .flatten()
+        }),
+        _ => None,
+    }
+}
+
+fn strip_search_query_prefix(text: &str) -> Option<String> {
+    let text = text.trim();
+    let query = text
+        .strip_prefix(WEB_SEARCH_QUERY_PREFIX)
+        .unwrap_or(text)
+        .trim();
+    (!query.is_empty()).then(|| query.to_string())
+}
+
+fn estimate_input_tokens(body: &Value) -> u64 {
+    let size = serde_json::to_string(body)
+        .map(|body| body.len() as u64)
+        .unwrap_or_default();
+    (size / 4).max(1)
+}
+
+fn create_mcp_request(query: &str) -> (String, McpRequest) {
+    let random = Uuid::new_v4().simple().to_string();
+    let timestamp = chrono::Utc::now().timestamp_millis();
+    let suffix = Uuid::new_v4().simple().to_string();
+    let request_id = format!(
+        "web_search_tooluse_{}_{}_{}",
+        &random[..22],
+        timestamp,
+        &suffix[..8]
+    );
+    let tool_use_id = format!("srvtoolu_{}", Uuid::new_v4().simple());
+    (
+        tool_use_id,
+        McpRequest {
+            jsonrpc: "2.0",
+            id: request_id,
+            method: "tools/call",
+            params: McpParams {
+                name: WEB_SEARCH_TOOL_NAME,
+                arguments: McpArguments {
+                    query: query.to_string(),
+                },
+            },
+        },
+    )
+}
+
+fn parse_mcp_search_results(result: &ExecutionResult) -> Option<WebSearchResults> {
+    let body_json = execution_result_body_json(result)?;
+    let response: McpResponse = serde_json::from_value(body_json).ok()?;
+    if let Some(error) = response.error {
+        warn!(
+            event_name = "kiro_web_search_mcp_error",
+            log_type = "event",
+            code = error.code.unwrap_or_default(),
+            message = error.message.as_deref().unwrap_or("unknown"),
+            "Kiro MCP web_search returned JSON-RPC error"
+        );
+        return None;
+    }
+    let mcp_result = response.result?;
+    if mcp_result.is_error {
+        warn!(
+            event_name = "kiro_web_search_mcp_tool_error",
+            log_type = "event",
+            "Kiro MCP web_search returned tool error"
+        );
+        return None;
+    }
+    let content = mcp_result
+        .content
+        .iter()
+        .find(|content| content.content_type == "text")?;
+    serde_json::from_str::<WebSearchResults>(content.text.as_str()).ok()
+}
+
+fn execution_result_body_json(result: &ExecutionResult) -> Option<Value> {
+    let body = result.body.as_ref()?;
+    if let Some(json_body) = body.json_body.as_ref() {
+        return Some(json_body.clone());
+    }
+    let body = body.body_bytes_b64.as_deref()?;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(body)
+        .ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn build_web_search_sse_body(
+    model: &str,
+    query: &str,
+    tool_use_id: &str,
+    search_results: Option<WebSearchResults>,
+    input_tokens: u64,
+) -> Result<Vec<u8>, serde_json::Error> {
+    let events = build_web_search_events(model, query, tool_use_id, search_results, input_tokens);
+    crate::ai_pipeline_api::encode_kiro_sse_events(events)
+}
+
+fn build_web_search_events(
+    model: &str,
+    query: &str,
+    tool_use_id: &str,
+    search_results: Option<WebSearchResults>,
+    input_tokens: u64,
+) -> Vec<Value> {
+    let message_id = format!("msg_{}", &Uuid::new_v4().simple().to_string()[..24]);
+    let mut events = vec![
+        json!({
+            "type": "message_start",
+            "message": {
+                "id": message_id,
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": Value::Null,
+                "stop_sequence": Value::Null,
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0
+                }
+            }
+        }),
+        json!({
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "text",
+                "text": ""
+            }
+        }),
+        json!({
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "text_delta",
+                "text": format!("I'll search for \"{}\".", query)
+            }
+        }),
+        json!({
+            "type": "content_block_stop",
+            "index": 0
+        }),
+        json!({
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "id": tool_use_id,
+                "type": "server_tool_use",
+                "name": WEB_SEARCH_TOOL_NAME,
+                "input": {"query": query}
+            }
+        }),
+        json!({
+            "type": "content_block_stop",
+            "index": 1
+        }),
+        json!({
+            "type": "content_block_start",
+            "index": 2,
+            "content_block": {
+                "type": "web_search_tool_result",
+                "content": search_result_content(search_results.as_ref())
+            }
+        }),
+        json!({
+            "type": "content_block_stop",
+            "index": 2
+        }),
+        json!({
+            "type": "content_block_start",
+            "index": 3,
+            "content_block": {
+                "type": "text",
+                "text": ""
+            }
+        }),
+    ];
+
+    let summary = generate_search_summary(query, search_results.as_ref());
+    for chunk in chunk_text(summary.as_str(), 100) {
+        events.push(json!({
+            "type": "content_block_delta",
+            "index": 3,
+            "delta": {
+                "type": "text_delta",
+                "text": chunk
+            }
+        }));
+    }
+    events.extend([
+        json!({
+            "type": "content_block_stop",
+            "index": 3
+        }),
+        json!({
+            "type": "message_delta",
+            "delta": {
+                "stop_reason": "end_turn",
+                "stop_sequence": Value::Null
+            },
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": estimate_text_tokens(summary.as_str()),
+                "server_tool_use": {
+                    "web_search_requests": 1
+                }
+            }
+        }),
+        json!({
+            "type": "message_stop"
+        }),
+    ]);
+    events
+}
+
+fn search_result_content(results: Option<&WebSearchResults>) -> Vec<Value> {
+    results
+        .into_iter()
+        .flat_map(|results| results.results.iter())
+        .filter(|result| !result.title.trim().is_empty() && !result.url.trim().is_empty())
+        .map(|result| {
+            json!({
+                "type": "web_search_result",
+                "title": result.title,
+                "url": result.url,
+                "encrypted_content": result.snippet.clone().unwrap_or_default(),
+                "page_age": page_age(result.published_date.as_ref())
+            })
+        })
+        .collect()
+}
+
+fn page_age(value: Option<&Value>) -> Option<String> {
+    let timestamp_ms = value.and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_str().and_then(|text| text.parse::<i64>().ok()))
+    })?;
+    chrono::DateTime::from_timestamp_millis(timestamp_ms)
+        .map(|value| value.format("%B %-d, %Y").to_string())
+}
+
+fn generate_search_summary(query: &str, results: Option<&WebSearchResults>) -> String {
+    let mut summary = format!("Here are the search results for \"{}\":\n\n", query);
+    match results {
+        Some(results) if !results.results.is_empty() => {
+            if let Some(source_query) = results
+                .query
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty() && *value != query)
+            {
+                summary.push_str(&format!("Search query used: {source_query}\n\n"));
+            }
+            if let Some(total) = results.total_results {
+                summary.push_str(&format!("Total results reported: {total}\n\n"));
+            }
+            for (idx, result) in results.results.iter().enumerate() {
+                if result.title.trim().is_empty() || result.url.trim().is_empty() {
+                    continue;
+                }
+                summary.push_str(&format!("{}. **{}**\n", idx + 1, result.title));
+                if let Some(snippet) = result
+                    .snippet
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                {
+                    summary.push_str("   ");
+                    summary.push_str(truncate_chars(snippet, 200).as_str());
+                    summary.push('\n');
+                }
+                summary.push_str(&format!("   Source: {}\n\n", result.url));
+            }
+            if let Some(error) = results
+                .error
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                summary.push_str(&format!("Search warning: {error}\n\n"));
+            }
+        }
+        _ => summary.push_str("No results found.\n"),
+    }
+    summary.push_str(
+        "\nPlease note that these are web search results and may not be fully accurate or up-to-date.",
+    );
+    summary
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    match value.char_indices().nth(max_chars) {
+        Some((idx, _)) => format!("{}...", &value[..idx]),
+        None => value.to_string(),
+    }
+}
+
+fn chunk_text(value: &str, chunk_size: usize) -> Vec<String> {
+    if value.is_empty() {
+        return Vec::new();
+    }
+    let chars = value.chars().collect::<Vec<_>>();
+    chars
+        .chunks(chunk_size.max(1))
+        .map(|chunk| chunk.iter().collect())
+        .collect()
+}
+
+fn estimate_text_tokens(text: &str) -> u64 {
+    ((text.len() as u64 + 3) / 4).max(1)
+}
+
+fn synthetic_report_context(report_context: Option<&Value>, mcp_url: String) -> Option<Value> {
+    let mut context = report_context.cloned()?;
+    if let Some(object) = context.as_object_mut() {
+        object.insert("has_envelope".to_string(), Value::Bool(false));
+        object.insert("needs_conversion".to_string(), Value::Bool(false));
+        object.insert("upstream_url".to_string(), Value::String(mcp_url));
+        object.remove("envelope_name");
+    }
+    Some(context)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use aether_contracts::{ExecutionPlan, RequestBody};
+    use serde_json::json;
+
+    use super::{
+        build_mcp_headers_from_plan, build_web_search_sse_body, detect_kiro_web_search_request,
+        parse_mcp_search_results, strip_search_query_prefix,
+    };
+
+    fn sample_plan(body: serde_json::Value) -> ExecutionPlan {
+        ExecutionPlan {
+            request_id: "req-1".to_string(),
+            candidate_id: Some("cand-1".to_string()),
+            provider_name: Some("Kiro".to_string()),
+            provider_id: "provider-1".to_string(),
+            endpoint_id: "endpoint-1".to_string(),
+            key_id: "key-1".to_string(),
+            method: "POST".to_string(),
+            url: "https://q.us-east-1.amazonaws.com/generateAssistantResponse?beta=true"
+                .to_string(),
+            headers: BTreeMap::from([
+                ("authorization".to_string(), "Bearer token".to_string()),
+                (
+                    "accept".to_string(),
+                    "application/vnd.amazon.eventstream".to_string(),
+                ),
+                ("x-amzn-kiro-agent-mode".to_string(), "vibe".to_string()),
+            ]),
+            content_type: Some("application/json".to_string()),
+            content_encoding: None,
+            body: RequestBody::from_json(body),
+            stream: true,
+            client_api_format: "claude:cli".to_string(),
+            provider_api_format: "claude:cli".to_string(),
+            model_name: Some("claude-sonnet-4.6".to_string()),
+            proxy: None,
+            tls_profile: None,
+            timeouts: None,
+        }
+    }
+
+    #[test]
+    fn strips_web_search_query_prefix() {
+        assert_eq!(
+            strip_search_query_prefix("Perform a web search for the query: Shanghai weather")
+                .as_deref(),
+            Some("Shanghai weather")
+        );
+        assert_eq!(
+            strip_search_query_prefix("Shanghai weather").as_deref(),
+            Some("Shanghai weather")
+        );
+    }
+
+    #[test]
+    fn detects_builtin_web_search_from_original_report_context() {
+        let plan = sample_plan(json!({"conversationState": {}}));
+        let report_context = json!({
+            "envelope_name": "kiro:generateAssistantResponse",
+            "client_api_format": "claude:cli",
+            "original_request_body": {
+                "model": "claude-haiku-4-5-20251001",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Perform a web search for the query: Shanghai weather today"
+                    }]
+                }],
+                "tools": [{
+                    "type": "web_search_20250305",
+                    "name": "web_search",
+                    "max_uses": 8
+                }]
+            }
+        });
+
+        let detected = detect_kiro_web_search_request(&plan, Some(&report_context))
+            .expect("web_search should be detected");
+        assert_eq!(detected.query, "Shanghai weather today");
+        assert_eq!(detected.model, "claude-haiku-4-5-20251001");
+    }
+
+    #[test]
+    fn detects_builtin_web_search_from_kiro_envelope_fallback() {
+        let plan = sample_plan(json!({
+            "conversationState": {
+                "currentMessage": {
+                    "userInputMessage": {
+                        "content": "Perform a web search for the query: Rust 2026",
+                        "modelId": "claude-sonnet-4.6",
+                        "userInputMessageContext": {
+                            "tools": [{
+                                "toolSpecification": {
+                                    "name": "web_search",
+                                    "description": "",
+                                    "inputSchema": {"json": {"type": "object", "properties": {}}}
+                                }
+                            }]
+                        }
+                    }
+                }
+            }
+        }));
+        let report_context = json!({
+            "envelope_name": "kiro:generateAssistantResponse",
+            "client_api_format": "claude:cli"
+        });
+
+        let detected = detect_kiro_web_search_request(&plan, Some(&report_context))
+            .expect("web_search should be detected");
+        assert_eq!(detected.query, "Rust 2026");
+        assert_eq!(detected.model, "claude-sonnet-4.6");
+    }
+
+    #[test]
+    fn builds_mcp_headers_for_profile_and_external_idp_modes() {
+        let headers = BTreeMap::from([
+            ("authorization".to_string(), "Bearer token".to_string()),
+            (
+                "accept".to_string(),
+                "application/vnd.amazon.eventstream".to_string(),
+            ),
+            ("host".to_string(), "q.us-east-1.amazonaws.com".to_string()),
+            ("x-amzn-kiro-agent-mode".to_string(), "vibe".to_string()),
+        ]);
+        let social = build_mcp_headers_from_plan(&headers, Some("arn:profile"));
+        assert_eq!(
+            social.headers.get("accept").map(String::as_str),
+            Some("application/json")
+        );
+        assert_eq!(
+            social
+                .headers
+                .get(aether_provider_transport::kiro::KIRO_PROFILE_ARN_HEADER)
+                .map(String::as_str),
+            Some("arn:profile")
+        );
+        assert!(!social.headers.contains_key("x-amzn-kiro-agent-mode"));
+        assert!(social.profile_arn_present);
+
+        let idc = build_mcp_headers_from_plan(&headers, None);
+        assert_eq!(
+            idc.headers
+                .get(aether_provider_transport::kiro::KIRO_TOKEN_TYPE_HEADER),
+            None
+        );
+        assert!(!idc.profile_arn_present);
+    }
+
+    #[test]
+    fn mcp_plan_header_fallback_does_not_invent_external_idp_token_type() {
+        let headers = BTreeMap::from([("authorization".to_string(), "Bearer token".to_string())]);
+
+        let context = build_mcp_headers_from_plan(&headers, None);
+
+        assert_eq!(
+            context
+                .headers
+                .get(aether_provider_transport::kiro::KIRO_TOKEN_TYPE_HEADER),
+            None
+        );
+    }
+
+    #[test]
+    fn mcp_plan_header_fallback_preserves_api_key_token_type() {
+        let headers = BTreeMap::from([
+            ("authorization".to_string(), "Bearer token".to_string()),
+            ("tokentype".to_string(), "API_KEY".to_string()),
+        ]);
+
+        let context = build_mcp_headers_from_plan(&headers, None);
+
+        assert_eq!(
+            context.headers.get("tokentype").map(String::as_str),
+            Some("API_KEY")
+        );
+    }
+
+    #[test]
+    fn parses_mcp_search_result_text_payload() {
+        let result = aether_contracts::ExecutionResult {
+            request_id: "req-1".to_string(),
+            candidate_id: None,
+            status_code: 200,
+            headers: BTreeMap::new(),
+            body: Some(aether_contracts::ResponseBody {
+                json_body: Some(json!({
+                    "jsonrpc": "2.0",
+                    "id": "web_search_tooluse_1",
+                    "result": {
+                        "isError": false,
+                        "content": [{
+                            "type": "text",
+                            "text": "{\"results\":[{\"title\":\"Example\",\"url\":\"https://example.com\",\"snippet\":\"Snippet\"}],\"totalResults\":1}"
+                        }]
+                    }
+                })),
+                body_bytes_b64: None,
+            }),
+            telemetry: None,
+            error: None,
+        };
+
+        let parsed = parse_mcp_search_results(&result).expect("results should parse");
+        assert_eq!(parsed.results.len(), 1);
+        assert_eq!(parsed.results[0].title, "Example");
+    }
+
+    #[test]
+    fn builds_anthropic_web_search_sse() {
+        let sse = build_web_search_sse_body(
+            "claude-sonnet-4.6",
+            "Shanghai weather",
+            "srvtoolu_123",
+            None,
+            12,
+        )
+        .expect("sse should encode");
+        let text = String::from_utf8(sse).expect("sse should be utf8");
+        assert!(text.contains("\"type\":\"server_tool_use\""));
+        assert!(text.contains("\"type\":\"web_search_tool_result\""));
+        assert!(text.contains("\"web_search_requests\":1"));
+    }
+}

--- a/apps/aether-gateway/src/execution_runtime/mod.rs
+++ b/apps/aether-gateway/src/execution_runtime/mod.rs
@@ -5,6 +5,7 @@ use serde_json::{Map, Value};
 
 mod constants;
 mod fallback;
+mod kiro_web_search;
 pub(crate) mod ndjson;
 mod oauth_retry;
 #[cfg(test)]

--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -51,6 +51,7 @@ use crate::clock::current_unix_ms as current_request_candidate_unix_ms;
 use crate::constants::{CONTROL_CANDIDATE_ID_HEADER, CONTROL_REQUEST_ID_HEADER};
 use crate::control::GatewayControlDecision;
 use crate::execution_runtime::build_direct_execution_frame_stream;
+use crate::execution_runtime::kiro_web_search::maybe_execute_kiro_web_search_stream;
 use crate::execution_runtime::oauth_retry::refresh_oauth_plan_auth_for_retry;
 #[cfg(test)]
 use crate::execution_runtime::remote_compat::post_stream_plan_to_remote_execution_runtime;
@@ -384,6 +385,57 @@ pub(crate) async fn execute_execution_runtime_stream(
         .and_then(|context| context.candidate_index)
         .map(|value| value.to_string())
         .unwrap_or_else(|| "-".to_string());
+    match maybe_execute_kiro_web_search_stream(state, &plan, report_context.as_ref()).await {
+        Ok(Some(kiro_web_search)) => {
+            return execute_stream_from_frame_stream(
+                state,
+                plan,
+                trace_id,
+                decision,
+                plan_kind,
+                report_kind,
+                kiro_web_search.report_context.or(report_context),
+                candidate_started_unix_secs,
+                stream_started_at,
+                kiro_web_search.frame_stream,
+            )
+            .await;
+        }
+        Ok(None) => {}
+        Err(err) => {
+            info!(
+                event_name = "kiro_web_search_mcp_unavailable",
+                log_type = "ops",
+                trace_id = %trace_id,
+                request_id = %plan_request_id_for_log,
+                candidate_id = ?plan.candidate_id,
+                provider_name = provider_name.as_str(),
+                endpoint_id = %endpoint_id,
+                key_id = %key_id,
+                model_name = model_name.as_str(),
+                candidate_index = candidate_index.as_str(),
+                error = %err,
+                "gateway Kiro web_search MCP execution unavailable"
+            );
+            let terminal_unix_secs = current_request_candidate_unix_ms();
+            record_local_request_candidate_status(
+                state,
+                &plan,
+                report_context.as_ref(),
+                SchedulerRequestCandidateStatusUpdate {
+                    status: RequestCandidateStatus::Failed,
+                    status_code: None,
+                    error_type: Some("kiro_web_search_mcp_unavailable".to_string()),
+                    error_message: Some(format!("{err:?}")),
+                    latency_ms: None,
+                    started_at_unix_ms: Some(candidate_started_unix_secs),
+                    finished_at_unix_ms: Some(terminal_unix_secs),
+                },
+            )
+            .await;
+            return Ok(None);
+        }
+    }
     #[cfg(not(test))]
     {
         let execution = match execute_in_process_stream_with_oauth_retry(

--- a/crates/aether-ai-formats/src/canonical.rs
+++ b/crates/aether-ai-formats/src/canonical.rs
@@ -2807,7 +2807,29 @@ pub(crate) fn openai_responses_tools_to_canonical(
             .unwrap_or("function")
             .trim()
             .to_ascii_lowercase();
-        if tool_type == "function" && tool_object.get("function").is_none() {
+        if tool_type == "function" {
+            if let Some(function) = tool_object.get("function").and_then(Value::as_object) {
+                let name = function
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())?;
+                let mut extensions =
+                    openai_responses_extensions(tool_object, &["type", "function"]);
+                let function_extensions =
+                    openai_responses_extensions(function, &["name", "description", "parameters"]);
+                merge_tool_extensions(&mut extensions, function_extensions);
+                canonical.push(CanonicalToolDefinition {
+                    name: name.to_string(),
+                    description: function
+                        .get("description")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned),
+                    parameters: function.get("parameters").cloned(),
+                    extensions,
+                });
+                continue;
+            }
             let name = tool_object
                 .get("name")
                 .and_then(Value::as_str)
@@ -2825,6 +2847,41 @@ pub(crate) fn openai_responses_tools_to_canonical(
                     &["type", "name", "description", "parameters"],
                 ),
             });
+        } else if tool_type == "custom" {
+            let custom = tool_object.get("custom").and_then(Value::as_object);
+            let name = tool_object
+                .get("name")
+                .and_then(Value::as_str)
+                .or_else(|| {
+                    custom
+                        .and_then(|value| value.get("name"))
+                        .and_then(Value::as_str)
+                })
+                .map(str::trim)
+                .filter(|value| !value.is_empty())?;
+            let description = tool_object
+                .get("description")
+                .and_then(Value::as_str)
+                .or_else(|| {
+                    custom
+                        .and_then(|value| value.get("description"))
+                        .and_then(Value::as_str)
+                })
+                .map(ToOwned::to_owned);
+            let parameters = tool_object
+                .get("parameters")
+                .or_else(|| custom.and_then(|value| value.get("parameters")))
+                .filter(|value| value.is_object())
+                .cloned();
+            canonical.push(CanonicalToolDefinition {
+                name: name.to_string(),
+                description,
+                parameters,
+                extensions: BTreeMap::from([(
+                    OPENAI_RESPONSES_EXTENSION_NAMESPACE.to_string(),
+                    tool.clone(),
+                )]),
+            });
         } else if tool_type.starts_with("web_search") {
             canonical.push(CanonicalToolDefinition {
                 name: tool_type,
@@ -2838,6 +2895,19 @@ pub(crate) fn openai_responses_tools_to_canonical(
         }
     }
     Some(canonical)
+}
+
+fn merge_tool_extensions(target: &mut BTreeMap<String, Value>, source: BTreeMap<String, Value>) {
+    for (namespace, value) in source {
+        match (target.get_mut(&namespace), value) {
+            (Some(Value::Object(target)), Value::Object(source)) => {
+                target.extend(source);
+            }
+            (_, value) => {
+                target.insert(namespace, value);
+            }
+        }
+    }
 }
 
 pub(crate) fn canonical_tool_to_openai(tool: &CanonicalToolDefinition) -> Value {
@@ -2901,6 +2971,31 @@ pub(crate) fn openai_responses_tool_choice_to_canonical(
                 object
                     .get("name")
                     .and_then(Value::as_str)
+                    .or_else(|| {
+                        object
+                            .get("function")
+                            .and_then(Value::as_object)
+                            .and_then(|function| function.get("name"))
+                            .and_then(Value::as_str)
+                    })
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(|name| CanonicalToolChoice::Tool {
+                        name: name.to_string(),
+                    })
+            } else if choice_type == "custom" {
+                object
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .or_else(|| {
+                        object
+                            .get("custom")
+                            .and_then(Value::as_object)
+                            .and_then(|custom| custom.get("name"))
+                            .and_then(Value::as_str)
+                    })
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
                     .map(|name| CanonicalToolChoice::Tool {
                         name: name.to_string(),
                     })
@@ -4269,6 +4364,72 @@ mod tests {
         assert_eq!(rebuilt["text"]["format"]["json_schema"]["name"], "answer");
         assert_eq!(rebuilt["text"]["verbosity"], "low");
         assert_eq!(rebuilt["tool_choice"]["name"], "lookup");
+    }
+
+    #[test]
+    fn openai_responses_request_adapter_accepts_nested_function_and_custom_tools() {
+        let request = json!({
+            "model": "gpt-5",
+            "input": "Use a tool",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "lookup_weather",
+                        "description": "Lookup weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "city": {"type": "string"}
+                            },
+                            "required": ["city"]
+                        }
+                    }
+                },
+                {
+                    "type": "custom",
+                    "custom": {
+                        "name": "shell_command",
+                        "description": "Run a shell command"
+                    }
+                }
+            ],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "lookup_weather"}
+            }
+        });
+
+        let canonical =
+            from_openai_responses_to_canonical_request(&request).expect("canonical request");
+        assert_eq!(canonical.tools.len(), 2);
+        assert_eq!(canonical.tools[0].name, "lookup_weather");
+        assert_eq!(
+            canonical.tools[0]
+                .parameters
+                .as_ref()
+                .and_then(|value| value.get("required"))
+                .and_then(Value::as_array)
+                .map(Vec::len),
+            Some(1)
+        );
+        assert_eq!(canonical.tools[1].name, "shell_command");
+        assert!(matches!(
+            canonical.tool_choice,
+            Some(super::CanonicalToolChoice::Tool { ref name }) if name == "lookup_weather"
+        ));
+
+        let claude = canonical_to_claude_request(&canonical, "claude-sonnet-4-upstream", false)
+            .expect("claude request");
+        assert_eq!(claude["tools"][0]["name"], "lookup_weather");
+        assert_eq!(claude["tools"][1]["name"], "shell_command");
+        assert_eq!(claude["tool_choice"]["name"], "lookup_weather");
+
+        let rebuilt = canonical_to_openai_responses_request(&canonical, "gpt-5-upstream", false)
+            .expect("openai responses request");
+        assert_eq!(rebuilt["tools"][0]["name"], "lookup_weather");
+        assert_eq!(rebuilt["tools"][1]["type"], "custom");
+        assert_eq!(rebuilt["tools"][1]["custom"]["name"], "shell_command");
     }
 
     #[test]

--- a/crates/aether-ai-formats/src/formats/openai_responses/request.rs
+++ b/crates/aether-ai-formats/src/formats/openai_responses/request.rs
@@ -447,7 +447,9 @@ fn canonical_tool_to_responses(tool: &CanonicalToolDefinition) -> Value {
             value
                 .get("type")
                 .and_then(Value::as_str)
-                .is_some_and(|tool_type| tool_type.starts_with("web_search"))
+                .is_some_and(|tool_type| {
+                    tool_type == "custom" || tool_type.starts_with("web_search")
+                })
         })
     {
         return raw.clone();

--- a/crates/aether-ai-pipeline/src/planner/standard/matrix.rs
+++ b/crates/aether-ai-pipeline/src/planner/standard/matrix.rs
@@ -1071,4 +1071,76 @@ mod tests {
             "image/jpeg"
         );
     }
+
+    #[test]
+    fn openai_responses_nested_tools_survive_claude_cli_and_kiro_envelope_conversion() {
+        let request = json!({
+            "model": "gpt-5",
+            "input": "Use the weather tool for Shanghai.",
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"}
+                        },
+                        "required": []
+                    }
+                }
+            }],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "get_weather"}
+            }
+        });
+
+        let claude = build_standard_request_body(
+            &request,
+            "openai:responses",
+            "claude-sonnet-4.6",
+            "kiro",
+            "claude:cli",
+            "/v1/responses",
+            true,
+            None,
+            None,
+        )
+        .expect("openai responses should convert to claude cli");
+        assert_eq!(claude["tools"][0]["name"], "get_weather");
+        assert_eq!(claude["tool_choice"]["name"], "get_weather");
+
+        let auth_config = aether_provider_transport::kiro::KiroAuthConfig {
+            auth_method: None,
+            refresh_token: None,
+            expires_at: None,
+            profile_arn: Some("arn:aws:bedrock:demo".to_string()),
+            region: None,
+            auth_region: None,
+            api_region: Some("us-east-1".to_string()),
+            client_id: None,
+            client_secret: None,
+            machine_id: None,
+            kiro_version: None,
+            system_version: None,
+            node_version: None,
+            access_token: Some("token".to_string()),
+        };
+        let kiro = aether_provider_transport::kiro::build_kiro_provider_request_body(
+            &claude,
+            "claude-sonnet-4.6",
+            &auth_config,
+            None,
+        )
+        .expect("kiro envelope should build");
+        let tool_spec = &kiro["conversationState"]["currentMessage"]["userInputMessage"]
+            ["userInputMessageContext"]["tools"][0]["toolSpecification"];
+        assert_eq!(tool_spec["name"], "get_weather");
+        assert!(
+            tool_spec["inputSchema"]["json"].get("required").is_none(),
+            "Kiro envelope should strip empty required arrays from tool schema"
+        );
+    }
 }

--- a/crates/aether-provider-transport/src/kiro.rs
+++ b/crates/aether-provider-transport/src/kiro.rs
@@ -15,7 +15,10 @@ pub use auth::{
 };
 pub use converter::convert_claude_messages_to_conversation_state;
 pub use credentials::{generate_machine_id, normalize_machine_id, KiroAuthConfig};
-pub use headers::{build_generate_assistant_headers, AWS_EVENTSTREAM_CONTENT_TYPE};
+pub use headers::{
+    build_generate_assistant_headers, build_mcp_headers, AWS_EVENTSTREAM_CONTENT_TYPE,
+    KIRO_EXTERNAL_IDP_TOKEN_TYPE, KIRO_PROFILE_ARN_HEADER, KIRO_TOKEN_TYPE_HEADER,
+};
 pub use policy::{
     local_kiro_request_transport_unsupported_reason_with_network,
     supports_local_kiro_request_transport, supports_local_kiro_request_transport_with_network,
@@ -28,6 +31,7 @@ pub use request::{
     KiroProviderHeadersInput,
 };
 pub use url::{
-    build_kiro_generate_assistant_response_url, resolve_kiro_base_url,
-    GENERATE_ASSISTANT_RESPONSE_PATH, KIRO_ENVELOPE_NAME,
+    build_kiro_generate_assistant_response_url, build_kiro_mcp_url,
+    build_kiro_mcp_url_from_resolved_url, resolve_kiro_base_url, GENERATE_ASSISTANT_RESPONSE_PATH,
+    KIRO_ENVELOPE_NAME, MCP_PATH, MCP_STREAM_PATH,
 };

--- a/crates/aether-provider-transport/src/kiro/credentials.rs
+++ b/crates/aether-provider-transport/src/kiro/credentials.rs
@@ -3,7 +3,7 @@ use sha2::{Digest, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub const DEFAULT_REGION: &str = "us-east-1";
-pub const DEFAULT_KIRO_VERSION: &str = "0.8.0";
+pub const DEFAULT_KIRO_VERSION: &str = "0.3.210";
 pub const DEFAULT_NODE_VERSION: &str = "22.21.1";
 pub const DEFAULT_SYSTEM_VERSION: &str = "other#unknown";
 
@@ -158,7 +158,7 @@ impl KiroAuthConfig {
             .map(normalize_auth_method)
             .unwrap_or_else(|| "social".to_string());
         if explicit_method != "social" {
-            return explicit_method == "idc";
+            return matches!(explicit_method.as_str(), "idc" | "external_idp");
         }
         self.client_id
             .as_deref()
@@ -173,10 +173,25 @@ impl KiroAuthConfig {
                 .is_some()
     }
 
+    pub fn uses_external_idp_token_type(&self) -> bool {
+        self.auth_method
+            .as_deref()
+            .map(normalize_auth_method)
+            .as_deref()
+            == Some("external_idp")
+    }
+
     pub fn profile_arn_for_payload(&self) -> Option<&str> {
         if self.is_idc_auth() {
             return None;
         }
+        self.profile_arn
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    }
+
+    pub fn profile_arn_for_mcp(&self) -> Option<&str> {
         self.profile_arn
             .as_deref()
             .map(str::trim)
@@ -309,6 +324,7 @@ fn normalize_auth_method(raw: &str) -> String {
         | "identity_center"
         | "identitycenter"
         | "idc" => "idc".to_string(),
+        "external-idp" | "external_idp" | "externalidp" => "external_idp".to_string(),
         _ => value,
     }
 }
@@ -395,6 +411,29 @@ mod tests {
     }
 
     #[test]
+    fn preserves_external_idp_auth_method_for_header_selection() {
+        let auth_config = KiroAuthConfig::from_raw_json(Some(
+            r#"{
+                "authMethod":"external_idp",
+                "refreshToken":"rt-1",
+                "clientId":"cid",
+                "clientSecret":"secret",
+                "profileArn":"arn:aws:bedrock:demo"
+            }"#,
+        ))
+        .expect("auth config should parse");
+
+        assert_eq!(auth_config.auth_method.as_deref(), Some("external_idp"));
+        assert!(auth_config.is_idc_auth());
+        assert!(auth_config.uses_external_idp_token_type());
+        assert!(auth_config.profile_arn_for_payload().is_none());
+        assert_eq!(
+            auth_config.profile_arn_for_mcp(),
+            Some("arn:aws:bedrock:demo")
+        );
+    }
+
+    #[test]
     fn infers_idc_when_client_credentials_exist() {
         let auth_config = KiroAuthConfig::from_raw_json(Some(
             r#"{
@@ -407,7 +446,12 @@ mod tests {
         .expect("auth config should parse");
 
         assert!(auth_config.is_idc_auth());
+        assert!(!auth_config.uses_external_idp_token_type());
         assert!(auth_config.profile_arn_for_payload().is_none());
+        assert_eq!(
+            auth_config.profile_arn_for_mcp(),
+            Some("arn:aws:bedrock:demo")
+        );
     }
 
     #[test]

--- a/crates/aether-provider-transport/src/kiro/headers.rs
+++ b/crates/aether-provider-transport/src/kiro/headers.rs
@@ -5,6 +5,9 @@ use uuid::Uuid;
 use super::credentials::KiroAuthConfig;
 
 pub const AWS_EVENTSTREAM_CONTENT_TYPE: &str = "application/vnd.amazon.eventstream";
+pub const KIRO_PROFILE_ARN_HEADER: &str = "x-amzn-kiro-profile-arn";
+pub const KIRO_TOKEN_TYPE_HEADER: &str = "TokenType";
+pub const KIRO_EXTERNAL_IDP_TOKEN_TYPE: &str = "EXTERNAL_IDP";
 const AWS_SDK_JS_MAIN_VERSION: &str = "1.0.27";
 const CODEWHISPERER_OPTOUT: &str = "true";
 const KIRO_AGENT_MODE: &str = "vibe";
@@ -81,10 +84,55 @@ pub fn build_generate_assistant_headers(
     ])
 }
 
+pub fn build_mcp_headers(
+    auth_config: &KiroAuthConfig,
+    machine_id: &str,
+) -> BTreeMap<String, String> {
+    let kiro_version = auth_config.effective_kiro_version();
+    let system_version = auth_config.effective_system_version();
+    let node_version = auth_config.effective_node_version();
+    let region = auth_config.effective_api_region();
+    let host = format!("q.{region}.amazonaws.com");
+
+    let mut headers = BTreeMap::from([
+        ("accept".to_string(), "application/json".to_string()),
+        (
+            "amz-sdk-invocation-id".to_string(),
+            Uuid::new_v4().to_string(),
+        ),
+        (
+            "amz-sdk-request".to_string(),
+            "attempt=1; max=3".to_string(),
+        ),
+        ("connection".to_string(), "close".to_string()),
+        ("content-type".to_string(), "application/json".to_string()),
+        ("host".to_string(), host),
+        (
+            "user-agent".to_string(),
+            build_user_agent_main(system_version, node_version, kiro_version, machine_id),
+        ),
+        (
+            "x-amz-user-agent".to_string(),
+            build_x_amz_user_agent_main(kiro_version, machine_id),
+        ),
+        (
+            "x-amzn-codewhisperer-optout".to_string(),
+            CODEWHISPERER_OPTOUT.to_string(),
+        ),
+    ]);
+    if let Some(profile_arn) = auth_config.profile_arn_for_mcp() {
+        headers.insert(KIRO_PROFILE_ARN_HEADER.to_string(), profile_arn.to_string());
+    }
+    headers
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::credentials::KiroAuthConfig;
-    use super::{build_generate_assistant_headers, AWS_EVENTSTREAM_CONTENT_TYPE};
+    use super::{
+        build_generate_assistant_headers, build_mcp_headers, AWS_EVENTSTREAM_CONTENT_TYPE,
+        KIRO_PROFILE_ARN_HEADER, KIRO_TOKEN_TYPE_HEADER,
+    };
 
     #[test]
     fn builds_generate_assistant_headers_for_region() {
@@ -118,5 +166,96 @@ mod tests {
             headers.get("x-amzn-kiro-agent-mode").map(String::as_str),
             Some("vibe")
         );
+        assert!(!headers.contains_key(KIRO_TOKEN_TYPE_HEADER));
+    }
+
+    #[test]
+    fn keeps_generate_assistant_headers_without_external_idp_token_type() {
+        let auth_config = KiroAuthConfig {
+            auth_method: Some("idc".to_string()),
+            refresh_token: None,
+            expires_at: None,
+            profile_arn: Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/demo".into()),
+            region: None,
+            auth_region: None,
+            api_region: Some("us-east-1".to_string()),
+            client_id: Some("client-id".to_string()),
+            client_secret: Some("client-secret".to_string()),
+            machine_id: None,
+            kiro_version: None,
+            system_version: None,
+            node_version: None,
+            access_token: None,
+        };
+
+        let headers = build_generate_assistant_headers(&auth_config, "machine-123");
+
+        assert_eq!(
+            headers.get("accept").map(String::as_str),
+            Some(AWS_EVENTSTREAM_CONTENT_TYPE)
+        );
+        assert!(!headers.contains_key(KIRO_TOKEN_TYPE_HEADER));
+    }
+
+    #[test]
+    fn builds_mcp_headers_with_profile_arn_for_social_auth() {
+        let auth_config = KiroAuthConfig {
+            auth_method: Some("social".to_string()),
+            refresh_token: None,
+            expires_at: None,
+            profile_arn: Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/demo".into()),
+            region: None,
+            auth_region: None,
+            api_region: Some("us-east-1".to_string()),
+            client_id: None,
+            client_secret: None,
+            machine_id: None,
+            kiro_version: Some("0.3.210".to_string()),
+            system_version: Some("darwin#24.6.0".to_string()),
+            node_version: Some("22.21.1".to_string()),
+            access_token: None,
+        };
+
+        let headers = build_mcp_headers(&auth_config, "machine-123");
+        assert_eq!(
+            headers.get("accept").map(String::as_str),
+            Some("application/json")
+        );
+        assert_eq!(
+            headers.get(KIRO_PROFILE_ARN_HEADER).map(String::as_str),
+            Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/demo")
+        );
+        assert!(!headers.contains_key(KIRO_TOKEN_TYPE_HEADER));
+    }
+
+    #[test]
+    fn builds_mcp_headers_with_profile_arn_for_idc_auth() {
+        let auth_config = KiroAuthConfig {
+            auth_method: Some("idc".to_string()),
+            refresh_token: None,
+            expires_at: None,
+            profile_arn: Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/demo".into()),
+            region: None,
+            auth_region: None,
+            api_region: Some("us-west-2".to_string()),
+            client_id: Some("client-id".to_string()),
+            client_secret: Some("client-secret".to_string()),
+            machine_id: None,
+            kiro_version: None,
+            system_version: None,
+            node_version: None,
+            access_token: None,
+        };
+
+        let headers = build_mcp_headers(&auth_config, "machine-123");
+        assert_eq!(
+            headers.get("host").map(String::as_str),
+            Some("q.us-west-2.amazonaws.com")
+        );
+        assert_eq!(
+            headers.get(KIRO_PROFILE_ARN_HEADER).map(String::as_str),
+            Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/demo")
+        );
+        assert!(!headers.contains_key(KIRO_TOKEN_TYPE_HEADER));
     }
 }

--- a/crates/aether-provider-transport/src/kiro/url.rs
+++ b/crates/aether-provider-transport/src/kiro/url.rs
@@ -2,6 +2,8 @@ use super::super::url::build_passthrough_path_url;
 use super::credentials::DEFAULT_REGION;
 
 pub const GENERATE_ASSISTANT_RESPONSE_PATH: &str = "/generateAssistantResponse";
+pub const MCP_PATH: &str = "/mcp";
+pub const MCP_STREAM_PATH: &str = "/mcp/stream";
 pub const KIRO_ENVELOPE_NAME: &str = "kiro:generateAssistantResponse";
 
 pub fn resolve_kiro_base_url(upstream_base_url: &str, api_region: Option<&str>) -> String {
@@ -30,11 +32,24 @@ pub fn build_kiro_generate_assistant_response_url(
     )
 }
 
+pub fn build_kiro_mcp_url(upstream_base_url: &str, api_region: Option<&str>) -> Option<String> {
+    let upstream_base_url = resolve_kiro_base_url(upstream_base_url, api_region);
+    build_passthrough_path_url(upstream_base_url.as_str(), MCP_PATH, None, &[])
+}
+
+pub fn build_kiro_mcp_url_from_resolved_url(resolved_url: &str) -> Option<String> {
+    let mut parsed = url::Url::parse(resolved_url).ok()?;
+    parsed.set_path(MCP_PATH);
+    parsed.set_query(None);
+    Some(parsed.to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        build_kiro_generate_assistant_response_url, resolve_kiro_base_url,
-        GENERATE_ASSISTANT_RESPONSE_PATH, KIRO_ENVELOPE_NAME,
+        build_kiro_generate_assistant_response_url, build_kiro_mcp_url,
+        build_kiro_mcp_url_from_resolved_url, resolve_kiro_base_url,
+        GENERATE_ASSISTANT_RESPONSE_PATH, KIRO_ENVELOPE_NAME, MCP_PATH, MCP_STREAM_PATH,
     };
 
     #[test]
@@ -43,6 +58,8 @@ mod tests {
             GENERATE_ASSISTANT_RESPONSE_PATH,
             "/generateAssistantResponse"
         );
+        assert_eq!(MCP_PATH, "/mcp");
+        assert_eq!(MCP_STREAM_PATH, "/mcp/stream");
         assert_eq!(KIRO_ENVELOPE_NAME, "kiro:generateAssistantResponse");
     }
 
@@ -66,6 +83,25 @@ mod tests {
         assert_eq!(
             resolve_kiro_base_url("https://kiro.{region}.example/", Some("us-west-2")),
             "https://kiro.us-west-2.example"
+        );
+    }
+
+    #[test]
+    fn builds_mcp_url_for_latest_kiro_endpoint() {
+        assert_eq!(
+            build_kiro_mcp_url("https://q.{region}.amazonaws.com", Some("eu-west-1")).as_deref(),
+            Some("https://q.eu-west-1.amazonaws.com/mcp")
+        );
+    }
+
+    #[test]
+    fn rewrites_generate_assistant_url_to_mcp_url() {
+        assert_eq!(
+            build_kiro_mcp_url_from_resolved_url(
+                "https://q.us-east-1.amazonaws.com/generateAssistantResponse?beta=true"
+            )
+            .as_deref(),
+            Some("https://q.us-east-1.amazonaws.com/mcp")
         );
     }
 }


### PR DESCRIPTION
* fix(kiro): 接入 Kiro MCP web_search 工具调用
* fix(kiro): 对齐 Kiro IDE MCP 鉴权与 profileArn 头部
* fix(responses): 保留 Responses 嵌套与自定义工具参数
* test(ci): 通过 Rust Action 三项检查