### PR TITLE
Fix provider model mapping selection

### DIFF
--- a/apps/aether-gateway/src/data/tests.rs
+++ b/apps/aether-gateway/src/data/tests.rs
@@ -641,7 +641,7 @@ async fn data_state_reads_minimal_candidate_selection_with_auth_filters() {
     assert_eq!(selection[1].key_id, "key-3");
     assert_eq!(
         selection[1].selected_provider_model_name,
-        "gpt-4.1-edge".to_string()
+        "gpt-4.1-canary".to_string()
     );
     assert_eq!(
         selection[1].mapping_matched_model,

--- a/apps/aether-gateway/src/scheduler/candidate/tests/model.rs
+++ b/apps/aether-gateway/src/scheduler/candidate/tests/model.rs
@@ -39,13 +39,13 @@ fn candidate_model_names_keep_base_and_scoped_mappings() {
 #[test]
 fn resolves_mapping_matched_model_from_key_allowed_models() {
     let mut row = sample_row();
-    row.key_allowed_models = Some(vec!["gpt-4.1-canary".to_string()]);
+    row.key_allowed_models = Some(vec!["gpt-4.1-upstream".to_string()]);
 
     let resolved = resolve_provider_model_name(&row, "gpt-4.1", "openai:chat")
         .expect("candidate should resolve");
 
     assert_eq!(resolved.0, "gpt-4.1-canary");
-    assert_eq!(resolved.1, Some("gpt-4.1-canary".to_string()));
+    assert_eq!(resolved.1, Some("gpt-4.1-upstream".to_string()));
 }
 
 #[test]
@@ -56,7 +56,7 @@ fn resolves_mapping_matched_model_from_global_regex_mapping() {
     let resolved = resolve_provider_model_name(&row, "gpt-4.1", "openai:chat")
         .expect("candidate should resolve");
 
-    assert_eq!(resolved.0, "gpt-4.1-variant");
+    assert_eq!(resolved.0, "gpt-4.1-canary");
     assert_eq!(resolved.1, Some("gpt-4.1-variant".to_string()));
 }
 

--- a/crates/aether-scheduler-core/src/model.rs
+++ b/crates/aether-scheduler-core/src/model.rs
@@ -114,7 +114,7 @@ pub fn resolve_provider_model_name(
     for &allowed_model in &sorted_allowed_models {
         if row_has_candidate_model_name(row, api_format, allowed_model) {
             let allowed_model = allowed_model.to_owned();
-            return Some((allowed_model.clone(), Some(allowed_model)));
+            return Some((selected_provider_model_name.clone(), Some(allowed_model)));
         }
     }
 
@@ -123,7 +123,7 @@ pub fn resolve_provider_model_name(
         for pattern in global_model_mappings {
             if matches_model_mapping(pattern, allowed_model) {
                 let allowed_model = allowed_model.to_owned();
-                return Some((allowed_model.clone(), Some(allowed_model)));
+                return Some((selected_provider_model_name.clone(), Some(allowed_model)));
             }
         }
     }


### PR DESCRIPTION
## Summary
- Preserve the provider-selected upstream model when key `allowed_models` matches via provider/global model mappings
- Keep the matched allowed model as `mapping_matched_model` evidence instead of using it as the upstream dispatch model
- Add regression coverage for direct allowed-model and regex mapping fallback paths

## Database Changes
None

## Verification
- `cargo test -p aether-gateway resolves_mapping_matched_model_from_key_allowed_models -- --nocapture`
- `cargo test -p aether-gateway resolves_mapping_matched_model_from_global_regex_mapping -- --nocapture`
- `cargo test -p aether-gateway data_state_reads_minimal_candidate_selection_with_auth_filters -- --nocapture`
- `cargo test -p aether-gateway scheduler::candidate::tests::model -- --nocapture`
- `cargo fmt --check`
- `cargo build -p aether-gateway`

## Notes
- Draft PR for review.
- Single clean commit on top of `aether-rust-pioneer`.