### PR TITLE
fix(scheduler): 恢复正则模型映射作为上游模型

### DIFF
--- a/apps/aether-gateway/src/data/tests.rs
+++ b/apps/aether-gateway/src/data/tests.rs
@@ -641,7 +641,7 @@ async fn data_state_reads_minimal_candidate_selection_with_auth_filters() {
     assert_eq!(selection[1].key_id, "key-3");
     assert_eq!(
         selection[1].selected_provider_model_name,
-        "gpt-4.1-canary".to_string()
+        "gpt-4.1-edge".to_string()
     );
     assert_eq!(
         selection[1].mapping_matched_model,

--- a/apps/aether-gateway/src/scheduler/candidate/tests/model.rs
+++ b/apps/aether-gateway/src/scheduler/candidate/tests/model.rs
@@ -56,7 +56,7 @@ fn resolves_mapping_matched_model_from_global_regex_mapping() {
     let resolved = resolve_provider_model_name(&row, "gpt-4.1", "openai:chat")
         .expect("candidate should resolve");
 
-    assert_eq!(resolved.0, "gpt-4.1-canary");
+    assert_eq!(resolved.0, "gpt-4.1-variant");
     assert_eq!(resolved.1, Some("gpt-4.1-variant".to_string()));
 }
 

--- a/crates/aether-scheduler-core/src/model.rs
+++ b/crates/aether-scheduler-core/src/model.rs
@@ -123,7 +123,7 @@ pub fn resolve_provider_model_name(
         for pattern in global_model_mappings {
             if matches_model_mapping(pattern, allowed_model) {
                 let allowed_model = allowed_model.to_owned();
-                return Some((selected_provider_model_name.clone(), Some(allowed_model)));
+                return Some((allowed_model.clone(), Some(allowed_model)));
             }
         }
     }


### PR DESCRIPTION
保留 provider_model_mappings 的优先级选择逻辑，但恢复
GlobalModel model_mappings 正则命中后的行为：使用命中的
allowed_model 作为实际上游 mapped_model。

修复了 #354 请求绕过基于正则表达式的模型映射的问题