### PR TITLE
fix: codex free accounts incorrectly marked as quota exhausted

### DIFF
--- a/apps/aether-gateway/src/handlers/shared/catalog.rs
+++ b/apps/aether-gateway/src/handlers/shared/catalog.rs
@@ -626,8 +626,9 @@ fn build_codex_quota_status_snapshot(
         .filter_map(admin_provider_quota_pure::coerce_json_u64)
         .min();
     let reset_at = quota_windows_min_reset_at(&windows);
-    let exhausted_by_credits =
-        credits_unlimited != Some(true) && credits_has_credits == Some(false);
+    let exhausted_by_credits = windows.is_empty()
+        && credits_unlimited != Some(true)
+        && credits_has_credits == Some(false);
     let exhausted_by_window = usage_ratio.is_some_and(|value| value >= 1.0 - 1e-6);
     let exhausted = exhausted_by_credits || exhausted_by_window;
 

--- a/apps/aether-gateway/src/handlers/shared/catalog.rs
+++ b/apps/aether-gateway/src/handlers/shared/catalog.rs
@@ -626,9 +626,8 @@ fn build_codex_quota_status_snapshot(
         .filter_map(admin_provider_quota_pure::coerce_json_u64)
         .min();
     let reset_at = quota_windows_min_reset_at(&windows);
-    let exhausted_by_credits = windows.is_empty()
-        && credits_unlimited != Some(true)
-        && credits_has_credits == Some(false);
+    let exhausted_by_credits =
+        windows.is_empty() && credits_unlimited != Some(true) && credits_has_credits == Some(false);
     let exhausted_by_window = usage_ratio.is_some_and(|value| value >= 1.0 - 1e-6);
     let exhausted = exhausted_by_credits || exhausted_by_window;
 
@@ -1649,6 +1648,45 @@ mod tests {
                 .and_then(Value::as_object)
                 .and_then(|credits| credits.get("balance")),
             Some(&json!(42.0))
+        );
+        assert_eq!(
+            quota.get("windows").and_then(Value::as_array).map(Vec::len),
+            Some(2usize)
+        );
+    }
+
+    #[test]
+    fn provider_key_status_snapshot_payload_keeps_codex_free_window_quota_available() {
+        let mut key = sample_catalog_key();
+        key.upstream_metadata = Some(json!({
+            "codex": {
+                "updated_at": 1_775_553_285u64,
+                "plan_type": "free",
+                "primary_used_percent": 64.0,
+                "primary_reset_at": 1_900_000_000u64,
+                "secondary_used_percent": 3.0,
+                "secondary_reset_at": 1_900_500_000u64,
+                "has_credits": false,
+                "credits_balance": 0.0,
+                "credits_unlimited": false
+            }
+        }));
+
+        let payload = provider_key_status_snapshot_payload(&key, "codex");
+        let quota = payload
+            .get("quota")
+            .and_then(Value::as_object)
+            .expect("quota snapshot should be object");
+
+        assert_eq!(quota.get("code"), Some(&json!("ok")));
+        assert_eq!(quota.get("exhausted"), Some(&json!(false)));
+        assert_eq!(quota.get("usage_ratio"), Some(&json!(0.64)));
+        assert_eq!(
+            quota
+                .get("credits")
+                .and_then(Value::as_object)
+                .and_then(|credits| credits.get("has_credits")),
+            Some(&json!(false))
         );
         assert_eq!(
             quota.get("windows").and_then(Value::as_array).map(Vec::len),

--- a/apps/aether-gateway/src/tests/control/admin/pool.rs
+++ b/apps/aether-gateway/src/tests/control/admin/pool.rs
@@ -1779,7 +1779,7 @@ async fn gateway_prefers_status_snapshot_codex_quota_over_stale_metadata() {
 }
 
 #[tokio::test]
-async fn gateway_shows_codex_quota_reset_for_exhausted_zero_usage_snapshot() {
+async fn gateway_treats_stale_codex_exhausted_snapshot_as_available_when_windows_have_capacity() {
     let mut provider = sample_provider("provider-codex", "codex", 10).with_transport_fields(
         true,
         false,
@@ -1881,11 +1881,8 @@ async fn gateway_shows_codex_quota_reset_for_exhausted_zero_usage_snapshot() {
     .expect("json body should parse");
     let keys = payload["keys"].as_array().expect("keys should be array");
 
-    assert_eq!(keys[0]["scheduling_status"], json!("blocked"));
-    assert_eq!(
-        keys[0]["scheduling_reason"],
-        json!("account_quota_exhausted")
-    );
+    assert_eq!(keys[0]["scheduling_status"], json!("available"));
+    assert_eq!(keys[0]["scheduling_reason"], json!("available"));
     assert_eq!(
         keys[0]["account_quota"],
         json!("周剩余 100.0% (7天0小时后重置) | 5H剩余 100.0% (5小时0分钟后重置)")

--- a/crates/aether-admin/src/provider/pool.rs
+++ b/crates/aether-admin/src/provider/pool.rs
@@ -183,8 +183,8 @@ pub fn admin_pool_key_account_quota_exhausted(
     key: &StoredProviderCatalogKey,
     provider_type: &str,
 ) -> bool {
-    if let Some(exhausted) = admin_pool_key_quota_snapshot(key, provider_type)
-        .and_then(|quota_snapshot| {
+    if let Some(exhausted) =
+        admin_pool_key_quota_snapshot(key, provider_type).and_then(|quota_snapshot| {
             let exhausted = admin_pool_json_bool(quota_snapshot.get("exhausted"))?;
             if exhausted {
                 let windows_max_ratio = quota_snapshot
@@ -220,12 +220,9 @@ pub fn admin_pool_key_account_quota_exhausted(
             if admin_pool_json_bool(bucket.get("credits_unlimited")) == Some(true) {
                 return false;
             }
-            let has_window_data =
-                admin_pool_json_f64(bucket.get("primary_used_percent")).is_some()
-                    || admin_pool_json_f64(bucket.get("secondary_used_percent")).is_some();
-            if !has_window_data
-                && admin_pool_json_bool(bucket.get("has_credits")) == Some(false)
-            {
+            let has_window_data = admin_pool_json_f64(bucket.get("primary_used_percent")).is_some()
+                || admin_pool_json_f64(bucket.get("secondary_used_percent")).is_some();
+            if !has_window_data && admin_pool_json_bool(bucket.get("has_credits")) == Some(false) {
                 return true;
             }
             admin_pool_json_f64(bucket.get("primary_used_percent"))
@@ -689,6 +686,17 @@ mod tests {
             &sample_key(Some(json!({
                 "codex": {
                     "has_credits": false,
+                    "credits_unlimited": false,
+                    "primary_used_percent": 64.0,
+                    "secondary_used_percent": 3.0
+                }
+            }))),
+            "codex",
+        ));
+        assert!(!admin_pool_key_account_quota_exhausted(
+            &sample_key(Some(json!({
+                "codex": {
+                    "has_credits": false,
                     "credits_unlimited": true
                 }
             }))),
@@ -713,6 +721,40 @@ mod tests {
                 "provider_type": "codex",
                 "code": "ok",
                 "exhausted": false,
+                "usage_ratio": 0.0,
+                "updated_at": 1_776_395_200u64,
+                "windows": [
+                    {
+                        "code": "weekly",
+                        "used_ratio": 0.0,
+                        "remaining_ratio": 1.0
+                    },
+                    {
+                        "code": "5h",
+                        "used_ratio": 0.0,
+                        "remaining_ratio": 1.0
+                    }
+                ]
+            }
+        }));
+
+        assert!(!admin_pool_key_account_quota_exhausted(&key, "codex"));
+    }
+
+    #[test]
+    fn clears_stale_codex_exhausted_snapshot_when_windows_have_capacity() {
+        let mut key = sample_key(Some(json!({
+            "codex": {
+                "has_credits": false,
+                "primary_used_percent": 100.0
+            }
+        })));
+        key.status_snapshot = Some(json!({
+            "quota": {
+                "version": 2,
+                "provider_type": "codex",
+                "code": "exhausted",
+                "exhausted": true,
                 "usage_ratio": 0.0,
                 "updated_at": 1_776_395_200u64,
                 "windows": [

--- a/crates/aether-admin/src/provider/pool.rs
+++ b/crates/aether-admin/src/provider/pool.rs
@@ -184,7 +184,27 @@ pub fn admin_pool_key_account_quota_exhausted(
     provider_type: &str,
 ) -> bool {
     if let Some(exhausted) = admin_pool_key_quota_snapshot(key, provider_type)
-        .and_then(|quota_snapshot| admin_pool_json_bool(quota_snapshot.get("exhausted")))
+        .and_then(|quota_snapshot| {
+            let exhausted = admin_pool_json_bool(quota_snapshot.get("exhausted"))?;
+            if exhausted {
+                let windows_max_ratio = quota_snapshot
+                    .get("windows")
+                    .and_then(Value::as_array)
+                    .filter(|w| !w.is_empty())
+                    .and_then(|windows| {
+                        windows
+                            .iter()
+                            .filter_map(Value::as_object)
+                            .filter_map(|w| w.get("used_ratio"))
+                            .filter_map(Value::as_f64)
+                            .max_by(f64::total_cmp)
+                    });
+                if windows_max_ratio.is_some_and(|ratio| ratio < 1.0 - 1e-6) {
+                    return Some(false);
+                }
+            }
+            Some(exhausted)
+        })
     {
         return exhausted;
     }
@@ -200,7 +220,12 @@ pub fn admin_pool_key_account_quota_exhausted(
             if admin_pool_json_bool(bucket.get("credits_unlimited")) == Some(true) {
                 return false;
             }
-            if admin_pool_json_bool(bucket.get("has_credits")) == Some(false) {
+            let has_window_data =
+                admin_pool_json_f64(bucket.get("primary_used_percent")).is_some()
+                    || admin_pool_json_f64(bucket.get("secondary_used_percent")).is_some();
+            if !has_window_data
+                && admin_pool_json_bool(bucket.get("has_credits")) == Some(false)
+            {
                 return true;
             }
             admin_pool_json_f64(bucket.get("primary_used_percent"))


### PR DESCRIPTION
## Problem
When "skip exhausted accounts" (`skip_exhausted_accounts`) is enabled, **all** codex free accounts are incorrectly marked as quota exhausted, even when their window-based quotas (weekly/5h) still have remaining capacity.

## Root Cause
Codex free accounts have `has_credits: false` (they use window-based quotas, not credits). The old logic treated `has_credits: false` as "credits depleted" and short-circuited to `exhausted = true`, skipping the actual window usage ratio checks.

This affected 3 code paths:
1. **Snapshot reader** (`pool.rs`): read stored `exhausted: true` without verifying against window data
2. **Metadata fallback** (`pool.rs`): `has_credits: false` returned `true` immediately, ignoring window percentages
3. **Snapshot builder** (`catalog.rs`): `exhausted_by_credits` was `true` even when non-exhausted windows existed

## Fix
1. Cross-validate stored `exhausted: true` against window `used_ratio` — if windows show remaining capacity, override stale flag
2. Guard `has_credits: false` check with window data presence — only treat as exhausted when no window data exists
3. Add `windows.is_empty()` precondition to `exhausted_by_credits` in snapshot builder

## Files Changed
- `crates/aether-admin/src/provider/pool.rs` — fixes 1 & 2
- `apps/aether-gateway/src/handlers/shared/catalog.rs` — fix 3
