### PR TITLE
Add reversible chat PII redaction

### DIFF
--- a/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/decision/payload.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/decision/payload.rs
@@ -11,7 +11,7 @@ use crate::ai_serving::transport::{
 };
 use crate::{
     append_execution_contract_fields_to_value, append_local_failover_policy_to_value,
-    AiExecutionDecision, AppState,
+    AiExecutionDecision, AppState, GatewayError,
 };
 
 use super::request::resolve_local_openai_chat_candidate_payload_parts;
@@ -28,7 +28,7 @@ pub(crate) async fn maybe_build_local_openai_chat_decision_payload_for_candidate
     decision_kind: &str,
     report_kind: &str,
     upstream_is_stream: bool,
-) -> Option<AiExecutionDecision> {
+) -> Result<Option<AiExecutionDecision>, GatewayError> {
     let attempt_identity = attempt.attempt_identity();
     let LocalOpenAiChatCandidateAttempt {
         eligible,
@@ -36,7 +36,7 @@ pub(crate) async fn maybe_build_local_openai_chat_decision_payload_for_candidate
         candidate_id,
         ..
     } = attempt;
-    let resolved = resolve_local_openai_chat_candidate_payload_parts(
+    let Some(resolved) = resolve_local_openai_chat_candidate_payload_parts(
         state,
         parts,
         trace_id,
@@ -49,7 +49,10 @@ pub(crate) async fn maybe_build_local_openai_chat_decision_payload_for_candidate
         report_kind,
         upstream_is_stream,
     )
-    .await?;
+    .await?
+    else {
+        return Ok(None);
+    };
     let candidate = &eligible.candidate;
 
     let prompt_cache_key = resolved
@@ -142,9 +145,10 @@ pub(crate) async fn maybe_build_local_openai_chat_decision_payload_for_candidate
         report_kind,
         envelope_name: _,
         transport,
+        request_redacted: _,
     } = resolved;
 
-    Some(build_ai_execution_decision_response(
+    Ok(Some(build_ai_execution_decision_response(
         AiExecutionDecisionResponseParts {
             decision_is_stream: upstream_is_stream,
             decision_kind: decision_kind.to_string(),
@@ -178,5 +182,5 @@ pub(crate) async fn maybe_build_local_openai_chat_decision_payload_for_candidate
             report_context: Some(report_context),
             auth_context: input.auth_context.clone(),
         },
-    ))
+    )))
 }

--- a/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/decision/request.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/decision/request.rs
@@ -1,5 +1,7 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::Value;
 
@@ -31,7 +33,13 @@ use crate::ai_serving::{
     LocalResolvedOAuthRequestAuth,
 };
 use crate::ai_serving::{ConversionMode, ExecutionStrategy};
-use crate::AppState;
+use crate::privacy::{
+    build_redaction_session_config, provider_chat_pii_redaction_enabled,
+    read_chat_pii_redaction_runtime_config, try_mask_chat_request_json_with_cache_options,
+    MaskChatRequestOptions, RedactionMaskError, RedactionSessionSlot, RedisRedactionMappingCache,
+};
+use crate::{AppState, GatewayError};
+use tracing::warn;
 
 use super::support::{
     mark_skipped_local_openai_chat_candidate,
@@ -52,6 +60,30 @@ pub(crate) struct LocalOpenAiChatCandidatePayloadParts {
     pub(super) report_kind: String,
     pub(super) envelope_name: Option<&'static str>,
     pub(super) transport: Arc<GatewayProviderTransportSnapshot>,
+    pub(super) request_redacted: bool,
+}
+
+fn request_identity_response_encoding_when_redacted(
+    headers: &mut BTreeMap<String, String>,
+    redacted: bool,
+) {
+    if redacted {
+        headers.insert("accept-encoding".to_string(), "identity".to_string());
+    }
+}
+
+struct ProviderChatRequestRedaction<'a> {
+    body_json: Cow<'a, Value>,
+    redacted: bool,
+}
+
+impl<'a> ProviderChatRequestRedaction<'a> {
+    fn disabled(body_json: &'a Value, _parts: &http::request::Parts) -> Self {
+        Self {
+            body_json: Cow::Borrowed(body_json),
+            redacted: false,
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -67,7 +99,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
     decision_kind: &str,
     report_kind: &str,
     upstream_is_stream: bool,
-) -> Option<LocalOpenAiChatCandidatePayloadParts> {
+) -> Result<Option<LocalOpenAiChatCandidatePayloadParts>, GatewayError> {
     let planner_state = crate::ai_serving::PlannerAppState::new(state);
     let candidate = &eligible.candidate;
     let provider_api_format = eligible.provider_api_format.as_str();
@@ -79,6 +111,10 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             Some(&input.requested_model),
         )
         .await;
+    let redaction =
+        resolve_provider_chat_request_redaction(state, parts, body_json, transport, candidate_id)
+            .await?;
+    let body_json = redaction.body_json.as_ref();
 
     if provider_api_format == "openai:chat" {
         if let Some(skip_reason) = local_openai_chat_transport_unsupported_reason(transport) {
@@ -92,8 +128,8 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
                 skip_reason,
             )
             .await;
-            return None;
-        }
+            return Ok(None);
+        };
 
         let prepared_candidate = match prepare_header_authenticated_candidate(
             planner_state,
@@ -120,7 +156,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
                     skip_reason,
                 )
                 .await;
-                return None;
+                return Ok(None);
             }
         };
 
@@ -146,7 +182,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
                 ),
             )
             .await;
-            return None;
+            return Ok(None);
         };
 
         let Some(upstream_url) = build_local_openai_chat_upstream_url(parts, transport) else {
@@ -165,7 +201,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
                 ),
             )
             .await;
-            return None;
+            return Ok(None);
         };
 
         let Some(resolved_headers) =
@@ -198,7 +234,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
                 ),
             )
             .await;
-            return None;
+            return Ok(None);
         };
         let mut provider_request_headers = resolved_headers.headers;
         apply_codex_openai_responses_special_headers(
@@ -210,10 +246,14 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             Some(trace_id),
             transport.key.decrypted_auth_config.as_deref(),
         );
-
         let (execution_strategy, conversion_mode) =
             ai_local_execution_contract_for_formats("openai:chat", "openai:chat");
-        return Some(LocalOpenAiChatCandidatePayloadParts {
+        request_identity_response_encoding_when_redacted(
+            &mut provider_request_headers,
+            redaction.redacted,
+        );
+
+        return Ok(Some(LocalOpenAiChatCandidatePayloadParts {
             auth_header: resolved_headers.auth_header,
             auth_value: resolved_headers.auth_value,
             mapped_model: prepared_candidate.mapped_model,
@@ -226,8 +266,9 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             report_kind: report_kind.to_string(),
             envelope_name: None,
             transport: Arc::clone(transport),
-        });
-    }
+            request_redacted: redaction.redacted,
+        }));
+    };
 
     let provider_api_format = provider_api_format.trim().to_ascii_lowercase();
     let Some(conversion_kind) =
@@ -243,7 +284,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             "transport_api_format_unsupported",
         )
         .await;
-        return None;
+        return Ok(None);
     };
     if let Some(skip_reason) = crate::ai_serving::request_conversion_transport_unsupported_reason(
         transport,
@@ -259,7 +300,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             skip_reason,
         )
         .await;
-        return None;
+        return Ok(None);
     }
     let is_kiro_claude_cli =
         is_kiro_claude_messages_transport(transport, provider_api_format.as_str());
@@ -288,7 +329,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
                     "transport_auth_unavailable",
                 )
                 .await;
-                return None;
+                return Ok(None);
             }
         }
     } else {
@@ -312,7 +353,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
                     skip_reason,
                 )
                 .await;
-                return None;
+                return Ok(None);
             }
         }
     } else {
@@ -337,7 +378,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
                     skip_reason,
                 )
                 .await;
-                return None;
+                return Ok(None);
             }
         }
     };
@@ -371,7 +412,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             ),
         )
         .await;
-        return None;
+        return Ok(None);
     };
     if let Some(mapping) =
         crate::system_features::reasoning_model_directive_mapping_for_api_format_and_model(
@@ -388,7 +429,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
     }
 
     if let Some(kiro_auth) = kiro_auth.as_ref() {
-        return build_kiro_openai_chat_cross_format_payload_parts(
+        return Ok(build_kiro_openai_chat_cross_format_payload_parts(
             state,
             parts,
             trace_id,
@@ -406,8 +447,9 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             provider_request_body,
             upstream_is_stream,
             kiro_auth,
+            redaction.redacted,
         )
-        .await;
+        .await);
     }
 
     let Some(upstream_url) = build_cross_format_openai_chat_upstream_url(
@@ -432,7 +474,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             ),
         )
         .await;
-        return None;
+        return Ok(None);
     };
     let Some(resolved_headers) =
         build_standard_provider_request_headers(StandardProviderRequestHeadersInput {
@@ -464,7 +506,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             ),
         )
         .await;
-        return None;
+        return Ok(None);
     };
     let mut provider_request_headers = resolved_headers.headers;
     apply_codex_openai_responses_special_headers(
@@ -476,6 +518,10 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
         Some(trace_id),
         transport.key.decrypted_auth_config.as_deref(),
     );
+    request_identity_response_encoding_when_redacted(
+        &mut provider_request_headers,
+        redaction.redacted,
+    );
 
     let resolved_report_kind = if decision_kind == OPENAI_CHAT_STREAM_PLAN_KIND {
         "openai_chat_stream_success".to_string()
@@ -485,7 +531,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
     let (execution_strategy, conversion_mode) =
         ai_local_execution_contract_for_formats("openai:chat", provider_api_format.as_str());
 
-    Some(LocalOpenAiChatCandidatePayloadParts {
+    Ok(Some(LocalOpenAiChatCandidatePayloadParts {
         auth_header: resolved_headers.auth_header,
         auth_value: resolved_headers.auth_value,
         mapped_model: prepared_candidate.mapped_model,
@@ -498,7 +544,8 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
         report_kind: resolved_report_kind,
         envelope_name: None,
         transport: Arc::clone(transport),
-    })
+        request_redacted: redaction.redacted,
+    }))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -520,6 +567,7 @@ async fn build_kiro_openai_chat_cross_format_payload_parts(
     claude_request_body: Value,
     upstream_is_stream: bool,
     kiro_auth: &KiroRequestAuth,
+    request_redacted: bool,
 ) -> Option<LocalOpenAiChatCandidatePayloadParts> {
     let candidate = &eligible.candidate;
     let provider_request_body = match build_kiro_provider_request_body(
@@ -576,7 +624,7 @@ async fn build_kiro_openai_chat_cross_format_payload_parts(
             return None;
         }
     };
-    let provider_request_headers = match build_kiro_provider_headers(KiroProviderHeadersInput {
+    let mut provider_request_headers = match build_kiro_provider_headers(KiroProviderHeadersInput {
         headers: &parts.headers,
         provider_request_body: &provider_request_body,
         original_request_body: original_body_json,
@@ -606,6 +654,10 @@ async fn build_kiro_openai_chat_cross_format_payload_parts(
             return None;
         }
     };
+    request_identity_response_encoding_when_redacted(
+        &mut provider_request_headers,
+        request_redacted,
+    );
     let resolved_report_kind = if decision_kind == OPENAI_CHAT_STREAM_PLAN_KIND {
         "openai_chat_stream_success".to_string()
     } else {
@@ -627,5 +679,87 @@ async fn build_kiro_openai_chat_cross_format_payload_parts(
         report_kind: resolved_report_kind,
         envelope_name: Some(KIRO_ENVELOPE_NAME),
         transport: Arc::clone(transport),
+        request_redacted,
     })
+}
+
+async fn resolve_provider_chat_request_redaction<'a>(
+    state: &AppState,
+    parts: &http::request::Parts,
+    body_json: &'a Value,
+    transport: &GatewayProviderTransportSnapshot,
+    candidate_id: &str,
+) -> Result<ProviderChatRequestRedaction<'a>, GatewayError> {
+    if parts.uri.path() != "/v1/chat/completions" {
+        return Ok(ProviderChatRequestRedaction::disabled(body_json, parts));
+    }
+    let Some(slot) = parts.extensions.get::<RedactionSessionSlot>() else {
+        return Ok(ProviderChatRequestRedaction::disabled(body_json, parts));
+    };
+    let runtime_config = read_chat_pii_redaction_runtime_config(state)
+        .await
+        .map_err(|err| {
+            warn!(
+                error = ?err,
+                "gateway failed to read chat pii redaction runtime config"
+            );
+            GatewayError::Internal("chat pii redaction setup failed".to_string())
+        })?;
+    if !provider_chat_pii_redaction_enabled(transport.provider.config.as_ref(), &runtime_config) {
+        return Ok(ProviderChatRequestRedaction::disabled(body_json, parts));
+    }
+    let Some(hmac_key) = state.encryption_key().map(str::as_bytes).map(Vec::from) else {
+        warn!("gateway chat pii redaction is enabled but encryption key is unavailable");
+        return Err(GatewayError::Internal(
+            "chat pii redaction setup failed".to_string(),
+        ));
+    };
+    let body_bytes = serde_json::to_vec(body_json).map_err(|err| {
+        warn!(
+            error = ?err,
+            "gateway failed to serialize provider chat pii redaction body"
+        );
+        GatewayError::Internal("chat pii redaction setup failed".to_string())
+    })?;
+    let now_unix_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let runner = state.redis_kv_runner();
+    let cache = runner.as_ref().map(RedisRedactionMappingCache::new);
+    let masked = try_mask_chat_request_json_with_cache_options(
+        &body_bytes,
+        build_redaction_session_config(hmac_key, &runtime_config, now_unix_secs),
+        MaskChatRequestOptions::runtime(runtime_config.inject_model_instruction),
+        cache.as_ref(),
+    )
+    .await
+    .map_err(redaction_mask_error_to_gateway_error)?;
+    if !masked.redacted {
+        return Ok(ProviderChatRequestRedaction {
+            body_json: Cow::Borrowed(body_json),
+            redacted: false,
+        });
+    }
+    let masked_body_json = serde_json::from_slice::<Value>(&masked.body).map_err(|err| {
+        warn!(
+            error = ?err,
+            "gateway failed to decode redacted provider chat pii body"
+        );
+        GatewayError::Internal("chat pii redaction setup failed".to_string())
+    })?;
+    slot.put_for_candidate(candidate_id, masked.session);
+    Ok(ProviderChatRequestRedaction {
+        body_json: Cow::Owned(masked_body_json),
+        redacted: true,
+    })
+}
+
+fn redaction_mask_error_to_gateway_error(error: RedactionMaskError) -> GatewayError {
+    match error {
+        RedactionMaskError::Limit(limit) => GatewayError::Client {
+            status: limit.client_status(),
+            message: limit.safe_message().to_string(),
+        },
+    }
 }

--- a/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/mod.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/mod.rs
@@ -183,7 +183,7 @@ pub(crate) async fn maybe_build_sync_local_decision_payload(
             "openai_chat_sync_success",
             false,
         )
-        .await
+        .await?
         {
             return Ok(Some(payload));
         }
@@ -249,7 +249,7 @@ pub(crate) async fn maybe_build_stream_local_decision_payload(
             "openai_chat_stream_success",
             true,
         )
-        .await
+        .await?
         {
             return Ok(Some(payload));
         }

--- a/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/plans/stream.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/plans/stream.rs
@@ -131,7 +131,7 @@ impl LocalOpenAiChatStreamAttemptSource<'_> {
             "openai_chat_stream_success",
             true,
         )
-        .await
+        .await?
         else {
             return Ok(None);
         };
@@ -233,7 +233,7 @@ pub(crate) async fn build_local_openai_chat_stream_plan_and_reports(
             "openai_chat_stream_success",
             true,
         )
-        .await
+        .await?
         else {
             continue;
         };

--- a/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/plans/sync.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/plans/sync.rs
@@ -144,7 +144,7 @@ impl LocalOpenAiChatSyncAttemptSource<'_> {
             "openai_chat_sync_success",
             upstream_is_stream,
         )
-        .await
+        .await?
         else {
             return Ok(None);
         };
@@ -250,7 +250,7 @@ pub(crate) async fn build_local_openai_chat_sync_plan_and_reports(
             "openai_chat_sync_success",
             upstream_is_stream,
         )
-        .await
+        .await?
         else {
             continue;
         };

--- a/apps/aether-gateway/src/error.rs
+++ b/apps/aether-gateway/src/error.rs
@@ -13,6 +13,7 @@ use crate::insert_header_if_missing;
 pub(crate) enum GatewayError {
     UpstreamUnavailable { trace_id: String, message: String },
     ControlUnavailable { trace_id: String, message: String },
+    Client { status: StatusCode, message: String },
     Internal(String),
 }
 
@@ -55,6 +56,15 @@ impl IntoResponse for GatewayError {
                 );
                 response
             }
+            Self::Client { status, message } => (
+                status,
+                Json(json!({
+                    "error": {
+                        "message": message,
+                    }
+                })),
+            )
+                .into_response(),
             Self::Internal(message) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(json!({

--- a/apps/aether-gateway/src/executor/candidate_loop.rs
+++ b/apps/aether-gateway/src/executor/candidate_loop.rs
@@ -18,12 +18,24 @@ use crate::execution_runtime::{execute_execution_runtime_stream, execute_executi
 use crate::executor::{build_local_execution_exhaustion, LocalExecutionRequestOutcome};
 use crate::log_ids::short_request_id;
 use crate::orchestration::local_execution_candidate_metadata_from_report_context;
+use crate::privacy::RedactionExecutionCandidateId;
 use crate::request_candidate_runtime::{
     record_local_request_candidate_status, RequestCandidateRuntimeWriter,
 };
 use crate::{AppState, GatewayError};
 
 const DEFAULT_STREAM_CANDIDATE_WATCHDOG_TIMEOUT_MS: u64 = 300_000;
+
+fn attach_redaction_execution_candidate(response: &mut Response<Body>, candidate_id: Option<&str>) {
+    if let Some(candidate_id) = candidate_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        response
+            .extensions_mut()
+            .insert(RedactionExecutionCandidateId::new(candidate_id));
+    }
+}
 
 pub(crate) async fn execute_sync_plan_and_reports<T>(
     state: &AppState,
@@ -135,7 +147,7 @@ where
     type Error = GatewayError;
 
     async fn execute_attempt(&self, attempt: &T) -> Result<Option<Self::Response>, Self::Error> {
-        execute_execution_runtime_sync(
+        let mut response = execute_execution_runtime_sync(
             self.state,
             self.parts.uri.path(),
             attempt.execution_plan().clone(),
@@ -145,7 +157,14 @@ where
             attempt.report_kind(),
             attempt.report_context(),
         )
-        .await
+        .await?;
+        if let Some(response) = response.as_mut() {
+            attach_redaction_execution_candidate(
+                response,
+                attempt.execution_plan().candidate_id.as_deref(),
+            );
+        }
+        Ok(response)
     }
 
     async fn mark_unused_attempts(&self, attempts: Vec<T>) -> Result<(), Self::Error> {
@@ -332,7 +351,7 @@ where
         let execution_plan_kind = self.plan_kind.to_string();
         let execution_decision = self.decision.clone();
         let execution_report_kind = attempt.report_kind();
-        execute_stream_candidate_with_watchdog(
+        let mut response = execute_stream_candidate_with_watchdog(
             self.state,
             self.trace_id,
             self.plan_kind,
@@ -351,7 +370,11 @@ where
                 .await
             },
         )
-        .await
+        .await?;
+        if let Some(response) = response.as_mut() {
+            attach_redaction_execution_candidate(response, watchdog_plan.candidate_id.as_deref());
+        }
+        Ok(response)
     }
 
     async fn mark_unused_attempts(&self, attempts: Vec<T>) -> Result<(), Self::Error> {

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/shared.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/shared.rs
@@ -172,6 +172,7 @@ pub(super) async fn execute_provider_quota_plan(
             let error = match err {
                 GatewayError::UpstreamUnavailable { message, .. }
                 | GatewayError::ControlUnavailable { message, .. }
+                | GatewayError::Client { message, .. }
                 | GatewayError::Internal(message) => message,
             };
             let proxy_node_id = plan

--- a/apps/aether-gateway/src/handlers/admin/provider/ops/providers/verify/request.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/ops/providers/verify/request.rs
@@ -304,6 +304,7 @@ fn admin_provider_ops_gateway_error_message(error: GatewayError) -> String {
     match error {
         GatewayError::UpstreamUnavailable { message, .. }
         | GatewayError::ControlUnavailable { message, .. }
+        | GatewayError::Client { message, .. }
         | GatewayError::Internal(message) => message,
     }
 }

--- a/apps/aether-gateway/src/handlers/admin/provider/summary/value.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/summary/value.rs
@@ -176,6 +176,7 @@ pub(crate) fn build_admin_provider_summary_value(
         "claude_code_advanced": config.and_then(|cfg| cfg.get("claude_code_advanced")).cloned(),
         "pool_advanced": config.and_then(|cfg| cfg.get("pool_advanced")).cloned(),
         "failover_rules": config.and_then(|cfg| cfg.get("failover_rules")).cloned(),
+        "chat_pii_redaction": config.and_then(|cfg| cfg.get("chat_pii_redaction")).cloned(),
         "total_endpoints": total_endpoints,
         "active_endpoints": active_endpoints,
         "total_keys": total_keys,

--- a/apps/aether-gateway/src/handlers/admin/provider/write/normalize.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/write/normalize.rs
@@ -133,6 +133,28 @@ pub(crate) fn normalize_pool_advanced_config(
     }
 }
 
+pub(crate) fn normalize_chat_pii_redaction_config(
+    value: Option<serde_json::Value>,
+) -> Result<Option<serde_json::Value>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    match value {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::Object(mut map) => {
+            if map.len() != 1 || !map.contains_key("enabled") {
+                return Err("chat_pii_redaction 仅支持 enabled 布尔配置".to_string());
+            }
+            let enabled = map
+                .remove("enabled")
+                .and_then(|value| value.as_bool())
+                .ok_or_else(|| "chat_pii_redaction.enabled 必须是布尔值".to_string())?;
+            Ok(Some(serde_json::json!({ "enabled": enabled })))
+        }
+        _ => Err("chat_pii_redaction 必须是 JSON 对象".to_string()),
+    }
+}
+
 pub(crate) fn validate_vertex_api_formats(
     provider_type: &str,
     auth_type: &str,
@@ -180,7 +202,8 @@ fn normalize_json_like_object(
 mod tests {
     use super::{
         normalize_api_format_json_object_keys, normalize_api_format_list, normalize_auth_type,
-        normalize_auth_type_by_format, normalize_pool_advanced_config, validate_vertex_api_formats,
+        normalize_auth_type_by_format, normalize_chat_pii_redaction_config,
+        normalize_pool_advanced_config, validate_vertex_api_formats,
     };
     use serde_json::json;
 
@@ -201,6 +224,26 @@ mod tests {
         assert_eq!(
             normalize_pool_advanced_config(Some(json!(false))).unwrap_err(),
             "pool_advanced 必须是 JSON 对象"
+        );
+    }
+
+    #[test]
+    fn normalize_chat_pii_redaction_requires_enabled_boolean_only() {
+        assert_eq!(
+            normalize_chat_pii_redaction_config(Some(json!({ "enabled": true })))
+                .expect("chat pii redaction should normalize"),
+            Some(json!({ "enabled": true }))
+        );
+        assert_eq!(
+            normalize_chat_pii_redaction_config(Some(
+                json!({ "enabled": true, "entities": ["email"] })
+            ))
+            .unwrap_err(),
+            "chat_pii_redaction 仅支持 enabled 布尔配置"
+        );
+        assert_eq!(
+            normalize_chat_pii_redaction_config(Some(json!({ "enabled": "yes" }))).unwrap_err(),
+            "chat_pii_redaction.enabled 必须是布尔值"
         );
     }
 

--- a/apps/aether-gateway/src/handlers/admin/provider/write/provider/create.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/write/provider/create.rs
@@ -2,6 +2,7 @@ use crate::handlers::admin::provider::shared::payloads::AdminProviderCreateReque
 use crate::handlers::admin::provider::shared::support::{
     normalize_provider_billing_type, parse_optional_rfc3339_unix_secs,
 };
+use crate::handlers::admin::provider::write::normalize::normalize_chat_pii_redaction_config;
 use crate::handlers::admin::provider::write::normalize::normalize_pool_advanced_config;
 use crate::handlers::admin::provider::write::normalize::normalize_provider_type_input;
 use crate::handlers::admin::request::AdminAppState;
@@ -133,6 +134,12 @@ pub(crate) async fn build_admin_create_provider_record(
             return Err("claude_code_advanced 仅适用于 provider_type=claude_code".to_string());
         }
         config_map.insert("claude_code_advanced".to_string(), value);
+    }
+    if config_map.contains_key("chat_pii_redaction") {
+        let value = normalize_chat_pii_redaction_config(config_map.remove("chat_pii_redaction"))?;
+        if let Some(value) = value {
+            config_map.insert("chat_pii_redaction".to_string(), value);
+        }
     }
     let config = (!config_map.is_empty()).then_some(serde_json::Value::Object(config_map));
 

--- a/apps/aether-gateway/src/handlers/admin/provider/write/provider/update.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/write/provider/update.rs
@@ -2,6 +2,7 @@ use crate::handlers::admin::provider::shared::payloads::AdminProviderUpdatePatch
 use crate::handlers::admin::provider::shared::support::{
     normalize_provider_billing_type, parse_optional_rfc3339_unix_secs,
 };
+use crate::handlers::admin::provider::write::normalize::normalize_chat_pii_redaction_config;
 use crate::handlers::admin::provider::write::normalize::normalize_pool_advanced_config;
 use crate::handlers::admin::provider::write::normalize::normalize_provider_type_input;
 use crate::handlers::admin::request::AdminAppState;
@@ -225,14 +226,29 @@ pub(crate) async fn build_admin_update_provider_record(
         updated.enable_format_conversion = enable_format_conversion;
     }
 
-    let config_seed = if fields.contains("config") {
-        normalize_json_object(payload.config, "config")?
-    } else {
-        updated.config.clone()
-    };
-    let mut config_map = config_seed
+    let mut config_map = updated
+        .config
+        .clone()
         .and_then(|value| value.as_object().cloned())
         .unwrap_or_default();
+    if fields.contains("config") {
+        if fields.is_null("config") {
+            config_map.clear();
+        } else {
+            let value = normalize_json_object(payload.config, "config")?
+                .ok_or_else(|| "config 必须是 JSON 对象".to_string())?;
+            let serde_json::Value::Object(patch_map) = value else {
+                return Err("config 必须是 JSON 对象".to_string());
+            };
+            for (key, value) in patch_map {
+                if value.is_null() {
+                    config_map.remove(&key);
+                } else {
+                    config_map.insert(key, value);
+                }
+            }
+        }
+    }
 
     if fields.contains("claude_code_advanced") {
         if fields.is_null("claude_code_advanced") {
@@ -267,6 +283,13 @@ pub(crate) async fn build_admin_update_provider_record(
             let value = normalize_json_object(payload.failover_rules, "failover_rules")?
                 .ok_or_else(|| "failover_rules 必须是 JSON 对象".to_string())?;
             config_map.insert("failover_rules".to_string(), value);
+        }
+    }
+
+    if config_map.contains_key("chat_pii_redaction") {
+        let value = normalize_chat_pii_redaction_config(config_map.remove("chat_pii_redaction"))?;
+        if let Some(value) = value {
+            config_map.insert("chat_pii_redaction".to_string(), value);
         }
     }
 

--- a/apps/aether-gateway/src/handlers/admin/request/provider/oauth.rs
+++ b/apps/aether-gateway/src/handlers/admin/request/provider/oauth.rs
@@ -753,6 +753,7 @@ fn admin_provider_oauth_gateway_error_message(error: GatewayError) -> String {
     match error {
         GatewayError::UpstreamUnavailable { message, .. }
         | GatewayError::ControlUnavailable { message, .. }
+        | GatewayError::Client { message, .. }
         | GatewayError::Internal(message) => message,
     }
 }

--- a/apps/aether-gateway/src/handlers/admin/system/shared/modules.rs
+++ b/apps/aether-gateway/src/handlers/admin/system/shared/modules.rs
@@ -56,6 +56,18 @@ pub(crate) const ADMIN_MODULE_DEFINITIONS: &[AdminModuleDefinition] = &[
         admin_menu_order: 0,
     },
     AdminModuleDefinition {
+        name: "chat_pii_redaction",
+        display_name: "敏感信息替换保护",
+        description: "发送给供应商前将聊天消息中的敏感信息替换为占位符，返回客户端前自动还原。",
+        category: "security",
+        env_key: "CHAT_PII_REDACTION_AVAILABLE",
+        default_available: true,
+        admin_route: Some("/admin/modules/chat-pii-redaction"),
+        admin_menu_icon: Some("ShieldCheck"),
+        admin_menu_group: Some("system"),
+        admin_menu_order: 59,
+    },
+    AdminModuleDefinition {
         name: "notification_email",
         display_name: "异常通知",
         description: "为 5xx 异常发送邮件通知，可在模块管理中启用或禁用",

--- a/apps/aether-gateway/src/handlers/internal/gateway_helpers.rs
+++ b/apps/aether-gateway/src/handlers/internal/gateway_helpers.rs
@@ -357,6 +357,7 @@ pub(crate) fn gateway_error_message(error: GatewayError) -> String {
     match error {
         GatewayError::UpstreamUnavailable { message, .. }
         | GatewayError::ControlUnavailable { message, .. }
+        | GatewayError::Client { message, .. }
         | GatewayError::Internal(message) => message,
     }
 }

--- a/apps/aether-gateway/src/handlers/proxy/mod.rs
+++ b/apps/aether-gateway/src/handlers/proxy/mod.rs
@@ -16,7 +16,7 @@ use crate::api::response::{
     build_local_user_rpm_limited_response,
 };
 use crate::constants::{
-    DEPENDENCY_REASON_HEADER, EXECUTION_PATH_CONTROL_EXECUTE_STREAM,
+    CONTROL_CANDIDATE_ID_HEADER, DEPENDENCY_REASON_HEADER, EXECUTION_PATH_CONTROL_EXECUTE_STREAM,
     EXECUTION_PATH_CONTROL_EXECUTE_SYNC, EXECUTION_PATH_DISTRIBUTED_OVERLOADED,
     EXECUTION_PATH_EXECUTION_RUNTIME_STREAM, EXECUTION_PATH_EXECUTION_RUNTIME_SYNC,
     EXECUTION_PATH_LOCAL_AI_PUBLIC, EXECUTION_PATH_LOCAL_API_KEY_CONCURRENCY_LIMITED,
@@ -61,6 +61,7 @@ use crate::{
 use axum::body::{to_bytes, Body, Bytes};
 use axum::extract::{ConnectInfo, Request, State};
 use axum::http::{self, header::HeaderName, header::HeaderValue, Response};
+use futures_util::StreamExt;
 use sha2::{Digest, Sha256};
 use std::{collections::BTreeMap, time::Instant};
 use tracing::{debug, info, warn};
@@ -456,6 +457,109 @@ fn collect_upstream_response_headers(
         .collect()
 }
 
+fn collect_response_headers(headers: &http::HeaderMap) -> BTreeMap<String, String> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str().to_string(),
+                value.to_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect()
+}
+
+fn replace_response_headers(
+    headers: &mut http::HeaderMap,
+    values: &BTreeMap<String, String>,
+) -> Result<(), GatewayError> {
+    headers.clear();
+    for (name, value) in values {
+        headers.insert(
+            HeaderName::from_bytes(name.as_bytes())
+                .map_err(|err| GatewayError::Internal(err.to_string()))?,
+            HeaderValue::from_str(value).map_err(|err| GatewayError::Internal(err.to_string()))?,
+        );
+    }
+    Ok(())
+}
+
+fn take_redaction_session_for_response(
+    headers: &http::HeaderMap,
+    redaction_slot: &crate::privacy::RedactionSessionSlot,
+) -> Option<crate::privacy::RedactionSession> {
+    let candidate_id = headers
+        .get(CONTROL_CANDIDATE_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    redaction_slot.take_for_candidate(candidate_id)
+}
+
+async fn restore_redacted_sync_execution_response(
+    response: Response<Body>,
+    redaction_slot: &crate::privacy::RedactionSessionSlot,
+) -> Result<Response<Body>, GatewayError> {
+    let (mut parts, body) = response.into_parts();
+    let Some(session) = take_redaction_session_for_response(&parts.headers, redaction_slot) else {
+        return Ok(Response::from_parts(parts, body));
+    };
+    let mut headers = collect_response_headers(&parts.headers);
+    let body_bytes = to_bytes(body, usize::MAX)
+        .await
+        .map_err(|err| GatewayError::Internal(err.to_string()))?;
+    let restored =
+        crate::privacy::restore_sync_response_body(&mut headers, body_bytes.as_ref(), &session)?;
+    replace_response_headers(&mut parts.headers, &headers)?;
+    Ok(Response::from_parts(parts, Body::from(restored.body)))
+}
+
+fn restore_redacted_stream_execution_response(
+    response: Response<Body>,
+    redaction_slot: &crate::privacy::RedactionSessionSlot,
+) -> Result<Response<Body>, GatewayError> {
+    let (mut parts, body) = response.into_parts();
+    let Some(session) = take_redaction_session_for_response(&parts.headers, redaction_slot) else {
+        return Ok(Response::from_parts(parts, body));
+    };
+    let headers = collect_response_headers(&parts.headers);
+    let _ = crate::privacy::StreamingResponseRestorer::new(&headers, &session)?;
+    parts.headers.remove(http::header::CONTENT_LENGTH);
+    let stream_headers = headers;
+    let stream = async_stream::stream! {
+        let mut restorer = match crate::privacy::StreamingResponseRestorer::new(&stream_headers, &session) {
+            Ok(restorer) => restorer,
+            Err(err) => {
+                yield Err(std::io::Error::other(format!("{err:?}")));
+                return;
+            }
+        };
+        let mut body_stream = body.into_data_stream();
+        while let Some(chunk) = body_stream.next().await {
+            match chunk {
+                Ok(chunk) => match restorer.push_chunk(chunk.as_ref()) {
+                    Ok(restored) if restored.is_empty() => {}
+                    Ok(restored) => yield Ok(Bytes::from(restored)),
+                    Err(err) => {
+                        yield Err(std::io::Error::other(format!("{err:?}")));
+                        return;
+                    }
+                },
+                Err(err) => {
+                    yield Err(std::io::Error::other(err.to_string()));
+                    return;
+                }
+            }
+        }
+        match restorer.finish() {
+            Ok(restored) if restored.is_empty() => {}
+            Ok(restored) => yield Ok(Bytes::from(restored)),
+            Err(err) => yield Err(std::io::Error::other(format!("{err:?}"))),
+        }
+    };
+    Ok(Response::from_parts(parts, Body::from_stream(stream)))
+}
+
 fn aggregate_sync_sse_response_for_client(
     decision: &GatewayControlDecision,
     public_path: &str,
@@ -711,6 +815,8 @@ pub(crate) async fn proxy_request(
     };
     let request_admission_ms = started_at.elapsed().as_millis() as u64;
     let (mut parts, body) = request.into_parts();
+    let redaction_slot = crate::privacy::RedactionSessionSlot::default();
+    parts.extensions.insert(redaction_slot.clone());
     parts
         .extensions
         .insert(request_origin_from_headers_and_remote_addr(
@@ -1139,6 +1245,10 @@ pub(crate) async fn proxy_request(
             );
             match stream_outcome {
                 LocalExecutionRequestOutcome::Responded(execution_runtime_response) => {
+                    let execution_runtime_response = restore_redacted_stream_execution_response(
+                        execution_runtime_response,
+                        &redaction_slot,
+                    )?;
                     state.clear_local_execution_runtime_miss_diagnostic(&trace_id);
                     return Ok(finalize_gateway_response_with_context(
                         &state,
@@ -1160,6 +1270,11 @@ pub(crate) async fn proxy_request(
             .await?
         {
             LocalExecutionRequestOutcome::Responded(execution_runtime_response) => {
+                let execution_runtime_response = restore_redacted_sync_execution_response(
+                    execution_runtime_response,
+                    &redaction_slot,
+                )
+                .await?;
                 state.clear_local_execution_runtime_miss_diagnostic(&trace_id);
                 return Ok(finalize_gateway_response_with_context(
                     &state,
@@ -1187,6 +1302,10 @@ pub(crate) async fn proxy_request(
             .await?
             {
                 LocalExecutionRequestOutcome::Responded(execution_runtime_response) => {
+                    let execution_runtime_response = restore_redacted_stream_execution_response(
+                        execution_runtime_response,
+                        &redaction_slot,
+                    )?;
                     state.clear_local_execution_runtime_miss_diagnostic(&trace_id);
                     return Ok(finalize_gateway_response_with_context(
                         &state,
@@ -1236,6 +1355,15 @@ pub(crate) async fn proxy_request(
                         Some(control_execution_path),
                         reason,
                     );
+                    let control_response = if stream_request {
+                        restore_redacted_stream_execution_response(
+                            control_response,
+                            &redaction_slot,
+                        )?
+                    } else {
+                        restore_redacted_sync_execution_response(control_response, &redaction_slot)
+                            .await?
+                    };
                     let mut control_response = control_response;
                     state.clear_local_execution_runtime_miss_diagnostic(&trace_id);
                     control_response.headers_mut().insert(
@@ -1731,8 +1859,109 @@ fn local_execution_runtime_miss_route_detail(
 mod tests {
     use super::{
         diagnostic_is_auth_api_key_concurrency_limited, local_execution_runtime_miss_detail,
+        restore_redacted_stream_execution_response, restore_redacted_sync_execution_response,
         GatewayControlDecision, LocalExecutionRuntimeMissDiagnostic,
     };
+    use axum::body::{to_bytes, Body};
+    use axum::http::{header, Response};
+    use serde_json::json;
+
+    fn redaction_slot_for_email() -> (crate::privacy::RedactionSessionSlot, String) {
+        let masked = crate::privacy::mask_chat_request_json(
+            br#"{"messages":[{"role":"user","content":"Email alice@example.com"}]}"#,
+            crate::privacy::RedactionSessionConfig::new(
+                b"proxy-wrapper-test-key".to_vec(),
+                300,
+                600,
+            ),
+        );
+        let sentinel = masked
+            .session
+            .sentinel_for_original("alice@example.com")
+            .expect("email sentinel should exist")
+            .to_string();
+        let slot = crate::privacy::RedactionSessionSlot::default();
+        slot.put(masked.session);
+        (slot, sentinel)
+    }
+
+    #[tokio::test]
+    async fn proxy_pii_redaction_sync_response_wrapper_restores_current_request_sentinel() {
+        let (slot, sentinel) = redaction_slot_for_email();
+        let body = serde_json::to_vec(&json!({
+            "choices": [{"message": {"role": "assistant", "content": format!("hello {sentinel}")}}]
+        }))
+        .expect("response should serialize");
+        let response = Response::builder()
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::CONTENT_LENGTH, body.len().to_string())
+            .body(Body::from(body))
+            .expect("response should build");
+
+        let restored = restore_redacted_sync_execution_response(response, &slot)
+            .await
+            .expect("sync wrapper should restore");
+        let restored_content_length = restored
+            .headers()
+            .get(header::CONTENT_LENGTH)
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned);
+        let body = to_bytes(restored.into_body(), usize::MAX)
+            .await
+            .expect("body should read");
+        let value: serde_json::Value = serde_json::from_slice(&body).expect("body should parse");
+
+        assert_eq!(restored_content_length, Some(body.len().to_string()));
+        assert_eq!(
+            value["choices"][0]["message"]["content"],
+            "hello alice@example.com"
+        );
+    }
+
+    #[tokio::test]
+    async fn proxy_pii_redaction_stream_response_wrapper_restores_current_request_sentinel() {
+        let (slot, sentinel) = redaction_slot_for_email();
+        let response = Response::builder()
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .header(header::CONTENT_LENGTH, "999")
+            .body(Body::from(format!(
+                "data: {{\"choices\":[{{\"delta\":{{\"content\":\"hello {sentinel}\"}}}}]}}\n\n"
+            )))
+            .expect("response should build");
+
+        let restored = restore_redacted_stream_execution_response(response, &slot)
+            .expect("stream wrapper should restore");
+        assert!(restored.headers().get(header::CONTENT_LENGTH).is_none());
+        let body = to_bytes(restored.into_body(), usize::MAX)
+            .await
+            .expect("body should read");
+        let text = String::from_utf8(body.to_vec()).expect("body should be utf8");
+
+        assert!(text.contains("hello alice@example.com"));
+        assert!(!text.contains(&sentinel));
+    }
+
+    #[tokio::test]
+    async fn proxy_pii_redaction_compressed_response_safe_error() {
+        let (slot, sentinel) = redaction_slot_for_email();
+        let response = Response::builder()
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::CONTENT_ENCODING, "gzip")
+            .header(header::CONTENT_LENGTH, "999")
+            .body(Body::from(format!(
+                "{{\"choices\":[{{\"message\":{{\"content\":\"hello {sentinel}\"}}}}]}}"
+            )))
+            .expect("response should build");
+
+        let err = restore_redacted_sync_execution_response(response, &slot)
+            .await
+            .expect_err("compressed active redaction should fail safely");
+        let message = format!("{err:?}");
+
+        assert!(message.contains("encoded response bodies"));
+        assert!(!message.contains("alice@example.com"));
+        assert!(!message.contains(&sentinel));
+    }
 
     #[test]
     fn runtime_miss_detail_returns_model_specific_stream_message_when_candidates_are_unavailable() {

--- a/apps/aether-gateway/src/handlers/public/support/announcements/shared.rs
+++ b/apps/aether-gateway/src/handlers/public/support/announcements/shared.rs
@@ -138,6 +138,7 @@ pub(super) fn announcements_internal_detail(err: GatewayError) -> String {
     match err {
         GatewayError::UpstreamUnavailable { message, .. }
         | GatewayError::ControlUnavailable { message, .. }
+        | GatewayError::Client { message, .. }
         | GatewayError::Internal(message) => message,
     }
 }

--- a/apps/aether-gateway/src/lib.rs
+++ b/apps/aether-gateway/src/lib.rs
@@ -49,6 +49,7 @@ pub(crate) mod middleware;
 mod model_fetch;
 mod oauth;
 mod orchestration;
+mod privacy;
 mod provider_key_auth;
 pub(crate) use aether_provider_transport as provider_transport;
 mod rate_limit;

--- a/apps/aether-gateway/src/oauth/http_executor.rs
+++ b/apps/aether-gateway/src/oauth/http_executor.rs
@@ -160,6 +160,7 @@ fn gateway_error_to_oauth_error(error: GatewayError) -> OAuthError {
     match error {
         GatewayError::UpstreamUnavailable { message, .. }
         | GatewayError::ControlUnavailable { message, .. }
+        | GatewayError::Client { message, .. }
         | GatewayError::Internal(message) => OAuthError::Transport(message),
     }
 }

--- a/apps/aether-gateway/src/privacy/mod.rs
+++ b/apps/aether-gateway/src/privacy/mod.rs
@@ -1,0 +1,4331 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::{Arc, LazyLock, Mutex};
+
+use aether_data::driver::redis::RedisKvRunner;
+use aether_data_contracts::DataLayerError;
+use chrono::NaiveDate;
+use hmac::Mac;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::Digest as _;
+
+use crate::GatewayError;
+
+type HmacSha256 = hmac::Hmac<sha2::Sha256>;
+
+const DEFAULT_REDACTION_TTL_SECONDS: u64 = 300;
+const DEFAULT_MAX_SCANNED_CHAT_TEXT_BYTES: usize = 2 * 1024 * 1024;
+const DEFAULT_MAX_REDACTION_DETECTIONS: usize = 1024;
+const HMAC96_BYTES: usize = 12;
+const SENTINEL_PREFIX: &str = "<AETHER:";
+const DIRECT_RESTORE_SENTINEL_LIMIT: usize = 32;
+const MAX_CACHE_SENTINEL_BYTES: usize = 128;
+const MAX_CACHE_RECORD_BYTES: usize = 512;
+
+static EMAIL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)[A-Z0-9._%+-]{1,64}@[A-Z0-9.-]{1,253}\.[A-Z]{2,63}")
+        .expect("email regex should compile")
+});
+static CN_MOBILE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?:\+?86[- ]?)?1[3-9]\d[- ]?\d{4}[- ]?\d{4}")
+        .expect("cn mobile regex should compile")
+});
+static CN_LANDLINE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?:\+?86[- ]?)?0\d{2,3}[- ]\d{7,8}(?:-\d{1,6})?")
+        .expect("cn landline regex should compile")
+});
+static E164_PHONE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\+[1-9]\d(?:[ -]?\d){6,13}\d").expect("e164 phone regex should compile")
+});
+static CN_ID_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)\b\d{17}[\dX]\b").expect("cn id regex should compile"));
+static PAYMENT_CARD_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b(?:\d[ -]?){12,18}\d\b").expect("payment card regex should compile")
+});
+static IPV4_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b(?:\d{1,3}\.){3}\d{1,3}\b").expect("ipv4 regex should compile")
+});
+static OPENAI_KEY_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b").expect("openai key regex should compile")
+});
+static ANTHROPIC_KEY_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b").expect("anthropic key regex should compile")
+});
+static GITHUB_TOKEN_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b(?:gh[pousr]_[A-Za-z0-9_]{30,}|github_pat_[A-Za-z0-9_]{30,})\b")
+        .expect("github token regex should compile")
+});
+static SLACK_TOKEN_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b").expect("slack token regex should compile")
+});
+static AWS_KEY_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b").expect("aws key regex should compile")
+});
+static BEARER_TOKEN_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{20,}")
+        .expect("bearer token regex should compile")
+});
+static JWT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b")
+        .expect("jwt regex should compile")
+});
+static ACCESS_TOKEN_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?i)\baccess[_-]?token\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{20,}"#)
+        .expect("access token regex should compile")
+});
+static SECRET_KEY_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?i)\bsecret[_-]?key\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{20,}"#)
+        .expect("secret key regex should compile")
+});
+static HIGH_ENTROPY_TOKEN_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b[A-Za-z0-9_-]{32,}\b").expect("api key regex should compile"));
+static SENTINEL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"<AETHER:[A-Z0-9_]+:[A-Z2-7]{20}>").expect("sentinel regex should compile")
+});
+
+#[derive(Clone, Copy, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub(crate) enum RedactionKind {
+    Email,
+    ChinaMobile,
+    ChinaLandline,
+    Phone,
+    ChinaResidentId,
+    PaymentCard,
+    Ipv4,
+    Ipv6,
+    OpenAiKey,
+    AnthropicKey,
+    GitHubToken,
+    SlackToken,
+    AwsKey,
+    BearerToken,
+    Jwt,
+    AccessToken,
+    SecretKey,
+    ApiKey,
+}
+
+impl RedactionKind {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Email => "EMAIL",
+            Self::ChinaMobile | Self::ChinaLandline => "CN_PHONE",
+            Self::Phone => "PHONE",
+            Self::ChinaResidentId => "CN_ID",
+            Self::PaymentCard => "PAYMENT_CARD",
+            Self::Ipv4 => "IPV4",
+            Self::Ipv6 => "IPV6",
+            Self::OpenAiKey => "OPENAI_KEY",
+            Self::AnthropicKey => "ANTHROPIC_KEY",
+            Self::GitHubToken => "GITHUB_TOKEN",
+            Self::SlackToken => "SLACK_TOKEN",
+            Self::AwsKey => "AWS_KEY",
+            Self::BearerToken => "BEARER_TOKEN",
+            Self::Jwt => "JWT",
+            Self::AccessToken => "ACCESS_TOKEN",
+            Self::SecretKey => "SECRET_KEY",
+            Self::ApiKey => "API_KEY",
+        }
+    }
+}
+
+impl fmt::Debug for RedactionKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.label())
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct RedactionSessionConfig {
+    hmac_key: Vec<u8>,
+    ttl_seconds: u64,
+    now_unix_secs: u64,
+    enabled_kinds: Option<HashSet<RedactionKind>>,
+}
+
+impl RedactionSessionConfig {
+    pub(crate) fn new(hmac_key: impl Into<Vec<u8>>, ttl_seconds: u64, now_unix_secs: u64) -> Self {
+        Self {
+            hmac_key: hmac_key.into(),
+            ttl_seconds: ttl_seconds.max(1),
+            now_unix_secs,
+            enabled_kinds: None,
+        }
+    }
+
+    pub(crate) fn default_ttl(hmac_key: impl Into<Vec<u8>>, now_unix_secs: u64) -> Self {
+        Self::new(hmac_key, DEFAULT_REDACTION_TTL_SECONDS, now_unix_secs)
+    }
+
+    fn bucket(&self) -> u64 {
+        self.now_unix_secs / self.ttl_seconds
+    }
+
+    fn expires_at_unix_secs(&self) -> u64 {
+        self.bucket()
+            .saturating_add(1)
+            .saturating_mul(self.ttl_seconds)
+    }
+
+    pub(crate) fn with_enabled_kinds(mut self, enabled_kinds: HashSet<RedactionKind>) -> Self {
+        self.enabled_kinds = Some(enabled_kinds);
+        self
+    }
+
+    fn kind_enabled(&self, kind: RedactionKind) -> bool {
+        self.enabled_kinds
+            .as_ref()
+            .is_none_or(|enabled_kinds| enabled_kinds.contains(&kind))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RedactionScanLimits {
+    pub(crate) max_scanned_text_bytes: usize,
+    pub(crate) max_detections: usize,
+}
+
+impl Default for RedactionScanLimits {
+    fn default() -> Self {
+        Self {
+            max_scanned_text_bytes: DEFAULT_MAX_SCANNED_CHAT_TEXT_BYTES,
+            max_detections: DEFAULT_MAX_REDACTION_DETECTIONS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum RedactionLimitError {
+    ScannedTextTooLarge { limit: usize },
+    TooManyDetections { limit: usize },
+}
+
+impl RedactionLimitError {
+    pub(crate) const fn client_status(&self) -> http::StatusCode {
+        match self {
+            Self::ScannedTextTooLarge { .. } => http::StatusCode::PAYLOAD_TOO_LARGE,
+            Self::TooManyDetections { .. } => http::StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+
+    pub(crate) const fn safe_message(&self) -> &'static str {
+        match self {
+            Self::ScannedTextTooLarge { .. } => "chat pii redaction scanned text limit exceeded",
+            Self::TooManyDetections { .. } => "chat pii redaction detection limit exceeded",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum RedactionMaskError {
+    Limit(RedactionLimitError),
+}
+
+impl From<RedactionLimitError> for RedactionMaskError {
+    fn from(error: RedactionLimitError) -> Self {
+        Self::Limit(error)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RedactionScanState {
+    limits: RedactionScanLimits,
+    scanned_text_bytes: usize,
+    detections: usize,
+}
+
+impl RedactionScanState {
+    fn new(limits: RedactionScanLimits) -> Self {
+        Self {
+            limits,
+            scanned_text_bytes: 0,
+            detections: 0,
+        }
+    }
+
+    fn record_scan(&mut self, text: &str) -> Result<(), RedactionLimitError> {
+        self.scanned_text_bytes = self.scanned_text_bytes.saturating_add(text.len());
+        if self.scanned_text_bytes > self.limits.max_scanned_text_bytes {
+            return Err(RedactionLimitError::ScannedTextTooLarge {
+                limit: self.limits.max_scanned_text_bytes,
+            });
+        }
+        Ok(())
+    }
+
+    fn record_detections(&mut self, count: usize) -> Result<(), RedactionLimitError> {
+        self.detections = self.detections.saturating_add(count);
+        if self.detections > self.limits.max_detections {
+            return Err(RedactionLimitError::TooManyDetections {
+                limit: self.limits.max_detections,
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct DetectorProbe {
+    validator_calls: HashMap<RedactionKind, usize>,
+}
+
+impl DetectorProbe {
+    fn record_validator_call(&mut self, kind: RedactionKind) {
+        *self.validator_calls.entry(kind).or_default() += 1;
+    }
+
+    #[cfg(test)]
+    fn validator_calls(&self, kind: RedactionKind) -> usize {
+        self.validator_calls.get(&kind).copied().unwrap_or_default()
+    }
+}
+
+impl fmt::Debug for RedactionSessionConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RedactionSessionConfig")
+            .field("hmac_key", &"<redacted>")
+            .field("ttl_seconds", &self.ttl_seconds)
+            .field("now_unix_secs", &self.now_unix_secs)
+            .field(
+                "enabled_kind_count",
+                &self.enabled_kinds.as_ref().map(HashSet::len),
+            )
+            .finish()
+    }
+}
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct MappingKey {
+    kind: RedactionKind,
+    original: String,
+}
+
+pub(crate) struct RedactionSession {
+    config: RedactionSessionConfig,
+    mappings: HashMap<MappingKey, RedactionMapping>,
+    sentinel_index: HashMap<String, MappingKey>,
+    collision_corpus: Vec<String>,
+}
+
+impl RedactionSession {
+    pub(crate) fn new(config: RedactionSessionConfig) -> Self {
+        Self {
+            config,
+            mappings: HashMap::new(),
+            sentinel_index: HashMap::new(),
+            collision_corpus: Vec::new(),
+        }
+    }
+
+    fn set_collision_corpus(&mut self, collision_corpus: Vec<String>) {
+        self.collision_corpus = collision_corpus;
+    }
+
+    pub(crate) fn redact_text(&mut self, input: &str) -> RedactedText {
+        self.redact_text_internal(input, None)
+            .expect("unlimited redaction scan should not fail")
+    }
+
+    fn redact_text_checked(
+        &mut self,
+        input: &str,
+        scan_state: &mut RedactionScanState,
+    ) -> Result<RedactedText, RedactionLimitError> {
+        scan_state.record_scan(input)?;
+        self.redact_text_internal(input, Some(scan_state))
+    }
+
+    async fn redact_text_with_cache(
+        &mut self,
+        input: &str,
+        scan_state: &mut RedactionScanState,
+        cache: Option<&RedisRedactionMappingCache<'_>>,
+    ) -> Result<RedactedText, RedactionMaskError> {
+        scan_state.record_scan(input)?;
+        let candidates = select_non_overlapping(
+            detect_candidates(input)
+                .into_iter()
+                .filter(|candidate| self.config.kind_enabled(candidate.kind))
+                .collect(),
+        );
+        scan_state.record_detections(candidates.len())?;
+        if candidates.is_empty() {
+            return Ok(RedactedText {
+                text: input.to_string(),
+                matches: Vec::new(),
+            });
+        }
+
+        let mut redacted = String::with_capacity(input.len());
+        let mut cursor = 0;
+        let mut matches = Vec::with_capacity(candidates.len());
+
+        for candidate in candidates {
+            redacted.push_str(&input[cursor..candidate.start]);
+            let sentinel = self
+                .sentinel_for_candidate_with_cache(input, candidate.kind, &candidate.value, cache)
+                .await;
+            redacted.push_str(&sentinel);
+            matches.push(RedactionMatch {
+                kind: candidate.kind,
+                start: candidate.start,
+                end: candidate.end,
+                original: candidate.value,
+                sentinel,
+            });
+            cursor = candidate.end;
+        }
+        redacted.push_str(&input[cursor..]);
+
+        Ok(RedactedText {
+            text: redacted,
+            matches,
+        })
+    }
+
+    fn redact_text_internal(
+        &mut self,
+        input: &str,
+        mut scan_state: Option<&mut RedactionScanState>,
+    ) -> Result<RedactedText, RedactionLimitError> {
+        let candidates = select_non_overlapping(
+            detect_candidates(input)
+                .into_iter()
+                .filter(|candidate| self.config.kind_enabled(candidate.kind))
+                .collect(),
+        );
+        if let Some(scan_state) = scan_state.as_mut() {
+            scan_state.record_detections(candidates.len())?;
+        }
+        if candidates.is_empty() {
+            return Ok(RedactedText {
+                text: input.to_string(),
+                matches: Vec::new(),
+            });
+        }
+
+        let mut redacted = String::with_capacity(input.len());
+        let mut cursor = 0;
+        let mut matches = Vec::with_capacity(candidates.len());
+
+        for candidate in candidates {
+            redacted.push_str(&input[cursor..candidate.start]);
+            let sentinel = self.sentinel_for_candidate(input, candidate.kind, &candidate.value);
+            redacted.push_str(&sentinel);
+            matches.push(RedactionMatch {
+                kind: candidate.kind,
+                start: candidate.start,
+                end: candidate.end,
+                original: candidate.value,
+                sentinel,
+            });
+            cursor = candidate.end;
+        }
+        redacted.push_str(&input[cursor..]);
+
+        Ok(RedactedText {
+            text: redacted,
+            matches,
+        })
+    }
+
+    pub(crate) fn mapping_count(&self) -> usize {
+        self.mappings.len()
+    }
+
+    pub(crate) fn sentinel_for_original(&self, original: &str) -> Option<&str> {
+        self.mappings
+            .values()
+            .find(|mapping| mapping.original == original)
+            .map(|mapping| mapping.sentinel.as_str())
+    }
+
+    pub(crate) fn mappings(&self) -> impl Iterator<Item = &RedactionMapping> {
+        self.mappings.values()
+    }
+
+    fn restore_text(&self, input: &str) -> RestoredText {
+        if self.mapping_count() <= DIRECT_RESTORE_SENTINEL_LIMIT {
+            return restore_text_direct_longest_first(input, self);
+        }
+        restore_text_with_matcher(input, &SentinelMatcher::new(self))
+    }
+
+    fn sentinel_for_candidate(
+        &mut self,
+        source_text: &str,
+        kind: RedactionKind,
+        original: &str,
+    ) -> String {
+        let key = MappingKey {
+            kind,
+            original: normalize_redaction_value(kind, original),
+        };
+        if let Some(mapping) = self.mappings.get(&key) {
+            return mapping.sentinel.clone();
+        }
+
+        let bucket = self.config.bucket();
+        let mut collision_counter = 0u32;
+        let sentinel = loop {
+            let candidate = self.build_sentinel(kind, original, bucket, collision_counter);
+            let collides_with_input =
+                self.sentinel_collides_with_original_text(source_text, &candidate);
+            let collides_with_mapping = self
+                .sentinel_index
+                .get(&candidate)
+                .is_some_and(|existing_key| existing_key != &key);
+            if !collides_with_input && !collides_with_mapping {
+                break candidate;
+            }
+            collision_counter = collision_counter.saturating_add(1);
+        };
+
+        let mapping = RedactionMapping {
+            kind,
+            original: original.to_string(),
+            normalized_value: key.original.clone(),
+            sentinel: sentinel.clone(),
+            bucket,
+            created_at_unix_secs: self.config.now_unix_secs,
+            expires_at_unix_secs: self.config.expires_at_unix_secs(),
+        };
+        self.sentinel_index.insert(sentinel.clone(), key.clone());
+        self.mappings.insert(key, mapping);
+        sentinel
+    }
+
+    async fn sentinel_for_candidate_with_cache(
+        &mut self,
+        source_text: &str,
+        kind: RedactionKind,
+        original: &str,
+        cache: Option<&RedisRedactionMappingCache<'_>>,
+    ) -> String {
+        let key = MappingKey {
+            kind,
+            original: normalize_redaction_value(kind, original),
+        };
+        if let Some(mapping) = self.mappings.get(&key) {
+            return mapping.sentinel.clone();
+        }
+
+        let bucket = self.config.bucket();
+        if let Some(cache) = cache {
+            if let Ok(Some(sentinel)) = cache.lookup_sentinel(kind, &key.original, bucket).await {
+                if sentinel.len() <= MAX_CACHE_SENTINEL_BYTES
+                    && self.cached_sentinel_usable(source_text, &key, &sentinel)
+                {
+                    self.insert_mapping_for_sentinel(key, kind, original, sentinel.clone(), bucket);
+                    return sentinel;
+                }
+            }
+        }
+
+        let sentinel = self.sentinel_for_candidate(source_text, kind, original);
+        if let Some(cache) = cache {
+            if let Some(mapping) = self.mappings.get(&key) {
+                let ttl_seconds = self
+                    .config
+                    .expires_at_unix_secs()
+                    .saturating_sub(self.config.now_unix_secs)
+                    .max(1);
+                let _ = cache
+                    .store(
+                        &RedactionCacheRecord::from_mapping(mapping),
+                        &mapping.normalized_value,
+                        ttl_seconds,
+                    )
+                    .await;
+            }
+        }
+        sentinel
+    }
+
+    fn cached_sentinel_usable(&self, source_text: &str, key: &MappingKey, sentinel: &str) -> bool {
+        if self.sentinel_collides_with_original_text(source_text, sentinel) {
+            return false;
+        }
+        !self
+            .sentinel_index
+            .get(sentinel)
+            .is_some_and(|existing_key| existing_key != key)
+    }
+
+    fn sentinel_collides_with_original_text(&self, source_text: &str, sentinel: &str) -> bool {
+        source_text.contains(sentinel)
+            || self
+                .collision_corpus
+                .iter()
+                .any(|original_text| original_text.contains(sentinel))
+    }
+
+    fn insert_mapping_for_sentinel(
+        &mut self,
+        key: MappingKey,
+        kind: RedactionKind,
+        original: &str,
+        sentinel: String,
+        bucket: u64,
+    ) {
+        let mapping = RedactionMapping {
+            kind,
+            original: original.to_string(),
+            normalized_value: key.original.clone(),
+            sentinel: sentinel.clone(),
+            bucket,
+            created_at_unix_secs: self.config.now_unix_secs,
+            expires_at_unix_secs: self.config.expires_at_unix_secs(),
+        };
+        self.sentinel_index.insert(sentinel, key.clone());
+        self.mappings.insert(key, mapping);
+    }
+
+    fn build_sentinel(
+        &self,
+        kind: RedactionKind,
+        original: &str,
+        bucket: u64,
+        collision_counter: u32,
+    ) -> String {
+        let mut mac = HmacSha256::new_from_slice(&self.config.hmac_key)
+            .expect("HMAC accepts keys of any size");
+        mac.update(b"aether-redaction-v1\0");
+        mac.update(kind.label().as_bytes());
+        mac.update(b"\0");
+        mac.update(bucket.to_string().as_bytes());
+        mac.update(b"\0");
+        mac.update(collision_counter.to_string().as_bytes());
+        mac.update(b"\0");
+        mac.update(normalize_redaction_value(kind, original).as_bytes());
+        let digest = mac.finalize().into_bytes();
+        format!(
+            "{}{}:{}>",
+            SENTINEL_PREFIX,
+            kind.label(),
+            base32_no_pad(&digest[..HMAC96_BYTES])
+        )
+    }
+}
+
+impl fmt::Debug for RedactionSession {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut counts: HashMap<&'static str, usize> = HashMap::new();
+        for mapping in self.mappings.values() {
+            *counts.entry(mapping.kind.label()).or_default() += 1;
+        }
+        formatter
+            .debug_struct("RedactionSession")
+            .field("ttl_seconds", &self.config.ttl_seconds)
+            .field("bucket", &self.config.bucket())
+            .field("mapping_count", &self.mappings.len())
+            .field("type_counts", &counts)
+            .finish()
+    }
+}
+
+pub(crate) struct MaskedChatRequest {
+    pub(crate) body: Vec<u8>,
+    pub(crate) session: RedactionSession,
+    pub(crate) redacted: bool,
+}
+
+impl fmt::Debug for MaskedChatRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MaskedChatRequest")
+            .field("body_len", &self.body.len())
+            .field("session", &self.session)
+            .field("redacted", &self.redacted)
+            .finish()
+    }
+}
+
+#[derive(Default, Clone)]
+pub(crate) struct RedactionSessionSlot {
+    session: Arc<Mutex<Option<RedactionSession>>>,
+    sessions_by_candidate: Arc<Mutex<HashMap<String, RedactionSession>>>,
+}
+
+impl RedactionSessionSlot {
+    pub(crate) fn put(&self, session: RedactionSession) {
+        *self
+            .session
+            .lock()
+            .expect("redaction session slot should lock") = Some(session);
+    }
+
+    pub(crate) fn put_for_candidate(&self, candidate_id: &str, session: RedactionSession) {
+        self.sessions_by_candidate
+            .lock()
+            .expect("redaction session candidate slot should lock")
+            .insert(candidate_id.to_string(), session);
+    }
+
+    pub(crate) fn clear(&self) {
+        *self
+            .session
+            .lock()
+            .expect("redaction session slot should lock") = None;
+        self.sessions_by_candidate
+            .lock()
+            .expect("redaction session candidate slot should lock")
+            .clear();
+    }
+
+    pub(crate) fn take(&self) -> Option<RedactionSession> {
+        self.session
+            .lock()
+            .expect("redaction session slot should lock")
+            .take()
+    }
+
+    pub(crate) fn take_for_candidate(
+        &self,
+        candidate_id: Option<&str>,
+    ) -> Option<RedactionSession> {
+        let Some(candidate_id) = candidate_id else {
+            return self.take_without_candidate_id();
+        };
+        let mut sessions_by_candidate = self
+            .sessions_by_candidate
+            .lock()
+            .expect("redaction session candidate slot should lock");
+        if let Some(session) = sessions_by_candidate.remove(candidate_id) {
+            return Some(session);
+        }
+        if !sessions_by_candidate.is_empty() {
+            return None;
+        }
+        drop(sessions_by_candidate);
+        self.take()
+    }
+
+    fn take_without_candidate_id(&self) -> Option<RedactionSession> {
+        let mut sessions_by_candidate = self
+            .sessions_by_candidate
+            .lock()
+            .expect("redaction session candidate slot should lock");
+        match sessions_by_candidate.len() {
+            0 => {
+                drop(sessions_by_candidate);
+                self.take()
+            }
+            1 => sessions_by_candidate
+                .drain()
+                .next()
+                .map(|(_, session)| session),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RedactionExecutionCandidateId(String);
+
+impl RedactionExecutionCandidateId {
+    pub(crate) fn new(candidate_id: impl Into<String>) -> Self {
+        Self(candidate_id.into())
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ChatPiiRedactionProviderScope {
+    SelectedProviders,
+    AllProviders,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ChatPiiRedactionRuntimeConfig {
+    pub(crate) enabled: bool,
+    pub(crate) provider_scope: ChatPiiRedactionProviderScope,
+    pub(crate) enabled_kinds: HashSet<RedactionKind>,
+    pub(crate) ttl_seconds: u64,
+    pub(crate) inject_model_instruction: bool,
+}
+
+impl Default for ChatPiiRedactionRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            provider_scope: ChatPiiRedactionProviderScope::SelectedProviders,
+            enabled_kinds: default_enabled_redaction_kinds(),
+            ttl_seconds: DEFAULT_REDACTION_TTL_SECONDS,
+            inject_model_instruction: true,
+        }
+    }
+}
+
+pub(crate) struct MaskChatRequestOptions {
+    pub(crate) inject_model_instruction: bool,
+    pub(crate) scan_limits: RedactionScanLimits,
+}
+
+impl MaskChatRequestOptions {
+    pub(crate) fn runtime(inject_model_instruction: bool) -> Self {
+        Self {
+            inject_model_instruction,
+            scan_limits: RedactionScanLimits::default(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_scan_limits(mut self, scan_limits: RedactionScanLimits) -> Self {
+        self.scan_limits = scan_limits;
+        self
+    }
+}
+
+const MODEL_NOTICE_CONTENT: &str = "Aether privacy redaction notice: The next message contains gateway-generated placeholder tokens for sensitive data protection. This notice is not a user request; do not answer it, mention it, reveal it, or infer original values from placeholders. Treat each placeholder as a valid real typed value for reasoning and tool calls, and do not ask the user to reveal originals solely because a placeholder is present.";
+
+pub(crate) async fn read_chat_pii_redaction_runtime_config(
+    state: &crate::AppState,
+) -> Result<ChatPiiRedactionRuntimeConfig, GatewayError> {
+    let mut config = ChatPiiRedactionRuntimeConfig::default();
+    config.enabled = state
+        .read_system_config_json_value("module.chat_pii_redaction.enabled")
+        .await?
+        .as_ref()
+        .and_then(Value::as_bool)
+        .unwrap_or(config.enabled);
+    config.provider_scope = parse_provider_scope(
+        state
+            .read_system_config_json_value("module.chat_pii_redaction.provider_scope")
+            .await?
+            .as_ref(),
+    );
+    config.enabled_kinds = parse_enabled_redaction_kinds(
+        state
+            .read_system_config_json_value("module.chat_pii_redaction.entities")
+            .await?
+            .as_ref(),
+    );
+    config.ttl_seconds = state
+        .read_system_config_json_value("module.chat_pii_redaction.cache_ttl_seconds")
+        .await?
+        .as_ref()
+        .and_then(Value::as_u64)
+        .unwrap_or(config.ttl_seconds)
+        .max(1);
+    config.inject_model_instruction = state
+        .read_system_config_json_value("module.chat_pii_redaction.inject_model_instruction")
+        .await?
+        .as_ref()
+        .and_then(Value::as_bool)
+        .unwrap_or(config.inject_model_instruction);
+    Ok(config)
+}
+
+pub(crate) fn provider_chat_pii_redaction_enabled(
+    provider_config: Option<&Value>,
+    runtime_config: &ChatPiiRedactionRuntimeConfig,
+) -> bool {
+    if !runtime_config.enabled {
+        return false;
+    }
+    match runtime_config.provider_scope {
+        ChatPiiRedactionProviderScope::AllProviders => true,
+        ChatPiiRedactionProviderScope::SelectedProviders => provider_config
+            .and_then(|value| value.get("chat_pii_redaction"))
+            .and_then(|value| value.get("enabled"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    }
+}
+
+pub(crate) fn build_redaction_session_config(
+    hmac_key: impl Into<Vec<u8>>,
+    runtime_config: &ChatPiiRedactionRuntimeConfig,
+    now_unix_secs: u64,
+) -> RedactionSessionConfig {
+    RedactionSessionConfig::new(hmac_key, runtime_config.ttl_seconds, now_unix_secs)
+        .with_enabled_kinds(runtime_config.enabled_kinds.clone())
+}
+
+pub(crate) fn mask_chat_request_json_with_options(
+    body: &[u8],
+    config: RedactionSessionConfig,
+    options: MaskChatRequestOptions,
+) -> MaskedChatRequest {
+    try_mask_chat_request_json_with_options(body, config, options)
+        .expect("default chat redaction limits should not be exceeded")
+}
+
+pub(crate) fn mask_chat_request_json(
+    body: &[u8],
+    config: RedactionSessionConfig,
+) -> MaskedChatRequest {
+    mask_chat_request_json_with_options(body, config, MaskChatRequestOptions::runtime(false))
+}
+
+pub(crate) fn try_mask_chat_request_json_with_options(
+    body: &[u8],
+    config: RedactionSessionConfig,
+    options: MaskChatRequestOptions,
+) -> Result<MaskedChatRequest, RedactionLimitError> {
+    mask_chat_request_json_internal(body, config, options, None)
+}
+
+pub(crate) async fn try_mask_chat_request_json_with_cache_options(
+    body: &[u8],
+    config: RedactionSessionConfig,
+    options: MaskChatRequestOptions,
+    cache: Option<&RedisRedactionMappingCache<'_>>,
+) -> Result<MaskedChatRequest, RedactionMaskError> {
+    mask_chat_request_json_internal_async(body, config, options, cache).await
+}
+
+fn mask_chat_request_json_internal(
+    body: &[u8],
+    config: RedactionSessionConfig,
+    options: MaskChatRequestOptions,
+    _cache: Option<&RedisRedactionMappingCache<'_>>,
+) -> Result<MaskedChatRequest, RedactionLimitError> {
+    let mut session = RedactionSession::new(config);
+    let Ok(mut value) = serde_json::from_slice::<Value>(body) else {
+        return Ok(MaskedChatRequest {
+            body: body.to_vec(),
+            session,
+            redacted: false,
+        });
+    };
+
+    let Some(collision_corpus) = value
+        .get("messages")
+        .and_then(Value::as_array)
+        .map(|messages| chat_message_collision_corpus(messages))
+    else {
+        return Ok(MaskedChatRequest {
+            body: body.to_vec(),
+            session,
+            redacted: false,
+        });
+    };
+    session.set_collision_corpus(collision_corpus);
+
+    let Some(messages) = value.get_mut("messages").and_then(Value::as_array_mut) else {
+        return Ok(MaskedChatRequest {
+            body: body.to_vec(),
+            session,
+            redacted: false,
+        });
+    };
+
+    let mut scan_state = RedactionScanState::new(options.scan_limits);
+    let mut redacted = false;
+    let mut notice_inserted = false;
+    let mut index = 0;
+    while index < messages.len() {
+        let message_redacted =
+            mask_chat_message_value(&mut messages[index], &mut session, &mut scan_state)?;
+        redacted |= message_redacted;
+        if options.inject_model_instruction && message_redacted && !notice_inserted {
+            messages.insert(index, model_notice_message());
+            notice_inserted = true;
+            index += 1;
+        }
+        index += 1;
+    }
+
+    if !redacted {
+        return Ok(MaskedChatRequest {
+            body: body.to_vec(),
+            session,
+            redacted,
+        });
+    }
+
+    let body = serde_json::to_vec(&value).unwrap_or_else(|_| body.to_vec());
+    Ok(MaskedChatRequest {
+        body,
+        session,
+        redacted,
+    })
+}
+
+async fn mask_chat_request_json_internal_async(
+    body: &[u8],
+    config: RedactionSessionConfig,
+    options: MaskChatRequestOptions,
+    cache: Option<&RedisRedactionMappingCache<'_>>,
+) -> Result<MaskedChatRequest, RedactionMaskError> {
+    let mut session = RedactionSession::new(config);
+    let Ok(mut value) = serde_json::from_slice::<Value>(body) else {
+        return Ok(MaskedChatRequest {
+            body: body.to_vec(),
+            session,
+            redacted: false,
+        });
+    };
+
+    let Some(collision_corpus) = value
+        .get("messages")
+        .and_then(Value::as_array)
+        .map(|messages| chat_message_collision_corpus(messages))
+    else {
+        return Ok(MaskedChatRequest {
+            body: body.to_vec(),
+            session,
+            redacted: false,
+        });
+    };
+    session.set_collision_corpus(collision_corpus);
+
+    let Some(messages) = value.get_mut("messages").and_then(Value::as_array_mut) else {
+        return Ok(MaskedChatRequest {
+            body: body.to_vec(),
+            session,
+            redacted: false,
+        });
+    };
+
+    let mut scan_state = RedactionScanState::new(options.scan_limits);
+    let mut redacted = false;
+    let mut notice_inserted = false;
+    let mut index = 0;
+    while index < messages.len() {
+        let message_redacted = mask_chat_message_value_async(
+            &mut messages[index],
+            &mut session,
+            &mut scan_state,
+            cache,
+        )
+        .await?;
+        redacted |= message_redacted;
+        if options.inject_model_instruction && message_redacted && !notice_inserted {
+            messages.insert(index, model_notice_message());
+            notice_inserted = true;
+            index += 1;
+        }
+        index += 1;
+    }
+
+    if !redacted {
+        return Ok(MaskedChatRequest {
+            body: body.to_vec(),
+            session,
+            redacted,
+        });
+    }
+
+    let body = serde_json::to_vec(&value).unwrap_or_else(|_| body.to_vec());
+    Ok(MaskedChatRequest {
+        body,
+        session,
+        redacted,
+    })
+}
+
+fn model_notice_message() -> Value {
+    serde_json::json!({
+        "role": "assistant",
+        "content": MODEL_NOTICE_CONTENT,
+    })
+}
+
+fn chat_message_collision_corpus(messages: &[Value]) -> Vec<String> {
+    let mut corpus = Vec::new();
+    for message in messages {
+        collect_chat_message_collision_text(message, &mut corpus);
+    }
+    corpus
+}
+
+fn collect_chat_message_collision_text(message: &Value, corpus: &mut Vec<String>) {
+    let Some(message) = message.as_object() else {
+        return;
+    };
+    if let Some(content) = message.get("content") {
+        collect_chat_content_collision_text(content, corpus);
+    }
+    if let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) {
+        for tool_call in tool_calls {
+            collect_tool_call_argument_collision_text(tool_call, corpus);
+        }
+    }
+}
+
+fn collect_chat_content_collision_text(content: &Value, corpus: &mut Vec<String>) {
+    match content {
+        Value::String(text) => corpus.push(text.clone()),
+        Value::Array(parts) => {
+            for part in parts {
+                collect_chat_content_part_collision_text(part, corpus);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_chat_content_part_collision_text(part: &Value, corpus: &mut Vec<String>) {
+    let Some(part) = part.as_object() else {
+        return;
+    };
+    if part.get("type").and_then(Value::as_str) != Some("text") {
+        return;
+    }
+    if let Some(text) = part.get("text").and_then(Value::as_str) {
+        corpus.push(text.to_string());
+    }
+}
+
+fn collect_tool_call_argument_collision_text(tool_call: &Value, corpus: &mut Vec<String>) {
+    if let Some(arguments) = tool_call
+        .get("function")
+        .and_then(Value::as_object)
+        .and_then(|function| function.get("arguments"))
+        .and_then(Value::as_str)
+    {
+        corpus.push(arguments.to_string());
+    }
+}
+
+fn mask_chat_message_value(
+    message: &mut Value,
+    session: &mut RedactionSession,
+    scan_state: &mut RedactionScanState,
+) -> Result<bool, RedactionLimitError> {
+    let Some(message) = message.as_object_mut() else {
+        return Ok(false);
+    };
+
+    let mut redacted = false;
+    if let Some(content) = message.get_mut("content") {
+        redacted |= mask_chat_content_value(content, session, scan_state)?;
+    }
+    if let Some(tool_calls) = message.get_mut("tool_calls").and_then(Value::as_array_mut) {
+        for tool_call in tool_calls {
+            redacted |= mask_tool_call_arguments(tool_call, session, scan_state)?;
+        }
+    }
+    Ok(redacted)
+}
+
+fn mask_chat_content_value(
+    content: &mut Value,
+    session: &mut RedactionSession,
+    scan_state: &mut RedactionScanState,
+) -> Result<bool, RedactionLimitError> {
+    match content {
+        Value::String(text) => mask_json_string(text, session, scan_state),
+        Value::Array(parts) => {
+            let mut redacted = false;
+            for part in parts {
+                redacted |= mask_chat_content_part(part, session, scan_state)?;
+            }
+            Ok(redacted)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn mask_chat_content_part(
+    part: &mut Value,
+    session: &mut RedactionSession,
+    scan_state: &mut RedactionScanState,
+) -> Result<bool, RedactionLimitError> {
+    let Some(part) = part.as_object_mut() else {
+        return Ok(false);
+    };
+    if part.get("type").and_then(Value::as_str) != Some("text") {
+        return Ok(false);
+    }
+    let Some(Value::String(text)) = part.get_mut("text") else {
+        return Ok(false);
+    };
+    mask_json_string(text, session, scan_state)
+}
+
+fn mask_tool_call_arguments(
+    tool_call: &mut Value,
+    session: &mut RedactionSession,
+    scan_state: &mut RedactionScanState,
+) -> Result<bool, RedactionLimitError> {
+    let Some(function) = tool_call.get_mut("function").and_then(Value::as_object_mut) else {
+        return Ok(false);
+    };
+    let Some(Value::String(arguments)) = function.get_mut("arguments") else {
+        return Ok(false);
+    };
+    mask_json_string(arguments, session, scan_state)
+}
+
+fn mask_json_string(
+    text: &mut String,
+    session: &mut RedactionSession,
+    scan_state: &mut RedactionScanState,
+) -> Result<bool, RedactionLimitError> {
+    let redacted = session.redact_text_checked(text, scan_state)?;
+    if redacted.matches.is_empty() {
+        return Ok(false);
+    }
+    *text = redacted.text;
+    Ok(true)
+}
+
+async fn mask_chat_message_value_async(
+    message: &mut Value,
+    session: &mut RedactionSession,
+    scan_state: &mut RedactionScanState,
+    cache: Option<&RedisRedactionMappingCache<'_>>,
+) -> Result<bool, RedactionMaskError> {
+    let Some(message) = message.as_object_mut() else {
+        return Ok(false);
+    };
+
+    let mut redacted = false;
+    if let Some(content) = message.get_mut("content") {
+        redacted |= mask_chat_content_value_async(content, session, scan_state, cache).await?;
+    }
+    if let Some(tool_calls) = message.get_mut("tool_calls").and_then(Value::as_array_mut) {
+        for tool_call in tool_calls {
+            redacted |=
+                mask_tool_call_arguments_async(tool_call, session, scan_state, cache).await?;
+        }
+    }
+    Ok(redacted)
+}
+
+async fn mask_chat_content_value_async(
+    content: &mut Value,
+    session: &mut RedactionSession,
+    scan_state: &mut RedactionScanState,
+    cache: Option<&RedisRedactionMappingCache<'_>>,
+) -> Result<bool, RedactionMaskError> {
+    match content {
+        Value::String(text) => mask_json_string_async(text, session, scan_state, cache).await,
+        Value::Array(parts) => {
+            let mut redacted = false;
+            for part in parts {
+                redacted |= mask_chat_content_part_async(part, session, scan_state, cache).await?;
+            }
+            Ok(redacted)
+        }
+        _ => Ok(false),
+    }
+}
+
+async fn mask_chat_content_part_async(
+    part: &mut Value,
+    session: &mut RedactionSession,
+    scan_state: &mut RedactionScanState,
+    cache: Option<&RedisRedactionMappingCache<'_>>,
+) -> Result<bool, RedactionMaskError> {
+    let Some(part) = part.as_object_mut() else {
+        return Ok(false);
+    };
+    if part.get("type").and_then(Value::as_str) != Some("text") {
+        return Ok(false);
+    }
+    let Some(Value::String(text)) = part.get_mut("text") else {
+        return Ok(false);
+    };
+    mask_json_string_async(text, session, scan_state, cache).await
+}
+
+async fn mask_tool_call_arguments_async(
+    tool_call: &mut Value,
+    session: &mut RedactionSession,
+    scan_state: &mut RedactionScanState,
+    cache: Option<&RedisRedactionMappingCache<'_>>,
+) -> Result<bool, RedactionMaskError> {
+    let Some(function) = tool_call.get_mut("function").and_then(Value::as_object_mut) else {
+        return Ok(false);
+    };
+    let Some(Value::String(arguments)) = function.get_mut("arguments") else {
+        return Ok(false);
+    };
+    mask_json_string_async(arguments, session, scan_state, cache).await
+}
+
+async fn mask_json_string_async(
+    text: &mut String,
+    session: &mut RedactionSession,
+    scan_state: &mut RedactionScanState,
+    cache: Option<&RedisRedactionMappingCache<'_>>,
+) -> Result<bool, RedactionMaskError> {
+    let redacted = session
+        .redact_text_with_cache(text, scan_state, cache)
+        .await?;
+    if redacted.matches.is_empty() {
+        return Ok(false);
+    }
+    *text = redacted.text;
+    Ok(true)
+}
+
+pub(crate) struct RestoredSyncResponseBody {
+    pub(crate) body: Vec<u8>,
+    pub(crate) restored: bool,
+}
+
+impl fmt::Debug for RestoredSyncResponseBody {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestoredSyncResponseBody")
+            .field("body_len", &self.body.len())
+            .field("restored", &self.restored)
+            .finish()
+    }
+}
+
+struct RestoredText {
+    text: String,
+    restored: bool,
+}
+
+pub(crate) fn restore_sync_response_body(
+    headers: &mut BTreeMap<String, String>,
+    body: &[u8],
+    session: &RedactionSession,
+) -> Result<RestoredSyncResponseBody, GatewayError> {
+    if session.mapping_count() == 0 {
+        return Ok(RestoredSyncResponseBody {
+            body: body.to_vec(),
+            restored: false,
+        });
+    }
+
+    ensure_identity_response_encoding(headers)?;
+
+    let restored = if response_body_is_json(headers, body) {
+        restore_json_response_body(body, session)?
+    } else {
+        restore_text_response_body(body, session)
+    };
+    if restored.restored {
+        set_content_length(headers, restored.body.len());
+    }
+    Ok(restored)
+}
+
+fn ensure_identity_response_encoding(
+    headers: &BTreeMap<String, String>,
+) -> Result<(), GatewayError> {
+    for encoding in headers
+        .iter()
+        .filter(|(header_name, _)| header_name.eq_ignore_ascii_case("content-encoding"))
+        .map(|(_, value)| value)
+    {
+        if encoding.trim().is_empty() || encoding.trim().eq_ignore_ascii_case("identity") {
+            continue;
+        }
+        return Err(GatewayError::Internal(
+            "redaction response restoration does not support encoded response bodies".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn response_body_is_json(headers: &BTreeMap<String, String>, body: &[u8]) -> bool {
+    if header_value(headers, "content-type").is_some_and(content_type_is_json) {
+        return true;
+    }
+    body.iter()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .is_some_and(|byte| matches!(byte, b'{' | b'['))
+}
+
+fn content_type_is_json(content_type: &str) -> bool {
+    content_type
+        .split(';')
+        .next()
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .is_some_and(|mime| mime == "application/json" || mime.ends_with("+json"))
+}
+
+fn restore_json_response_body(
+    body: &[u8],
+    session: &RedactionSession,
+) -> Result<RestoredSyncResponseBody, GatewayError> {
+    let Ok(mut value) = serde_json::from_slice::<Value>(body) else {
+        return Ok(restore_text_response_body(body, session));
+    };
+    if !restore_json_strings(&mut value, session) {
+        return Ok(RestoredSyncResponseBody {
+            body: body.to_vec(),
+            restored: false,
+        });
+    }
+    let body = serde_json::to_vec(&value).map_err(|err| GatewayError::Internal(err.to_string()))?;
+    Ok(RestoredSyncResponseBody {
+        body,
+        restored: true,
+    })
+}
+
+fn restore_json_strings(value: &mut Value, session: &RedactionSession) -> bool {
+    match value {
+        Value::String(text) => {
+            let restored = session.restore_text(text);
+            if !restored.restored {
+                return false;
+            }
+            *text = restored.text;
+            true
+        }
+        Value::Array(values) => {
+            let mut restored = false;
+            for value in values {
+                restored = restore_json_strings(value, session) || restored;
+            }
+            restored
+        }
+        Value::Object(values) => {
+            let mut restored = false;
+            for value in values.values_mut() {
+                restored = restore_json_strings(value, session) || restored;
+            }
+            restored
+        }
+        _ => false,
+    }
+}
+
+fn restore_text_response_body(body: &[u8], session: &RedactionSession) -> RestoredSyncResponseBody {
+    let Ok(text) = std::str::from_utf8(body) else {
+        return RestoredSyncResponseBody {
+            body: body.to_vec(),
+            restored: false,
+        };
+    };
+    let restored = session.restore_text(text);
+    RestoredSyncResponseBody {
+        body: restored.text.into_bytes(),
+        restored: restored.restored,
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum StreamRestoreMode {
+    Sse,
+    Text,
+}
+
+pub(crate) struct StreamingResponseRestorer<'a> {
+    session: &'a RedactionSession,
+    matcher: SentinelMatcher<'a>,
+    mode: StreamRestoreMode,
+    max_sentinel_len: usize,
+    text_carry: Vec<u8>,
+    sse_line_buffer: Vec<u8>,
+    sse_json_event_lines: Vec<Vec<u8>>,
+}
+
+impl<'a> StreamingResponseRestorer<'a> {
+    pub(crate) fn new(
+        headers: &BTreeMap<String, String>,
+        session: &'a RedactionSession,
+    ) -> Result<Self, GatewayError> {
+        if session.mapping_count() > 0 {
+            ensure_identity_response_encoding(headers)?;
+        }
+        let mode = if header_value(headers, "content-type").is_some_and(content_type_is_sse) {
+            StreamRestoreMode::Sse
+        } else {
+            StreamRestoreMode::Text
+        };
+        Ok(Self::with_mode(session, mode))
+    }
+
+    #[cfg(test)]
+    fn for_sse(session: &'a RedactionSession) -> Self {
+        Self::with_mode(session, StreamRestoreMode::Sse)
+    }
+
+    #[cfg(test)]
+    fn for_text(session: &'a RedactionSession) -> Self {
+        Self::with_mode(session, StreamRestoreMode::Text)
+    }
+
+    fn with_mode(session: &'a RedactionSession, mode: StreamRestoreMode) -> Self {
+        let max_sentinel_len = session
+            .mappings()
+            .map(|mapping| mapping.sentinel.len())
+            .max()
+            .unwrap_or_default();
+        Self {
+            session,
+            matcher: SentinelMatcher::new(session),
+            mode,
+            max_sentinel_len,
+            text_carry: Vec::new(),
+            sse_line_buffer: Vec::new(),
+            sse_json_event_lines: Vec::new(),
+        }
+    }
+
+    pub(crate) fn push_chunk(&mut self, chunk: &[u8]) -> Result<Vec<u8>, GatewayError> {
+        if self.max_sentinel_len == 0 {
+            return Ok(chunk.to_vec());
+        }
+        match self.mode {
+            StreamRestoreMode::Sse => self.push_sse_chunk(chunk),
+            StreamRestoreMode::Text => Ok(self.push_text_chunk(chunk)),
+        }
+    }
+
+    pub(crate) fn finish(&mut self) -> Result<Vec<u8>, GatewayError> {
+        if self.max_sentinel_len == 0 {
+            return Ok(Vec::new());
+        }
+        match self.mode {
+            StreamRestoreMode::Sse => self.finish_sse(),
+            StreamRestoreMode::Text => Ok(self.flush_text_carry()),
+        }
+    }
+
+    #[cfg(test)]
+    fn max_text_carry_len(&self) -> usize {
+        self.max_sentinel_len.saturating_sub(1)
+    }
+
+    #[cfg(test)]
+    fn pending_text_carry_len(&self) -> usize {
+        self.text_carry.len()
+    }
+
+    fn push_text_chunk(&mut self, chunk: &[u8]) -> Vec<u8> {
+        self.text_carry.extend_from_slice(chunk);
+        self.restore_available_text(false)
+    }
+
+    fn flush_text_carry(&mut self) -> Vec<u8> {
+        self.restore_available_text(true)
+    }
+
+    fn restore_available_text(&mut self, flush: bool) -> Vec<u8> {
+        let scan_limit = if flush {
+            self.text_carry.len()
+        } else {
+            self.text_carry
+                .len()
+                .saturating_sub(self.max_sentinel_len.saturating_sub(1))
+        };
+        let mut output = Vec::with_capacity(scan_limit);
+        let mut index = 0;
+        while index < scan_limit {
+            if let Some(mapping) = self.matcher.matching_mapping_at(&self.text_carry, index) {
+                output.extend_from_slice(mapping.original.as_bytes());
+                index += mapping.sentinel.len();
+            } else {
+                output.push(self.text_carry[index]);
+                index += 1;
+            }
+        }
+        self.text_carry.drain(..index);
+        output
+    }
+
+    fn push_sse_chunk(&mut self, chunk: &[u8]) -> Result<Vec<u8>, GatewayError> {
+        self.sse_line_buffer.extend_from_slice(chunk);
+        let mut output = Vec::new();
+        while let Some(line_end) = self.sse_line_buffer.iter().position(|byte| *byte == b'\n') {
+            let line = self.sse_line_buffer.drain(..=line_end).collect::<Vec<_>>();
+            self.push_sse_line(line, &mut output)?;
+        }
+        Ok(output)
+    }
+
+    fn finish_sse(&mut self) -> Result<Vec<u8>, GatewayError> {
+        let mut output = Vec::new();
+        if !self.sse_line_buffer.is_empty() {
+            let line = std::mem::take(&mut self.sse_line_buffer);
+            self.push_sse_line(line, &mut output)?;
+        }
+        self.flush_sse_json_event(&mut output)?;
+        Ok(output)
+    }
+
+    fn push_sse_line(&mut self, line: Vec<u8>, output: &mut Vec<u8>) -> Result<(), GatewayError> {
+        if !self.sse_json_event_lines.is_empty() {
+            if sse_line_is_blank(&line) {
+                self.flush_sse_json_event(output)?;
+                output.extend_from_slice(&line);
+            } else {
+                self.sse_json_event_lines.push(line);
+            }
+            return Ok(());
+        }
+
+        if sse_line_is_blank(&line) {
+            output.extend_from_slice(&line);
+            return Ok(());
+        }
+
+        let Some(value) = sse_data_line_value(&line) else {
+            output.extend_from_slice(&line);
+            return Ok(());
+        };
+        if sse_data_value_is_done(value) {
+            output.extend_from_slice(&line);
+            return Ok(());
+        }
+        if sse_data_value_may_be_json(value) {
+            self.sse_json_event_lines.push(line);
+            return Ok(());
+        }
+        output.extend(self.restore_sse_text_data_line(&line));
+        Ok(())
+    }
+
+    fn flush_sse_json_event(&mut self, output: &mut Vec<u8>) -> Result<(), GatewayError> {
+        if self.sse_json_event_lines.is_empty() {
+            return Ok(());
+        }
+
+        let event_lines = std::mem::take(&mut self.sse_json_event_lines);
+        let Some(payload) = sse_event_data_payload(&event_lines) else {
+            output.extend(event_lines.into_iter().flatten());
+            return Ok(());
+        };
+        if payload.trim() == "[DONE]" {
+            output.extend(event_lines.into_iter().flatten());
+            return Ok(());
+        }
+
+        let Ok(mut value) = serde_json::from_str::<Value>(&payload) else {
+            for line in event_lines {
+                if sse_data_line_value(&line).is_some() {
+                    output.extend(self.restore_sse_text_data_line(&line));
+                } else {
+                    output.extend_from_slice(&line);
+                }
+            }
+            return Ok(());
+        };
+
+        if !restore_json_strings(&mut value, self.session) {
+            output.extend(event_lines.into_iter().flatten());
+            return Ok(());
+        }
+
+        let restored_payload =
+            serde_json::to_string(&value).map_err(|err| GatewayError::Internal(err.to_string()))?;
+        let mut wrote_data_line = false;
+        for line in event_lines {
+            if sse_data_line_value(&line).is_some() {
+                if !wrote_data_line {
+                    output.extend(replace_sse_data_line_value(
+                        &line,
+                        restored_payload.as_bytes(),
+                    ));
+                    wrote_data_line = true;
+                }
+            } else {
+                output.extend_from_slice(&line);
+            }
+        }
+        Ok(())
+    }
+
+    fn restore_sse_text_data_line(&self, line: &[u8]) -> Vec<u8> {
+        let Some(range) = sse_data_line_value_range(line) else {
+            return line.to_vec();
+        };
+        let (body, ending) = split_sse_line_ending(line);
+        let restored = restore_known_sentinels_in_bytes(&body[range.clone()], self.session);
+        let mut output = Vec::with_capacity(line.len());
+        output.extend_from_slice(&body[..range.start]);
+        output.extend(restored);
+        output.extend_from_slice(ending);
+        output
+    }
+}
+
+enum SentinelMatcher<'a> {
+    Direct(Vec<&'a RedactionMapping>),
+    Trie(SentinelTrie<'a>),
+}
+
+impl<'a> SentinelMatcher<'a> {
+    fn new(session: &'a RedactionSession) -> Self {
+        let mut mappings = session.mappings().collect::<Vec<_>>();
+        mappings.sort_by_key(|mapping| std::cmp::Reverse(mapping.sentinel.len()));
+        if mappings.len() <= DIRECT_RESTORE_SENTINEL_LIMIT {
+            Self::Direct(mappings)
+        } else {
+            Self::Trie(SentinelTrie::new(mappings))
+        }
+    }
+
+    fn matching_mapping_at(&self, input: &[u8], index: usize) -> Option<&'a RedactionMapping> {
+        match self {
+            Self::Direct(mappings) => mappings.iter().copied().find(|mapping| {
+                input
+                    .get(index..)
+                    .is_some_and(|remaining| remaining.starts_with(mapping.sentinel.as_bytes()))
+            }),
+            Self::Trie(trie) => trie.matching_mapping_at(input, index),
+        }
+    }
+}
+
+struct SentinelTrie<'a> {
+    nodes: Vec<SentinelTrieNode<'a>>,
+}
+
+struct SentinelTrieNode<'a> {
+    children: HashMap<u8, usize>,
+    mapping: Option<&'a RedactionMapping>,
+}
+
+impl<'a> SentinelTrie<'a> {
+    fn new(mappings: Vec<&'a RedactionMapping>) -> Self {
+        let mut trie = Self {
+            nodes: vec![SentinelTrieNode {
+                children: HashMap::new(),
+                mapping: None,
+            }],
+        };
+        for mapping in mappings {
+            trie.insert(mapping);
+        }
+        trie
+    }
+
+    fn insert(&mut self, mapping: &'a RedactionMapping) {
+        let mut node_index = 0;
+        for byte in mapping.sentinel.bytes() {
+            let next_index = if let Some(next_index) = self.nodes[node_index].children.get(&byte) {
+                *next_index
+            } else {
+                self.nodes.push(SentinelTrieNode {
+                    children: HashMap::new(),
+                    mapping: None,
+                });
+                let next_index = self.nodes.len() - 1;
+                self.nodes[node_index].children.insert(byte, next_index);
+                next_index
+            };
+            node_index = next_index;
+        }
+        self.nodes[node_index].mapping = Some(mapping);
+    }
+
+    fn matching_mapping_at(&self, input: &[u8], index: usize) -> Option<&'a RedactionMapping> {
+        let mut node_index = 0;
+        let mut best = None;
+        for byte in input.get(index..).unwrap_or_default() {
+            let Some(next_index) = self.nodes[node_index].children.get(byte).copied() else {
+                break;
+            };
+            node_index = next_index;
+            if let Some(mapping) = self.nodes[node_index].mapping {
+                best = Some(mapping);
+            }
+        }
+        best
+    }
+}
+
+fn restore_text_direct_longest_first(input: &str, session: &RedactionSession) -> RestoredText {
+    let mut mappings = session.mappings().collect::<Vec<_>>();
+    mappings.sort_by_key(|mapping| std::cmp::Reverse(mapping.sentinel.len()));
+    let mut text = input.to_string();
+    let mut restored = false;
+    for mapping in mappings {
+        if text.contains(&mapping.sentinel) {
+            text = text.replace(&mapping.sentinel, &mapping.original);
+            restored = true;
+        }
+    }
+    RestoredText { text, restored }
+}
+
+fn restore_text_with_matcher(input: &str, matcher: &SentinelMatcher<'_>) -> RestoredText {
+    let input_bytes = input.as_bytes();
+    let mut output = Vec::with_capacity(input_bytes.len());
+    let mut restored = false;
+    let mut index = 0;
+    while index < input_bytes.len() {
+        if let Some(mapping) = matcher.matching_mapping_at(input_bytes, index) {
+            output.extend_from_slice(mapping.original.as_bytes());
+            index += mapping.sentinel.len();
+            restored = true;
+        } else {
+            output.push(input_bytes[index]);
+            index += 1;
+        }
+    }
+    let text = String::from_utf8(output).unwrap_or_else(|_| input.to_string());
+    RestoredText { text, restored }
+}
+
+fn restore_known_sentinels_in_bytes(input: &[u8], session: &RedactionSession) -> Vec<u8> {
+    let matcher = SentinelMatcher::new(session);
+    let mut output = Vec::with_capacity(input.len());
+    let mut index = 0;
+    while index < input.len() {
+        if let Some(mapping) = matcher.matching_mapping_at(input, index) {
+            output.extend_from_slice(mapping.original.as_bytes());
+            index += mapping.sentinel.len();
+        } else {
+            output.push(input[index]);
+            index += 1;
+        }
+    }
+    output
+}
+
+fn content_type_is_sse(content_type: &str) -> bool {
+    content_type
+        .split(';')
+        .next()
+        .map(str::trim)
+        .is_some_and(|mime| mime.eq_ignore_ascii_case("text/event-stream"))
+}
+
+fn split_sse_line_ending(line: &[u8]) -> (&[u8], &[u8]) {
+    if line.ends_with(b"\r\n") {
+        (&line[..line.len() - 2], &line[line.len() - 2..])
+    } else if line.ends_with(b"\n") {
+        (&line[..line.len() - 1], &line[line.len() - 1..])
+    } else {
+        (line, &[])
+    }
+}
+
+fn sse_line_is_blank(line: &[u8]) -> bool {
+    split_sse_line_ending(line).0.is_empty()
+}
+
+fn sse_data_line_value_range(line: &[u8]) -> Option<std::ops::Range<usize>> {
+    let (body, _) = split_sse_line_ending(line);
+    if !body.starts_with(b"data:") {
+        return None;
+    }
+    let start = if body.get(5) == Some(&b' ') { 6 } else { 5 };
+    Some(start..body.len())
+}
+
+fn sse_data_line_value(line: &[u8]) -> Option<&[u8]> {
+    let (body, _) = split_sse_line_ending(line);
+    sse_data_line_value_range(line).map(|range| &body[range])
+}
+
+fn sse_data_value_is_done(value: &[u8]) -> bool {
+    std::str::from_utf8(value)
+        .map(str::trim)
+        .is_ok_and(|value| value == "[DONE]")
+}
+
+fn sse_data_value_may_be_json(value: &[u8]) -> bool {
+    value
+        .iter()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .is_some_and(|byte| matches!(byte, b'{' | b'['))
+}
+
+fn sse_event_data_payload(lines: &[Vec<u8>]) -> Option<String> {
+    let mut payload = String::new();
+    let mut saw_data = false;
+    for line in lines {
+        let Some(value) = sse_data_line_value(line) else {
+            continue;
+        };
+        if saw_data {
+            payload.push('\n');
+        }
+        payload.push_str(std::str::from_utf8(value).ok()?);
+        saw_data = true;
+    }
+    saw_data.then_some(payload)
+}
+
+fn replace_sse_data_line_value(line: &[u8], value: &[u8]) -> Vec<u8> {
+    let Some(range) = sse_data_line_value_range(line) else {
+        return line.to_vec();
+    };
+    let (body, ending) = split_sse_line_ending(line);
+    let mut output = Vec::with_capacity(body.len() - range.len() + value.len() + ending.len());
+    output.extend_from_slice(&body[..range.start]);
+    output.extend_from_slice(value);
+    output.extend_from_slice(ending);
+    output
+}
+
+fn header_value<'a>(headers: &'a BTreeMap<String, String>, name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(header_name, _)| header_name.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
+}
+
+fn set_content_length(headers: &mut BTreeMap<String, String>, body_len: usize) {
+    headers.retain(|name, _| !name.eq_ignore_ascii_case("content-length"));
+    headers.insert("content-length".to_string(), body_len.to_string());
+}
+
+pub(crate) struct RedactedText {
+    pub(crate) text: String,
+    pub(crate) matches: Vec<RedactionMatch>,
+}
+
+impl fmt::Debug for RedactedText {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RedactedText")
+            .field("text_len", &self.text.len())
+            .field("match_count", &self.matches.len())
+            .finish()
+    }
+}
+
+pub(crate) struct RedactionMatch {
+    pub(crate) kind: RedactionKind,
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+    pub(crate) original: String,
+    pub(crate) sentinel: String,
+}
+
+impl fmt::Debug for RedactionMatch {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RedactionMatch")
+            .field("kind", &self.kind)
+            .field("start", &self.start)
+            .field("end", &self.end)
+            .field("original_len", &self.original.len())
+            .field("sentinel", &redacted_sentinel_debug(&self.sentinel))
+            .finish()
+    }
+}
+
+pub(crate) struct RedactionMapping {
+    pub(crate) kind: RedactionKind,
+    pub(crate) original: String,
+    pub(crate) normalized_value: String,
+    pub(crate) sentinel: String,
+    pub(crate) bucket: u64,
+    pub(crate) created_at_unix_secs: u64,
+    pub(crate) expires_at_unix_secs: u64,
+}
+
+impl fmt::Debug for RedactionMapping {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RedactionMapping")
+            .field("kind", &self.kind)
+            .field("original_len", &self.original.len())
+            .field("normalized_value_len", &self.normalized_value.len())
+            .field("sentinel", &redacted_sentinel_debug(&self.sentinel))
+            .field("bucket", &self.bucket)
+            .field("created_at_unix_secs", &self.created_at_unix_secs)
+            .field("expires_at_unix_secs", &self.expires_at_unix_secs)
+            .finish()
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct RedactionCacheRecord {
+    pub(crate) kind: RedactionKind,
+    pub(crate) sentinel: String,
+    pub(crate) bucket: u64,
+    pub(crate) expires_at_unix_secs: u64,
+}
+
+impl RedactionCacheRecord {
+    pub(crate) fn from_mapping(mapping: &RedactionMapping) -> Self {
+        Self {
+            kind: mapping.kind,
+            sentinel: mapping.sentinel.clone(),
+            bucket: mapping.bucket,
+            expires_at_unix_secs: mapping.expires_at_unix_secs,
+        }
+    }
+}
+
+impl fmt::Debug for RedactionCacheRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RedactionCacheRecord")
+            .field("kind", &self.kind)
+            .field("sentinel", &redacted_sentinel_debug(&self.sentinel))
+            .field("bucket", &self.bucket)
+            .field("expires_at_unix_secs", &self.expires_at_unix_secs)
+            .finish()
+    }
+}
+
+pub(crate) struct RedisRedactionMappingCache<'a> {
+    runner: &'a RedisKvRunner,
+    key_prefix: String,
+}
+
+impl<'a> RedisRedactionMappingCache<'a> {
+    pub(crate) fn new(runner: &'a RedisKvRunner) -> Self {
+        Self {
+            runner,
+            key_prefix: "privacy:redaction:mapping".to_string(),
+        }
+    }
+
+    pub(crate) fn with_key_prefix(
+        runner: &'a RedisKvRunner,
+        key_prefix: impl Into<String>,
+    ) -> Self {
+        Self {
+            runner,
+            key_prefix: key_prefix.into(),
+        }
+    }
+
+    pub(crate) async fn store(
+        &self,
+        record: &RedactionCacheRecord,
+        normalized_value: &str,
+        ttl_seconds: u64,
+    ) -> Result<(), DataLayerError> {
+        if record.sentinel.len() > MAX_CACHE_SENTINEL_BYTES {
+            return Err(DataLayerError::InvalidInput(
+                "redaction cache sentinel is too large".to_string(),
+            ));
+        }
+        let value = serde_json::to_string(record)
+            .map_err(|err| DataLayerError::InvalidInput(err.to_string()))?;
+        if value.len() > MAX_CACHE_RECORD_BYTES {
+            return Err(DataLayerError::InvalidInput(
+                "redaction cache record is too large".to_string(),
+            ));
+        }
+        let ttl_seconds = ttl_seconds.max(1);
+        self.runner
+            .setex(
+                &self.forward_cache_key(record.kind, normalized_value, record.bucket),
+                &record.sentinel,
+                Some(ttl_seconds),
+            )
+            .await?;
+        self.runner
+            .setex(
+                &self.reverse_cache_key(&record.sentinel),
+                &value,
+                Some(ttl_seconds),
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn lookup_sentinel(
+        &self,
+        kind: RedactionKind,
+        normalized_value: &str,
+        bucket: u64,
+    ) -> Result<Option<String>, DataLayerError> {
+        let sentinel = self
+            .get_string(&self.forward_cache_key(kind, normalized_value, bucket))
+            .await?;
+        Ok(sentinel.filter(|value| {
+            value.len() <= MAX_CACHE_SENTINEL_BYTES && sentinel_matches_kind(kind, value)
+        }))
+    }
+
+    pub(crate) async fn load(
+        &self,
+        sentinel: &str,
+    ) -> Result<Option<RedactionCacheRecord>, DataLayerError> {
+        let raw = self.get_string(&self.reverse_cache_key(sentinel)).await?;
+        raw.map(|value| {
+            serde_json::from_str::<RedactionCacheRecord>(&value)
+                .map_err(|err| DataLayerError::UnexpectedValue(err.to_string()))
+        })
+        .transpose()
+    }
+
+    async fn get_string(&self, key: &str) -> Result<Option<String>, DataLayerError> {
+        let mut connection = self
+            .runner
+            .client()
+            .get_multiplexed_async_connection()
+            .await
+            .map_err(DataLayerError::redis)?;
+        let namespaced_key = self.runner.keyspace().key(key);
+        redis::cmd("GET")
+            .arg(&namespaced_key)
+            .query_async::<Option<String>>(&mut connection)
+            .await
+            .map_err(DataLayerError::redis)
+    }
+
+    fn forward_cache_key(
+        &self,
+        kind: RedactionKind,
+        normalized_value: &str,
+        bucket: u64,
+    ) -> String {
+        format!(
+            "{}:forward:{}:{}:{}",
+            self.key_prefix,
+            kind.label(),
+            bucket,
+            normalized_value_cache_digest(normalized_value)
+        )
+    }
+
+    fn reverse_cache_key(&self, sentinel: &str) -> String {
+        format!("{}:reverse:{}", self.key_prefix, sentinel)
+    }
+}
+
+#[derive(Clone)]
+struct Candidate {
+    kind: RedactionKind,
+    start: usize,
+    end: usize,
+    value: String,
+    priority: u8,
+}
+
+impl Candidate {
+    fn new(kind: RedactionKind, start: usize, end: usize, value: &str, priority: u8) -> Self {
+        Self {
+            kind,
+            start,
+            end,
+            value: value.to_string(),
+            priority,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+}
+
+fn detect_candidates(input: &str) -> Vec<Candidate> {
+    detect_candidates_with_probe(input, None)
+}
+
+fn detect_candidates_with_probe(
+    input: &str,
+    mut probe: Option<&mut DetectorProbe>,
+) -> Vec<Candidate> {
+    // Segment-level scan-bypass cache is intentionally deferred until profiling shows regex scanning is the bottleneck.
+    let mut candidates = Vec::new();
+
+    if input.contains('@') {
+        push_regex_candidates(
+            input,
+            &EMAIL_REGEX,
+            RedactionKind::Email,
+            10,
+            &mut candidates,
+            probe.as_deref_mut(),
+            |value| value.contains('@'),
+        );
+    }
+
+    let digit_count = input.chars().filter(|ch| ch.is_ascii_digit()).count();
+    if digit_count >= 8 {
+        push_regex_candidates(
+            input,
+            &CN_MOBILE_REGEX,
+            RedactionKind::ChinaMobile,
+            20,
+            &mut candidates,
+            probe.as_deref_mut(),
+            is_valid_cn_mobile,
+        );
+        push_regex_candidates(
+            input,
+            &CN_LANDLINE_REGEX,
+            RedactionKind::ChinaLandline,
+            21,
+            &mut candidates,
+            probe.as_deref_mut(),
+            is_valid_cn_landline,
+        );
+        push_regex_candidates(
+            input,
+            &E164_PHONE_REGEX,
+            RedactionKind::Phone,
+            30,
+            &mut candidates,
+            probe.as_deref_mut(),
+            is_valid_e164_phone,
+        );
+        push_regex_candidates(
+            input,
+            &CN_ID_REGEX,
+            RedactionKind::ChinaResidentId,
+            40,
+            &mut candidates,
+            probe.as_deref_mut(),
+            is_valid_cn_resident_id,
+        );
+        push_regex_candidates(
+            input,
+            &PAYMENT_CARD_REGEX,
+            RedactionKind::PaymentCard,
+            50,
+            &mut candidates,
+            probe.as_deref_mut(),
+            is_valid_payment_card,
+        );
+    }
+
+    if input.contains('.') {
+        push_regex_candidates(
+            input,
+            &IPV4_REGEX,
+            RedactionKind::Ipv4,
+            60,
+            &mut candidates,
+            probe.as_deref_mut(),
+            |value| value.parse::<Ipv4Addr>().is_ok(),
+        );
+        push_regex_candidates(
+            input,
+            &JWT_REGEX,
+            RedactionKind::Jwt,
+            120,
+            &mut candidates,
+            probe.as_deref_mut(),
+            is_valid_jwt_like,
+        );
+    }
+
+    if input.contains(':') {
+        candidates.extend(detect_ipv6_candidates(input));
+    }
+
+    if input.contains("sk-") {
+        push_regex_candidates(
+            input,
+            &OPENAI_KEY_REGEX,
+            RedactionKind::OpenAiKey,
+            80,
+            &mut candidates,
+            probe.as_deref_mut(),
+            |_| true,
+        );
+    }
+    if input.contains("sk-ant-") {
+        push_regex_candidates(
+            input,
+            &ANTHROPIC_KEY_REGEX,
+            RedactionKind::AnthropicKey,
+            70,
+            &mut candidates,
+            probe.as_deref_mut(),
+            |_| true,
+        );
+    }
+    if input.contains("ghp_")
+        || input.contains("gho_")
+        || input.contains("ghu_")
+        || input.contains("ghs_")
+        || input.contains("ghr_")
+        || input.contains("github_pat_")
+    {
+        push_regex_candidates(
+            input,
+            &GITHUB_TOKEN_REGEX,
+            RedactionKind::GitHubToken,
+            90,
+            &mut candidates,
+            probe.as_deref_mut(),
+            |_| true,
+        );
+    }
+    if input.contains("xox") {
+        push_regex_candidates(
+            input,
+            &SLACK_TOKEN_REGEX,
+            RedactionKind::SlackToken,
+            100,
+            &mut candidates,
+            probe.as_deref_mut(),
+            |_| true,
+        );
+    }
+    if input.contains("AKIA") || input.contains("ASIA") {
+        push_regex_candidates(
+            input,
+            &AWS_KEY_REGEX,
+            RedactionKind::AwsKey,
+            110,
+            &mut candidates,
+            probe.as_deref_mut(),
+            |_| true,
+        );
+    }
+    if input.contains("Bearer ") || input.contains("bearer ") {
+        push_regex_candidates(
+            input,
+            &BEARER_TOKEN_REGEX,
+            RedactionKind::BearerToken,
+            115,
+            &mut candidates,
+            probe.as_deref_mut(),
+            is_valid_bearer_token,
+        );
+    }
+    if input.contains("access_token")
+        || input.contains("access-token")
+        || input.contains("AccessToken")
+    {
+        push_regex_candidates(
+            input,
+            &ACCESS_TOKEN_REGEX,
+            RedactionKind::AccessToken,
+            116,
+            &mut candidates,
+            probe.as_deref_mut(),
+            is_valid_named_token,
+        );
+    }
+    if input.contains("secret_key") || input.contains("secret-key") || input.contains("SecretKey") {
+        push_regex_candidates(
+            input,
+            &SECRET_KEY_REGEX,
+            RedactionKind::SecretKey,
+            117,
+            &mut candidates,
+            probe.as_deref_mut(),
+            is_valid_named_token,
+        );
+    }
+
+    if input_may_contain_high_entropy_token(input) {
+        push_regex_candidates(
+            input,
+            &HIGH_ENTROPY_TOKEN_REGEX,
+            RedactionKind::ApiKey,
+            200,
+            &mut candidates,
+            probe,
+            is_strict_high_entropy_token,
+        );
+    }
+
+    candidates.retain(|candidate| !looks_like_existing_sentinel(&candidate.value));
+    candidates
+}
+
+fn push_regex_candidates(
+    input: &str,
+    regex: &Regex,
+    kind: RedactionKind,
+    priority: u8,
+    candidates: &mut Vec<Candidate>,
+    mut probe: Option<&mut DetectorProbe>,
+    validator: impl Fn(&str) -> bool,
+) {
+    for matched in regex.find_iter(input) {
+        let value = matched.as_str();
+        if !has_token_boundary(input, matched.start(), matched.end()) {
+            continue;
+        }
+        if let Some(probe) = probe.as_deref_mut() {
+            probe.record_validator_call(kind);
+        }
+        if validator(value) {
+            candidates.push(Candidate::new(
+                kind,
+                matched.start(),
+                matched.end(),
+                value,
+                priority,
+            ));
+        }
+    }
+}
+
+fn detect_ipv6_candidates(input: &str) -> Vec<Candidate> {
+    let mut candidates = Vec::new();
+    let mut start = None;
+    for (index, ch) in input.char_indices() {
+        if ch.is_ascii_hexdigit() || ch == ':' || ch == '.' {
+            start.get_or_insert(index);
+            continue;
+        }
+        if let Some(token_start) = start.take() {
+            push_ipv6_candidate(input, token_start, index, &mut candidates);
+        }
+    }
+    if let Some(token_start) = start {
+        push_ipv6_candidate(input, token_start, input.len(), &mut candidates);
+    }
+    candidates
+}
+
+fn push_ipv6_candidate(input: &str, start: usize, end: usize, candidates: &mut Vec<Candidate>) {
+    let value = &input[start..end];
+    if value.contains(':') && value.parse::<Ipv6Addr>().is_ok() {
+        candidates.push(Candidate::new(RedactionKind::Ipv6, start, end, value, 65));
+    }
+}
+
+fn select_non_overlapping(mut candidates: Vec<Candidate>) -> Vec<Candidate> {
+    candidates.sort_by(|left, right| {
+        right
+            .len()
+            .cmp(&left.len())
+            .then_with(|| left.priority.cmp(&right.priority))
+            .then_with(|| left.start.cmp(&right.start))
+    });
+    let mut occupied = HashSet::new();
+    let mut selected = Vec::new();
+    for candidate in candidates {
+        if (candidate.start..candidate.end).any(|index| occupied.contains(&index)) {
+            continue;
+        }
+        occupied.extend(candidate.start..candidate.end);
+        selected.push(candidate);
+    }
+    selected.sort_by_key(|candidate| candidate.start);
+    selected
+}
+
+fn has_token_boundary(input: &str, start: usize, end: usize) -> bool {
+    let before = input[..start].chars().next_back();
+    let after = input[end..].chars().next();
+    !before.is_some_and(is_sensitive_token_char) && !after.is_some_and(is_sensitive_token_char)
+}
+
+fn is_sensitive_token_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | '@')
+}
+
+fn input_may_contain_high_entropy_token(input: &str) -> bool {
+    let mut token_len = 0usize;
+    let mut class_mask = 0u8;
+    for ch in input.chars() {
+        let class = high_entropy_token_char_class(ch);
+        if class == 0 {
+            if token_len >= 32 && class_mask.count_ones() >= 3 {
+                return true;
+            }
+            token_len = 0;
+            class_mask = 0;
+            continue;
+        }
+        token_len += 1;
+        class_mask |= class;
+    }
+    token_len >= 32 && class_mask.count_ones() >= 3
+}
+
+fn high_entropy_token_char_class(ch: char) -> u8 {
+    match ch {
+        'a'..='z' => 0b0001,
+        'A'..='Z' => 0b0010,
+        '0'..='9' => 0b0100,
+        '_' | '-' => 0b1000,
+        _ => 0,
+    }
+}
+
+fn digits_only(value: &str) -> String {
+    value.chars().filter(|ch| ch.is_ascii_digit()).collect()
+}
+
+fn is_valid_cn_mobile(value: &str) -> bool {
+    let mut digits = digits_only(value);
+    if digits.len() == 13 && digits.starts_with("86") {
+        digits = digits[2..].to_string();
+    }
+    digits.len() == 11
+        && digits.starts_with('1')
+        && digits
+            .as_bytes()
+            .get(1)
+            .is_some_and(|digit| matches!(digit, b'3'..=b'9'))
+}
+
+fn is_valid_cn_landline(value: &str) -> bool {
+    if !value.contains('-') {
+        return false;
+    }
+    let mut digits = digits_only(value);
+    if digits.len() >= 12 && digits.starts_with("86") {
+        digits = digits[2..].to_string();
+    }
+    digits.starts_with('0') && (10..=17).contains(&digits.len())
+}
+
+fn is_valid_e164_phone(value: &str) -> bool {
+    if !value.starts_with('+') {
+        return false;
+    }
+    let digits = digits_only(value);
+    (8..=15).contains(&digits.len()) && !digits.starts_with('0')
+}
+
+fn is_valid_cn_resident_id(value: &str) -> bool {
+    if value.len() != 18 || !value[..17].chars().all(|ch| ch.is_ascii_digit()) {
+        return false;
+    }
+    let birth = &value[6..14];
+    let year = birth[0..4].parse::<i32>().ok();
+    let month = birth[4..6].parse::<u32>().ok();
+    let day = birth[6..8].parse::<u32>().ok();
+    if year
+        .zip(month)
+        .zip(day)
+        .and_then(|((year, month), day)| NaiveDate::from_ymd_opt(year, month, day))
+        .is_none()
+    {
+        return false;
+    }
+
+    const WEIGHTS: [u32; 17] = [7, 9, 10, 5, 8, 4, 2, 1, 6, 3, 7, 9, 10, 5, 8, 4, 2];
+    const CHECK_CODES: [char; 11] = ['1', '0', 'X', '9', '8', '7', '6', '5', '4', '3', '2'];
+    let checksum = value[..17]
+        .chars()
+        .zip(WEIGHTS)
+        .map(|(digit, weight)| digit.to_digit(10).unwrap_or_default() * weight)
+        .sum::<u32>();
+    let expected = CHECK_CODES[(checksum % 11) as usize];
+    value
+        .chars()
+        .nth(17)
+        .is_some_and(|actual| actual.to_ascii_uppercase() == expected)
+}
+
+fn is_valid_payment_card(value: &str) -> bool {
+    let digits = digits_only(value);
+    if !(13..=19).contains(&digits.len())
+        || digits
+            .chars()
+            .all(|ch| ch == digits.chars().next().unwrap_or_default())
+    {
+        return false;
+    }
+    if !matches!(digits.as_bytes().first(), Some(b'3' | b'4' | b'5' | b'6')) {
+        return false;
+    }
+    luhn_valid(&digits)
+}
+
+fn luhn_valid(digits: &str) -> bool {
+    let mut sum = 0u32;
+    let mut double = false;
+    for digit in digits.chars().rev().filter_map(|ch| ch.to_digit(10)) {
+        let mut value = digit;
+        if double {
+            value *= 2;
+            if value > 9 {
+                value -= 9;
+            }
+        }
+        sum += value;
+        double = !double;
+    }
+    sum.is_multiple_of(10)
+}
+
+fn is_valid_bearer_token(value: &str) -> bool {
+    value
+        .split_once(char::is_whitespace)
+        .map(|(_, token)| token.trim().len() >= 20)
+        .unwrap_or(false)
+}
+
+fn is_valid_named_token(value: &str) -> bool {
+    value
+        .split_once([':', '='])
+        .map(|(_, token)| {
+            let token = token.trim().trim_matches(['\'', '"']);
+            token.len() >= 20 && token.chars().any(|ch| ch.is_ascii_digit())
+        })
+        .unwrap_or(false)
+}
+
+fn is_valid_jwt_like(value: &str) -> bool {
+    let parts = value.split('.').collect::<Vec<_>>();
+    parts.len() == 3
+        && parts.iter().all(|part| {
+            part.len() >= 10
+                && part
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+        })
+}
+
+fn is_strict_high_entropy_token(value: &str) -> bool {
+    if value.len() < 32 || looks_like_existing_sentinel(value) {
+        return false;
+    }
+    let mut classes = 0;
+    classes += value.chars().any(|ch| ch.is_ascii_lowercase()) as u8;
+    classes += value.chars().any(|ch| ch.is_ascii_uppercase()) as u8;
+    classes += value.chars().any(|ch| ch.is_ascii_digit()) as u8;
+    classes += value.chars().any(|ch| matches!(ch, '_' | '-')) as u8;
+    classes >= 3 && shannon_entropy(value) >= 4.0
+}
+
+fn shannon_entropy(value: &str) -> f64 {
+    let mut counts = HashMap::<u8, usize>::new();
+    for byte in value.bytes() {
+        *counts.entry(byte).or_default() += 1;
+    }
+    let len = value.len() as f64;
+    counts
+        .values()
+        .map(|count| {
+            let probability = *count as f64 / len;
+            -probability * probability.log2()
+        })
+        .sum()
+}
+
+fn looks_like_existing_sentinel(value: &str) -> bool {
+    SENTINEL_REGEX.is_match(value)
+}
+
+fn sentinel_matches_kind(kind: RedactionKind, sentinel: &str) -> bool {
+    if !full_sentinel_match(sentinel) {
+        return false;
+    }
+    sentinel
+        .strip_prefix(SENTINEL_PREFIX)
+        .and_then(|value| value.strip_suffix('>'))
+        .and_then(|value| value.split_once(':'))
+        .is_some_and(|(label, _)| label == kind.label())
+}
+
+fn full_sentinel_match(value: &str) -> bool {
+    SENTINEL_REGEX
+        .find(value)
+        .is_some_and(|matched| matched.start() == 0 && matched.end() == value.len())
+}
+
+fn normalize_redaction_value(kind: RedactionKind, value: &str) -> String {
+    match kind {
+        RedactionKind::Email => value.trim().to_ascii_lowercase(),
+        RedactionKind::ChinaMobile
+        | RedactionKind::ChinaLandline
+        | RedactionKind::Phone
+        | RedactionKind::PaymentCard => digits_only(value),
+        RedactionKind::AccessToken | RedactionKind::SecretKey => value
+            .split_once([':', '='])
+            .map(|(_, token)| token.trim().trim_matches(['\'', '"']).to_string())
+            .unwrap_or_else(|| value.trim().to_string()),
+        RedactionKind::BearerToken => value
+            .split_once(char::is_whitespace)
+            .map(|(_, token)| token.trim().to_string())
+            .unwrap_or_else(|| value.trim().to_string()),
+        _ => value.trim().to_string(),
+    }
+}
+
+fn normalized_value_cache_digest(normalized_value: &str) -> String {
+    let digest = sha2::Sha256::digest(normalized_value.as_bytes());
+    base32_no_pad(&digest[..HMAC96_BYTES])
+}
+
+fn parse_provider_scope(value: Option<&Value>) -> ChatPiiRedactionProviderScope {
+    match value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("all_providers") => ChatPiiRedactionProviderScope::AllProviders,
+        _ => ChatPiiRedactionProviderScope::SelectedProviders,
+    }
+}
+
+fn parse_enabled_redaction_kinds(value: Option<&Value>) -> HashSet<RedactionKind> {
+    let Some(values) = value.and_then(Value::as_array) else {
+        return default_enabled_redaction_kinds();
+    };
+    values
+        .iter()
+        .filter_map(Value::as_str)
+        .flat_map(redaction_kinds_for_entity)
+        .collect::<HashSet<_>>()
+}
+
+fn default_enabled_redaction_kinds() -> HashSet<RedactionKind> {
+    [
+        RedactionKind::Email,
+        RedactionKind::ChinaMobile,
+        RedactionKind::ChinaLandline,
+        RedactionKind::Phone,
+        RedactionKind::ChinaResidentId,
+        RedactionKind::PaymentCard,
+        RedactionKind::Ipv4,
+        RedactionKind::Ipv6,
+        RedactionKind::OpenAiKey,
+        RedactionKind::AnthropicKey,
+        RedactionKind::GitHubToken,
+        RedactionKind::SlackToken,
+        RedactionKind::AwsKey,
+        RedactionKind::ApiKey,
+        RedactionKind::AccessToken,
+        RedactionKind::SecretKey,
+        RedactionKind::BearerToken,
+        RedactionKind::Jwt,
+    ]
+    .into_iter()
+    .collect()
+}
+
+fn redaction_kinds_for_entity(entity: &str) -> impl Iterator<Item = RedactionKind> {
+    match entity.trim().to_ascii_lowercase().as_str() {
+        "email" => vec![RedactionKind::Email],
+        "cn_phone" => vec![RedactionKind::ChinaMobile, RedactionKind::ChinaLandline],
+        "global_phone" => vec![RedactionKind::Phone],
+        "cn_id" => vec![RedactionKind::ChinaResidentId],
+        "payment_card" => vec![RedactionKind::PaymentCard],
+        "ipv4" => vec![RedactionKind::Ipv4],
+        "ipv6" => vec![RedactionKind::Ipv6],
+        "api_key" => vec![
+            RedactionKind::OpenAiKey,
+            RedactionKind::AnthropicKey,
+            RedactionKind::GitHubToken,
+            RedactionKind::SlackToken,
+            RedactionKind::AwsKey,
+            RedactionKind::ApiKey,
+        ],
+        "access_token" => vec![RedactionKind::AccessToken],
+        "secret_key" => vec![RedactionKind::SecretKey],
+        "bearer_token" => vec![RedactionKind::BearerToken],
+        "jwt" => vec![RedactionKind::Jwt],
+        _ => Vec::new(),
+    }
+    .into_iter()
+}
+
+fn base32_no_pad(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 32] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    let mut output = String::with_capacity((bytes.len() * 8).div_ceil(5));
+    let mut bit_buffer = 0u32;
+    let mut bit_count = 0u8;
+
+    for byte in bytes {
+        bit_buffer = (bit_buffer << 8) | u32::from(*byte);
+        bit_count += 8;
+        while bit_count >= 5 {
+            bit_count -= 5;
+            let index = ((bit_buffer >> bit_count) & 0x1f) as usize;
+            output.push(ALPHABET[index] as char);
+        }
+    }
+
+    if bit_count > 0 {
+        let index = ((bit_buffer << (5 - bit_count)) & 0x1f) as usize;
+        output.push(ALPHABET[index] as char);
+    }
+
+    output
+}
+
+fn redacted_sentinel_debug(sentinel: &str) -> String {
+    let kind = sentinel
+        .strip_prefix(SENTINEL_PREFIX)
+        .and_then(|rest| rest.split_once(':'))
+        .map(|(kind, _)| kind)
+        .unwrap_or("UNKNOWN");
+    format!("<AETHER:{kind}:redacted>")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_redaction_session_config, detect_candidates_with_probe, mask_chat_request_json,
+        mask_chat_request_json_with_options, parse_enabled_redaction_kinds,
+        provider_chat_pii_redaction_enabled, restore_sync_response_body,
+        try_mask_chat_request_json_with_cache_options, try_mask_chat_request_json_with_options,
+        ChatPiiRedactionProviderScope, ChatPiiRedactionRuntimeConfig, DetectorProbe, MappingKey,
+        MaskChatRequestOptions, RedactionKind, RedactionLimitError, RedactionMapping,
+        RedactionScanLimits, RedactionSession, RedactionSessionConfig, RedactionSessionSlot,
+        RedisRedactionMappingCache, SentinelMatcher, StreamingResponseRestorer,
+    };
+    use std::collections::BTreeMap;
+
+    use aether_data::driver::redis::{
+        RedisClientConfig, RedisClientFactory, RedisKvRunner, RedisKvRunnerConfig,
+    };
+    use aether_testkit::ManagedRedisServer;
+    use serde_json::json;
+
+    fn assert_debug_surface_hides_values(debug: &str, originals: &[&str], sentinels: &[String]) {
+        for original in originals {
+            assert!(
+                !debug.contains(original),
+                "debug leaked original {original}"
+            );
+        }
+        for sentinel in sentinels {
+            assert!(
+                !debug.contains(sentinel),
+                "debug leaked sentinel {sentinel}"
+            );
+        }
+    }
+
+    fn source_chunk_before_struct<'a>(source: &'a str, marker: &str) -> &'a str {
+        let marker_start = source.find(marker).expect("struct marker should exist");
+        let chunk_start = marker_start.saturating_sub(220);
+        &source[chunk_start..marker_start]
+    }
+
+    fn assert_not_serde_derived(source: &str, marker: &str) {
+        let chunk = source_chunk_before_struct(source, marker);
+        assert!(
+            !chunk.contains("Serialize"),
+            "{marker} must not derive Serialize"
+        );
+        assert!(
+            !chunk.contains("Deserialize"),
+            "{marker} must not derive Deserialize"
+        );
+    }
+
+    fn session_at(now_unix_secs: u64) -> RedactionSession {
+        RedactionSession::new(RedactionSessionConfig::new(
+            b"redaction-test-key".to_vec(),
+            300,
+            now_unix_secs,
+        ))
+    }
+
+    fn assert_base32_sentinel(sentinel: &str) {
+        let body = sentinel
+            .strip_prefix("<AETHER:")
+            .and_then(|rest| rest.strip_suffix('>'))
+            .expect("sentinel should use Aether wrapper");
+        let (_, payload) = body
+            .split_once(':')
+            .expect("sentinel should include type and payload");
+        assert_eq!(payload.len(), 20, "HMAC96 base32 payload is 20 chars");
+        assert!(payload
+            .chars()
+            .all(|ch| matches!(ch, 'A'..='Z' | '2'..='7')));
+        assert_ne!(payload.len(), 24, "old hex HMAC96 payload must not be used");
+    }
+
+    fn session_with_response_mapping(original: &str, sentinel: &str) -> RedactionSession {
+        let mut session = session_at(600);
+        let key = MappingKey {
+            kind: RedactionKind::Email,
+            original: original.to_string(),
+        };
+        session
+            .sentinel_index
+            .insert(sentinel.to_string(), key.clone());
+        session.mappings.insert(
+            key,
+            RedactionMapping {
+                kind: RedactionKind::Email,
+                original: original.to_string(),
+                normalized_value: original.to_string(),
+                sentinel: sentinel.to_string(),
+                bucket: 2,
+                created_at_unix_secs: 600,
+                expires_at_unix_secs: 900,
+            },
+        );
+        session
+    }
+
+    async fn start_managed_redis_or_skip() -> Option<ManagedRedisServer> {
+        match ManagedRedisServer::start().await {
+            Ok(server) => Some(server),
+            Err(err) if err.to_string().contains("No such file or directory") => None,
+            Err(err) => panic!("redis server should start: {err}"),
+        }
+    }
+
+    fn redis_runner(redis_url: &str, key_prefix: &str) -> RedisKvRunner {
+        let factory = RedisClientFactory::new(RedisClientConfig {
+            url: redis_url.to_string(),
+            key_prefix: Some(key_prefix.to_string()),
+        })
+        .expect("redis factory should build");
+        RedisKvRunner::new(
+            factory.connect_lazy().expect("redis client should build"),
+            factory.config().keyspace(),
+            RedisKvRunnerConfig::default(),
+        )
+        .expect("redis runner should build")
+    }
+
+    #[test]
+    fn pii_redaction_session_detects_reuses_rolls_over_and_avoids_collisions() {
+        let input = concat!(
+            "email alice@example.com again alice@example.com ",
+            "mobile 13800138000 landline 010-12345678 phone +14155552671 ",
+            "id 11010519491231002X card 4111 1111 1111 1111 ",
+            "ips 192.168.0.1 2001:db8::1 ",
+            "keys sk-proj-AbCdEfGhIjKlMnOpQrStUvWxYz123456 sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz1234567890 ",
+            "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ ",
+            "xo", "xb-123456789012-123456789012-AbCdEfGhIjKlMnOpQrStUvWx ",
+            "AKIAIOSFODNN7EXAMPLE Bearer abcdefghijklmnopqrstuvwxyzABCDEF1234567890 ",
+            "access_token=accessValueABCDEF1234567890abcdef secret_key=secretValueABCDEF1234567890abcdef ",
+            "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJ0ZXN0IiwiZXhwIjoyMDAwMDAwMDAwfQ.signature123456789 ",
+            "q8HjK2LmN9PqR4StU7VwX0YzA3BcD6Ef"
+        );
+        let originals = [
+            "alice@example.com",
+            "13800138000",
+            "010-12345678",
+            "+14155552671",
+            "11010519491231002X",
+            "4111 1111 1111 1111",
+            "192.168.0.1",
+            "2001:db8::1",
+            "sk-proj-AbCdEfGhIjKlMnOpQrStUvWxYz123456",
+            "sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz1234567890",
+            "ghp_abcdefghijklmnopqrstuvwxyzABCDEFGHIJ",
+            concat!("xo", "xb-123456789012-123456789012-AbCdEfGhIjKlMnOpQrStUvWx"),
+            "AKIAIOSFODNN7EXAMPLE",
+            "Bearer abcdefghijklmnopqrstuvwxyzABCDEF1234567890",
+            "access_token=accessValueABCDEF1234567890abcdef",
+            "secret_key=secretValueABCDEF1234567890abcdef",
+            "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJ0ZXN0IiwiZXhwIjoyMDAwMDAwMDAwfQ.signature123456789",
+            "q8HjK2LmN9PqR4StU7VwX0YzA3BcD6Ef",
+        ];
+
+        let mut session = session_at(600);
+        let redacted = session.redact_text(input);
+
+        for original in originals {
+            assert!(!redacted.text.contains(original), "leaked {original}");
+        }
+        assert!(redacted.text.contains("<AETHER:EMAIL:"));
+        assert!(redacted.text.contains("<AETHER:CN_PHONE:"));
+        assert!(redacted.text.contains("<AETHER:ACCESS_TOKEN:"));
+        assert!(redacted.text.contains("<AETHER:SECRET_KEY:"));
+        assert!(redacted
+            .matches
+            .iter()
+            .all(|matched| matched.sentinel.starts_with("<AETHER:")
+                && matched.sentinel.ends_with('>')));
+        for matched in &redacted.matches {
+            assert_base32_sentinel(&matched.sentinel);
+        }
+        assert!(redacted.matches.iter().any(|matched| {
+            matched.kind == RedactionKind::ChinaMobile && matched.sentinel.contains(":CN_PHONE:")
+        }));
+        assert!(redacted.matches.iter().any(|matched| {
+            matched.kind == RedactionKind::ChinaLandline && matched.sentinel.contains(":CN_PHONE:")
+        }));
+        assert!(redacted
+            .matches
+            .iter()
+            .any(|matched| matched.kind == RedactionKind::AccessToken));
+        assert!(redacted
+            .matches
+            .iter()
+            .any(|matched| matched.kind == RedactionKind::SecretKey));
+        assert_eq!(session.mapping_count(), originals.len());
+
+        let first_email = session
+            .sentinel_for_original("alice@example.com")
+            .expect("email sentinel should exist")
+            .to_string();
+        assert_base32_sentinel(&first_email);
+        assert_eq!(redacted.text.matches(&first_email).count(), 2);
+
+        let debug = format!("{session:?}");
+        assert!(debug.contains("mapping_count"));
+        assert!(!debug.contains("alice@example.com"));
+        assert!(!debug.contains(&first_email));
+        assert!(!debug.contains("redaction-test-key"));
+
+        let mut same_bucket = session_at(899);
+        same_bucket.redact_text("alice@example.com");
+        assert_eq!(
+            same_bucket.sentinel_for_original("alice@example.com"),
+            Some(first_email.as_str())
+        );
+
+        let mut next_bucket = session_at(900);
+        next_bucket.redact_text("alice@example.com");
+        assert_ne!(
+            next_bucket.sentinel_for_original("alice@example.com"),
+            Some(first_email.as_str())
+        );
+
+        let colliding_literal = first_email;
+        let mut collision_session = session_at(600);
+        collision_session.redact_text(&format!(
+            "literal {colliding_literal} value alice@example.com"
+        ));
+        assert_ne!(
+            collision_session.sentinel_for_original("alice@example.com"),
+            Some(colliding_literal.as_str())
+        );
+    }
+
+    #[test]
+    fn pii_redaction_no_mapping_leak() {
+        let originals = [
+            "alice@example.com",
+            "sk-proj-AbCdEfGhIjKlMnOpQrStUvWxYz123456",
+            "access_token=accessValueABCDEF1234567890abcdef",
+        ];
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [{
+                "role": "user",
+                "content": format!(
+                    "Email {} key {} token {}",
+                    originals[0], originals[1], originals[2]
+                ),
+            }]
+        });
+        let masked = mask_chat_request_json(
+            &serde_json::to_vec(&request).expect("request should serialize"),
+            test_config(),
+        );
+        assert!(masked.redacted);
+        let sentinels = originals
+            .iter()
+            .map(|original| {
+                masked
+                    .session
+                    .sentinel_for_original(original)
+                    .expect("sentinel should exist")
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+
+        for debug in [
+            format!("{:?}", masked.session),
+            format!("{:?}", masked),
+            format!(
+                "{:?}",
+                RedactionSessionConfig::new(originals[1].as_bytes().to_vec(), 300, 600)
+            ),
+        ] {
+            assert_debug_surface_hides_values(&debug, &originals, &sentinels);
+        }
+
+        let mut session = session_at(600);
+        let redacted = session.redact_text(&format!(
+            "Email {} key {} token {}",
+            originals[0], originals[1], originals[2]
+        ));
+        let redacted_debug = format!("{redacted:?}");
+        assert_debug_surface_hides_values(&redacted_debug, &originals, &sentinels);
+        for matched in &redacted.matches {
+            let matched_debug = format!("{matched:?}");
+            assert_debug_surface_hides_values(&matched_debug, &originals, &sentinels);
+            assert!(matched_debug.contains("<AETHER:"));
+            assert!(matched_debug.contains(":redacted>"));
+        }
+        for mapping in session.mappings() {
+            let mapping_debug = format!("{mapping:?}");
+            assert_debug_surface_hides_values(&mapping_debug, &originals, &sentinels);
+            assert!(mapping_debug.contains("original_len"));
+            assert!(mapping_debug.contains("normalized_value_len"));
+            assert!(mapping_debug.contains(":redacted>"));
+        }
+
+        let privacy_source = include_str!("mod.rs");
+        for marker in [
+            "pub(crate) struct RedactionSession {",
+            "pub(crate) struct RedactionSessionSlot {",
+            "pub(crate) struct MaskedChatRequest {",
+            "pub(crate) struct RedactionMatch {",
+            "pub(crate) struct RedactionMapping {",
+        ] {
+            assert_not_serde_derived(privacy_source, marker);
+        }
+        let session_serialize_impl = format!("impl {} for {}", "Serialize", "RedactionSession");
+        let mapping_serialize_impl = format!("impl {} for {}", "Serialize", "RedactionMapping");
+        assert!(!privacy_source.contains(&session_serialize_impl));
+        assert!(!privacy_source.contains(&mapping_serialize_impl));
+
+        let report_context_source = include_str!("../ai_serving/planner/report_context.rs");
+        for forbidden in [
+            "RedactionSession",
+            "RedactionMapping",
+            "RedactionSessionSlot",
+            "redaction_session",
+            "redaction_mapping",
+            "sentinel_index",
+        ] {
+            assert!(
+                !report_context_source.contains(forbidden),
+                "report context source must not expose {forbidden}"
+            );
+        }
+        assert!(report_context_source.contains("original_request_body_json"));
+    }
+
+    #[test]
+    fn pii_redaction_false_positives_are_not_detected() {
+        let input = concat!(
+            "Order AETHER-20240502-123456 date 2026-05-02 decimal 12345.67890 ",
+            "short ids 123456 9876543210 invalid card 4111111111111112 ",
+            "short sk word sk-test low entropy aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ",
+            "name Alice Zhang address 北京市朝阳区建国路88号"
+        );
+        let mut session = session_at(600);
+        let redacted = session.redact_text(input);
+
+        assert_eq!(redacted.text, input);
+        assert!(redacted.matches.is_empty());
+        assert_eq!(session.mapping_count(), 0);
+    }
+
+    #[test]
+    fn pii_redaction_request_masks_chat_message_text_and_tool_arguments() {
+        let request = json!({
+            "model": "gpt-5",
+            "metadata": {
+                "owner": "metadata@example.com"
+            },
+            "temperature": 0.2,
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "lookup_customer",
+                    "description": "schema owner schema@example.com stays visible",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "email": {"type": "string", "description": "example schema@example.com"}
+                        }
+                    }
+                }
+            }],
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Contact alice@example.com with quote \"ok\", path C:\\tmp, and newline\nend."
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Phone +14155552671 should be masked."},
+                        {"type": "image_url", "text": "image text bob@example.com must stay."},
+                        {"type": "input_text", "text": "input text carol@example.com must stay."},
+                        {"type": "text", "text": 42}
+                    ]
+                },
+                {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_customer",
+                            "arguments": "{\"phone\":\"13800138000\",\"secret\":\"secret_key=secretValueABCDEF1234567890abcdef\"}"
+                        }
+                    }]
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": "Tool result access_token=accessValueABCDEF1234567890abcdef"
+                }
+            ]
+        });
+        let raw = serde_json::to_vec(&request).expect("request should serialize");
+
+        let masked = mask_chat_request_json(&raw, test_config());
+
+        assert!(masked.redacted);
+        assert_eq!(masked.session.mapping_count(), 5);
+        let masked_json: serde_json::Value =
+            serde_json::from_slice(&masked.body).expect("masked request should stay valid JSON");
+
+        assert_eq!(masked_json["model"], "gpt-5");
+        assert_eq!(masked_json["metadata"]["owner"], "metadata@example.com");
+        assert_eq!(masked_json["temperature"], 0.2);
+        assert_eq!(
+            masked_json["tools"][0]["function"]["description"],
+            "schema owner schema@example.com stays visible"
+        );
+        assert_eq!(
+            masked_json["tools"][0]["function"]["parameters"]["properties"]["email"]["description"],
+            "example schema@example.com"
+        );
+
+        let system_content = masked_json["messages"][0]["content"]
+            .as_str()
+            .expect("system content should remain a string");
+        assert!(!system_content.contains("alice@example.com"));
+        assert!(system_content.contains("\"ok\""));
+        assert!(system_content.contains("C:\\tmp"));
+        assert!(system_content.contains("newline\nend"));
+        assert!(system_content.contains(
+            masked
+                .session
+                .sentinel_for_original("alice@example.com")
+                .expect("email sentinel should exist")
+        ));
+
+        let text_part = masked_json["messages"][1]["content"][0]["text"]
+            .as_str()
+            .expect("text part should remain a string");
+        assert!(!text_part.contains("+14155552671"));
+        assert!(text_part.contains(
+            masked
+                .session
+                .sentinel_for_original("+14155552671")
+                .expect("phone sentinel should exist")
+        ));
+        assert_eq!(
+            masked_json["messages"][1]["content"][1]["text"],
+            "image text bob@example.com must stay."
+        );
+        assert_eq!(
+            masked_json["messages"][1]["content"][2]["text"],
+            "input text carol@example.com must stay."
+        );
+
+        let arguments = masked_json["messages"][2]["tool_calls"][0]["function"]["arguments"]
+            .as_str()
+            .expect("tool call arguments should remain a string");
+        assert!(!arguments.contains("13800138000"));
+        assert!(!arguments.contains("secretValueABCDEF1234567890abcdef"));
+        assert!(arguments.contains(
+            masked
+                .session
+                .sentinel_for_original("13800138000")
+                .expect("mobile sentinel should exist")
+        ));
+        assert!(arguments.contains(
+            masked
+                .session
+                .sentinel_for_original("secret_key=secretValueABCDEF1234567890abcdef")
+                .expect("secret sentinel should exist")
+        ));
+
+        let tool_content = masked_json["messages"][3]["content"]
+            .as_str()
+            .expect("tool content should remain a string");
+        assert!(!tool_content.contains("accessValueABCDEF1234567890abcdef"));
+        assert!(tool_content.contains(
+            masked
+                .session
+                .sentinel_for_original("access_token=accessValueABCDEF1234567890abcdef")
+                .expect("access token sentinel should exist")
+        ));
+    }
+
+    #[test]
+    fn pii_redaction_request_avoids_cross_message_and_tool_argument_sentinel_collisions() {
+        let mut probe = session_at(600);
+        probe.redact_text("Contact alice@example.com");
+        let colliding_literal = probe
+            .sentinel_for_original("alice@example.com")
+            .expect("probe sentinel should exist")
+            .to_string();
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [
+                {"role": "user", "content": format!("literal {colliding_literal} stays unknown")},
+                {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_contact",
+                            "arguments": "{\"email\":\"alice@example.com\"}"
+                        }
+                    }]
+                }
+            ]
+        });
+
+        let masked = mask_chat_request_json(
+            &serde_json::to_vec(&request).expect("request should serialize"),
+            test_config(),
+        );
+
+        let current_sentinel = masked
+            .session
+            .sentinel_for_original("alice@example.com")
+            .expect("current request sentinel should exist")
+            .to_string();
+        assert_ne!(current_sentinel, colliding_literal);
+        let masked_json: serde_json::Value =
+            serde_json::from_slice(&masked.body).expect("masked request should parse");
+        assert_eq!(
+            masked_json["messages"][0]["content"],
+            format!("literal {colliding_literal} stays unknown")
+        );
+        let arguments = masked_json["messages"][1]["tool_calls"][0]["function"]["arguments"]
+            .as_str()
+            .expect("arguments should be text");
+        assert!(!arguments.contains("alice@example.com"));
+        assert!(arguments.contains(&current_sentinel));
+
+        let mut headers =
+            BTreeMap::from([("content-type".to_string(), "application/json".to_string())]);
+        let restored = restore_sync_response_body(
+            &mut headers,
+            serde_json::to_vec(&json!({
+                "message": format!("literal {colliding_literal} current {current_sentinel}")
+            }))
+            .expect("response should serialize")
+            .as_slice(),
+            &masked.session,
+        )
+        .expect("restore should succeed");
+        let restored_json: serde_json::Value =
+            serde_json::from_slice(&restored.body).expect("restored body should parse");
+        assert_eq!(
+            restored_json["message"],
+            format!("literal {colliding_literal} current alice@example.com")
+        );
+    }
+
+    #[test]
+    fn pii_redaction_request_noops_for_invalid_absent_or_malformed_messages() {
+        for raw in [
+            b"{not json".to_vec(),
+            br#"{"model":"gpt-5","metadata":{"owner":"alice@example.com"}}"#.to_vec(),
+            br#"{"model":"gpt-5","messages":{"role":"user","content":"alice@example.com"}}"#
+                .to_vec(),
+        ] {
+            let masked = mask_chat_request_json(&raw, test_config());
+
+            assert!(!masked.redacted);
+            assert_eq!(masked.body, raw);
+            assert_eq!(masked.session.mapping_count(), 0);
+        }
+    }
+
+    #[test]
+    fn pii_redaction_request_noops_when_chat_messages_are_clean() {
+        let raw = br#"{"model":"gpt-5","messages":[{"role":"user","content":"hello"}],"metadata":{"trace":"keep"}}"#;
+
+        let masked = mask_chat_request_json(raw, test_config());
+
+        assert!(!masked.redacted);
+        assert_eq!(masked.body, raw);
+        assert_eq!(masked.session.mapping_count(), 0);
+    }
+
+    #[test]
+    fn pii_redaction_sync_restore_json_strings_reserialize_safely_and_updates_content_length() {
+        let sentinel = "<AETHER:EMAIL:ABCDEFGHIJKLMNOPQRST>";
+        let original = "alice@example.com said \"ok\" from C:\\tmp\\a\nnext";
+        let session = session_with_response_mapping(original, sentinel);
+        let body = serde_json::to_vec(&json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": format!("Restored: {sentinel}"),
+                }
+            }]
+        }))
+        .expect("response should serialize");
+        let mut headers = BTreeMap::from([
+            ("content-type".to_string(), "application/json".to_string()),
+            ("content-length".to_string(), body.len().to_string()),
+        ]);
+
+        let restored = restore_sync_response_body(&mut headers, &body, &session)
+            .expect("restore should succeed");
+
+        assert!(restored.restored);
+        let restored_len = restored.body.len().to_string();
+        assert_eq!(
+            headers.get("content-length").map(String::as_str),
+            Some(restored_len.as_str())
+        );
+        let restored_json: serde_json::Value =
+            serde_json::from_slice(&restored.body).expect("restored body should stay valid JSON");
+        assert_eq!(
+            restored_json["choices"][0]["message"]["content"],
+            format!("Restored: {original}")
+        );
+    }
+
+    #[test]
+    fn pii_redaction_sync_restore_assistant_content_and_tool_call_arguments() {
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [
+                {"role": "user", "content": "Email alice@example.com"},
+                {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_customer",
+                            "arguments": "{\"phone\":\"13800138000\"}"
+                        }
+                    }]
+                }
+            ]
+        });
+        let masked = mask_chat_request_json(
+            &serde_json::to_vec(&request).expect("request should serialize"),
+            test_config(),
+        );
+        let email_sentinel = masked
+            .session
+            .sentinel_for_original("alice@example.com")
+            .expect("email sentinel should exist");
+        let phone_sentinel = masked
+            .session
+            .sentinel_for_original("13800138000")
+            .expect("phone sentinel should exist");
+        let body = serde_json::to_vec(&json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": format!("Customer {email_sentinel}"),
+                    "tool_calls": [{
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_customer",
+                            "arguments": format!("{{\"phone\":\"{phone_sentinel}\"}}")
+                        }
+                    }]
+                }
+            }]
+        }))
+        .expect("response should serialize");
+        let mut headers = BTreeMap::from([(
+            "content-type".to_string(),
+            "application/json; charset=utf-8".to_string(),
+        )]);
+
+        let restored = restore_sync_response_body(&mut headers, &body, &masked.session)
+            .expect("restore should succeed");
+
+        let restored_json: serde_json::Value =
+            serde_json::from_slice(&restored.body).expect("restored body should stay valid JSON");
+        assert_eq!(
+            restored_json["choices"][0]["message"]["content"],
+            "Customer alice@example.com"
+        );
+        assert_eq!(
+            restored_json["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"],
+            "{\"phone\":\"13800138000\"}"
+        );
+    }
+
+    #[test]
+    fn pii_redaction_sync_restore_unknown_sentinel_looking_strings_remain_unchanged() {
+        let known_sentinel = "<AETHER:EMAIL:ABCDEFGHIJKLMNOPQRST>";
+        let unknown_sentinel = "<AETHER:EMAIL:TSRQPONMLKJIHGFEDCBA>";
+        let session = session_with_response_mapping("alice@example.com", known_sentinel);
+        let body = serde_json::to_vec(&json!({
+            "message": format!("known {known_sentinel} unknown {unknown_sentinel}"),
+        }))
+        .expect("response should serialize");
+        let mut headers =
+            BTreeMap::from([("content-type".to_string(), "application/json".to_string())]);
+
+        let restored = restore_sync_response_body(&mut headers, &body, &session)
+            .expect("restore should succeed");
+
+        let restored_json: serde_json::Value =
+            serde_json::from_slice(&restored.body).expect("restored body should stay valid JSON");
+        assert_eq!(
+            restored_json["message"],
+            format!("known alice@example.com unknown {unknown_sentinel}")
+        );
+    }
+
+    #[test]
+    fn pii_redaction_sync_restore_text_body_replaces_current_request_sentinels() {
+        let known_sentinel = "<AETHER:EMAIL:ABCDEFGHIJKLMNOPQRST>";
+        let unknown_sentinel = "<AETHER:EMAIL:TSRQPONMLKJIHGFEDCBA>";
+        let session = session_with_response_mapping("alice@example.com", known_sentinel);
+        let body = format!("plain {known_sentinel} and {unknown_sentinel}").into_bytes();
+        let mut headers = BTreeMap::from([
+            ("content-type".to_string(), "text/plain".to_string()),
+            ("Content-Length".to_string(), body.len().to_string()),
+        ]);
+
+        let restored = restore_sync_response_body(&mut headers, &body, &session)
+            .expect("restore should succeed");
+
+        assert_eq!(
+            std::str::from_utf8(&restored.body).expect("restored text should be utf8"),
+            format!("plain alice@example.com and {unknown_sentinel}")
+        );
+        let restored_len = restored.body.len().to_string();
+        assert_eq!(headers.get("Content-Length"), None);
+        assert_eq!(
+            headers.get("content-length").map(String::as_str),
+            Some(restored_len.as_str())
+        );
+    }
+
+    #[test]
+    fn pii_redaction_compressed_response_safe_error() {
+        let sentinel = "<AETHER:EMAIL:ABCDEFGHIJKLMNOPQRST>";
+        let session = session_with_response_mapping("alice@example.com", sentinel);
+        let body = format!("compressed bytes with {sentinel}").into_bytes();
+        let mut headers = BTreeMap::from([
+            ("Content-Encoding".to_string(), "identity".to_string()),
+            ("content-encoding".to_string(), "gzip".to_string()),
+            ("content-length".to_string(), body.len().to_string()),
+        ]);
+
+        let err = restore_sync_response_body(&mut headers, &body, &session)
+            .expect_err("compressed response should fail safely");
+
+        let message = format!("{err:?}");
+        assert!(message.contains("encoded response bodies"));
+        assert!(!message.contains("alice@example.com"));
+        assert!(!message.contains(sentinel));
+        assert_eq!(
+            headers.get("Content-Encoding").map(String::as_str),
+            Some("identity")
+        );
+        assert_eq!(
+            headers.get("content-encoding").map(String::as_str),
+            Some("gzip")
+        );
+        let original_len = body.len().to_string();
+        assert_eq!(
+            headers.get("content-length").map(String::as_str),
+            Some(original_len.as_str())
+        );
+
+        let stream_err = match StreamingResponseRestorer::new(&headers, &session) {
+            Ok(_) => panic!("compressed stream response should fail safely"),
+            Err(err) => err,
+        };
+        let stream_message = format!("{stream_err:?}");
+        assert!(stream_message.contains("encoded response bodies"));
+        assert!(!stream_message.contains("alice@example.com"));
+        assert!(!stream_message.contains(sentinel));
+    }
+
+    #[test]
+    fn pii_redaction_stream_restore_raw_text_split_sentinel_across_three_chunks() {
+        let known_sentinel = "<AETHER:EMAIL:ABCDEFGHIJKLMNOPQRST>";
+        let unknown_sentinel = "<AETHER:EMAIL:TSRQPONMLKJIHGFEDCBA>";
+        let session = session_with_response_mapping("alice@example.com", known_sentinel);
+        let mut restorer = StreamingResponseRestorer::for_text(&session);
+        let chunks = [
+            b"prefix <AET".as_slice(),
+            b"HER:EMAIL:ABC".as_slice(),
+            b"DEFGHIJKLMNOPQRST> middle ".as_slice(),
+            unknown_sentinel.as_bytes(),
+        ];
+
+        let mut output = Vec::new();
+        for chunk in chunks {
+            output.extend(restorer.push_chunk(chunk).expect("restore should succeed"));
+            assert!(restorer.pending_text_carry_len() <= restorer.max_text_carry_len());
+        }
+        output.extend(restorer.finish().expect("finish should succeed"));
+
+        assert_eq!(
+            String::from_utf8(output).expect("restored stream should be utf8"),
+            format!("prefix alice@example.com middle {unknown_sentinel}")
+        );
+        assert_eq!(restorer.pending_text_carry_len(), 0);
+    }
+
+    #[test]
+    fn pii_redaction_stream_restore_bounded_carry_and_final_flush() {
+        let sentinel = "<AETHER:EMAIL:ABCDEFGHIJKLMNOPQRST>";
+        let session = session_with_response_mapping("alice@example.com", sentinel);
+        let mut restorer = StreamingResponseRestorer::for_text(&session);
+        let chunk = vec![b'x'; sentinel.len() * 3];
+
+        let first = restorer.push_chunk(&chunk).expect("restore should succeed");
+
+        assert!(!first.is_empty());
+        assert!(restorer.pending_text_carry_len() <= restorer.max_text_carry_len());
+        let flushed = restorer.finish().expect("finish should succeed");
+        assert_eq!(first.len() + flushed.len(), chunk.len());
+        assert_eq!(restorer.pending_text_carry_len(), 0);
+    }
+
+    #[test]
+    fn pii_redaction_stream_restore_sse_json_split_sentinel_across_three_chunks() {
+        let sentinel = "<AETHER:EMAIL:ABCDEFGHIJKLMNOPQRST>";
+        let session = session_with_response_mapping("alice@example.com", sentinel);
+        let mut restorer = StreamingResponseRestorer::for_sse(&session);
+        let chunks = [
+            b"data: {\"choices\":[{\"delta\":{\"content\":\"hello <AET".as_slice(),
+            b"HER:EMAIL:ABC".as_slice(),
+            b"DEFGHIJKLMNOPQRST>\"}}]}\n\n".as_slice(),
+        ];
+
+        let mut output = Vec::new();
+        for chunk in chunks {
+            output.extend(restorer.push_chunk(chunk).expect("restore should succeed"));
+        }
+        output.extend(restorer.finish().expect("finish should succeed"));
+        let output_text = String::from_utf8(output).expect("restored stream should be utf8");
+
+        assert!(output_text.contains("hello alice@example.com"));
+        assert!(!output_text.contains(sentinel));
+        assert!(output_text.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn pii_redaction_stream_restore_sse_tool_call_argument_delta_json_strings() {
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [
+                {"role": "user", "content": "Email alice@example.com"},
+                {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_customer",
+                            "arguments": "{\"phone\":\"13800138000\"}"
+                        }
+                    }]
+                }
+            ]
+        });
+        let masked = mask_chat_request_json(
+            &serde_json::to_vec(&request).expect("request should serialize"),
+            test_config(),
+        );
+        let email_sentinel = masked
+            .session
+            .sentinel_for_original("alice@example.com")
+            .expect("email sentinel should exist");
+        let phone_sentinel = masked
+            .session
+            .sentinel_for_original("13800138000")
+            .expect("phone sentinel should exist");
+        let event = format!(
+            "data: {}\n\n",
+            serde_json::to_string(&json!({
+                "choices": [{
+                    "delta": {
+                        "content": format!("Customer {email_sentinel}"),
+                        "tool_calls": [{
+                            "index": 0,
+                            "function": {
+                                "arguments": format!("{{\"phone\":\"{phone_sentinel}\"}}")
+                            }
+                        }]
+                    }
+                }]
+            }))
+            .expect("event should serialize")
+        );
+        let mut restorer = StreamingResponseRestorer::for_sse(&masked.session);
+
+        let output = restorer
+            .push_chunk(event.as_bytes())
+            .expect("restore should succeed");
+
+        let output_text = String::from_utf8(output).expect("restored stream should be utf8");
+        assert!(output_text.contains("Customer alice@example.com"));
+        assert!(output_text.contains("\\\"phone\\\":\\\"13800138000\\\""));
+        assert!(!output_text.contains(email_sentinel));
+        assert!(!output_text.contains(phone_sentinel));
+        assert!(restorer.finish().expect("finish should succeed").is_empty());
+    }
+
+    #[test]
+    fn pii_redaction_stream_restore_sse_preserves_comments_blank_crlf_multiple_data_and_done() {
+        let sentinel = "<AETHER:EMAIL:ABCDEFGHIJKLMNOPQRST>";
+        let session = session_with_response_mapping("alice@example.com", sentinel);
+        let mut restorer = StreamingResponseRestorer::for_sse(&session);
+        let input = format!(
+            ": keep-alive\r\n\r\nevent: message\r\ndata: plain {sentinel}\r\ndata: second line\r\n\r\ndata: [DONE]\r\n\r\n"
+        );
+
+        let mut output = restorer
+            .push_chunk(input.as_bytes())
+            .expect("restore should succeed");
+        output.extend(restorer.finish().expect("finish should succeed"));
+
+        assert_eq!(
+            String::from_utf8(output).expect("restored stream should be utf8"),
+            concat!(
+                ": keep-alive\r\n",
+                "\r\n",
+                "event: message\r\n",
+                "data: plain alice@example.com\r\n",
+                "data: second line\r\n",
+                "\r\n",
+                "data: [DONE]\r\n",
+                "\r\n"
+            )
+        );
+    }
+
+    #[test]
+    fn proxy_pii_redaction_provider_scope_gates_master_selected_and_all_provider_modes() {
+        let provider_config = json!({"chat_pii_redaction": {"enabled": true}});
+        let disabled_provider_config = json!({"chat_pii_redaction": {"enabled": false}});
+        let mut config = ChatPiiRedactionRuntimeConfig {
+            enabled: false,
+            ..ChatPiiRedactionRuntimeConfig::default()
+        };
+
+        assert!(!provider_chat_pii_redaction_enabled(
+            Some(&provider_config),
+            &config
+        ));
+
+        config.enabled = true;
+        config.provider_scope = ChatPiiRedactionProviderScope::SelectedProviders;
+        assert!(provider_chat_pii_redaction_enabled(
+            Some(&provider_config),
+            &config
+        ));
+        assert!(!provider_chat_pii_redaction_enabled(None, &config));
+        assert!(!provider_chat_pii_redaction_enabled(
+            Some(&disabled_provider_config),
+            &config
+        ));
+
+        config.provider_scope = ChatPiiRedactionProviderScope::AllProviders;
+        assert!(provider_chat_pii_redaction_enabled(None, &config));
+        assert!(provider_chat_pii_redaction_enabled(
+            Some(&disabled_provider_config),
+            &config
+        ));
+    }
+
+    #[test]
+    fn proxy_pii_redaction_entity_selection_controls_email_and_phone_detectors() {
+        let config = ChatPiiRedactionRuntimeConfig {
+            enabled_kinds: [RedactionKind::Email].into_iter().collect(),
+            ..ChatPiiRedactionRuntimeConfig::default()
+        };
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "Email alice@example.com phone +14155552671"}]
+        });
+
+        let masked = mask_chat_request_json_with_options(
+            &serde_json::to_vec(&request).expect("request should serialize"),
+            build_redaction_session_config(b"redaction-test-key".to_vec(), &config, 600),
+            MaskChatRequestOptions::runtime(false),
+        );
+
+        let masked_json: serde_json::Value =
+            serde_json::from_slice(&masked.body).expect("masked request should parse");
+        let content = masked_json["messages"][0]["content"]
+            .as_str()
+            .expect("content should stay string");
+        assert!(!content.contains("alice@example.com"));
+        assert!(content.contains("+14155552671"));
+        assert!(content.contains("<AETHER:EMAIL:"));
+        assert!(!content.contains("<AETHER:PHONE:"));
+    }
+
+    #[test]
+    fn proxy_pii_redaction_empty_entity_selection_disables_all_detectors() {
+        let config = ChatPiiRedactionRuntimeConfig {
+            enabled_kinds: parse_enabled_redaction_kinds(Some(&json!([]))),
+            ..ChatPiiRedactionRuntimeConfig::default()
+        };
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "Email alice@example.com phone +14155552671"}]
+        });
+
+        let masked = mask_chat_request_json_with_options(
+            &serde_json::to_vec(&request).expect("request should serialize"),
+            build_redaction_session_config(b"redaction-test-key".to_vec(), &config, 600),
+            MaskChatRequestOptions::runtime(true),
+        );
+
+        assert!(!masked.redacted);
+        let masked_json: serde_json::Value =
+            serde_json::from_slice(&masked.body).expect("masked request should parse");
+        assert_eq!(masked_json, request);
+        assert!(masked_json.to_string().contains("alice@example.com"));
+        assert!(!masked_json.to_string().contains("<AETHER:"));
+        assert!(!masked_json
+            .to_string()
+            .contains("Aether privacy redaction notice"));
+    }
+
+    #[test]
+    fn redaction_session_slot_uses_single_candidate_when_response_header_missing() {
+        let slot = RedactionSessionSlot::default();
+        let sentinel = "<AETHER:EMAIL:SINGLECANDIDATE001>";
+        slot.put_for_candidate(
+            "candidate-1",
+            session_with_response_mapping("alice@example.com", sentinel),
+        );
+
+        let session = slot
+            .take_for_candidate(None)
+            .expect("single candidate session should be used without header");
+
+        assert_eq!(
+            session.sentinel_for_original("alice@example.com"),
+            Some(sentinel)
+        );
+        assert!(slot.take_for_candidate(Some("candidate-1")).is_none());
+    }
+
+    #[test]
+    fn redaction_session_slot_does_not_guess_when_response_header_missing_for_multiple_candidates()
+    {
+        let slot = RedactionSessionSlot::default();
+        let alice_sentinel = "<AETHER:EMAIL:MULTICANDIDATE001>";
+        let bob_sentinel = "<AETHER:EMAIL:MULTICANDIDATE002>";
+        slot.put_for_candidate(
+            "candidate-1",
+            session_with_response_mapping("alice@example.com", alice_sentinel),
+        );
+        slot.put_for_candidate(
+            "candidate-2",
+            session_with_response_mapping("bob@example.com", bob_sentinel),
+        );
+
+        assert!(slot.take_for_candidate(None).is_none());
+
+        let session = slot
+            .take_for_candidate(Some("candidate-2"))
+            .expect("specific candidate session should remain available");
+        assert_eq!(
+            session.sentinel_for_original("bob@example.com"),
+            Some(bob_sentinel)
+        );
+    }
+
+    #[test]
+    fn redaction_session_slot_does_not_fallback_to_other_candidate_on_header_miss() {
+        let slot = RedactionSessionSlot::default();
+        slot.put_for_candidate(
+            "candidate-1",
+            session_with_response_mapping("alice@example.com", "<AETHER:EMAIL:HEADERMISS001>"),
+        );
+
+        assert!(slot.take_for_candidate(Some("candidate-2")).is_none());
+        assert!(slot.take_for_candidate(Some("candidate-1")).is_some());
+    }
+
+    #[test]
+    fn proxy_pii_redaction_provider_bound_request_uses_sentinels_and_inserts_safe_notice() {
+        let config = ChatPiiRedactionRuntimeConfig::default();
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [
+                {"role": "system", "content": "be brief"},
+                {"role": "user", "content": "Contact alice@example.com"},
+                {"role": "assistant", "content": "ok"}
+            ]
+        });
+
+        let masked = mask_chat_request_json_with_options(
+            &serde_json::to_vec(&request).expect("request should serialize"),
+            build_redaction_session_config(b"redaction-test-key".to_vec(), &config, 600),
+            MaskChatRequestOptions::runtime(true),
+        );
+
+        assert!(masked.redacted);
+        let masked_json: serde_json::Value =
+            serde_json::from_slice(&masked.body).expect("masked request should parse");
+        let messages = masked_json["messages"]
+            .as_array()
+            .expect("messages should be an array");
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[1]["role"], "assistant");
+        assert!(messages[1..]
+            .iter()
+            .all(|message| message["role"].as_str() != Some("system")));
+        let notice = messages[1]["content"]
+            .as_str()
+            .expect("notice should be text");
+        assert!(notice.contains("not a user request"));
+        assert!(notice.contains("do not answer"));
+        assert!(notice.contains("do not answer it, mention it"));
+        assert!(!notice.contains("alice@example.com"));
+        assert_eq!(messages[2]["role"], "user");
+        let content = messages[2]["content"]
+            .as_str()
+            .expect("user content should be text");
+        assert!(!content.contains("alice@example.com"));
+        assert!(content.contains("<AETHER:EMAIL:"));
+        assert_eq!(messages[3]["role"], "assistant");
+    }
+
+    #[test]
+    fn proxy_pii_redaction_sync_and_stream_client_responses_restore_current_sentinels() {
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "Email alice@example.com"}]
+        });
+        let masked = mask_chat_request_json(
+            &serde_json::to_vec(&request).expect("request should serialize"),
+            test_config(),
+        );
+        let sentinel = masked
+            .session
+            .sentinel_for_original("alice@example.com")
+            .expect("email sentinel should exist");
+        let sync_body = serde_json::to_vec(&json!({
+            "choices": [{"message": {"role": "assistant", "content": format!("hello {sentinel}")}}]
+        }))
+        .expect("response should serialize");
+        let mut headers =
+            BTreeMap::from([("content-type".to_string(), "application/json".to_string())]);
+
+        let restored = restore_sync_response_body(&mut headers, &sync_body, &masked.session)
+            .expect("sync restore should succeed");
+        let restored_json: serde_json::Value =
+            serde_json::from_slice(&restored.body).expect("restored response should parse");
+        assert_eq!(
+            restored_json["choices"][0]["message"]["content"],
+            "hello alice@example.com"
+        );
+
+        let sse =
+            format!("data: {{\"choices\":[{{\"delta\":{{\"content\":\"{sentinel}\"}}}}]}}\n\n");
+        let mut restorer = StreamingResponseRestorer::for_sse(&masked.session);
+        let mut output = restorer
+            .push_chunk(sse.as_bytes())
+            .expect("stream restore should succeed");
+        output.extend(restorer.finish().expect("stream finish should succeed"));
+        let output = String::from_utf8(output).expect("stream should be utf8");
+        assert!(output.contains("alice@example.com"));
+        assert!(!output.contains(sentinel));
+    }
+
+    #[test]
+    fn pii_redaction_performance_prefilters_skip_impossible_expensive_validators() {
+        let mut clean_probe = DetectorProbe::default();
+        let clean_candidates = detect_candidates_with_probe(
+            "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+            Some(&mut clean_probe),
+        );
+
+        assert!(clean_candidates.is_empty());
+        for kind in [
+            RedactionKind::ChinaResidentId,
+            RedactionKind::PaymentCard,
+            RedactionKind::Jwt,
+            RedactionKind::ApiKey,
+        ] {
+            assert_eq!(clean_probe.validator_calls(kind), 0);
+        }
+
+        let mut token_probe = DetectorProbe::default();
+        let token_candidates = detect_candidates_with_probe(
+            "token q8HjK2LmN9PqR4StU7VwX0YzA3BcD6Ef",
+            Some(&mut token_probe),
+        );
+
+        assert_eq!(token_probe.validator_calls(RedactionKind::ApiKey), 1);
+        assert!(token_candidates
+            .iter()
+            .any(|candidate| candidate.kind == RedactionKind::ApiKey));
+    }
+
+    #[test]
+    fn pii_redaction_performance_limits_reject_scanned_text_and_detection_overflow() {
+        assert_eq!(
+            RedactionScanLimits::default(),
+            RedactionScanLimits {
+                max_scanned_text_bytes: 2 * 1024 * 1024,
+                max_detections: 1024,
+            }
+        );
+
+        let large_request = json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "x".repeat(2 * 1024 * 1024 + 1)}]
+        });
+        let large_err = try_mask_chat_request_json_with_options(
+            &serde_json::to_vec(&large_request).expect("request should serialize"),
+            test_config(),
+            MaskChatRequestOptions::runtime(false),
+        )
+        .expect_err("oversized scan should fail closed");
+        assert_eq!(
+            large_err,
+            RedactionLimitError::ScannedTextTooLarge {
+                limit: 2 * 1024 * 1024,
+            }
+        );
+        assert_eq!(
+            large_err.client_status(),
+            http::StatusCode::PAYLOAD_TOO_LARGE
+        );
+        assert!(!large_err.safe_message().contains("alice@example.com"));
+
+        let dense_request = json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "alice@example.com bob@example.net"}]
+        });
+        let dense_err = try_mask_chat_request_json_with_options(
+            &serde_json::to_vec(&dense_request).expect("request should serialize"),
+            test_config(),
+            MaskChatRequestOptions::runtime(false).with_scan_limits(RedactionScanLimits {
+                max_scanned_text_bytes: 1024,
+                max_detections: 1,
+            }),
+        )
+        .expect_err("too many detections should fail closed");
+        assert_eq!(
+            dense_err,
+            RedactionLimitError::TooManyDetections { limit: 1 }
+        );
+        assert_eq!(
+            dense_err.client_status(),
+            http::StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert!(!dense_err.safe_message().contains("alice@example.com"));
+    }
+
+    #[tokio::test]
+    async fn pii_redaction_performance_multiturn_cache_reuses_and_rolls_over_sentinels() {
+        let Some(redis) = start_managed_redis_or_skip().await else {
+            return;
+        };
+        let runner = redis_runner(redis.redis_url(), "pii_redaction_performance_cache");
+        let cache = RedisRedactionMappingCache::new(&runner);
+        let config = ChatPiiRedactionRuntimeConfig {
+            enabled_kinds: [RedactionKind::Email].into_iter().collect(),
+            ..ChatPiiRedactionRuntimeConfig::default()
+        };
+
+        let first_request = json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "Contact Alice@Example.com"}],
+            "provider_context": "provider-a"
+        });
+        let first_masked = try_mask_chat_request_json_with_cache_options(
+            &serde_json::to_vec(&first_request).expect("request should serialize"),
+            build_redaction_session_config(b"redaction-test-key".to_vec(), &config, 600),
+            MaskChatRequestOptions::runtime(false),
+            Some(&cache),
+        )
+        .await
+        .expect("first masking should succeed");
+        let first_sentinel = first_masked
+            .session
+            .sentinel_for_original("Alice@Example.com")
+            .expect("first sentinel should exist")
+            .to_string();
+
+        let second_request = json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "Contact alice@example.com and bob@example.net"}],
+            "provider_context": "provider-b"
+        });
+        let second_masked = try_mask_chat_request_json_with_cache_options(
+            &serde_json::to_vec(&second_request).expect("request should serialize"),
+            build_redaction_session_config(b"redaction-test-key".to_vec(), &config, 899),
+            MaskChatRequestOptions::runtime(false),
+            Some(&cache),
+        )
+        .await
+        .expect("second masking should succeed");
+        assert_eq!(
+            second_masked
+                .session
+                .sentinel_for_original("alice@example.com"),
+            Some(first_sentinel.as_str())
+        );
+        assert!(second_masked
+            .session
+            .sentinel_for_original("bob@example.net")
+            .is_some());
+        let second_masked_json: serde_json::Value = serde_json::from_slice(&second_masked.body)
+            .expect("second masked request should parse");
+        assert_eq!(second_masked_json["provider_context"], "provider-b");
+        let second_content = second_masked_json["messages"][0]["content"]
+            .as_str()
+            .expect("second content should be text");
+        assert!(second_content.contains(&first_sentinel));
+        assert!(!second_content.contains("alice@example.com"));
+        assert!(!second_content.contains("bob@example.net"));
+        let mut headers =
+            BTreeMap::from([("content-type".to_string(), "application/json".to_string())]);
+        let restored = restore_sync_response_body(
+            &mut headers,
+            serde_json::to_vec(&json!({"message": format!("cached {first_sentinel}")}))
+                .expect("response should serialize")
+                .as_slice(),
+            &second_masked.session,
+        )
+        .expect("restore should succeed");
+        let restored_json: serde_json::Value =
+            serde_json::from_slice(&restored.body).expect("restored body should parse");
+        assert_eq!(restored_json["message"], "cached alice@example.com");
+
+        let rolled_masked = try_mask_chat_request_json_with_cache_options(
+            &serde_json::to_vec(&second_request).expect("request should serialize"),
+            build_redaction_session_config(b"redaction-test-key".to_vec(), &config, 900),
+            MaskChatRequestOptions::runtime(false),
+            Some(&cache),
+        )
+        .await
+        .expect("rolled masking should succeed");
+        let rolled_sentinel = rolled_masked
+            .session
+            .sentinel_for_original("alice@example.com")
+            .expect("rolled sentinel should exist")
+            .to_string();
+        assert_ne!(rolled_sentinel, first_sentinel);
+        let mut rolled_headers =
+            BTreeMap::from([("content-type".to_string(), "application/json".to_string())]);
+        let rolled_restored = restore_sync_response_body(
+            &mut rolled_headers,
+            serde_json::to_vec(&json!({"message": format!("rolled {rolled_sentinel}")}))
+                .expect("response should serialize")
+                .as_slice(),
+            &rolled_masked.session,
+        )
+        .expect("rolled restore should succeed");
+        let rolled_restored_json: serde_json::Value = serde_json::from_slice(&rolled_restored.body)
+            .expect("rolled restored body should parse");
+        assert_eq!(rolled_restored_json["message"], "rolled alice@example.com");
+
+        let mut connection = runner
+            .client()
+            .get_multiplexed_async_connection()
+            .await
+            .expect("redis connection should open");
+        let keys = redis::cmd("KEYS")
+            .arg(runner.keyspace().key("privacy:redaction:mapping:*"))
+            .query_async::<Vec<String>>(&mut connection)
+            .await
+            .expect("keys should read");
+        assert!(!keys.is_empty());
+        for key in keys {
+            assert!(!key.contains("alice@example.com"));
+            let ttl = redis::cmd("TTL")
+                .arg(&key)
+                .query_async::<i64>(&mut connection)
+                .await
+                .expect("ttl should read");
+            assert!(ttl > 0, "redaction cache key {key} should have ttl");
+        }
+    }
+
+    #[tokio::test]
+    async fn pii_redaction_performance_cache_hit_avoids_cached_sentinel_literal_collision() {
+        let Some(redis) = start_managed_redis_or_skip().await else {
+            return;
+        };
+        let runner = redis_runner(
+            redis.redis_url(),
+            "pii_redaction_performance_cache_collision",
+        );
+        let cache = RedisRedactionMappingCache::new(&runner);
+        let config = ChatPiiRedactionRuntimeConfig {
+            enabled_kinds: [RedactionKind::Email].into_iter().collect(),
+            ..ChatPiiRedactionRuntimeConfig::default()
+        };
+
+        let first_request = json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "Contact alice@example.com"}]
+        });
+        let first_masked = try_mask_chat_request_json_with_cache_options(
+            &serde_json::to_vec(&first_request).expect("request should serialize"),
+            build_redaction_session_config(b"redaction-test-key".to_vec(), &config, 600),
+            MaskChatRequestOptions::runtime(false),
+            Some(&cache),
+        )
+        .await
+        .expect("first masking should succeed");
+        let cached_sentinel = first_masked
+            .session
+            .sentinel_for_original("alice@example.com")
+            .expect("cached sentinel should exist")
+            .to_string();
+
+        let colliding_request = json!({
+            "model": "gpt-5",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": format!("literal {cached_sentinel} stays unknown")
+                },
+                {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_contact",
+                            "arguments": "{\"email\":\"alice@example.com\"}"
+                        }
+                    }]
+                }
+            ]
+        });
+        let second_masked = try_mask_chat_request_json_with_cache_options(
+            &serde_json::to_vec(&colliding_request).expect("request should serialize"),
+            build_redaction_session_config(b"redaction-test-key".to_vec(), &config, 899),
+            MaskChatRequestOptions::runtime(false),
+            Some(&cache),
+        )
+        .await
+        .expect("collision masking should succeed");
+        let current_sentinel = second_masked
+            .session
+            .sentinel_for_original("alice@example.com")
+            .expect("current request sentinel should exist")
+            .to_string();
+        assert_ne!(current_sentinel, cached_sentinel);
+
+        let masked_json: serde_json::Value =
+            serde_json::from_slice(&second_masked.body).expect("masked body should parse");
+        let content = masked_json["messages"][0]["content"]
+            .as_str()
+            .expect("content should be text");
+        assert_eq!(content.matches(&cached_sentinel).count(), 1);
+        assert!(!content.contains("alice@example.com"));
+        let arguments = masked_json["messages"][1]["tool_calls"][0]["function"]["arguments"]
+            .as_str()
+            .expect("arguments should be text");
+        assert_eq!(arguments.matches(&current_sentinel).count(), 1);
+        assert!(!arguments.contains("alice@example.com"));
+
+        let mut headers =
+            BTreeMap::from([("content-type".to_string(), "application/json".to_string())]);
+        let restored = restore_sync_response_body(
+            &mut headers,
+            serde_json::to_vec(&json!({
+                "message": format!("literal {cached_sentinel} and {current_sentinel}")
+            }))
+            .expect("response should serialize")
+            .as_slice(),
+            &second_masked.session,
+        )
+        .expect("restore should succeed");
+        let restored_json: serde_json::Value =
+            serde_json::from_slice(&restored.body).expect("restored body should parse");
+        assert_eq!(
+            restored_json["message"],
+            format!("literal {cached_sentinel} and alice@example.com")
+        );
+    }
+
+    #[tokio::test]
+    async fn pii_redaction_performance_ignores_malformed_cached_sentinel() {
+        let Some(redis) = start_managed_redis_or_skip().await else {
+            return;
+        };
+        let runner = redis_runner(redis.redis_url(), "pii_redaction_performance_bad_cache");
+        let cache = RedisRedactionMappingCache::new(&runner);
+        let config = ChatPiiRedactionRuntimeConfig {
+            enabled_kinds: [RedactionKind::Email].into_iter().collect(),
+            ..ChatPiiRedactionRuntimeConfig::default()
+        };
+        runner
+            .setex(
+                &cache.forward_cache_key(RedactionKind::Email, "alice@example.com", 2),
+                "<AETHER:PHONE:ABCDEFGHIJKLMNOPQRST>",
+                Some(300),
+            )
+            .await
+            .expect("malformed cache value should write");
+
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "Contact alice@example.com"}]
+        });
+        let masked = try_mask_chat_request_json_with_cache_options(
+            &serde_json::to_vec(&request).expect("request should serialize"),
+            build_redaction_session_config(b"redaction-test-key".to_vec(), &config, 600),
+            MaskChatRequestOptions::runtime(false),
+            Some(&cache),
+        )
+        .await
+        .expect("masking should ignore malformed cache value");
+
+        let sentinel = masked
+            .session
+            .sentinel_for_original("alice@example.com")
+            .expect("email sentinel should exist");
+        assert!(sentinel.starts_with("<AETHER:EMAIL:"));
+        assert_ne!(sentinel, "<AETHER:PHONE:ABCDEFGHIJKLMNOPQRST>");
+    }
+
+    #[test]
+    fn pii_redaction_performance_restore_uses_large_mapping_matcher() {
+        let mut session = session_at(600);
+        for index in 0..32 {
+            let original = format!("user{index}@example.com");
+            let sentinel = format!("<AETHER:EMAIL:{index:0>20}>");
+            let key = MappingKey {
+                kind: RedactionKind::Email,
+                original: original.clone(),
+            };
+            session.sentinel_index.insert(sentinel.clone(), key.clone());
+            session.mappings.insert(
+                key,
+                RedactionMapping {
+                    kind: RedactionKind::Email,
+                    original,
+                    normalized_value: format!("user{index}@example.com"),
+                    sentinel,
+                    bucket: 2,
+                    created_at_unix_secs: 600,
+                    expires_at_unix_secs: 900,
+                },
+            );
+        }
+        assert!(matches!(
+            SentinelMatcher::new(&session),
+            SentinelMatcher::Direct(_)
+        ));
+
+        for index in 32..40 {
+            let original = format!("user{index}@example.com");
+            let sentinel = format!("<AETHER:EMAIL:{index:0>20}>");
+            let key = MappingKey {
+                kind: RedactionKind::Email,
+                original: original.clone(),
+            };
+            session.sentinel_index.insert(sentinel.clone(), key.clone());
+            session.mappings.insert(
+                key,
+                RedactionMapping {
+                    kind: RedactionKind::Email,
+                    original,
+                    normalized_value: format!("user{index}@example.com"),
+                    sentinel,
+                    bucket: 2,
+                    created_at_unix_secs: 600,
+                    expires_at_unix_secs: 900,
+                },
+            );
+        }
+        assert!(matches!(
+            SentinelMatcher::new(&session),
+            SentinelMatcher::Trie(_)
+        ));
+
+        let text = "before <AETHER:EMAIL:00000000000000000039> middle <AETHER:EMAIL:00000000000000000001> after";
+        let restored = session.restore_text(text);
+        assert!(restored.restored);
+        assert_eq!(
+            restored.text,
+            "before user39@example.com middle user1@example.com after"
+        );
+    }
+
+    #[test]
+    fn pii_redaction_performance_documents_segment_scan_bypass_deferral() {
+        let source = include_str!("mod.rs");
+        assert!(source.contains("Segment-level scan-bypass cache is intentionally deferred"));
+    }
+
+    fn test_config() -> RedactionSessionConfig {
+        RedactionSessionConfig::new(b"redaction-test-key".to_vec(), 300, 600)
+    }
+}

--- a/apps/aether-gateway/src/state/integrations.rs
+++ b/apps/aether-gateway/src/state/integrations.rs
@@ -63,6 +63,7 @@ impl provider_transport::VideoTaskTransportSnapshotLookup for AppState {
             .map_err(|err| match err {
                 GatewayError::UpstreamUnavailable { message, .. }
                 | GatewayError::ControlUnavailable { message, .. }
+                | GatewayError::Client { message, .. }
                 | GatewayError::Internal(message) => message,
             })
     }
@@ -79,6 +80,7 @@ impl ModelFetchTransportRuntime for AppState {
             .map_err(|err| match err {
                 GatewayError::UpstreamUnavailable { message, .. }
                 | GatewayError::ControlUnavailable { message, .. }
+                | GatewayError::Client { message, .. }
                 | GatewayError::Internal(message) => message,
             })
     }
@@ -100,6 +102,7 @@ impl ModelFetchTransportRuntime for AppState {
             .map_err(|err| match err {
                 GatewayError::UpstreamUnavailable { message, .. }
                 | GatewayError::ControlUnavailable { message, .. }
+                | GatewayError::Client { message, .. }
                 | GatewayError::Internal(message) => message,
             })
     }

--- a/apps/aether-gateway/src/state/oauth.rs
+++ b/apps/aether-gateway/src/state/oauth.rs
@@ -1381,6 +1381,7 @@ impl AppState {
                         message: match err {
                             GatewayError::UpstreamUnavailable { message, .. }
                             | GatewayError::ControlUnavailable { message, .. }
+                            | GatewayError::Client { message, .. }
                             | GatewayError::Internal(message) => message,
                         },
                     },

--- a/apps/aether-gateway/src/tests/ai_execute/stream/mod.rs
+++ b/apps/aether-gateway/src/tests/ai_execute/stream/mod.rs
@@ -25,3 +25,4 @@ use super::{
 
 mod decision;
 mod image;
+mod pii_redaction;

--- a/apps/aether-gateway/src/tests/ai_execute/stream/pii_redaction.rs
+++ b/apps/aether-gateway/src/tests/ai_execute/stream/pii_redaction.rs
@@ -1,0 +1,339 @@
+use super::*;
+use aether_crypto::{encrypt_python_fernet_plaintext, DEVELOPMENT_ENCRYPTION_KEY};
+use aether_data::repository::auth::{
+    InMemoryAuthApiKeySnapshotRepository, StoredAuthApiKeySnapshot,
+};
+use aether_data::repository::candidate_selection::InMemoryMinimalCandidateSelectionReadRepository;
+use aether_data::repository::candidates::InMemoryRequestCandidateRepository;
+use aether_data::repository::provider_catalog::InMemoryProviderCatalogReadRepository;
+use aether_data_contracts::repository::candidate_selection::{
+    StoredMinimalCandidateSelectionRow, StoredProviderModelMapping,
+};
+use aether_data_contracts::repository::candidates::{
+    RequestCandidateReadRepository, RequestCandidateStatus,
+};
+use aether_data_contracts::repository::provider_catalog::{
+    StoredProviderCatalogEndpoint, StoredProviderCatalogKey, StoredProviderCatalogProvider,
+};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone)]
+struct SeenProviderStreamRequest {
+    body: serde_json::Value,
+    authorization: String,
+    accept_encoding: String,
+    accept: String,
+}
+
+fn hash_api_key(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn auth_snapshot() -> StoredAuthApiKeySnapshot {
+    StoredAuthApiKeySnapshot::new(
+        "user-ai-execute-stream-pii-redaction".to_string(),
+        "alice".to_string(),
+        Some("alice@example.com".to_string()),
+        "user".to_string(),
+        "local".to_string(),
+        true,
+        false,
+        Some(serde_json::json!(["openai"])),
+        Some(serde_json::json!(["openai:chat"])),
+        Some(serde_json::json!(["gpt-5"])),
+        "api-key-ai-execute-stream-pii-redaction".to_string(),
+        Some("default".to_string()),
+        true,
+        false,
+        false,
+        Some(60),
+        Some(5),
+        Some(4_102_444_800),
+        Some(serde_json::json!(["openai"])),
+        Some(serde_json::json!(["openai:chat"])),
+        Some(serde_json::json!(["gpt-5"])),
+    )
+    .expect("auth snapshot should build")
+}
+
+fn candidate_row() -> StoredMinimalCandidateSelectionRow {
+    StoredMinimalCandidateSelectionRow {
+        provider_id: "provider-ai-execute-stream-pii-redaction".to_string(),
+        provider_name: "openai".to_string(),
+        provider_type: "custom".to_string(),
+        provider_priority: 10,
+        provider_is_active: true,
+        endpoint_id: "endpoint-ai-execute-stream-pii-redaction".to_string(),
+        endpoint_api_format: "openai:chat".to_string(),
+        endpoint_api_family: Some("openai".to_string()),
+        endpoint_kind: Some("chat".to_string()),
+        endpoint_is_active: true,
+        key_id: "key-ai-execute-stream-pii-redaction".to_string(),
+        key_name: "prod".to_string(),
+        key_auth_type: "api_key".to_string(),
+        key_is_active: true,
+        key_api_formats: Some(vec!["openai:chat".to_string()]),
+        key_allowed_models: None,
+        key_capabilities: None,
+        key_internal_priority: 5,
+        key_global_priority_by_format: Some(serde_json::json!({"openai:chat": 1})),
+        model_id: "model-ai-execute-stream-pii-redaction".to_string(),
+        global_model_id: "global-model-ai-execute-stream-pii-redaction".to_string(),
+        global_model_name: "gpt-5".to_string(),
+        global_model_mappings: None,
+        global_model_supports_streaming: Some(true),
+        model_provider_model_name: "gpt-5-upstream".to_string(),
+        model_provider_model_mappings: Some(vec![StoredProviderModelMapping {
+            name: "gpt-5-upstream".to_string(),
+            priority: 1,
+            api_formats: Some(vec!["openai:chat".to_string()]),
+        }]),
+        model_supports_streaming: Some(true),
+        model_is_active: true,
+        model_is_available: true,
+    }
+}
+
+fn provider() -> StoredProviderCatalogProvider {
+    StoredProviderCatalogProvider::new(
+        "provider-ai-execute-stream-pii-redaction".to_string(),
+        "openai".to_string(),
+        Some("https://example.com".to_string()),
+        "custom".to_string(),
+    )
+    .expect("provider should build")
+    .with_transport_fields(
+        true,
+        false,
+        true,
+        None,
+        Some(2),
+        None,
+        Some(20.0),
+        None,
+        Some(serde_json::json!({"chat_pii_redaction": {"enabled": true}})),
+    )
+}
+
+fn endpoint(base_url: String) -> StoredProviderCatalogEndpoint {
+    StoredProviderCatalogEndpoint::new(
+        "endpoint-ai-execute-stream-pii-redaction".to_string(),
+        "provider-ai-execute-stream-pii-redaction".to_string(),
+        "openai:chat".to_string(),
+        Some("openai".to_string()),
+        Some("chat".to_string()),
+        true,
+    )
+    .expect("endpoint should build")
+    .with_transport_fields(base_url, None, None, Some(2), None, None, None, None)
+    .expect("endpoint transport should build")
+}
+
+fn key() -> StoredProviderCatalogKey {
+    StoredProviderCatalogKey::new(
+        "key-ai-execute-stream-pii-redaction".to_string(),
+        "provider-ai-execute-stream-pii-redaction".to_string(),
+        "prod".to_string(),
+        "api_key".to_string(),
+        None,
+        true,
+    )
+    .expect("key should build")
+    .with_transport_fields(
+        Some(serde_json::json!(["openai:chat"])),
+        encrypt_python_fernet_plaintext(DEVELOPMENT_ENCRYPTION_KEY, "sk-upstream-stream-pii")
+            .expect("api key should encrypt"),
+        None,
+        None,
+        Some(serde_json::json!({"openai:chat": 1})),
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("key transport should build")
+}
+
+fn collect_email_sentinel(text: &str) -> String {
+    let start = text
+        .find("<AETHER:EMAIL:")
+        .expect("email sentinel should exist");
+    let end = text[start..]
+        .find('>')
+        .map(|index| start + index + 1)
+        .expect("sentinel should close");
+    text[start..end].to_string()
+}
+
+#[tokio::test]
+async fn ai_execute_stream_pii_redaction_round_trip() {
+    let seen_provider_request = Arc::new(Mutex::new(None::<SeenProviderStreamRequest>));
+    let seen_provider_request_clone = Arc::clone(&seen_provider_request);
+    let provider_app = Router::new().route(
+        "/v1/chat/completions",
+        any(move |request: Request| {
+            let seen_provider_request_inner = Arc::clone(&seen_provider_request_clone);
+            async move {
+                let (parts, body) = request.into_parts();
+                let raw_body = to_bytes(body, usize::MAX).await.expect("body should read");
+                let payload: serde_json::Value =
+                    serde_json::from_slice(&raw_body).expect("provider payload should parse");
+                let payload_text = serde_json::to_string(&payload).expect("payload should serialize");
+                let sentinel = collect_email_sentinel(&payload_text);
+                *seen_provider_request_inner
+                    .lock()
+                    .expect("mutex should lock") = Some(SeenProviderStreamRequest {
+                    body: payload,
+                    authorization: parts
+                        .headers
+                        .get(http::header::AUTHORIZATION)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                    accept_encoding: parts
+                        .headers
+                        .get(http::header::ACCEPT_ENCODING)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                    accept: parts
+                        .headers
+                        .get(http::header::ACCEPT)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                });
+
+                let split_at = sentinel.len() / 2;
+                let (first_half, second_half) = sentinel.split_at(split_at);
+                let first_chunk = format!(
+                    "data: {{\"id\":\"chatcmpl-stream-pii\",\"object\":\"chat.completion.chunk\",\"model\":\"gpt-5-upstream\",\"choices\":[{{\"index\":0,\"delta\":{{\"role\":\"assistant\",\"content\":\"stream {first_half}"
+                );
+                let second_chunk = format!(
+                    "{second_half} restored\"}},\"finish_reason\":null}}]}}\n\n"
+                );
+                let stream = futures_util::stream::iter([
+                    Ok::<_, Infallible>(Bytes::from(first_chunk)),
+                    Ok::<_, Infallible>(Bytes::from(second_chunk)),
+                    Ok::<_, Infallible>(Bytes::from_static(b"data: [DONE]\n\n")),
+                ]);
+                let mut response = Response::builder()
+                    .status(StatusCode::OK)
+                    .body(Body::from_stream(stream))
+                    .expect("response should build");
+                response.headers_mut().insert(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream"),
+                );
+                response
+            }
+        }),
+    );
+    let (provider_url, provider_handle) = start_server(provider_app).await;
+    let auth_repository = Arc::new(InMemoryAuthApiKeySnapshotRepository::seed(vec![(
+        Some(hash_api_key("sk-client-ai-execute-stream-pii-redaction")),
+        auth_snapshot(),
+    )]));
+    let candidate_selection_repository =
+        Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed(vec![
+            candidate_row(),
+        ]));
+    let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider()],
+        vec![endpoint(provider_url)],
+        vec![key()],
+    ));
+    let data_state = crate::data::GatewayDataState::with_auth_candidate_selection_provider_catalog_and_request_candidate_repository_for_tests(
+        auth_repository,
+        candidate_selection_repository,
+        provider_catalog_repository,
+        Arc::clone(&request_candidate_repository),
+        DEVELOPMENT_ENCRYPTION_KEY,
+    )
+    .with_system_config_values_for_tests(vec![
+        ("module.chat_pii_redaction.enabled".to_string(), json!(true)),
+        (
+            "module.chat_pii_redaction.provider_scope".to_string(),
+            json!("selected_providers"),
+        ),
+        (
+            "module.chat_pii_redaction.entities".to_string(),
+            json!(["email"]),
+        ),
+        (
+            "module.chat_pii_redaction.cache_ttl_seconds".to_string(),
+            json!(300),
+        ),
+        (
+            "module.chat_pii_redaction.inject_model_instruction".to_string(),
+            json!(true),
+        ),
+    ]);
+    let gateway_state = AppState::new()
+        .expect("gateway state should build")
+        .with_data_state_for_tests(data_state);
+    let gateway = build_router_with_state(gateway_state);
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/chat/completions"))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(
+            http::header::AUTHORIZATION,
+            "Bearer sk-client-ai-execute-stream-pii-redaction",
+        )
+        .header(http::header::ACCEPT_ENCODING, "gzip")
+        .header(TRACE_ID_HEADER, "trace-ai-execute-stream-pii-redaction")
+        .body(
+            json!({
+                "model": "gpt-5",
+                "messages": [{"role": "user", "content": "Email stream.user@example.com"}],
+                "stream": true
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .expect("request should succeed");
+
+    let status = response.status();
+    let execution_path = response
+        .headers()
+        .get(EXECUTION_PATH_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned);
+    let response_text = response.text().await.expect("body should read");
+    assert_eq!(status, StatusCode::OK, "{response_text}");
+    assert_eq!(
+        execution_path.as_deref(),
+        Some(EXECUTION_PATH_EXECUTION_RUNTIME_STREAM)
+    );
+    assert!(response_text.contains("stream stream.user@example.com restored"));
+    assert!(response_text.contains("data: [DONE]"));
+    assert!(!response_text.contains("<AETHER:EMAIL:"));
+
+    let seen = seen_provider_request
+        .lock()
+        .expect("mutex should lock")
+        .clone()
+        .expect("provider stream request should be captured");
+    assert_eq!(seen.authorization, "Bearer sk-upstream-stream-pii");
+    assert_eq!(seen.accept, "text/event-stream");
+    assert_eq!(seen.accept_encoding, "identity");
+    let provider_body_text = serde_json::to_string(&seen.body).expect("body should serialize");
+    assert!(!provider_body_text.contains("stream.user@example.com"));
+    assert!(provider_body_text.contains("<AETHER:EMAIL:"));
+
+    let stored_candidates = request_candidate_repository
+        .list_by_request_id("trace-ai-execute-stream-pii-redaction")
+        .await
+        .expect("request candidate trace should read");
+    assert_eq!(stored_candidates.len(), 1);
+    assert_eq!(stored_candidates[0].status, RequestCandidateStatus::Success);
+
+    gateway_handle.abort();
+    provider_handle.abort();
+}

--- a/apps/aether-gateway/src/tests/ai_execute/sync/chat/local_decision.rs
+++ b/apps/aether-gateway/src/tests/ai_execute/sync/chat/local_decision.rs
@@ -11,6 +11,314 @@ use super::{
 };
 
 #[tokio::test]
+async fn proxy_pii_redaction_local_openai_chat_runtime_masks_headers_and_restores_sync_response() {
+    #[derive(Debug, Clone)]
+    struct SeenProviderRequest {
+        body: serde_json::Value,
+        authorization: String,
+        accept_encoding: String,
+    }
+
+    fn hash_api_key(value: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(value.as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn auth_snapshot() -> StoredAuthApiKeySnapshot {
+        StoredAuthApiKeySnapshot::new(
+            "user-redaction-1".to_string(),
+            "alice".to_string(),
+            Some("alice@example.com".to_string()),
+            "user".to_string(),
+            "local".to_string(),
+            true,
+            false,
+            Some(serde_json::json!(["openai"])),
+            Some(serde_json::json!(["openai:chat"])),
+            Some(serde_json::json!(["gpt-5"])),
+            "api-key-redaction-1".to_string(),
+            Some("default".to_string()),
+            true,
+            false,
+            false,
+            Some(60),
+            Some(5),
+            Some(4_102_444_800),
+            Some(serde_json::json!(["openai"])),
+            Some(serde_json::json!(["openai:chat"])),
+            Some(serde_json::json!(["gpt-5"])),
+        )
+        .expect("auth snapshot should build")
+    }
+
+    fn candidate_row() -> StoredMinimalCandidateSelectionRow {
+        StoredMinimalCandidateSelectionRow {
+            provider_id: "provider-redaction-1".to_string(),
+            provider_name: "openai".to_string(),
+            provider_type: "custom".to_string(),
+            provider_priority: 10,
+            provider_is_active: true,
+            endpoint_id: "endpoint-redaction-1".to_string(),
+            endpoint_api_format: "openai:chat".to_string(),
+            endpoint_api_family: Some("openai".to_string()),
+            endpoint_kind: Some("chat".to_string()),
+            endpoint_is_active: true,
+            key_id: "key-redaction-1".to_string(),
+            key_name: "prod".to_string(),
+            key_auth_type: "api_key".to_string(),
+            key_is_active: true,
+            key_api_formats: Some(vec!["openai:chat".to_string()]),
+            key_allowed_models: None,
+            key_capabilities: None,
+            key_internal_priority: 5,
+            key_global_priority_by_format: Some(serde_json::json!({"openai:chat": 1})),
+            model_id: "model-redaction-1".to_string(),
+            global_model_id: "global-model-redaction-1".to_string(),
+            global_model_name: "gpt-5".to_string(),
+            global_model_mappings: None,
+            global_model_supports_streaming: Some(true),
+            model_provider_model_name: "gpt-5-upstream".to_string(),
+            model_provider_model_mappings: Some(vec![StoredProviderModelMapping {
+                name: "gpt-5-upstream".to_string(),
+                priority: 1,
+                api_formats: Some(vec!["openai:chat".to_string()]),
+            }]),
+            model_supports_streaming: Some(true),
+            model_is_active: true,
+            model_is_available: true,
+        }
+    }
+
+    fn provider() -> StoredProviderCatalogProvider {
+        StoredProviderCatalogProvider::new(
+            "provider-redaction-1".to_string(),
+            "openai".to_string(),
+            Some("https://example.com".to_string()),
+            "custom".to_string(),
+        )
+        .expect("provider should build")
+        .with_transport_fields(
+            true,
+            false,
+            true,
+            None,
+            Some(2),
+            None,
+            Some(20.0),
+            None,
+            Some(serde_json::json!({"chat_pii_redaction": {"enabled": true}})),
+        )
+    }
+
+    fn endpoint(base_url: String) -> StoredProviderCatalogEndpoint {
+        StoredProviderCatalogEndpoint::new(
+            "endpoint-redaction-1".to_string(),
+            "provider-redaction-1".to_string(),
+            "openai:chat".to_string(),
+            Some("openai".to_string()),
+            Some("chat".to_string()),
+            true,
+        )
+        .expect("endpoint should build")
+        .with_transport_fields(base_url, None, None, Some(2), None, None, None, None)
+        .expect("endpoint transport should build")
+    }
+
+    fn key() -> StoredProviderCatalogKey {
+        StoredProviderCatalogKey::new(
+            "key-redaction-1".to_string(),
+            "provider-redaction-1".to_string(),
+            "prod".to_string(),
+            "api_key".to_string(),
+            None,
+            true,
+        )
+        .expect("key should build")
+        .with_transport_fields(
+            Some(serde_json::json!(["openai:chat"])),
+            encrypt_python_fernet_plaintext(DEVELOPMENT_ENCRYPTION_KEY, "sk-upstream-redaction")
+                .expect("api key should encrypt"),
+            None,
+            None,
+            Some(serde_json::json!({"openai:chat": 1})),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("key transport should build")
+    }
+
+    fn sentinel_from_body(body: &serde_json::Value) -> String {
+        let messages = body["messages"].as_array().expect("messages should exist");
+        let user_content = messages
+            .iter()
+            .find(|message| message["role"] == "user")
+            .and_then(|message| message["content"].as_str())
+            .expect("user content should be text");
+        let start = user_content
+            .find("<AETHER:EMAIL:")
+            .expect("redacted content should include email sentinel");
+        let end = user_content[start..]
+            .find('>')
+            .map(|index| start + index + 1)
+            .expect("sentinel should close");
+        user_content[start..end].to_string()
+    }
+
+    let seen_provider_request = Arc::new(Mutex::new(None::<SeenProviderRequest>));
+    let seen_provider_request_clone = Arc::clone(&seen_provider_request);
+    let provider_app = Router::new().route(
+        "/v1/chat/completions",
+        any(move |request: Request| {
+            let seen_provider_request_inner = Arc::clone(&seen_provider_request_clone);
+            async move {
+                let (parts, body) = request.into_parts();
+                let raw_body = to_bytes(body, usize::MAX).await.expect("body should read");
+                let payload: serde_json::Value =
+                    serde_json::from_slice(&raw_body).expect("provider payload should parse");
+                let sentinel = sentinel_from_body(&payload);
+                *seen_provider_request_inner
+                    .lock()
+                    .expect("mutex should lock") = Some(SeenProviderRequest {
+                    body: payload,
+                    authorization: parts
+                        .headers
+                        .get(http::header::AUTHORIZATION)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                    accept_encoding: parts
+                        .headers
+                        .get(http::header::ACCEPT_ENCODING)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                });
+                Json(json!({
+                    "id": "chatcmpl-redaction-1",
+                    "object": "chat.completion",
+                    "model": "gpt-5-upstream",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": format!("restored {sentinel}")},
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5}
+                }))
+            }
+        }),
+    );
+    let (provider_url, provider_handle) = start_server(provider_app).await;
+    let auth_repository = Arc::new(InMemoryAuthApiKeySnapshotRepository::seed(vec![(
+        Some(hash_api_key("sk-client-redaction")),
+        auth_snapshot(),
+    )]));
+    let candidate_selection_repository =
+        Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed(vec![
+            candidate_row(),
+        ]));
+    let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider()],
+        vec![endpoint(provider_url)],
+        vec![key()],
+    ));
+    let data_state = crate::data::GatewayDataState::with_auth_candidate_selection_provider_catalog_and_request_candidate_repository_for_tests(
+        auth_repository,
+        candidate_selection_repository,
+        provider_catalog_repository,
+        Arc::clone(&request_candidate_repository),
+        DEVELOPMENT_ENCRYPTION_KEY,
+    )
+    .with_system_config_values_for_tests(vec![
+        ("module.chat_pii_redaction.enabled".to_string(), json!(true)),
+        (
+            "module.chat_pii_redaction.provider_scope".to_string(),
+            json!("selected_providers"),
+        ),
+        (
+            "module.chat_pii_redaction.entities".to_string(),
+            json!(["email"]),
+        ),
+        (
+            "module.chat_pii_redaction.cache_ttl_seconds".to_string(),
+            json!(300),
+        ),
+        (
+            "module.chat_pii_redaction.inject_model_instruction".to_string(),
+            json!(true),
+        ),
+    ]);
+    let gateway_state = AppState::new()
+        .expect("gateway state should build")
+        .with_data_state_for_tests(data_state);
+    let gateway = build_router_with_state(gateway_state);
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/chat/completions"))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(http::header::AUTHORIZATION, "Bearer sk-client-redaction")
+        .header(http::header::ACCEPT_ENCODING, "gzip")
+        .header(TRACE_ID_HEADER, "trace-proxy-pii-redaction-sync")
+        .body(
+            r#"{"model":"gpt-5","messages":[{"role":"user","content":"Email alice@example.com"}]}"#,
+        )
+        .send()
+        .await
+        .expect("request should succeed");
+
+    let status = response.status();
+    let execution_path = response
+        .headers()
+        .get(EXECUTION_PATH_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned);
+    let response_text = response.text().await.expect("body should read");
+    assert_eq!(status, StatusCode::OK, "{response_text}");
+    assert_eq!(
+        execution_path.as_deref(),
+        Some(EXECUTION_PATH_EXECUTION_RUNTIME_SYNC)
+    );
+    let response_json: serde_json::Value =
+        serde_json::from_str(&response_text).expect("body should parse");
+    assert_eq!(
+        response_json["choices"][0]["message"]["content"],
+        "restored alice@example.com"
+    );
+
+    let seen = seen_provider_request
+        .lock()
+        .expect("mutex should lock")
+        .clone()
+        .expect("provider request should be captured");
+    assert_eq!(seen.authorization, "Bearer sk-upstream-redaction");
+    assert_eq!(seen.accept_encoding, "identity");
+    let provider_body_text = serde_json::to_string(&seen.body).expect("body should serialize");
+    assert!(!provider_body_text.contains("alice@example.com"));
+    assert!(provider_body_text.contains("<AETHER:EMAIL:"));
+    assert_eq!(seen.body["messages"][0]["role"], "assistant");
+    let notice = seen.body["messages"][0]["content"]
+        .as_str()
+        .expect("notice should be text");
+    assert!(notice.contains("not a user request"));
+    assert!(notice.contains("do not answer"));
+    assert_eq!(seen.body["messages"][1]["role"], "user");
+
+    let stored_candidates = request_candidate_repository
+        .list_by_request_id("trace-proxy-pii-redaction-sync")
+        .await
+        .expect("request candidate trace should read");
+    assert_eq!(stored_candidates.len(), 1);
+    assert_eq!(stored_candidates[0].status, RequestCandidateStatus::Success);
+
+    gateway_handle.abort();
+    provider_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_executes_openai_chat_sync_via_local_decision_gate_without_execution_runtime_override(
 ) {
     #[derive(Debug, Clone)]

--- a/apps/aether-gateway/src/tests/ai_execute/sync/chat/mod.rs
+++ b/apps/aether-gateway/src/tests/ai_execute/sync/chat/mod.rs
@@ -42,3 +42,4 @@ use sha2::{Digest, Sha256};
 
 mod failover;
 mod local_decision;
+mod pii_redaction;

--- a/apps/aether-gateway/src/tests/ai_execute/sync/chat/pii_redaction.rs
+++ b/apps/aether-gateway/src/tests/ai_execute/sync/chat/pii_redaction.rs
@@ -1,0 +1,835 @@
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Debug, Clone)]
+struct SeenProviderRequest {
+    body: serde_json::Value,
+    authorization: String,
+    accept_encoding: String,
+}
+
+fn hash_api_key(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn auth_snapshot(api_key_id: &str, user_id: &str) -> StoredAuthApiKeySnapshot {
+    StoredAuthApiKeySnapshot::new(
+        user_id.to_string(),
+        "alice".to_string(),
+        Some("alice@example.com".to_string()),
+        "user".to_string(),
+        "local".to_string(),
+        true,
+        false,
+        Some(serde_json::json!(["openai"])),
+        Some(serde_json::json!(["openai:chat"])),
+        Some(serde_json::json!(["gpt-5"])),
+        api_key_id.to_string(),
+        Some("default".to_string()),
+        true,
+        false,
+        false,
+        Some(60),
+        Some(5),
+        Some(4_102_444_800),
+        Some(serde_json::json!(["openai"])),
+        Some(serde_json::json!(["openai:chat"])),
+        Some(serde_json::json!(["gpt-5"])),
+    )
+    .expect("auth snapshot should build")
+}
+
+fn candidate_row(test_id: &str) -> StoredMinimalCandidateSelectionRow {
+    StoredMinimalCandidateSelectionRow {
+        provider_id: format!("provider-{test_id}"),
+        provider_name: "openai".to_string(),
+        provider_type: "custom".to_string(),
+        provider_priority: 10,
+        provider_is_active: true,
+        endpoint_id: format!("endpoint-{test_id}"),
+        endpoint_api_format: "openai:chat".to_string(),
+        endpoint_api_family: Some("openai".to_string()),
+        endpoint_kind: Some("chat".to_string()),
+        endpoint_is_active: true,
+        key_id: format!("key-{test_id}"),
+        key_name: "prod".to_string(),
+        key_auth_type: "api_key".to_string(),
+        key_is_active: true,
+        key_api_formats: Some(vec!["openai:chat".to_string()]),
+        key_allowed_models: None,
+        key_capabilities: None,
+        key_internal_priority: 5,
+        key_global_priority_by_format: Some(serde_json::json!({"openai:chat": 1})),
+        model_id: format!("model-{test_id}"),
+        global_model_id: format!("global-model-{test_id}"),
+        global_model_name: "gpt-5".to_string(),
+        global_model_mappings: None,
+        global_model_supports_streaming: Some(true),
+        model_provider_model_name: "gpt-5-upstream".to_string(),
+        model_provider_model_mappings: Some(vec![StoredProviderModelMapping {
+            name: "gpt-5-upstream".to_string(),
+            priority: 1,
+            api_formats: Some(vec!["openai:chat".to_string()]),
+        }]),
+        model_supports_streaming: Some(true),
+        model_is_active: true,
+        model_is_available: true,
+    }
+}
+
+fn provider(test_id: &str, redaction_enabled: bool) -> StoredProviderCatalogProvider {
+    StoredProviderCatalogProvider::new(
+        format!("provider-{test_id}"),
+        "openai".to_string(),
+        Some("https://example.com".to_string()),
+        "custom".to_string(),
+    )
+    .expect("provider should build")
+    .with_transport_fields(
+        true,
+        false,
+        true,
+        None,
+        Some(2),
+        None,
+        Some(20.0),
+        None,
+        Some(serde_json::json!({"chat_pii_redaction": {"enabled": redaction_enabled}})),
+    )
+}
+
+fn endpoint(test_id: &str, base_url: String) -> StoredProviderCatalogEndpoint {
+    StoredProviderCatalogEndpoint::new(
+        format!("endpoint-{test_id}"),
+        format!("provider-{test_id}"),
+        "openai:chat".to_string(),
+        Some("openai".to_string()),
+        Some("chat".to_string()),
+        true,
+    )
+    .expect("endpoint should build")
+    .with_transport_fields(base_url, None, None, Some(2), None, None, None, None)
+    .expect("endpoint transport should build")
+}
+
+fn key(test_id: &str) -> StoredProviderCatalogKey {
+    StoredProviderCatalogKey::new(
+        format!("key-{test_id}"),
+        format!("provider-{test_id}"),
+        "prod".to_string(),
+        "api_key".to_string(),
+        None,
+        true,
+    )
+    .expect("key should build")
+    .with_transport_fields(
+        Some(serde_json::json!(["openai:chat"])),
+        encrypt_python_fernet_plaintext(DEVELOPMENT_ENCRYPTION_KEY, "sk-upstream-pii-redaction")
+            .expect("api key should encrypt"),
+        None,
+        None,
+        Some(serde_json::json!({"openai:chat": 1})),
+        None,
+        None,
+        None,
+        None,
+    )
+    .expect("key transport should build")
+}
+
+fn redaction_config(module_enabled: bool) -> Vec<(String, serde_json::Value)> {
+    redaction_config_with_entities(
+        module_enabled,
+        json!(["email", "access_token", "secret_key"]),
+    )
+}
+
+fn redaction_config_with_entities(
+    module_enabled: bool,
+    entities: serde_json::Value,
+) -> Vec<(String, serde_json::Value)> {
+    vec![
+        (
+            "module.chat_pii_redaction.enabled".to_string(),
+            json!(module_enabled),
+        ),
+        (
+            "module.chat_pii_redaction.provider_scope".to_string(),
+            json!("selected_providers"),
+        ),
+        ("module.chat_pii_redaction.entities".to_string(), entities),
+        (
+            "module.chat_pii_redaction.cache_ttl_seconds".to_string(),
+            json!(300),
+        ),
+        (
+            "module.chat_pii_redaction.inject_model_instruction".to_string(),
+            json!(true),
+        ),
+    ]
+}
+
+fn collect_sentinels(text: &str, kind: &str) -> Vec<String> {
+    let prefix = format!("<AETHER:{kind}:");
+    let mut sentinels = Vec::new();
+    let mut offset = 0;
+    while let Some(relative_start) = text[offset..].find(&prefix) {
+        let start = offset + relative_start;
+        let Some(relative_end) = text[start..].find('>') else {
+            break;
+        };
+        let end = start + relative_end + 1;
+        sentinels.push(text[start..end].to_string());
+        offset = end;
+    }
+    sentinels
+}
+
+async fn run_sync_redaction_case(
+    test_id: &str,
+    module_enabled: bool,
+    provider_enabled: bool,
+    provider_response: &'static str,
+    request_body: serde_json::Value,
+) -> (serde_json::Value, SeenProviderRequest) {
+    run_sync_redaction_case_with_system_config(
+        test_id,
+        provider_enabled,
+        provider_response,
+        request_body,
+        redaction_config(module_enabled),
+    )
+    .await
+}
+
+async fn run_sync_redaction_case_with_system_config(
+    test_id: &str,
+    provider_enabled: bool,
+    provider_response: &'static str,
+    request_body: serde_json::Value,
+    system_config: Vec<(String, serde_json::Value)>,
+) -> (serde_json::Value, SeenProviderRequest) {
+    let seen_provider_request = Arc::new(Mutex::new(None::<SeenProviderRequest>));
+    let seen_provider_request_clone = Arc::clone(&seen_provider_request);
+    let provider_app = Router::new().route(
+        "/v1/chat/completions",
+        any(move |request: Request| {
+            let seen_provider_request_inner = Arc::clone(&seen_provider_request_clone);
+            async move {
+                let (parts, body) = request.into_parts();
+                let raw_body = to_bytes(body, usize::MAX).await.expect("body should read");
+                let payload: serde_json::Value =
+                    serde_json::from_slice(&raw_body).expect("provider payload should parse");
+                let payload_text =
+                    serde_json::to_string(&payload).expect("payload should serialize");
+                let email_sentinels = collect_sentinels(&payload_text, "EMAIL");
+                let access_token_sentinels = collect_sentinels(&payload_text, "ACCESS_TOKEN");
+                let secret_key_sentinels = collect_sentinels(&payload_text, "SECRET_KEY");
+                *seen_provider_request_inner
+                    .lock()
+                    .expect("mutex should lock") = Some(SeenProviderRequest {
+                    body: payload,
+                    authorization: parts
+                        .headers
+                        .get(http::header::AUTHORIZATION)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                    accept_encoding: parts
+                        .headers
+                        .get(http::header::ACCEPT_ENCODING)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default()
+                        .to_string(),
+                });
+
+                let content = match provider_response {
+                    "known" => format!(
+                        "restored {} {} {}",
+                        email_sentinels
+                            .first()
+                            .expect("user email sentinel should exist"),
+                        access_token_sentinels
+                            .first()
+                            .expect("access token sentinel should exist"),
+                        secret_key_sentinels
+                            .first()
+                            .expect("secret key sentinel should exist")
+                    ),
+                    "unknown" => "unknown <AETHER:EMAIL:TSRQPONMLKJIHGFEDCBA>".to_string(),
+                    "pass_through" => "pass alice@example.com".to_string(),
+                    _ => unreachable!("provider response mode should be known"),
+                };
+
+                Json(json!({
+                    "id": format!("chatcmpl-{provider_response}"),
+                    "object": "chat.completion",
+                    "model": "gpt-5-upstream",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": content},
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5}
+                }))
+            }
+        }),
+    );
+    let (provider_url, provider_handle) = start_server(provider_app).await;
+    let auth_repository = Arc::new(InMemoryAuthApiKeySnapshotRepository::seed(vec![(
+        Some(hash_api_key(&format!("sk-client-{test_id}"))),
+        auth_snapshot(&format!("api-key-{test_id}"), &format!("user-{test_id}")),
+    )]));
+    let candidate_selection_repository =
+        Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed(vec![
+            candidate_row(test_id),
+        ]));
+    let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider(test_id, provider_enabled)],
+        vec![endpoint(test_id, provider_url)],
+        vec![key(test_id)],
+    ));
+    let data_state = crate::data::GatewayDataState::with_auth_candidate_selection_provider_catalog_and_request_candidate_repository_for_tests(
+        auth_repository,
+        candidate_selection_repository,
+        provider_catalog_repository,
+        Arc::clone(&request_candidate_repository),
+        DEVELOPMENT_ENCRYPTION_KEY,
+    )
+    .with_system_config_values_for_tests(system_config);
+    let gateway_state = AppState::new()
+        .expect("gateway state should build")
+        .with_data_state_for_tests(data_state);
+    let gateway = build_router_with_state(gateway_state);
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/chat/completions"))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer sk-client-{test_id}"),
+        )
+        .header(http::header::ACCEPT_ENCODING, "gzip")
+        .header(TRACE_ID_HEADER, format!("trace-{test_id}"))
+        .body(request_body.to_string())
+        .send()
+        .await
+        .expect("request should succeed");
+
+    let status = response.status();
+    let execution_path = response
+        .headers()
+        .get(EXECUTION_PATH_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned);
+    let response_text = response.text().await.expect("body should read");
+    assert_eq!(status, StatusCode::OK, "{response_text}");
+    assert_eq!(
+        execution_path.as_deref(),
+        Some(EXECUTION_PATH_EXECUTION_RUNTIME_SYNC)
+    );
+    let response_json: serde_json::Value =
+        serde_json::from_str(&response_text).expect("response body should parse");
+
+    let stored_candidates = request_candidate_repository
+        .list_by_request_id(&format!("trace-{test_id}"))
+        .await
+        .expect("request candidate trace should read");
+    assert_eq!(stored_candidates.len(), 1);
+    assert_eq!(stored_candidates[0].status, RequestCandidateStatus::Success);
+
+    let seen = seen_provider_request
+        .lock()
+        .expect("mutex should lock")
+        .clone()
+        .expect("provider request should be captured");
+
+    gateway_handle.abort();
+    provider_handle.abort();
+
+    (response_json, seen)
+}
+
+fn rich_pii_request() -> serde_json::Value {
+    json!({
+        "model": "gpt-5",
+        "messages": [
+            {"role": "system", "content": "Be concise."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Contact alice@example.com now"},
+                    {"type": "input_audio", "input_audio": {"data": "AAAA", "format": "wav"}}
+                ]
+            },
+            {
+                "role": "assistant",
+                "content": "Preparing lookup.",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup_contact",
+                        "arguments": "{\"email\":\"bob@example.net\"}"
+                    }
+                }]
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "Tool returned access_token=accessValueABCDEF1234567890abcdef secret_key=secretValueABCDEF1234567890abcdef"
+            }
+        ],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "lookup_contact",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"email": {"type": "string"}}
+                }
+            }
+        }]
+    })
+}
+
+#[tokio::test]
+async fn ai_execute_sync_pii_redaction_round_trip() {
+    let (response_json, seen) = run_sync_redaction_case(
+        "ai-execute-sync-pii-redaction-round-trip",
+        true,
+        true,
+        "known",
+        rich_pii_request(),
+    )
+    .await;
+
+    assert_eq!(seen.authorization, "Bearer sk-upstream-pii-redaction");
+    assert_eq!(seen.accept_encoding, "identity");
+    let provider_body_text = serde_json::to_string(&seen.body).expect("body should serialize");
+    for original in [
+        "alice@example.com",
+        "bob@example.net",
+        "access_token=accessValueABCDEF1234567890abcdef",
+        "secret_key\\\":\\\"secretValueABCDEF1234567890abcdef",
+    ] {
+        assert!(
+            !provider_body_text.contains(original),
+            "leaked {original} in {provider_body_text}"
+        );
+    }
+    assert!(provider_body_text.contains("<AETHER:EMAIL:"));
+    assert!(provider_body_text.contains("<AETHER:ACCESS_TOKEN:"));
+    assert!(provider_body_text.contains("<AETHER:SECRET_KEY:"));
+    assert_eq!(seen.body["messages"][0]["role"], "system");
+    assert_eq!(seen.body["messages"][1]["role"], "assistant");
+    let notice = seen.body["messages"][1]["content"]
+        .as_str()
+        .expect("notice should be text");
+    assert!(notice.contains("not a user request"));
+    assert_eq!(seen.body["messages"][2]["role"], "user");
+    assert_eq!(seen.body["messages"][3]["role"], "assistant");
+    assert_eq!(seen.body["messages"][4]["role"], "tool");
+
+    let response_content = response_json["choices"][0]["message"]["content"]
+        .as_str()
+        .expect("assistant content should be text");
+    assert!(response_content.contains("alice@example.com"));
+    assert!(response_content.contains("access_token=accessValueABCDEF1234567890abcdef"));
+    assert!(response_content.contains("secretValueABCDEF1234567890abcdef"));
+    assert!(!response_content.contains("<AETHER:"));
+}
+
+#[tokio::test]
+async fn ai_execute_pii_redaction_disabled_module_passes_original_chat_through() {
+    let (response_json, seen) = run_sync_redaction_case(
+        "ai-execute-pii-redaction-disabled-module",
+        false,
+        true,
+        "pass_through",
+        rich_pii_request(),
+    )
+    .await;
+
+    let provider_body_text = serde_json::to_string(&seen.body).expect("body should serialize");
+    assert!(provider_body_text.contains("alice@example.com"));
+    assert!(provider_body_text.contains("bob@example.net"));
+    assert!(provider_body_text.contains("access_token=accessValueABCDEF1234567890abcdef"));
+    assert!(provider_body_text.contains("secretValueABCDEF1234567890abcdef"));
+    assert!(!provider_body_text.contains("<AETHER:"));
+    assert_eq!(
+        response_json["choices"][0]["message"]["content"],
+        "pass alice@example.com"
+    );
+}
+
+#[tokio::test]
+async fn ai_execute_pii_redaction_disabled_provider_passes_original_chat_through() {
+    let (response_json, seen) = run_sync_redaction_case(
+        "ai-execute-pii-redaction-disabled-provider",
+        true,
+        false,
+        "pass_through",
+        rich_pii_request(),
+    )
+    .await;
+
+    let provider_body_text = serde_json::to_string(&seen.body).expect("body should serialize");
+    assert!(provider_body_text.contains("alice@example.com"));
+    assert!(provider_body_text.contains("bob@example.net"));
+    assert!(provider_body_text.contains("access_token=accessValueABCDEF1234567890abcdef"));
+    assert!(provider_body_text.contains("secretValueABCDEF1234567890abcdef"));
+    assert!(!provider_body_text.contains("<AETHER:"));
+    assert_eq!(
+        response_json["choices"][0]["message"]["content"],
+        "pass alice@example.com"
+    );
+}
+
+#[tokio::test]
+async fn ai_execute_pii_redaction_empty_entities_passes_original_chat_through() {
+    let (response_json, seen) = run_sync_redaction_case_with_system_config(
+        "ai-execute-pii-redaction-empty-entities",
+        true,
+        "pass_through",
+        rich_pii_request(),
+        redaction_config_with_entities(true, json!([])),
+    )
+    .await;
+
+    let provider_body_text = serde_json::to_string(&seen.body).expect("body should serialize");
+    assert!(provider_body_text.contains("alice@example.com"));
+    assert!(provider_body_text.contains("bob@example.net"));
+    assert!(provider_body_text.contains("access_token=accessValueABCDEF1234567890abcdef"));
+    assert!(provider_body_text.contains("secretValueABCDEF1234567890abcdef"));
+    assert!(!provider_body_text.contains("<AETHER:"));
+    assert_eq!(
+        response_json["choices"][0]["message"]["content"],
+        "pass alice@example.com"
+    );
+}
+
+#[tokio::test]
+async fn ai_execute_pii_redaction_unknown_sentinel_like_output_is_not_restored() {
+    let (response_json, seen) = run_sync_redaction_case(
+        "ai-execute-pii-redaction-unknown-sentinel",
+        true,
+        true,
+        "unknown",
+        rich_pii_request(),
+    )
+    .await;
+
+    let provider_body_text = serde_json::to_string(&seen.body).expect("body should serialize");
+    assert!(!provider_body_text.contains("alice@example.com"));
+    assert!(provider_body_text.contains("<AETHER:EMAIL:"));
+    assert_eq!(
+        response_json["choices"][0]["message"]["content"],
+        "unknown <AETHER:EMAIL:TSRQPONMLKJIHGFEDCBA>"
+    );
+}
+
+#[tokio::test]
+async fn ai_execute_pii_redaction_restores_executed_candidate_session_after_later_candidate_planning(
+) {
+    let seen_provider_request = Arc::new(Mutex::new(None::<SeenProviderRequest>));
+    let seen_provider_request_clone = Arc::clone(&seen_provider_request);
+    let provider_app = Router::new().route(
+        "/v1/chat/completions",
+        any(move |request: Request| {
+            let seen_provider_request_inner = Arc::clone(&seen_provider_request_clone);
+            async move {
+                let (parts, body) = request.into_parts();
+                let raw_body = to_bytes(body, usize::MAX).await.expect("body should read");
+                let payload: serde_json::Value =
+                    serde_json::from_slice(&raw_body).expect("provider payload should parse");
+                let payload_text = serde_json::to_string(&payload).expect("payload should serialize");
+                let email_sentinel = collect_sentinels(&payload_text, "EMAIL")
+                    .into_iter()
+                    .next()
+                    .expect("email sentinel should exist");
+                *seen_provider_request_inner.lock().expect("mutex should lock") = Some(
+                    SeenProviderRequest {
+                        body: payload,
+                        authorization: parts
+                            .headers
+                            .get(http::header::AUTHORIZATION)
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or_default()
+                            .to_string(),
+                        accept_encoding: parts
+                            .headers
+                            .get(http::header::ACCEPT_ENCODING)
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or_default()
+                            .to_string(),
+                    },
+                );
+
+                Json(json!({
+                    "id": "chatcmpl-redaction-candidate-session",
+                    "object": "chat.completion",
+                    "model": "gpt-5-upstream",
+                    "choices": [{
+                        "index": 0,
+                        "message": {"role": "assistant", "content": format!("restored {email_sentinel}")},
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5}
+                }))
+            }
+        }),
+    );
+    let (provider_url, provider_handle) = start_server(provider_app).await;
+    let auth_repository = Arc::new(InMemoryAuthApiKeySnapshotRepository::seed(vec![(
+        Some(hash_api_key("sk-client-redaction-candidate-session")),
+        auth_snapshot(
+            "api-key-redaction-candidate-session",
+            "user-redaction-candidate-session",
+        ),
+    )]));
+    let mut later_candidate = candidate_row("redaction-candidate-session");
+    later_candidate.provider_id = "provider-redaction-candidate-session-later".to_string();
+    later_candidate.endpoint_id = "endpoint-redaction-candidate-session-later".to_string();
+    later_candidate.key_id = "key-redaction-candidate-session-later".to_string();
+    later_candidate.provider_priority = 20;
+    later_candidate.key_internal_priority = 6;
+    later_candidate.model_id = "model-redaction-candidate-session-later".to_string();
+    later_candidate.global_model_id = "global-model-redaction-candidate-session-later".to_string();
+    let candidate_selection_repository =
+        Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed(vec![
+            candidate_row("redaction-candidate-session"),
+            later_candidate,
+        ]));
+    let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
+    let mut later_provider = provider("redaction-candidate-session", false);
+    later_provider.id = "provider-redaction-candidate-session-later".to_string();
+    let mut later_endpoint = endpoint(
+        "redaction-candidate-session",
+        "http://127.0.0.1:9".to_string(),
+    );
+    later_endpoint.id = "endpoint-redaction-candidate-session-later".to_string();
+    later_endpoint.provider_id = "provider-redaction-candidate-session-later".to_string();
+    let mut later_key = key("redaction-candidate-session");
+    later_key.id = "key-redaction-candidate-session-later".to_string();
+    later_key.provider_id = "provider-redaction-candidate-session-later".to_string();
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![
+            provider("redaction-candidate-session", true),
+            later_provider,
+        ],
+        vec![
+            endpoint("redaction-candidate-session", provider_url),
+            later_endpoint,
+        ],
+        vec![key("redaction-candidate-session"), later_key],
+    ));
+    let data_state = crate::data::GatewayDataState::with_auth_candidate_selection_provider_catalog_and_request_candidate_repository_for_tests(
+        auth_repository,
+        candidate_selection_repository,
+        provider_catalog_repository,
+        Arc::clone(&request_candidate_repository),
+        DEVELOPMENT_ENCRYPTION_KEY,
+    )
+    .with_system_config_values_for_tests(redaction_config(true));
+    let gateway_state = AppState::new()
+        .expect("gateway state should build")
+        .with_data_state_for_tests(data_state);
+    let gateway = build_router_with_state(gateway_state);
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/chat/completions"))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(
+            http::header::AUTHORIZATION,
+            "Bearer sk-client-redaction-candidate-session",
+        )
+        .header(TRACE_ID_HEADER, "trace-redaction-candidate-session")
+        .body(
+            json!({
+                "model": "gpt-5",
+                "messages": [{"role": "user", "content": "Contact alice@example.com"}]
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .expect("request should succeed");
+
+    let status = response.status();
+    let response_text = response.text().await.expect("body should read");
+    assert_eq!(status, StatusCode::OK, "{response_text}");
+    let response_json: serde_json::Value =
+        serde_json::from_str(&response_text).expect("response body should parse");
+    assert_eq!(
+        response_json["choices"][0]["message"]["content"],
+        "restored alice@example.com"
+    );
+    let seen = seen_provider_request
+        .lock()
+        .expect("mutex should lock")
+        .clone()
+        .expect("provider request should be captured");
+    let provider_body_text = serde_json::to_string(&seen.body).expect("body should serialize");
+    assert!(!provider_body_text.contains("alice@example.com"));
+    assert!(provider_body_text.contains("<AETHER:EMAIL:"));
+
+    gateway_handle.abort();
+    provider_handle.abort();
+}
+
+#[tokio::test]
+async fn pii_redaction_performance_limits_do_not_forward_unredacted_body_upstream() {
+    let provider_hits = Arc::new(AtomicUsize::new(0));
+    let provider_hits_clone = Arc::clone(&provider_hits);
+    let provider_app = Router::new().route(
+        "/v1/chat/completions",
+        any(move |_request: Request| {
+            let provider_hits_inner = Arc::clone(&provider_hits_clone);
+            async move {
+                provider_hits_inner.fetch_add(1, Ordering::SeqCst);
+                Json(json!({
+                    "id": "unexpected",
+                    "choices": [{"message": {"role": "assistant", "content": "unexpected"}}]
+                }))
+            }
+        }),
+    );
+    let (provider_url, provider_handle) = start_server(provider_app).await;
+    let auth_repository = Arc::new(InMemoryAuthApiKeySnapshotRepository::seed(vec![(
+        Some(hash_api_key("sk-client-pii-redaction-limit")),
+        auth_snapshot("api-key-pii-redaction-limit", "user-pii-redaction-limit"),
+    )]));
+    let candidate_selection_repository =
+        Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed(vec![
+            candidate_row("pii-redaction-limit"),
+        ]));
+    let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider("pii-redaction-limit", true)],
+        vec![endpoint("pii-redaction-limit", provider_url)],
+        vec![key("pii-redaction-limit")],
+    ));
+    let data_state = crate::data::GatewayDataState::with_auth_candidate_selection_provider_catalog_and_request_candidate_repository_for_tests(
+        auth_repository,
+        candidate_selection_repository,
+        provider_catalog_repository,
+        Arc::clone(&request_candidate_repository),
+        DEVELOPMENT_ENCRYPTION_KEY,
+    )
+    .with_system_config_values_for_tests(redaction_config(true));
+    let gateway_state = AppState::new()
+        .expect("gateway state should build")
+        .with_data_state_for_tests(data_state);
+    let gateway = build_router_with_state(gateway_state);
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+    let original = format!("alice@example.com {}", "x".repeat(2 * 1024 * 1024));
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/chat/completions"))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(
+            http::header::AUTHORIZATION,
+            "Bearer sk-client-pii-redaction-limit",
+        )
+        .header(TRACE_ID_HEADER, "trace-pii-redaction-limit")
+        .body(
+            json!({
+                "model": "gpt-5",
+                "messages": [{"role": "user", "content": original}]
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .expect("request should complete");
+
+    let status = response.status();
+    let response_text = response.text().await.expect("body should read");
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{response_text}");
+    assert!(response_text.contains("scanned text limit exceeded"));
+    assert!(!response_text.contains("alice@example.com"));
+    assert_eq!(provider_hits.load(Ordering::SeqCst), 0);
+
+    gateway_handle.abort();
+    provider_handle.abort();
+}
+
+#[tokio::test]
+async fn ai_execute_pii_redaction_missing_encryption_key_fails_closed_before_provider() {
+    let execution_runtime_hits = Arc::new(AtomicUsize::new(0));
+    let execution_runtime_hits_clone = Arc::clone(&execution_runtime_hits);
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |_request: Request| {
+            let execution_runtime_hits_inner = Arc::clone(&execution_runtime_hits_clone);
+            async move {
+                execution_runtime_hits_inner.fetch_add(1, Ordering::SeqCst);
+                Json(json!({"ok": true}))
+            }
+        }),
+    );
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let test_id = "ai-execute-pii-redaction-missing-encryption-key";
+    let auth_repository = Arc::new(InMemoryAuthApiKeySnapshotRepository::seed(vec![(
+        Some(hash_api_key(&format!("sk-client-{test_id}"))),
+        auth_snapshot(&format!("api-key-{test_id}"), &format!("user-{test_id}")),
+    )]));
+    let candidate_selection_repository =
+        Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed(vec![
+            candidate_row(test_id),
+        ]));
+    let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider(test_id, true)],
+        vec![endpoint(test_id, "https://example.com".to_string())],
+        vec![key(test_id)],
+    ));
+    let gateway_state = build_state_with_execution_runtime_override(execution_runtime_url.clone())
+        .with_data_state_for_tests(
+            crate::data::GatewayDataState::with_auth_candidate_selection_provider_catalog_and_request_candidate_repository_for_tests(
+                auth_repository,
+                candidate_selection_repository,
+                provider_catalog_repository,
+                Arc::clone(&request_candidate_repository),
+                "",
+            )
+            .with_system_config_values_for_tests(redaction_config(true)),
+        );
+    let gateway = build_router_with_state(gateway_state);
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/chat/completions"))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer sk-client-{test_id}"),
+        )
+        .header(TRACE_ID_HEADER, format!("trace-{test_id}"))
+        .body(rich_pii_request().to_string())
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let response_text = response.text().await.expect("body should read");
+    for original in [
+        "alice@example.com",
+        "bob@example.net",
+        "accessValueABCDEF1234567890abcdef",
+        "secretValueABCDEF1234567890abcdef",
+    ] {
+        assert!(!response_text.contains(original));
+    }
+    assert!(!response_text.contains("<AETHER:"));
+    assert_eq!(execution_runtime_hits.load(Ordering::SeqCst), 0);
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
+}

--- a/apps/aether-gateway/src/tests/control/admin/health_access.rs
+++ b/apps/aether-gateway/src/tests/control/admin/health_access.rs
@@ -781,6 +781,19 @@ async fn gateway_handles_admin_modules_status_locally_with_trusted_admin_princip
     assert_eq!(payload["oauth"]["active"], json!(true));
     assert_eq!(payload["oauth"]["config_validated"], json!(true));
     assert_eq!(payload["management_tokens"]["active"], json!(true));
+    assert_eq!(payload["chat_pii_redaction"]["enabled"], json!(false));
+    assert_eq!(
+        payload["chat_pii_redaction"]["display_name"],
+        "敏感信息替换保护"
+    );
+    assert_eq!(
+        payload["chat_pii_redaction"]["config_validated"],
+        json!(true)
+    );
+    assert_eq!(
+        payload["chat_pii_redaction"]["admin_route"],
+        "/admin/modules/chat-pii-redaction"
+    );
     assert_eq!(
         payload["notification_email"]["config_validated"],
         json!(true)
@@ -901,6 +914,63 @@ async fn gateway_handles_admin_module_status_detail_locally_with_trusted_admin_p
     assert_eq!(payload["active"], json!(true));
     assert_eq!(payload["config_validated"], json!(true));
     assert_eq!(payload["admin_route"], "/admin/oauth");
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_handles_chat_pii_redaction_module_status_detail_locally_with_trusted_admin_principal(
+) {
+    let upstream_hits = Arc::new(Mutex::new(0usize));
+    let upstream_hits_clone = Arc::clone(&upstream_hits);
+    let upstream = Router::new().route(
+        "/api/admin/modules/status/chat_pii_redaction",
+        any(move |_request: Request| {
+            let upstream_hits_inner = Arc::clone(&upstream_hits_clone);
+            async move {
+                *upstream_hits_inner.lock().expect("mutex should lock") += 1;
+                (StatusCode::OK, Body::from("unexpected upstream hit"))
+            }
+        }),
+    );
+
+    let auth_module_repository = Arc::new(InMemoryAuthModuleReadRepository::default());
+    let data_state = GatewayDataState::with_auth_module_reader_for_tests(auth_module_repository)
+        .with_system_config_values_for_tests(vec![(
+            "module.chat_pii_redaction.enabled".to_string(),
+            json!(true),
+        )]);
+
+    let (upstream_url, upstream_handle) = start_server(upstream).await;
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(data_state),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .get(format!(
+            "{gateway_url}/api/admin/modules/status/chat_pii_redaction"
+        ))
+        .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["name"], "chat_pii_redaction");
+    assert_eq!(payload["display_name"], "敏感信息替换保护");
+    assert_eq!(payload["enabled"], json!(true));
+    assert_eq!(payload["active"], json!(true));
+    assert_eq!(payload["config_validated"], json!(true));
+    assert_eq!(payload["admin_route"], "/admin/modules/chat-pii-redaction");
     assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
 
     gateway_handle.abort();

--- a/apps/aether-gateway/src/tests/control/admin/providers.rs
+++ b/apps/aether-gateway/src/tests/control/admin/providers.rs
@@ -131,7 +131,7 @@ async fn gateway_handles_admin_providers_locally_with_trusted_admin_principal() 
             .expect("gateway should build")
             .with_data_state_for_tests(
                 GatewayDataState::with_provider_catalog_repository_for_tests(
-                    provider_catalog_repository,
+                    provider_catalog_repository.clone(),
                 ),
             ),
     );
@@ -240,6 +240,7 @@ async fn gateway_handles_admin_provider_summary_locally_with_trusted_admin_princ
                 "claude_code_advanced": {"pool_size": 3},
                 "pool_advanced": {"enabled": true},
                 "failover_rules": {"strategy": "ordered"},
+                "chat_pii_redaction": {"enabled": true},
                 "provider_ops": {"architecture_id": "anyrouter"}
             })),
         );
@@ -351,6 +352,7 @@ async fn gateway_handles_admin_provider_summary_locally_with_trusted_admin_princ
     );
     assert_eq!(payload["ops_configured"], true);
     assert_eq!(payload["ops_architecture_id"], "anyrouter");
+    assert_eq!(payload["chat_pii_redaction"], json!({"enabled": true}));
     assert_eq!(payload["created_at"], "2024-03-21T05:46:40Z");
     assert_eq!(payload["updated_at"], "2024-03-21T05:48:20Z");
     assert_eq!(
@@ -774,6 +776,20 @@ async fn gateway_updates_admin_provider_locally_with_trusted_admin_principal() {
     let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
         vec![
             sample_provider("provider-openai", "openai", 10)
+                .with_transport_fields(
+                    true,
+                    false,
+                    false,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(json!({
+                        "pool_advanced": {},
+                        "failover_rules": {"strategy": "ordered"}
+                    })),
+                )
                 .with_timestamps(Some(1_711_000_000), Some(1_711_000_100)),
             sample_provider("provider-other", "other", 20),
         ],
@@ -792,7 +808,7 @@ async fn gateway_updates_admin_provider_locally_with_trusted_admin_principal() {
             .expect("gateway should build")
             .with_data_state_for_tests(
                 GatewayDataState::with_provider_catalog_repository_for_tests(
-                    provider_catalog_repository,
+                    provider_catalog_repository.clone(),
                 ),
             ),
     );
@@ -817,10 +833,11 @@ async fn gateway_updates_admin_provider_locally_with_trusted_admin_principal() {
             "request_timeout": 55.0,
             "stream_first_byte_timeout": 11.0,
             "enable_format_conversion": false,
-            "config": {"provider_ops": {"architecture_id": "cubence"}},
+            "config": {
+                "provider_ops": {"architecture_id": "cubence"},
+                "chat_pii_redaction": {"enabled": true}
+            },
             "claude_code_advanced": {"pool_size": 2},
-            "pool_advanced": {},
-            "failover_rules": {"strategy": "ordered"},
             "proxy": {"url": "https://proxy.example"}
         }))
         .send()
@@ -847,8 +864,88 @@ async fn gateway_updates_admin_provider_locally_with_trusted_admin_principal() {
     assert_eq!(payload["claude_code_advanced"], json!({"pool_size": 2}));
     assert_eq!(payload["pool_advanced"], json!({}));
     assert_eq!(payload["failover_rules"], json!({"strategy": "ordered"}));
+    assert_eq!(payload["chat_pii_redaction"], json!({"enabled": true}));
     assert_eq!(payload["ops_configured"], true);
     assert_eq!(payload["ops_architecture_id"], "cubence");
+
+    let disable_response = reqwest::Client::new()
+        .patch(format!("{gateway_url}/api/admin/providers/provider-openai"))
+        .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "config": {
+                "chat_pii_redaction": {"enabled": false}
+            }
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+    let disable_status = disable_response.status();
+    let disable_body = disable_response.text().await.expect("body should read");
+    assert_eq!(disable_status, StatusCode::OK, "body={disable_body}");
+    let disable_payload: serde_json::Value =
+        serde_json::from_str(&disable_body).expect("json body should parse");
+    assert_eq!(
+        disable_payload["chat_pii_redaction"],
+        json!({"enabled": false})
+    );
+    assert_eq!(disable_payload["pool_advanced"], json!({}));
+    assert_eq!(
+        disable_payload["failover_rules"],
+        json!({"strategy": "ordered"})
+    );
+    assert_eq!(disable_payload["ops_architecture_id"], "cubence");
+
+    let invalid_response = reqwest::Client::new()
+        .patch(format!("{gateway_url}/api/admin/providers/provider-openai"))
+        .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "config": {
+                "chat_pii_redaction": {"enabled": true, "entities": ["email"]}
+            }
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+    assert_eq!(invalid_response.status(), StatusCode::BAD_REQUEST);
+
+    let providers = provider_catalog_repository
+        .list_providers(false)
+        .await
+        .expect("providers should list");
+    let updated_provider = providers
+        .iter()
+        .find(|provider| provider.id == "provider-openai")
+        .expect("provider should exist");
+    assert_eq!(
+        updated_provider
+            .config
+            .as_ref()
+            .and_then(|value| value.get("chat_pii_redaction"))
+            .cloned(),
+        Some(json!({"enabled": false}))
+    );
+    assert_eq!(
+        updated_provider
+            .config
+            .as_ref()
+            .and_then(|value| value.get("pool_advanced"))
+            .cloned(),
+        Some(json!({}))
+    );
+    assert_eq!(
+        updated_provider
+            .config
+            .as_ref()
+            .and_then(|value| value.get("failover_rules"))
+            .cloned(),
+        Some(json!({"strategy": "ordered"}))
+    );
     assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
 
     gateway_handle.abort();
@@ -901,6 +998,7 @@ async fn gateway_creates_admin_provider_locally_with_trusted_admin_principal() {
             "website": "codex.example",
             "keep_priority_on_conversion": true,
             "max_retries": 7,
+            "config": {"chat_pii_redaction": {"enabled": true}},
             "pool_advanced": {},
             "failover_rules": {"strategy": "ordered"},
             "proxy": {"url": "https://proxy.example"}
@@ -943,6 +1041,38 @@ async fn gateway_creates_admin_provider_locally_with_trusted_admin_principal() {
             .cloned(),
         Some(json!({}))
     );
+    assert_eq!(
+        created
+            .config
+            .as_ref()
+            .and_then(|value| value.get("chat_pii_redaction"))
+            .cloned(),
+        Some(json!({"enabled": true}))
+    );
+    assert_eq!(
+        created
+            .config
+            .as_ref()
+            .and_then(|value| value.get("failover_rules"))
+            .cloned(),
+        Some(json!({"strategy": "ordered"}))
+    );
+
+    let invalid_response = reqwest::Client::new()
+        .post(format!("{gateway_url}/api/admin/providers/"))
+        .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "name": "invalid-redaction-provider",
+            "provider_type": "custom",
+            "config": {"chat_pii_redaction": {"enabled": true, "entities": ["email"]}}
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+    assert_eq!(invalid_response.status(), StatusCode::BAD_REQUEST);
 
     let endpoints = provider_catalog_repository
         .list_endpoints_by_provider_ids(std::slice::from_ref(&created.id))

--- a/apps/aether-gateway/src/tests/control/admin/system.rs
+++ b/apps/aether-gateway/src/tests/control/admin/system.rs
@@ -1256,6 +1256,260 @@ async fn gateway_handles_admin_system_model_directives_default_as_disabled() {
 }
 
 #[tokio::test]
+async fn gateway_validates_chat_pii_redaction_system_config_locally_with_trusted_admin_principal() {
+    let upstream_hits = Arc::new(Mutex::new(0usize));
+    let upstream_hits_clone = Arc::clone(&upstream_hits);
+    let upstream = Router::new().route(
+        "/api/admin/system/configs/module.chat_pii_redaction.cache_ttl_seconds",
+        any(move |_request: Request| {
+            let upstream_hits_inner = Arc::clone(&upstream_hits_clone);
+            async move {
+                *upstream_hits_inner.lock().expect("mutex should lock") += 1;
+                (StatusCode::OK, Body::from("unexpected upstream hit"))
+            }
+        }),
+    );
+
+    let data_state =
+        GatewayDataState::disabled()
+            .with_system_config_values_for_tests(Vec::<(String, serde_json::Value)>::new());
+    let (upstream_url, upstream_handle) = start_server(upstream).await;
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(data_state),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+    let client = reqwest::Client::new();
+
+    let get_config = |key: &'static str| {
+        let client = client.clone();
+        let gateway_url = gateway_url.clone();
+        async move {
+            let response = client
+                .get(format!("{gateway_url}/api/admin/system/configs/{key}"))
+                .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
+                .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+                .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+                .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+                .send()
+                .await
+                .expect("request should succeed");
+            assert_eq!(response.status(), StatusCode::OK, "key={key}");
+            response
+                .json::<serde_json::Value>()
+                .await
+                .expect("json body should parse")
+        }
+    };
+    let put_config = |key: &'static str, value: serde_json::Value| {
+        let client = client.clone();
+        let gateway_url = gateway_url.clone();
+        async move {
+            client
+                .put(format!("{gateway_url}/api/admin/system/configs/{key}"))
+                .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
+                .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+                .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+                .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+                .json(&json!({ "value": value }))
+                .send()
+                .await
+                .expect("request should succeed")
+        }
+    };
+
+    assert_eq!(
+        get_config("module.chat_pii_redaction.enabled").await["value"],
+        json!(false)
+    );
+    assert_eq!(
+        get_config("module.chat_pii_redaction.provider_scope").await["value"],
+        json!("selected_providers")
+    );
+    assert_eq!(
+        get_config("module.chat_pii_redaction.inject_model_instruction").await["value"],
+        json!(true)
+    );
+    assert_eq!(
+        get_config("module.chat_pii_redaction.cache_ttl_seconds").await["value"],
+        json!(300)
+    );
+    assert_eq!(
+        get_config("module.chat_pii_redaction.entities").await["value"],
+        json!([
+            "email",
+            "cn_phone",
+            "global_phone",
+            "cn_id",
+            "payment_card",
+            "ipv4",
+            "ipv6",
+            "api_key",
+            "access_token",
+            "secret_key",
+            "bearer_token",
+            "jwt"
+        ])
+    );
+
+    let enabled_response = put_config("module.chat_pii_redaction.enabled", json!(true)).await;
+    assert_eq!(enabled_response.status(), StatusCode::OK);
+    let enabled_payload: serde_json::Value = enabled_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(enabled_payload["value"], json!(true));
+
+    let scope_response = put_config(
+        "module.chat_pii_redaction.provider_scope",
+        json!("all_providers"),
+    )
+    .await;
+    assert_eq!(scope_response.status(), StatusCode::OK);
+    let scope_payload: serde_json::Value =
+        scope_response.json().await.expect("json body should parse");
+    assert_eq!(scope_payload["value"], json!("all_providers"));
+
+    let selected_entities_response = put_config(
+        "module.chat_pii_redaction.entities",
+        json!(["email", "jwt", "cn_phone"]),
+    )
+    .await;
+    assert_eq!(selected_entities_response.status(), StatusCode::OK);
+    let selected_entities_payload: serde_json::Value = selected_entities_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(
+        selected_entities_payload["value"],
+        json!(["email", "cn_phone", "jwt"])
+    );
+
+    let ttl_response = put_config("module.chat_pii_redaction.cache_ttl_seconds", json!(3600)).await;
+    assert_eq!(ttl_response.status(), StatusCode::OK);
+    let ttl_payload: serde_json::Value = ttl_response.json().await.expect("json body should parse");
+    assert_eq!(ttl_payload["value"], json!(3600));
+
+    let instruction_response = put_config(
+        "module.chat_pii_redaction.inject_model_instruction",
+        json!(false),
+    )
+    .await;
+    assert_eq!(instruction_response.status(), StatusCode::OK);
+    let instruction_payload: serde_json::Value = instruction_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(instruction_payload["value"], json!(false));
+
+    let invalid_scope_response = put_config(
+        "module.chat_pii_redaction.provider_scope",
+        json!("enabled_providers"),
+    )
+    .await;
+    assert_eq!(invalid_scope_response.status(), StatusCode::BAD_REQUEST);
+
+    let invalid_entities_response = put_config(
+        "module.chat_pii_redaction.entities",
+        json!(["email", "name"]),
+    )
+    .await;
+    assert_eq!(invalid_entities_response.status(), StatusCode::BAD_REQUEST);
+
+    let invalid_ttl_response =
+        put_config("module.chat_pii_redaction.cache_ttl_seconds", json!(600)).await;
+    assert_eq!(invalid_ttl_response.status(), StatusCode::BAD_REQUEST);
+
+    let invalid_instruction_response = put_config(
+        "module.chat_pii_redaction.inject_model_instruction",
+        json!("yes"),
+    )
+    .await;
+    assert_eq!(
+        invalid_instruction_response.status(),
+        StatusCode::BAD_REQUEST
+    );
+
+    let enabled_default_response =
+        put_config("module.chat_pii_redaction.enabled", serde_json::Value::Null).await;
+    assert_eq!(enabled_default_response.status(), StatusCode::OK);
+    let enabled_default_payload: serde_json::Value = enabled_default_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(enabled_default_payload["value"], json!(false));
+
+    let scope_default_response = put_config(
+        "module.chat_pii_redaction.provider_scope",
+        serde_json::Value::Null,
+    )
+    .await;
+    assert_eq!(scope_default_response.status(), StatusCode::OK);
+    let scope_default_payload: serde_json::Value = scope_default_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(scope_default_payload["value"], json!("selected_providers"));
+
+    let entities_default_response = put_config(
+        "module.chat_pii_redaction.entities",
+        serde_json::Value::Null,
+    )
+    .await;
+    assert_eq!(entities_default_response.status(), StatusCode::OK);
+    let entities_default_payload: serde_json::Value = entities_default_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(
+        entities_default_payload["value"],
+        json!([
+            "email",
+            "cn_phone",
+            "global_phone",
+            "cn_id",
+            "payment_card",
+            "ipv4",
+            "ipv6",
+            "api_key",
+            "access_token",
+            "secret_key",
+            "bearer_token",
+            "jwt"
+        ])
+    );
+
+    let ttl_default_response = put_config(
+        "module.chat_pii_redaction.cache_ttl_seconds",
+        serde_json::Value::Null,
+    )
+    .await;
+    assert_eq!(ttl_default_response.status(), StatusCode::OK);
+    let ttl_default_payload: serde_json::Value = ttl_default_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(ttl_default_payload["value"], json!(300));
+
+    let instruction_default_response = put_config(
+        "module.chat_pii_redaction.inject_model_instruction",
+        serde_json::Value::Null,
+    )
+    .await;
+    assert_eq!(instruction_default_response.status(), StatusCode::OK);
+    let instruction_default_payload: serde_json::Value = instruction_default_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(instruction_default_payload["value"], json!(true));
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_handles_admin_system_provider_priority_mode_locally_with_bearer_admin_session() {
     let upstream_hits = Arc::new(Mutex::new(0usize));
     let upstream_hits_clone = Arc::clone(&upstream_hits);

--- a/apps/aether-gateway/src/tests/files/stream.rs
+++ b/apps/aether-gateway/src/tests/files/stream.rs
@@ -127,7 +127,8 @@ async fn gateway_executes_gemini_files_download_via_local_decision_gate_with_loc
                         .unwrap_or_default()
                         .to_string(),
                     tls_profile: payload
-                        .get("tls_profile")
+                        .get("transport_profile")
+                        .and_then(|value| value.get("profile_id"))
                         .and_then(|value| value.as_str())
                         .unwrap_or_default()
                         .to_string(),

--- a/apps/aether-gateway/src/tests/files/sync.rs
+++ b/apps/aether-gateway/src/tests/files/sync.rs
@@ -155,7 +155,8 @@ async fn gateway_executes_gemini_files_upload_via_local_decision_gate_with_local
                         .unwrap_or_default()
                         .to_string(),
                     tls_profile: payload
-                        .get("tls_profile")
+                        .get("transport_profile")
+                        .and_then(|value| value.get("profile_id"))
                         .and_then(|value| value.as_str())
                         .unwrap_or_default()
                         .to_string(),

--- a/apps/aether-gateway/src/tests/video/gemini_sync_create.rs
+++ b/apps/aether-gateway/src/tests/video/gemini_sync_create.rs
@@ -351,7 +351,8 @@ async fn gateway_executes_gemini_video_create_via_local_decision_gate_with_local
                         .unwrap_or_default()
                         .to_string(),
                     tls_profile: payload
-                        .get("tls_profile")
+                        .get("transport_profile")
+                        .and_then(|value| value.get("profile_id"))
                         .and_then(|value| value.as_str())
                         .unwrap_or_default()
                         .to_string(),

--- a/apps/aether-gateway/src/tests/video/openai_sync_create.rs
+++ b/apps/aether-gateway/src/tests/video/openai_sync_create.rs
@@ -363,7 +363,8 @@ async fn gateway_executes_openai_video_create_via_local_decision_gate_with_local
                         .unwrap_or_default()
                         .to_string(),
                     tls_profile: payload
-                        .get("tls_profile")
+                        .get("transport_profile")
+                        .and_then(|value| value.get("profile_id"))
                         .and_then(|value| value.as_str())
                         .unwrap_or_default()
                         .to_string(),

--- a/crates/aether-admin/src/system.rs
+++ b/crates/aether-admin/src/system.rs
@@ -56,6 +56,25 @@ fn default_true() -> bool {
     true
 }
 
+const CHAT_PII_REDACTION_ENTITY_KEYS: &[&str] = &[
+    "email",
+    "cn_phone",
+    "global_phone",
+    "cn_id",
+    "payment_card",
+    "ipv4",
+    "ipv6",
+    "api_key",
+    "access_token",
+    "secret_key",
+    "bearer_token",
+    "jwt",
+];
+
+fn chat_pii_redaction_default_entities() -> serde_json::Value {
+    json!(CHAT_PII_REDACTION_ENTITY_KEYS)
+}
+
 fn invalid_request(detail: impl Into<String>) -> (http::StatusCode, serde_json::Value) {
     (
         http::StatusCode::BAD_REQUEST,
@@ -1332,6 +1351,11 @@ pub fn admin_system_config_default_value(key: &str) -> Option<serde_json::Value>
         "smtp_from_email" => Some(serde_json::Value::Null),
         "smtp_from_name" => Some(json!("Aether")),
         "enable_oauth_token_refresh" => Some(json!(true)),
+        "module.chat_pii_redaction.enabled" => Some(json!(false)),
+        "module.chat_pii_redaction.provider_scope" => Some(json!("selected_providers")),
+        "module.chat_pii_redaction.entities" => Some(chat_pii_redaction_default_entities()),
+        "module.chat_pii_redaction.cache_ttl_seconds" => Some(json!(300)),
+        "module.chat_pii_redaction.inject_model_instruction" => Some(json!(true)),
         _ => None,
     }
 }
@@ -1438,6 +1462,93 @@ pub fn parse_admin_system_config_update(
                 ));
             }
         }
+    }
+
+    match normalized_key.as_str() {
+        "module.chat_pii_redaction.enabled"
+        | "module.chat_pii_redaction.inject_model_instruction" => match value.as_bool() {
+            Some(enabled) => value = json!(enabled),
+            None if value.is_null() => {
+                value = admin_system_config_default_value(&normalized_key).unwrap();
+            }
+            None => {
+                return Err((
+                    http::StatusCode::BAD_REQUEST,
+                    json!({ "detail": "请求数据验证失败" }),
+                ));
+            }
+        },
+        "module.chat_pii_redaction.provider_scope" => match value.as_str().map(str::trim) {
+            Some("all_providers" | "selected_providers") => {
+                value = json!(value.as_str().unwrap().trim());
+            }
+            Some(_) => {
+                return Err((
+                    http::StatusCode::BAD_REQUEST,
+                    json!({ "detail": "请求数据验证失败" }),
+                ));
+            }
+            None if value.is_null() => value = json!("selected_providers"),
+            None => {
+                return Err((
+                    http::StatusCode::BAD_REQUEST,
+                    json!({ "detail": "请求数据验证失败" }),
+                ));
+            }
+        },
+        "module.chat_pii_redaction.entities" => match value.as_array() {
+            Some(raw_entities) => {
+                let requested = raw_entities
+                    .iter()
+                    .map(|entity| entity.as_str().map(str::trim))
+                    .collect::<Option<BTreeSet<_>>>()
+                    .ok_or_else(|| {
+                        (
+                            http::StatusCode::BAD_REQUEST,
+                            json!({ "detail": "请求数据验证失败" }),
+                        )
+                    })?;
+                let allowed = CHAT_PII_REDACTION_ENTITY_KEYS
+                    .iter()
+                    .copied()
+                    .collect::<BTreeSet<_>>();
+                if !requested.is_subset(&allowed) {
+                    return Err((
+                        http::StatusCode::BAD_REQUEST,
+                        json!({ "detail": "请求数据验证失败" }),
+                    ));
+                }
+                value = json!(CHAT_PII_REDACTION_ENTITY_KEYS
+                    .iter()
+                    .copied()
+                    .filter(|entity| requested.contains(entity))
+                    .collect::<Vec<_>>());
+            }
+            None if value.is_null() => value = chat_pii_redaction_default_entities(),
+            None => {
+                return Err((
+                    http::StatusCode::BAD_REQUEST,
+                    json!({ "detail": "请求数据验证失败" }),
+                ));
+            }
+        },
+        "module.chat_pii_redaction.cache_ttl_seconds" => match value.as_u64() {
+            Some(300 | 3600) => value = json!(value.as_u64().unwrap()),
+            Some(_) => {
+                return Err((
+                    http::StatusCode::BAD_REQUEST,
+                    json!({ "detail": "请求数据验证失败" }),
+                ));
+            }
+            None if value.is_null() => value = json!(300),
+            None => {
+                return Err((
+                    http::StatusCode::BAD_REQUEST,
+                    json!({ "detail": "请求数据验证失败" }),
+                ));
+            }
+        },
+        _ => {}
     }
 
     Ok(AdminSystemConfigUpdate {

--- a/crates/aether-data/migrations/postgres/20260403000000_baseline.sql
+++ b/crates/aether-data/migrations/postgres/20260403000000_baseline.sql
@@ -1189,6 +1189,7 @@ CREATE TABLE IF NOT EXISTS public.user_sessions (
 
 CREATE TABLE IF NOT EXISTS public.users (
     id character varying(36) NOT NULL,
+    external_id character varying(255),
     email character varying(255),
     username character varying(100) NOT NULL,
     password_hash character varying(255),
@@ -1206,7 +1207,8 @@ CREATE TABLE IF NOT EXISTS public.users (
     ldap_dn character varying(512),
     ldap_username character varying(255),
     email_verified boolean NOT NULL,
-    rate_limit integer
+    rate_limit integer,
+    metadata json
 );
 
 

--- a/crates/aether-data/schema/bootstrap/postgres/001_types_and_tables.sql
+++ b/crates/aether-data/schema/bootstrap/postgres/001_types_and_tables.sql
@@ -1192,6 +1192,7 @@ CREATE TABLE IF NOT EXISTS public.user_sessions (
 
 CREATE TABLE IF NOT EXISTS public.users (
     id character varying(36) NOT NULL,
+    external_id character varying(255),
     email character varying(255),
     username character varying(100) NOT NULL,
     password_hash character varying(255),
@@ -1209,7 +1210,8 @@ CREATE TABLE IF NOT EXISTS public.users (
     ldap_dn character varying(512),
     ldap_username character varying(255),
     email_verified boolean NOT NULL,
-    rate_limit integer
+    rate_limit integer,
+    metadata json
 );
 
 

--- a/crates/aether-data/schema/drivers/postgres/baseline/001_types_and_tables.sql
+++ b/crates/aether-data/schema/drivers/postgres/baseline/001_types_and_tables.sql
@@ -1189,6 +1189,7 @@ CREATE TABLE IF NOT EXISTS public.user_sessions (
 
 CREATE TABLE IF NOT EXISTS public.users (
     id character varying(36) NOT NULL,
+    external_id character varying(255),
     email character varying(255),
     username character varying(100) NOT NULL,
     password_hash character varying(255),
@@ -1206,7 +1207,8 @@ CREATE TABLE IF NOT EXISTS public.users (
     ldap_dn character varying(512),
     ldap_username character varying(255),
     email_verified boolean NOT NULL,
-    rate_limit integer
+    rate_limit integer,
+    metadata json
 );
 
 

--- a/crates/aether-data/src/lifecycle/export.rs
+++ b/crates/aether-data/src/lifecycle/export.rs
@@ -1387,7 +1387,10 @@ fn domain_payload_table(
 fn sqlite_row_payload(row: &sqlx::sqlite::SqliteRow) -> Result<Value, DataLayerError> {
     let mut object = serde_json::Map::new();
     for (index, column) in row.columns().iter().enumerate() {
-        object.insert(column.name().to_string(), sqlite_value_to_json(row, index)?);
+        object.insert(
+            column.name().to_string(),
+            sqlite_value_to_json(row, index, column.name())?,
+        );
     }
     Ok(Value::Object(object))
 }
@@ -1395,6 +1398,7 @@ fn sqlite_row_payload(row: &sqlx::sqlite::SqliteRow) -> Result<Value, DataLayerE
 fn sqlite_value_to_json(
     row: &sqlx::sqlite::SqliteRow,
     index: usize,
+    column_name: &str,
 ) -> Result<Value, DataLayerError> {
     let raw = row.try_get_raw(index).map_sql_err()?;
     if raw.is_null() {
@@ -1402,7 +1406,17 @@ fn sqlite_value_to_json(
     }
 
     match raw.type_info().name().to_ascii_uppercase().as_str() {
-        "INTEGER" => Ok(Value::from(row.try_get::<i64, _>(index).map_sql_err()?)),
+        "INTEGER" => {
+            let value = row.try_get::<i64, _>(index).map_sql_err()?;
+            if sqlite_integer_column_is_boolean(column_name) {
+                match value {
+                    0 => return Ok(Value::Bool(false)),
+                    1 => return Ok(Value::Bool(true)),
+                    _ => {}
+                }
+            }
+            Ok(Value::from(value))
+        }
         "REAL" | "FLOAT" | "DOUBLE" => {
             let value = row.try_get::<f64, _>(index).map_sql_err()?;
             serde_json::Number::from_f64(value)
@@ -1425,6 +1439,29 @@ fn sqlite_value_to_json(
             "unsupported sqlite export column type '{other}' at index {index}"
         ))),
     }
+}
+
+fn sqlite_integer_column_is_boolean(column_name: &str) -> bool {
+    column_name.starts_with("is_")
+        || column_name.starts_with("has_")
+        || column_name.starts_with("supports_")
+        || column_name.starts_with("enable_")
+        || column_name.starts_with("use_")
+        || matches!(
+            column_name,
+            "announcement_notifications"
+                | "auto_delete_on_expiry"
+                | "auto_fetch_models"
+                | "email_notifications"
+                | "email_verified"
+                | "format_converted"
+                | "keep_priority_on_conversion"
+                | "signature_valid"
+                | "tunnel_connected"
+                | "tunnel_mode"
+                | "usage_alerts"
+                | "webhook_sent"
+        )
 }
 
 fn mysql_row_payload(row: &sqlx::mysql::MySqlRow) -> Result<Value, DataLayerError> {
@@ -1610,27 +1647,27 @@ not-json"#,
         sqlx::query(
             r#"
 INSERT INTO users (id, email, username, auth_source, created_at, updated_at)
-VALUES ('user-1', 'owner@example.com', 'owner', 'local', 1, 2);
+VALUES ('user-1', 'owner@example.com', 'owner', 'local', '1970-01-01T00:00:01Z', '1970-01-01T00:00:02Z');
 INSERT INTO api_keys (id, user_id, key_hash, key_encrypted, name, created_at, updated_at)
-VALUES ('api-key-1', 'user-1', 'hash-1', 'ciphertext-1', 'Default', 1, 2);
+VALUES ('api-key-1', 'user-1', 'hash-1', 'ciphertext-1', 'Default', '1970-01-01T00:00:01Z', '1970-01-01T00:00:02Z');
 INSERT INTO providers (id, name, provider_type, created_at, updated_at)
-VALUES ('provider-1', 'Provider One', 'openai', 1, 2);
+VALUES ('provider-1', 'Provider One', 'openai', '1970-01-01T00:00:01Z', '1970-01-01T00:00:02Z');
 INSERT INTO provider_api_keys (id, provider_id, name, encrypted_key, created_at, updated_at)
-VALUES ('provider-key-1', 'provider-1', 'Provider Key', 'ciphertext-provider', 1, 2);
+VALUES ('provider-key-1', 'provider-1', 'Provider Key', 'ciphertext-provider', '1970-01-01T00:00:01Z', '1970-01-01T00:00:02Z');
 INSERT INTO provider_endpoints (id, provider_id, name, base_url, created_at, updated_at)
-VALUES ('endpoint-1', 'provider-1', 'Primary', 'https://example.test', 1, 2);
+VALUES ('endpoint-1', 'provider-1', 'Primary', 'https://example.test', '1970-01-01T00:00:01Z', '1970-01-01T00:00:02Z');
 INSERT INTO global_models (id, name, created_at, updated_at)
-VALUES ('global-model-1', 'gpt-test', 1, 2);
+VALUES ('global-model-1', 'gpt-test', '1970-01-01T00:00:01Z', '1970-01-01T00:00:02Z');
 INSERT INTO models (id, provider_id, global_model_id, provider_model_name, created_at, updated_at)
-VALUES ('model-1', 'provider-1', 'global-model-1', 'gpt-test', 1, 2);
+VALUES ('model-1', 'provider-1', 'global-model-1', 'gpt-test', '1970-01-01T00:00:01Z', '1970-01-01T00:00:02Z');
 INSERT INTO billing_rules (id, global_model_id, name, task_type, expression, variables, dimension_mappings, is_enabled, created_at, updated_at)
-VALUES ('billing-rule-1', 'global-model-1', 'Rule One', 'chat', 'input_tokens * 0.01', '{}', '{"input":"input_tokens"}', 1, 1, 2);
+VALUES ('billing-rule-1', 'global-model-1', 'Rule One', 'chat', 'input_tokens * 0.01', '{}', '{"input":"input_tokens"}', 1, '1970-01-01T00:00:01Z', '1970-01-01T00:00:02Z');
 INSERT INTO dimension_collectors (id, api_format, task_type, dimension_name, source_type, value_type, transform_expression, priority, is_enabled, created_at, updated_at)
-VALUES ('collector-1', 'openai', 'chat', 'input_tokens', 'computed', 'float', 'usage.input_tokens', 10, 1, 1, 2);
+VALUES ('collector-1', 'openai', 'chat', 'input_tokens', 'computed', 'float', 'usage.input_tokens', 10, 1, '1970-01-01T00:00:01Z', '1970-01-01T00:00:02Z');
 INSERT INTO system_configs (id, key, value, created_at, updated_at)
-VALUES ('config-1', 'billing.enabled', 'true', 1, 2);
+VALUES ('config-1', 'billing.enabled', 'true', '1970-01-01T00:00:01Z', '1970-01-01T00:00:02Z');
 INSERT INTO wallets (id, user_id, created_at, updated_at)
-VALUES ('wallet-1', 'user-1', 1, 2);
+VALUES ('wallet-1', 'user-1', '1970-01-01T00:00:01Z', '1970-01-01T00:00:02Z');
 INSERT INTO "usage" (request_id, id, user_id, provider_name, model, status, billing_status, created_at_unix_ms, updated_at_unix_secs)
 VALUES ('request-1', 'request-1', 'user-1', 'Provider One', 'gpt-test', 'completed', 'settled', 1, 2);
 "#,

--- a/frontend/src/api/endpoints/providers.ts
+++ b/frontend/src/api/endpoints/providers.ts
@@ -4,10 +4,14 @@ import type {
   ClaudeCodeAdvancedConfig,
   FailoverRulesConfig,
   PoolAdvancedConfig,
+  ProviderConfig,
   ProviderWithEndpointsSummary,
   ProxyConfig,
 } from './types'
-import { normalizePoolAdvancedConfig as normalizePoolAdvanced } from './types'
+import {
+  normalizeChatPiiRedactionProviderConfig as normalizeChatPiiRedactionProvider,
+  normalizePoolAdvancedConfig as normalizePoolAdvanced,
+} from './types'
 
 interface ProviderRequestOptions {
   timeout?: number
@@ -42,6 +46,7 @@ function normalizeProviderSummary(
 ): ProviderWithEndpointsSummary {
   return {
     ...provider,
+    chat_pii_redaction: normalizeChatPiiRedactionProvider(provider.chat_pii_redaction),
     pool_advanced: normalizePoolAdvanced(provider.pool_advanced),
   }
 }
@@ -107,6 +112,7 @@ export async function updateProvider(
     claude_code_advanced: ClaudeCodeAdvancedConfig | null
     pool_advanced: PoolAdvancedConfig | null
     failover_rules: FailoverRulesConfig | null
+    config: ProviderConfig | null
   }>,
   requestOptions?: ProviderRequestOptions,
 ): Promise<ProviderWithEndpointsSummary> {
@@ -138,6 +144,7 @@ export async function createProvider(
     claude_code_advanced?: ClaudeCodeAdvancedConfig | null
     pool_advanced?: PoolAdvancedConfig | null
     failover_rules?: FailoverRulesConfig | null
+    config?: ProviderConfig | null
   }
 ): Promise<{ id: string; name: string; message?: string }> {
   const response = await client.post('/api/admin/providers/', data)

--- a/frontend/src/api/endpoints/types/__tests__/provider.spec.ts
+++ b/frontend/src/api/endpoints/types/__tests__/provider.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizePoolAdvancedConfig } from '@/api/endpoints/types'
+import { normalizeChatPiiRedactionProviderConfig, normalizePoolAdvancedConfig } from '@/api/endpoints/types'
 
 describe('normalizePoolAdvancedConfig', () => {
   it('keeps object payloads, including empty objects', () => {
@@ -17,5 +17,19 @@ describe('normalizePoolAdvancedConfig', () => {
     expect(normalizePoolAdvancedConfig(null)).toBeNull()
     expect(normalizePoolAdvancedConfig('enabled')).toBeNull()
     expect(normalizePoolAdvancedConfig(['lru'])).toBeNull()
+  })
+})
+
+
+describe('normalizeChatPiiRedactionProviderConfig', () => {
+  it('defaults unsupported payloads to disabled', () => {
+    expect(normalizeChatPiiRedactionProviderConfig(null)).toEqual({ enabled: false })
+    expect(normalizeChatPiiRedactionProviderConfig({})).toEqual({ enabled: false })
+    expect(normalizeChatPiiRedactionProviderConfig({ enabled: 'yes' })).toEqual({ enabled: false })
+  })
+
+  it('passes through enabled state only', () => {
+    expect(normalizeChatPiiRedactionProviderConfig({ enabled: true })).toEqual({ enabled: true })
+    expect(normalizeChatPiiRedactionProviderConfig({ enabled: false, entities: ['email'] })).toEqual({ enabled: false })
   })
 })

--- a/frontend/src/api/endpoints/types/provider.ts
+++ b/frontend/src/api/endpoints/types/provider.ts
@@ -186,6 +186,18 @@ export interface FormatAcceptanceConfig {
   reject_formats?: string[]       // 黑名单：拒绝哪些格式（优先级高于白名单）
 }
 
+export interface ChatPiiRedactionProviderConfig {
+  enabled: boolean
+}
+
+export interface ProviderConfig {
+  chat_pii_redaction?: ChatPiiRedactionProviderConfig
+  pool_advanced?: PoolAdvancedConfig
+  failover_rules?: FailoverRulesConfig
+  claude_code_advanced?: ClaudeCodeAdvancedConfig
+  [key: string]: unknown
+}
+
 export interface ProviderEndpoint {
   id: string
   provider_id: string
@@ -537,6 +549,13 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+export function normalizeChatPiiRedactionProviderConfig(value: unknown): ChatPiiRedactionProviderConfig {
+  if (!isPlainObject(value) || typeof value.enabled !== 'boolean') {
+    return { enabled: false }
+  }
+  return { enabled: value.enabled }
+}
+
 export function normalizePoolAdvancedConfig(value: unknown): PoolAdvancedConfig | null {
   if (value == null || value === false) return null
   if (value === true) return {}
@@ -589,6 +608,7 @@ export interface ProviderWithEndpointsSummary {
   api_formats: string[]
   endpoint_health_details: EndpointHealthDetail[]
   claude_code_advanced?: ClaudeCodeAdvancedConfig | null
+  chat_pii_redaction?: ChatPiiRedactionProviderConfig | null
   pool_advanced?: PoolAdvancedConfig | null
   failover_rules?: FailoverRulesConfig | null
   ops_configured: boolean  // 是否配置了扩展操作（余额监控等）

--- a/frontend/src/api/modules.ts
+++ b/frontend/src/api/modules.ts
@@ -23,6 +23,97 @@ export interface AuthModuleInfo {
   active: boolean
 }
 
+export type ChatPiiRedactionProviderScope = 'all_providers' | 'selected_providers'
+export type ChatPiiRedactionTtlSeconds = 300 | 3600
+export type ChatPiiRedactionEntity =
+  | 'email'
+  | 'cn_phone'
+  | 'global_phone'
+  | 'cn_id'
+  | 'payment_card'
+  | 'ipv4'
+  | 'ipv6'
+  | 'api_key'
+  | 'access_token'
+  | 'secret_key'
+  | 'bearer_token'
+  | 'jwt'
+
+export interface ChatPiiRedactionConfig {
+  enabled: boolean
+  provider_scope: ChatPiiRedactionProviderScope
+  entities: ChatPiiRedactionEntity[]
+  cache_ttl_seconds: ChatPiiRedactionTtlSeconds
+  inject_model_instruction: boolean
+}
+
+const CHAT_PII_REDACTION_ENTITIES: ChatPiiRedactionEntity[] = [
+  'email',
+  'cn_phone',
+  'global_phone',
+  'cn_id',
+  'payment_card',
+  'ipv4',
+  'ipv6',
+  'api_key',
+  'access_token',
+  'secret_key',
+  'bearer_token',
+  'jwt',
+]
+
+const CHAT_PII_REDACTION_CONFIG_KEYS = {
+  enabled: 'module.chat_pii_redaction.enabled',
+  provider_scope: 'module.chat_pii_redaction.provider_scope',
+  entities: 'module.chat_pii_redaction.entities',
+  cache_ttl_seconds: 'module.chat_pii_redaction.cache_ttl_seconds',
+  inject_model_instruction: 'module.chat_pii_redaction.inject_model_instruction',
+} as const
+
+const CHAT_PII_REDACTION_DEFAULT_CONFIG: ChatPiiRedactionConfig = {
+  enabled: false,
+  provider_scope: 'selected_providers',
+  entities: [...CHAT_PII_REDACTION_ENTITIES],
+  cache_ttl_seconds: 300,
+  inject_model_instruction: true,
+}
+
+function isChatPiiRedactionEntity(value: unknown): value is ChatPiiRedactionEntity {
+  return typeof value === 'string' && CHAT_PII_REDACTION_ENTITIES.includes(value as ChatPiiRedactionEntity)
+}
+
+function normalizeChatPiiRedactionEntities(value: unknown): ChatPiiRedactionEntity[] {
+  if (!Array.isArray(value)) return [...CHAT_PII_REDACTION_DEFAULT_CONFIG.entities]
+  const unique = new Set<ChatPiiRedactionEntity>()
+  for (const item of value) {
+    if (isChatPiiRedactionEntity(item)) unique.add(item)
+  }
+  return CHAT_PII_REDACTION_ENTITIES.filter((item) => unique.has(item))
+}
+
+function normalizeChatPiiRedactionConfig(values: Record<keyof ChatPiiRedactionConfig, unknown>): ChatPiiRedactionConfig {
+  return {
+    enabled: values.enabled === true,
+    provider_scope: values.provider_scope === 'all_providers' ? 'all_providers' : 'selected_providers',
+    entities: normalizeChatPiiRedactionEntities(values.entities),
+    cache_ttl_seconds: values.cache_ttl_seconds === 3600 ? 3600 : 300,
+    inject_model_instruction: values.inject_model_instruction !== false,
+  }
+}
+
+async function getSystemConfigValue(key: string): Promise<unknown> {
+  const response = await apiClient.get<{ key: string; value: unknown }>(`/api/admin/system/configs/${key}`)
+  return response.data.value
+}
+
+async function updateSystemConfigValue(key: string, value: unknown, description: string) {
+  const response = await apiClient.put<{ key: string; value: unknown; description?: string }>(
+    `/api/admin/system/configs/${key}`,
+    { value, description },
+  )
+  return response.data.value
+}
+
 export const modulesApi = {
   /**
    * 获取所有模块状态（管理员）
@@ -53,6 +144,42 @@ export const modulesApi = {
       { enabled }
     )
     return response.data
+  },
+
+  async getChatPiiRedactionConfig(): Promise<ChatPiiRedactionConfig> {
+    const [enabled, providerScope, entities, cacheTtlSeconds, injectModelInstruction] = await Promise.all([
+      getSystemConfigValue(CHAT_PII_REDACTION_CONFIG_KEYS.enabled),
+      getSystemConfigValue(CHAT_PII_REDACTION_CONFIG_KEYS.provider_scope),
+      getSystemConfigValue(CHAT_PII_REDACTION_CONFIG_KEYS.entities),
+      getSystemConfigValue(CHAT_PII_REDACTION_CONFIG_KEYS.cache_ttl_seconds),
+      getSystemConfigValue(CHAT_PII_REDACTION_CONFIG_KEYS.inject_model_instruction),
+    ])
+
+    return normalizeChatPiiRedactionConfig({
+      enabled,
+      provider_scope: providerScope,
+      entities,
+      cache_ttl_seconds: cacheTtlSeconds,
+      inject_model_instruction: injectModelInstruction,
+    })
+  },
+
+  async updateChatPiiRedactionConfig(config: ChatPiiRedactionConfig): Promise<ChatPiiRedactionConfig> {
+    const [enabled, providerScope, entities, cacheTtlSeconds, injectModelInstruction] = await Promise.all([
+      updateSystemConfigValue(CHAT_PII_REDACTION_CONFIG_KEYS.enabled, config.enabled, '敏感信息替换保护总开关'),
+      updateSystemConfigValue(CHAT_PII_REDACTION_CONFIG_KEYS.provider_scope, config.provider_scope, '敏感信息替换保护启用范围'),
+      updateSystemConfigValue(CHAT_PII_REDACTION_CONFIG_KEYS.entities, config.entities, '敏感信息替换保护检测类型'),
+      updateSystemConfigValue(CHAT_PII_REDACTION_CONFIG_KEYS.cache_ttl_seconds, config.cache_ttl_seconds, '敏感信息替换保护缓存 TTL'),
+      updateSystemConfigValue(CHAT_PII_REDACTION_CONFIG_KEYS.inject_model_instruction, config.inject_model_instruction, '敏感信息替换保护模型提示说明'),
+    ])
+
+    return normalizeChatPiiRedactionConfig({
+      enabled,
+      provider_scope: providerScope,
+      entities,
+      cache_ttl_seconds: cacheTtlSeconds,
+      inject_model_instruction: injectModelInstruction,
+    })
   },
 
   /**

--- a/frontend/src/features/providers/components/ProviderFormDialog.vue
+++ b/frontend/src/features/providers/components/ProviderFormDialog.vue
@@ -262,6 +262,34 @@
             @update:model-value="(v: boolean) => form.pool_mode_enabled = v"
           />
         </div>
+
+        <div
+          class="flex items-center justify-between gap-4 p-3 border rounded-lg bg-muted/50"
+          :class="redactionModuleScope === 'all_providers' ? 'border-primary/30 bg-primary/5' : ''"
+        >
+          <div class="space-y-0.5">
+            <span class="text-sm font-medium">敏感信息替换保护</span>
+            <p class="text-xs text-muted-foreground leading-relaxed">
+              {{ redactionHelperText }}
+            </p>
+            <p
+              v-if="!redactionModuleEnabled"
+              class="text-xs text-muted-foreground"
+            >
+              模块总开关未开启，保存此供应商不会立即生效。
+            </p>
+          </div>
+          <div class="flex shrink-0 items-center gap-3">
+            <span class="text-xs text-muted-foreground">
+              {{ redactionSwitchLabel }}
+            </span>
+            <Switch
+              :model-value="redactionSwitchValue"
+              :disabled="redactionModuleScope === 'all_providers' || redactionModuleLoading"
+              @update:model-value="(v: boolean) => form.chat_pii_redaction_enabled = v"
+            />
+          </div>
+        </div>
       </div>
     </form>
 
@@ -307,9 +335,12 @@ import {
   updateProvider,
   type ProviderWithEndpointsSummary,
 } from '@/api/endpoints'
+import { modulesApi, type ChatPiiRedactionProviderScope } from '@/api/modules'
 import { parseApiError } from '@/utils/errorParser'
 import { parseNumberInput } from '@/utils/form'
 import { dateTimeLocalToRfc3339, formatDateTimeLocalInput } from '@/utils/date'
+import { getProviderRedactionConfig, withProviderRedactionConfig } from '@/features/providers/utils/providerRedactionPayload'
+import { log } from '@/utils/logger'
 
 const props = defineProps<{
   modelValue: boolean
@@ -325,6 +356,9 @@ const emit = defineEmits<{
 
 const { success, error: showError } = useToast()
 const loading = ref(false)
+const redactionModuleLoading = ref(false)
+const redactionModuleEnabled = ref(false)
+const redactionModuleScope = ref<ChatPiiRedactionProviderScope>('selected_providers')
 
 // 内部状态
 const internalOpen = computed(() => props.modelValue)
@@ -362,7 +396,42 @@ const form = ref({
   request_timeout: undefined as number | undefined,
   // 号池模式
   pool_mode_enabled: false,
+  chat_pii_redaction_enabled: false,
 })
+
+const redactionSwitchValue = computed(() => {
+  if (redactionModuleScope.value === 'all_providers') {
+    return redactionModuleEnabled.value
+  }
+  return form.value.chat_pii_redaction_enabled
+})
+
+const redactionSwitchLabel = computed(() => {
+  if (redactionModuleScope.value === 'all_providers') {
+    return redactionModuleEnabled.value ? '继承开启' : '未生效'
+  }
+  return form.value.chat_pii_redaction_enabled ? '已开启' : '未开启'
+})
+
+const redactionHelperText = computed(() => {
+  if (redactionModuleScope.value === 'all_providers') {
+    return '模块管理已设置为“全部供应商”，此供应商会自动执行替换保护。替换类型由模块管理中的“替换类型配置”决定。'
+  }
+  return '仅当“开启敏感信息替换保护”和此供应商开关都开启时生效。替换类型在模块管理的“替换类型配置”中统一选择，适用于所有已开启该功能的供应商。供应商只会看到占位符，客户端响应会自动还原。'
+})
+
+async function loadRedactionModuleState() {
+  redactionModuleLoading.value = true
+  try {
+    const config = await modulesApi.getChatPiiRedactionConfig()
+    redactionModuleEnabled.value = config.enabled
+    redactionModuleScope.value = config.provider_scope
+  } catch (err) {
+    log.warn('加载敏感信息替换保护模块配置失败', err)
+  } finally {
+    redactionModuleLoading.value = false
+  }
+}
 
 // 重置表单
 function resetForm() {
@@ -388,6 +457,7 @@ function resetForm() {
     request_timeout: undefined,
     // 号池模式
     pool_mode_enabled: false,
+    chat_pii_redaction_enabled: false,
   }
 }
 
@@ -418,6 +488,7 @@ function loadProviderData() {
     request_timeout: props.provider.request_timeout ?? undefined,
     // 号池模式
     pool_mode_enabled: poolAdvanced !== null,
+    chat_pii_redaction_enabled: getProviderRedactionConfig(props.provider).enabled,
   }
 }
 
@@ -429,6 +500,12 @@ const { isEditMode, handleDialogUpdate, handleCancel } = useFormDialog({
   onClose: () => emit('update:modelValue', false),
   loadData: loadProviderData,
   resetForm,
+})
+
+watch(() => props.modelValue, (open) => {
+  if (open) {
+    loadRedactionModuleState()
+  }
 })
 
 // 新建模式下切换 provider_type 时不自动开启号池模式
@@ -465,7 +542,7 @@ const handleSubmit = async () => {
   loading.value = true
   try {
     const currentPoolAdvanced = normalizePoolAdvancedConfig(props.provider?.pool_advanced)
-    const basePayload = {
+    const basePayload = withProviderRedactionConfig({
       name: form.value.name,
       provider_type: form.value.provider_type,
       description: form.value.description || undefined,
@@ -485,7 +562,7 @@ const handleSubmit = async () => {
       pool_advanced: form.value.pool_mode_enabled
         ? (currentPoolAdvanced ?? {})
         : null,
-    }
+    }, form.value.chat_pii_redaction_enabled)
 
     if (isEditMode.value && props.provider) {
       // 更新提供商

--- a/frontend/src/features/providers/utils/__tests__/providerRedactionPayload.spec.ts
+++ b/frontend/src/features/providers/utils/__tests__/providerRedactionPayload.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ProviderWithEndpointsSummary } from '@/api/endpoints/types'
+import {
+  buildProviderRedactionConfig,
+  getProviderRedactionConfig,
+  withProviderRedactionConfig,
+} from '../providerRedactionPayload'
+
+function makeProvider(overrides: Partial<ProviderWithEndpointsSummary> = {}): ProviderWithEndpointsSummary {
+  return {
+    id: 'provider-1',
+    name: 'Provider One',
+    provider_priority: 1,
+    keep_priority_on_conversion: false,
+    enable_format_conversion: true,
+    is_active: true,
+    total_endpoints: 0,
+    active_endpoints: 0,
+    total_keys: 0,
+    active_keys: 0,
+    total_models: 0,
+    active_models: 0,
+    global_model_ids: [],
+    avg_health_score: 0,
+    unhealthy_endpoints: 0,
+    api_formats: [],
+    endpoint_health_details: [],
+    ops_configured: false,
+    created_at: '2026-05-02T00:00:00Z',
+    updated_at: '2026-05-02T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('provider redaction payload helpers', () => {
+  it('defaults provider redaction to disabled', () => {
+    expect(getProviderRedactionConfig()).toEqual({ enabled: false })
+    expect(getProviderRedactionConfig(makeProvider())).toEqual({ enabled: false })
+  })
+
+  it('loads existing provider redaction config', () => {
+    const provider = makeProvider({ chat_pii_redaction: { enabled: true } })
+
+    expect(getProviderRedactionConfig(provider)).toEqual({ enabled: true })
+  })
+
+  it('builds create and update payloads with provider-level enabled only', () => {
+    expect(buildProviderRedactionConfig(true)).toEqual({
+      chat_pii_redaction: { enabled: true },
+    })
+
+    expect(
+      withProviderRedactionConfig(
+        {
+          name: 'Provider One',
+          config: { pool_advanced: { global_priority: 10 } },
+        },
+        false,
+      ),
+    ).toEqual({
+      name: 'Provider One',
+      config: {
+        pool_advanced: { global_priority: 10 },
+        chat_pii_redaction: { enabled: false },
+      },
+    })
+  })
+
+  it('does not include provider-level entity or ttl config', () => {
+    const payload = withProviderRedactionConfig({ name: 'Provider One' }, true)
+
+    expect(payload.config.chat_pii_redaction).toEqual({ enabled: true })
+    expect(payload.config.chat_pii_redaction).not.toHaveProperty('entities')
+    expect(payload.config.chat_pii_redaction).not.toHaveProperty('cache_ttl_seconds')
+    expect(payload.config.chat_pii_redaction).not.toHaveProperty('inject_model_instruction')
+  })
+})

--- a/frontend/src/features/providers/utils/providerRedactionPayload.ts
+++ b/frontend/src/features/providers/utils/providerRedactionPayload.ts
@@ -1,0 +1,35 @@
+import type { ProviderConfig, ProviderWithEndpointsSummary } from '@/api/endpoints/types'
+import { normalizeChatPiiRedactionProviderConfig } from '@/api/endpoints/types'
+
+export const DEFAULT_PROVIDER_REDACTION_CONFIG = Object.freeze({ enabled: false })
+
+type ProviderConfigWithRedaction = ProviderConfig & Required<Pick<ProviderConfig, 'chat_pii_redaction'>>
+
+type ProviderRedactionPayload<TPayload extends object> = Omit<TPayload, 'config'> & {
+  config: ProviderConfigWithRedaction
+}
+
+export function getProviderRedactionConfig(provider?: ProviderWithEndpointsSummary | null) {
+  return normalizeChatPiiRedactionProviderConfig(provider?.chat_pii_redaction)
+}
+
+export function buildProviderRedactionConfig(enabled: boolean): ProviderConfigWithRedaction {
+  return {
+    chat_pii_redaction: { enabled },
+  }
+}
+
+export function withProviderRedactionConfig<TPayload extends object>(
+  payload: TPayload & { config?: ProviderConfig | null },
+  enabled: boolean,
+): ProviderRedactionPayload<TPayload> {
+  const { config, ...payloadWithoutConfig } = payload
+
+  return {
+    ...payloadWithoutConfig,
+    config: {
+      ...(config ?? {}),
+      ...buildProviderRedactionConfig(enabled),
+    },
+  }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -227,6 +227,12 @@ const routes: RouteRecordRaw[] = [
         meta: { module: 'model_directives' }
       },
       {
+        path: 'modules/chat-pii-redaction',
+        name: 'ChatPiiRedactionModule',
+        component: () => importWithRetry(() => import('@/views/admin/modules/ChatPiiRedaction.vue')),
+        meta: { module: 'chat_pii_redaction' }
+      },
+      {
         path: 'email',
         name: 'EmailSettings',
         component: () => importWithRetry(() => import('@/views/admin/EmailSettings.vue'))

--- a/frontend/src/views/admin/ModuleManagement.vue
+++ b/frontend/src/views/admin/ModuleManagement.vue
@@ -133,6 +133,13 @@
             {{ module.description }}
           </p>
 
+          <p
+            v-if="module.name === 'chat_pii_redaction'"
+            class="mt-3 rounded-lg border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
+          >
+            {{ getModuleStatusCopy(module) }}
+          </p>
+
           <!-- 不可用提示 -->
           <div
             v-if="!module.available"
@@ -244,6 +251,15 @@ function getCategoryIcon(category: string) {
     integration: Link,
   }
   return icons[category] || Puzzle
+}
+
+function getModuleStatusCopy(module: { name: string; enabled: boolean; active: boolean; config_validated: boolean; config_error: string | null }) {
+  if (module.name !== 'chat_pii_redaction') {
+    return module.enabled ? '已启用' : '已禁用'
+  }
+  if (!module.config_validated) return '配置异常，替换保护未生效'
+  if (!module.enabled) return '全局替换开关未开启，所有供应商均不会执行替换保护'
+  return '全局替换开关已开启，可在供应商中单独启用'
 }
 
 // 所有模块列表（按 admin_menu_order 排序）

--- a/frontend/src/views/admin/modules/ChatPiiRedaction.vue
+++ b/frontend/src/views/admin/modules/ChatPiiRedaction.vue
@@ -1,0 +1,355 @@
+<template>
+  <PageContainer>
+    <PageHeader
+      title="敏感信息替换保护"
+      description="对聊天消息中的手机号、邮箱、证件号、银行卡号、IP、API Key 与令牌进行可逆占位符替换，防止原文发送给上游供应商。"
+      :icon="ShieldCheck"
+    >
+      <template #actions>
+        <Button
+          variant="outline"
+          :disabled="loading || saving"
+          @click="loadConfig"
+        >
+          <RefreshCw
+            class="w-4 h-4 mr-2"
+            :class="{ 'animate-spin': loading }"
+          />
+          刷新
+        </Button>
+        <Button
+          :disabled="loading || saving || !hasChanges"
+          @click="saveConfig"
+        >
+          {{ saving ? '保存中...' : '保存配置' }}
+        </Button>
+      </template>
+    </PageHeader>
+
+    <div class="mt-6 space-y-6">
+      <section class="rounded-2xl border border-border bg-card p-5">
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div class="space-y-2">
+            <div class="flex items-center gap-2">
+              <span
+                class="h-2.5 w-2.5 rounded-full ring-2 ring-offset-2 ring-offset-background"
+                :class="redactionConfig.enabled ? 'bg-primary ring-primary/30' : 'bg-muted ring-muted/60'"
+              />
+              <p class="text-sm font-semibold text-foreground">
+                {{ statusLabel }}
+              </p>
+            </div>
+            <p class="max-w-3xl text-sm text-muted-foreground">
+              发送给供应商前将聊天消息中的敏感信息替换为占位符，返回客户端前自动还原。
+            </p>
+          </div>
+          <div class="flex items-center gap-3 rounded-xl border border-border bg-muted/40 px-4 py-3">
+            <div class="text-right">
+              <p class="text-sm font-medium text-foreground">
+                开启敏感信息替换保护
+              </p>
+              <p class="text-xs text-muted-foreground">
+                关闭后所有供应商均不会执行替换
+              </p>
+            </div>
+            <Switch
+              :model-value="redactionConfig.enabled"
+              @update:model-value="(value: boolean) => redactionConfig.enabled = value"
+            />
+          </div>
+        </div>
+      </section>
+
+      <CardSection
+        title="启用范围"
+        description="关闭后，所有供应商都不会执行替换；开启后，按下方“启用范围”决定是全部供应商生效还是指定供应商生效。"
+      >
+        <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <button
+            v-for="option in scopeOptions"
+            :key="option.value"
+            type="button"
+            class="rounded-xl border p-4 text-left transition-all duration-200"
+            :class="redactionConfig.provider_scope === option.value
+              ? 'border-primary bg-primary/10 text-primary shadow-sm'
+              : 'border-border bg-card/70 text-muted-foreground hover:border-primary/50 hover:text-foreground'"
+            @click="redactionConfig.provider_scope = option.value"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <span class="text-sm font-semibold">{{ option.label }}</span>
+              <span
+                class="h-2 w-2 rounded-full"
+                :class="redactionConfig.provider_scope === option.value ? 'bg-primary' : 'bg-muted'"
+              />
+            </div>
+            <p class="mt-2 text-xs leading-relaxed text-muted-foreground">
+              {{ option.helper }}
+            </p>
+          </button>
+        </div>
+      </CardSection>
+
+      <CardSection
+        title="替换类型配置"
+        description="适用于所有已开启该功能的供应商。"
+      >
+        <div class="space-y-5">
+          <div
+            v-for="group in entityGroups"
+            :key="group.title"
+            class="rounded-xl border border-border bg-muted/30 p-4"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <h3 class="text-sm font-semibold text-foreground">
+                  {{ group.title }}
+                </h3>
+                <p class="mt-1 text-xs text-muted-foreground">
+                  已选择 {{ selectedCount(group.entities) }} / {{ group.entities.length }} 项
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                @click="setGroupSelection(group.entities, selectedCount(group.entities) !== group.entities.length)"
+              >
+                {{ selectedCount(group.entities) === group.entities.length ? '清除本组' : '选择本组' }}
+              </Button>
+            </div>
+            <div class="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2">
+              <label
+                v-for="entity in group.entities"
+                :key="entity.key"
+                class="flex items-start gap-3 rounded-lg border border-border bg-card/70 px-3 py-3 text-sm transition-colors hover:border-primary/40"
+              >
+                <Checkbox
+                  :checked="redactionConfig.entities.includes(entity.key)"
+                  @update:checked="(checked: boolean) => toggleEntity(entity.key, checked)"
+                />
+                <span class="leading-tight">
+                  <span class="block font-medium text-foreground">{{ entity.label }}</span>
+                  <span class="mt-1 block text-xs text-muted-foreground">{{ entity.description }}</span>
+                </span>
+              </label>
+            </div>
+          </div>
+          <div class="rounded-xl border border-border bg-card px-4 py-3 text-sm text-muted-foreground">
+            真实姓名、地址、公司名暂不支持自动识别，避免误判影响模型理解。
+          </div>
+        </div>
+      </CardSection>
+
+      <CardSection
+        title="多轮上下文缓存"
+        description="此时间控制“真实值 ↔ 占位符”映射在 Redis 中的缓存窗口。窗口内相同敏感值使用相同占位符，以减少上游 prompt cache 失效；窗口过期后新请求会生成新的占位符。缓存写入 Redis，必须设置 TTL，不写入数据库或日志。"
+      >
+        <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <button
+            v-for="option in ttlOptions"
+            :key="option.value"
+            type="button"
+            class="rounded-xl border p-4 text-left transition-all duration-200"
+            :class="redactionConfig.cache_ttl_seconds === option.value
+              ? 'border-primary bg-primary/10 text-primary shadow-sm'
+              : 'border-border bg-card/70 text-muted-foreground hover:border-primary/50 hover:text-foreground'"
+            @click="redactionConfig.cache_ttl_seconds = option.value"
+          >
+            <span class="text-sm font-semibold">{{ option.label }}</span>
+            <p class="mt-2 text-xs leading-relaxed text-muted-foreground">
+              {{ option.helper }}
+            </p>
+          </button>
+        </div>
+      </CardSection>
+
+      <CardSection title="模型提示说明">
+        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div class="space-y-1">
+            <p class="text-sm font-medium text-foreground">
+              向模型说明占位符含义
+            </p>
+            <p class="max-w-3xl text-xs leading-relaxed text-muted-foreground">
+              开启后，Aether 会在发往供应商的请求中插入一条简短内部说明，说明 `&lt;AETHER:TYPE:ID&gt;` 是已保护的真实信息占位符，应按对应类型正常理解和处理，不要要求用户重新提供原文。
+            </p>
+          </div>
+          <Switch
+            :model-value="redactionConfig.inject_model_instruction"
+            @update:model-value="(value: boolean) => redactionConfig.inject_model_instruction = value"
+          />
+        </div>
+      </CardSection>
+    </div>
+  </PageContainer>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { RefreshCw, ShieldCheck } from 'lucide-vue-next'
+import { PageContainer, PageHeader, CardSection } from '@/components/layout'
+import Button from '@/components/ui/button.vue'
+import Checkbox from '@/components/ui/checkbox.vue'
+import Switch from '@/components/ui/switch.vue'
+import { modulesApi, type ChatPiiRedactionConfig, type ChatPiiRedactionEntity, type ChatPiiRedactionProviderScope } from '@/api/modules'
+import { useModuleStore } from '@/stores/modules'
+import { useToast } from '@/composables/useToast'
+import { parseApiError } from '@/utils/errorParser'
+import { log } from '@/utils/logger'
+
+interface EntityOption {
+  key: ChatPiiRedactionEntity
+  label: string
+  description: string
+}
+
+const defaultConfig: ChatPiiRedactionConfig = {
+  enabled: false,
+  provider_scope: 'selected_providers',
+  entities: [
+    'email',
+    'cn_phone',
+    'global_phone',
+    'cn_id',
+    'payment_card',
+    'ipv4',
+    'ipv6',
+    'api_key',
+    'access_token',
+    'secret_key',
+    'bearer_token',
+    'jwt',
+  ],
+  cache_ttl_seconds: 300,
+  inject_model_instruction: true,
+}
+
+const scopeOptions: Array<{ value: ChatPiiRedactionProviderScope; label: string; helper: string }> = [
+  {
+    value: 'all_providers',
+    label: '全部供应商',
+    helper: '所有供应商都会执行替换保护，无需逐个开启。',
+  },
+  {
+    value: 'selected_providers',
+    label: '指定供应商',
+    helper: '仅对在供应商管理中开启的供应商生效。',
+  },
+]
+
+const ttlOptions = [
+  {
+    value: 300 as const,
+    label: '5 分钟（默认）',
+    helper: '更保守，适合短对话或较高隐私偏好；同一敏感信息在 5 分钟内保持相同占位符。',
+  },
+  {
+    value: 3600 as const,
+    label: '1 小时',
+    helper: '更适合长多轮对话，可减少重复上下文检测成本；同一敏感信息在 1 小时内保持相同占位符。',
+  },
+]
+
+const entityGroups: Array<{ title: string; entities: EntityOption[] }> = [
+  {
+    title: '个人信息',
+    entities: [
+      { key: 'email', label: '邮箱', description: '识别常见电子邮箱地址。' },
+      { key: 'cn_phone', label: '手机号/固话', description: '识别中国大陆手机号和固定电话。' },
+      { key: 'global_phone', label: '全球电话号码', description: '识别 E.164 风格国际号码。' },
+      { key: 'cn_id', label: '中国大陆身份证号', description: '识别通过校验的居民身份证号。' },
+      { key: 'payment_card', label: '银行卡号', description: '识别通过 Luhn 校验的卡号。' },
+      { key: 'ipv4', label: 'IPv4', description: '识别 IPv4 地址。' },
+      { key: 'ipv6', label: 'IPv6', description: '识别 IPv6 地址。' },
+    ],
+  },
+  {
+    title: '密钥与令牌',
+    entities: [
+      { key: 'api_key', label: 'API Key', description: '识别 OpenAI、Anthropic、GitHub、Slack、AWS 等常见密钥。' },
+      { key: 'access_token', label: 'Access Token', description: '识别访问令牌形态的敏感凭证。' },
+      { key: 'secret_key', label: 'Secret Key', description: '识别高熵密钥和 secret 字段值。' },
+      { key: 'bearer_token', label: 'Bearer Token', description: '识别 Authorization Bearer 凭证。' },
+      { key: 'jwt', label: 'JWT', description: '识别三段式 JWT 令牌。' },
+    ],
+  },
+]
+
+const moduleStore = useModuleStore()
+const { success, error } = useToast()
+
+const loading = ref(false)
+const saving = ref(false)
+const redactionConfig = ref<ChatPiiRedactionConfig>({ ...defaultConfig })
+const originalConfig = ref<ChatPiiRedactionConfig>({ ...defaultConfig })
+
+const hasChanges = computed(() => JSON.stringify(redactionConfig.value) !== JSON.stringify(originalConfig.value))
+
+const statusLabel = computed(() => {
+  const moduleStatus = moduleStore.modules.chat_pii_redaction
+  if (moduleStatus && !moduleStatus.config_validated) return '配置异常，替换保护未生效'
+  if (!redactionConfig.value.enabled) return '全局替换开关未开启，所有供应商均不会执行替换保护'
+  return redactionConfig.value.provider_scope === 'all_providers'
+    ? '全局替换开关已开启，全部供应商都会执行替换保护'
+    : '全局替换开关已开启，可在供应商中单独启用'
+})
+
+async function loadConfig() {
+  loading.value = true
+  try {
+    const [config] = await Promise.all([
+      modulesApi.getChatPiiRedactionConfig(),
+      moduleStore.fetchModules(),
+    ])
+    redactionConfig.value = { ...config }
+    originalConfig.value = { ...config }
+  } catch (err) {
+    error(parseApiError(err, '加载敏感信息替换保护配置失败'))
+    log.error('加载敏感信息替换保护配置失败:', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function saveConfig() {
+  saving.value = true
+  try {
+    const saved = await modulesApi.updateChatPiiRedactionConfig(redactionConfig.value)
+    redactionConfig.value = { ...saved }
+    originalConfig.value = { ...saved }
+    await moduleStore.fetchModules()
+    success('敏感信息替换保护配置已保存')
+  } catch (err) {
+    error(parseApiError(err, '保存敏感信息替换保护配置失败'))
+    log.error('保存敏感信息替换保护配置失败:', err)
+  } finally {
+    saving.value = false
+  }
+}
+
+function selectedCount(entities: EntityOption[]) {
+  return entities.filter((entity) => redactionConfig.value.entities.includes(entity.key)).length
+}
+
+function toggleEntity(entity: ChatPiiRedactionEntity, checked: boolean) {
+  const current = new Set(redactionConfig.value.entities)
+  if (checked) {
+    current.add(entity)
+  } else {
+    current.delete(entity)
+  }
+  redactionConfig.value.entities = defaultConfig.entities.filter((item) => current.has(item))
+}
+
+function setGroupSelection(entities: EntityOption[], checked: boolean) {
+  const current = new Set(redactionConfig.value.entities)
+  for (const entity of entities) {
+    if (checked) {
+      current.add(entity.key)
+    } else {
+      current.delete(entity.key)
+    }
+  }
+  redactionConfig.value.entities = defaultConfig.entities.filter((item) => current.has(item))
+}
+
+onMounted(loadConfig)
+</script>


### PR DESCRIPTION
## Summary
- Add reversible chat PII redaction for Aether chat requests across supported provider execution paths.
- Mask provider-bound chat content and tool-call arguments with Redis-backed sentinels, then restore current-request sentinels in sync and streaming responses.
- Add Module Management and provider-level configuration surfaces, plus align the Postgres baseline/bootstrap and SQLite export smoke shapes used by CI.

## Verification
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p aether-data --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p aether-data sqlite --lib`
- `cargo test -p aether-data split_baseline_sources_match_executable_migrations --lib`
- `cargo test -p aether-gateway gateway_executes_gemini_files_download_via_local_decision_gate_with_local_planning_only -- --nocapture`
- `cargo test -p aether-gateway gateway_executes_gemini_files_upload_via_local_decision_gate_with_local_planning_only -- --nocapture`
- `cargo test -p aether-gateway gateway_executes_gemini_video_create_via_local_decision_gate_with_local_planning_only -- --nocapture`
- `cargo test -p aether-gateway gateway_executes_openai_video_create_via_local_decision_gate_with_local_planning_only -- --nocapture`
- `npm run test:run -- src/features/providers/utils/__tests__/providerRedactionPayload.spec.ts src/api/endpoints/types/__tests__/provider.spec.ts`