### PR TITLE
fix: preserve mapped model directive behavior

### DIFF
--- a/apps/aether-gateway/src/ai_serving/planner/candidate_source.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/candidate_source.rs
@@ -701,7 +701,9 @@ mod tests {
     use crate::data::GatewayDataState;
     use crate::AppState;
     use aether_data::repository::candidate_selection::InMemoryMinimalCandidateSelectionReadRepository;
-    use aether_data_contracts::repository::candidate_selection::MinimalCandidateSelectionReadRepository;
+    use aether_data_contracts::repository::candidate_selection::{
+        MinimalCandidateSelectionReadRepository, StoredProviderModelMapping,
+    };
     use std::sync::Arc;
 
     fn unrestricted_auth_snapshot() -> GatewayAuthApiKeySnapshot {
@@ -766,6 +768,25 @@ mod tests {
         }
     }
 
+    fn openai_responses_provider_model_mapping_row() -> StoredMinimalCandidateSelectionRow {
+        let mut row = openai_responses_mapping_row();
+        row.provider_id = "provider-openai-responses-exact-mapped-1".to_string();
+        row.endpoint_id = "endpoint-openai-responses-exact-mapped-1".to_string();
+        row.key_id = "key-openai-responses-exact-mapped-1".to_string();
+        row.model_id = "model-openai-responses-exact-mapped-1".to_string();
+        row.global_model_id = "global-model-openai-responses-exact-mapped-1".to_string();
+        row.global_model_name = "catalog-gpt-5".to_string();
+        row.global_model_mappings = None;
+        row.model_provider_model_name = "default-upstream-gpt-5".to_string();
+        row.model_provider_model_mappings = Some(vec![StoredProviderModelMapping {
+            name: "gpt-5.5".to_string(),
+            priority: 1,
+            api_formats: Some(vec!["openai:responses".to_string()]),
+            endpoint_ids: Some(vec!["endpoint-openai-responses-exact-mapped-1".to_string()]),
+        }]);
+        row
+    }
+
     #[tokio::test]
     async fn paged_preselection_falls_back_to_format_scan_for_directive_mapping_match() {
         let repository: Arc<dyn MinimalCandidateSelectionReadRepository> =
@@ -809,5 +830,128 @@ mod tests {
             page.candidates[0].selected_provider_model_name,
             "gpt-5-upstream"
         );
+    }
+
+    #[tokio::test]
+    async fn paged_preselection_uses_default_directive_mapping_for_streaming_suffix() {
+        let repository: Arc<dyn MinimalCandidateSelectionReadRepository> =
+            Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed([
+                openai_responses_mapping_row(),
+            ]));
+        let data_state =
+            GatewayDataState::with_minimal_candidate_selection_reader_for_tests(repository)
+                .with_system_config_values_for_tests([
+                    (
+                        crate::system_features::ENABLE_MODEL_DIRECTIVES_CONFIG_KEY.to_string(),
+                        serde_json::json!(true),
+                    ),
+                    (
+                        crate::system_features::MODEL_DIRECTIVES_CONFIG_KEY.to_string(),
+                        serde_json::json!({
+                            "reasoning_effort": {
+                                "enabled": true,
+                                "api_formats": {
+                                    "openai:responses": {
+                                        "enabled": true,
+                                        "mappings": {
+                                            "low": { "reasoning": { "effort": "low" } }
+                                        }
+                                    }
+                                }
+                            }
+                        }),
+                    ),
+                ]);
+        let app = AppState::new()
+            .expect("gateway state should build")
+            .with_data_state_for_tests(data_state);
+        let auth_snapshot = unrestricted_auth_snapshot();
+        let mut cursor = LocalCandidatePreselectionPageCursor::new(
+            PlannerAppState::new(&app),
+            "claude:messages",
+            "gpt-5.5-xhigh",
+            true,
+            None,
+            &auth_snapshot,
+            None,
+            true,
+            LocalCandidatePreselectionKeyMode::ProviderEndpointKeyModelAndApiFormat,
+        )
+        .await;
+
+        let page = cursor
+            .next_page()
+            .await
+            .expect("preselection should succeed")
+            .expect("streaming directive fallback should find a provider");
+
+        assert_eq!(page.skipped_candidates.len(), 0);
+        assert_eq!(page.candidates.len(), 1);
+        assert_eq!(page.candidates[0].endpoint_api_format, "openai:responses");
+        assert_eq!(page.candidates[0].global_model_name, "gpt-5");
+        assert_eq!(
+            page.candidates[0].selected_provider_model_name,
+            "gpt-5-upstream"
+        );
+    }
+
+    #[tokio::test]
+    async fn paged_preselection_applies_provider_model_mapping_after_format_conversion() {
+        let repository: Arc<dyn MinimalCandidateSelectionReadRepository> =
+            Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed([
+                openai_responses_provider_model_mapping_row(),
+            ]));
+        let data_state =
+            GatewayDataState::with_minimal_candidate_selection_reader_for_tests(repository)
+                .with_system_config_values_for_tests([
+                    (
+                        crate::system_features::ENABLE_MODEL_DIRECTIVES_CONFIG_KEY.to_string(),
+                        serde_json::json!(true),
+                    ),
+                    (
+                        crate::system_features::MODEL_DIRECTIVES_CONFIG_KEY.to_string(),
+                        serde_json::json!({
+                            "reasoning_effort": {
+                                "enabled": true,
+                                "api_formats": {
+                                    "openai:responses": {
+                                        "enabled": true,
+                                        "mappings": {
+                                            "low": { "reasoning": { "effort": "low" } }
+                                        }
+                                    }
+                                }
+                            }
+                        }),
+                    ),
+                ]);
+        let app = AppState::new()
+            .expect("gateway state should build")
+            .with_data_state_for_tests(data_state);
+        let auth_snapshot = unrestricted_auth_snapshot();
+        let mut cursor = LocalCandidatePreselectionPageCursor::new(
+            PlannerAppState::new(&app),
+            "claude:messages",
+            "gpt-5.5-xhigh",
+            true,
+            None,
+            &auth_snapshot,
+            None,
+            true,
+            LocalCandidatePreselectionKeyMode::ProviderEndpointKeyModelAndApiFormat,
+        )
+        .await;
+
+        let page = cursor
+            .next_page()
+            .await
+            .expect("preselection should succeed")
+            .expect("provider model mapping should find a converted-format provider");
+
+        assert_eq!(page.skipped_candidates.len(), 0);
+        assert_eq!(page.candidates.len(), 1);
+        assert_eq!(page.candidates[0].endpoint_api_format, "openai:responses");
+        assert_eq!(page.candidates[0].global_model_name, "catalog-gpt-5");
+        assert_eq!(page.candidates[0].selected_provider_model_name, "gpt-5.5");
     }
 }

--- a/apps/aether-gateway/src/system_features.rs
+++ b/apps/aether-gateway/src/system_features.rs
@@ -94,9 +94,9 @@ pub(crate) async fn reasoning_model_directive_enabled_for_api_format_and_model(
 
     settings
         .as_ref()
-        .and_then(|settings| settings.api_format_mappings(&api_format))
-        .map(|mappings| mappings.contains_key(&suffix))
-        .unwrap_or_else(|| DEFAULT_REASONING_SUFFIXES.contains(&suffix.as_str()))
+        .and_then(|settings| settings.api_format_mapping(&api_format, &suffix))
+        .or_else(|| default_reasoning_mapping(&api_format, &suffix))
+        .is_some()
 }
 
 pub(crate) async fn reasoning_model_directive_mapping_for_api_format_and_model(
@@ -118,8 +118,7 @@ pub(crate) async fn reasoning_model_directive_mapping_for_api_format_and_model(
     let settings = read_reasoning_model_directive_settings(state).await;
     settings
         .as_ref()
-        .and_then(|settings| settings.api_format_mappings(&api_format))
-        .and_then(|mappings| mappings.get(&suffix).cloned())
+        .and_then(|settings| settings.api_format_mapping(&api_format, &suffix))
         .or_else(|| default_reasoning_mapping(&api_format, &suffix))
 }
 
@@ -180,6 +179,11 @@ impl ReasoningModelDirectiveSettings {
                 .collect::<serde_json::Map<_, _>>();
             Some(mappings)
         })
+    }
+
+    fn api_format_mapping(&self, api_format: &str, suffix: &str) -> Option<serde_json::Value> {
+        self.api_format_mappings(api_format)
+            .and_then(|mappings| mappings.get(suffix).cloned())
     }
 }
 
@@ -325,9 +329,7 @@ mod tests {
         assert_eq!(settings.api_format_enabled("openai:chat"), Some(false));
         assert_eq!(settings.api_format_enabled("claude:messages"), Some(true));
         assert_eq!(
-            settings
-                .api_format_mappings("claude:messages")
-                .and_then(|mappings| mappings.get("max").cloned()),
+            settings.api_format_mapping("claude:messages", "max"),
             Some(json!({ "thinking": { "type": "enabled", "budget_tokens": 32768 } }))
         );
         assert_eq!(settings.api_format_enabled("gemini:generate_content"), None);

--- a/crates/aether-ai-formats/src/request/standard/matrix.rs
+++ b/crates/aether-ai-formats/src/request/standard/matrix.rs
@@ -582,6 +582,59 @@ mod tests {
     }
 
     #[test]
+    fn standard_request_body_rules_match_original_model_after_format_conversion() {
+        let request = json!({
+            "model": "gpt-5.5-xhigh",
+            "messages": [{"role": "user", "content": "hello"}]
+        });
+        let body_rules = json!([
+            {
+                "action": "set",
+                "path": "metadata.original_model_hit",
+                "value": true,
+                "condition": {"path": "model", "op": "eq", "value": "gpt-5.5-xhigh"}
+            },
+            {
+                "action": "set",
+                "path": "metadata.default_mapped_model_hit",
+                "value": true,
+                "condition": {"path": "model", "op": "eq", "value": "gpt-5.5"}
+            },
+            {
+                "action": "set",
+                "path": "metadata.current_model_hit",
+                "value": true,
+                "condition": {
+                    "source": "current",
+                    "path": "model",
+                    "op": "eq",
+                    "value": "gpt-5.5"
+                }
+            }
+        ]);
+
+        let converted = build_standard_request_body(
+            &request,
+            "openai:chat",
+            "gpt-5.5",
+            "openai",
+            "openai:responses",
+            "/v1/chat/completions",
+            false,
+            Some(&body_rules),
+            None,
+        )
+        .expect("openai chat should convert to responses");
+
+        assert_eq!(converted["model"], "gpt-5.5");
+        assert_eq!(converted["metadata"]["original_model_hit"], true);
+        assert_eq!(converted["metadata"]["current_model_hit"], true);
+        assert!(converted["metadata"]
+            .get("default_mapped_model_hit")
+            .is_none());
+    }
+
+    #[test]
     fn openai_chat_request_uses_typed_canonical_without_changing_target_payloads() {
         let request = json!({
             "model": "gpt-5",

--- a/crates/aether-provider-transport/src/same_format_provider.rs
+++ b/crates/aether-provider-transport/src/same_format_provider.rs
@@ -557,6 +557,57 @@ mod tests {
     }
 
     #[test]
+    fn same_format_body_rules_match_original_model_after_provider_mapping() {
+        let body = build_same_format_provider_request_body(SameFormatProviderRequestBodyInput {
+            body_json: &json!({
+                "model": "gpt-5.5-xhigh",
+                "messages": [{"role": "user", "content": "hello"}]
+            }),
+            mapped_model: "gpt-5.5",
+            client_api_format: "openai:chat",
+            provider_api_format: "openai:chat",
+            source_model: Some("gpt-5.5-xhigh"),
+            family: SameFormatProviderFamily::Standard,
+            body_rules: Some(&json!([
+                {
+                    "action": "set",
+                    "path": "metadata.original_model_hit",
+                    "value": true,
+                    "condition": {"path": "model", "op": "eq", "value": "gpt-5.5-xhigh"}
+                },
+                {
+                    "action": "set",
+                    "path": "metadata.default_mapped_model_hit",
+                    "value": true,
+                    "condition": {"path": "model", "op": "eq", "value": "gpt-5.5"}
+                },
+                {
+                    "action": "set",
+                    "path": "metadata.current_model_hit",
+                    "value": true,
+                    "condition": {
+                        "source": "current",
+                        "path": "model",
+                        "op": "eq",
+                        "value": "gpt-5.5"
+                    }
+                }
+            ])),
+            request_headers: None,
+            upstream_is_stream: false,
+            kiro_auth_config: None,
+            is_claude_code: false,
+            enable_model_directives: false,
+        })
+        .expect("body should build");
+
+        assert_eq!(body["model"], "gpt-5.5");
+        assert_eq!(body["metadata"]["original_model_hit"], true);
+        assert_eq!(body["metadata"]["current_model_hit"], true);
+        assert!(body["metadata"].get("default_mapped_model_hit").is_none());
+    }
+
+    #[test]
     fn builds_same_format_headers_with_auth_and_stream_accept() {
         let provider_request_body = json!({"model": "upstream-model"});
         let original_request_body = json!({"model": "client-model"});

--- a/crates/aether-provider-transport/src/standard.rs
+++ b/crates/aether-provider-transport/src/standard.rs
@@ -402,6 +402,116 @@ mod tests {
     }
 
     #[test]
+    fn standard_body_rules_match_original_model_after_provider_mapping() {
+        let body = apply_standard_provider_request_body_rules(
+            json!({"model":"gpt-5.5"}),
+            Some(&json!([
+                {
+                    "action": "set",
+                    "path": "metadata.original_model_hit",
+                    "value": true,
+                    "condition": {"path": "model", "op": "eq", "value": "gpt-5.5-xhigh"}
+                },
+                {
+                    "action": "set",
+                    "path": "metadata.default_mapped_model_hit",
+                    "value": true,
+                    "condition": {"path": "model", "op": "eq", "value": "gpt-5.5"}
+                },
+                {
+                    "action": "set",
+                    "path": "metadata.current_model_hit",
+                    "value": true,
+                    "condition": {
+                        "source": "current",
+                        "path": "model",
+                        "op": "eq",
+                        "value": "gpt-5.5"
+                    }
+                }
+            ])),
+            &json!({"model":"gpt-5.5-xhigh"}),
+        )
+        .expect("body rules should apply");
+
+        assert_eq!(body["model"], "gpt-5.5");
+        assert_eq!(body["metadata"]["original_model_hit"], true);
+        assert_eq!(body["metadata"]["current_model_hit"], true);
+        assert!(body["metadata"].get("default_mapped_model_hit").is_none());
+    }
+
+    #[test]
+    fn header_rules_match_original_model_after_provider_mapping() {
+        let mut request_headers = HeaderMap::new();
+        request_headers.insert("x-mode", "debug".parse().expect("header"));
+        let transport = sample_transport("openai:responses");
+        let resolved =
+            build_standard_provider_request_headers(StandardProviderRequestHeadersInput {
+                transport: &transport,
+                provider_api_format: "openai:responses",
+                same_format: false,
+                headers: &request_headers,
+                auth_header: "authorization",
+                auth_value: "Bearer secret",
+                extra_headers: &BTreeMap::new(),
+                header_rules: Some(&json!([
+                    {
+                        "action": "set",
+                        "key": "x-original-model-hit",
+                        "value": "true",
+                        "condition": {"path": "model", "op": "eq", "value": "gpt-5.5-xhigh"}
+                    },
+                    {
+                        "action": "set",
+                        "key": "x-default-mapped-model-hit",
+                        "value": "true",
+                        "condition": {"path": "model", "op": "eq", "value": "gpt-5.5"}
+                    },
+                    {
+                        "action": "set",
+                        "key": "x-current-model-hit",
+                        "value": "true",
+                        "condition": {
+                            "source": "current",
+                            "path": "model",
+                            "op": "eq",
+                            "value": "gpt-5.5"
+                        }
+                    },
+                    {
+                        "action": "set",
+                        "key": "x-request-header-hit",
+                        "value": "true",
+                        "condition": {
+                            "source": "request_headers",
+                            "path": "x-mode",
+                            "op": "eq",
+                            "value": "debug"
+                        }
+                    }
+                ])),
+                provider_request_body: &json!({"model":"gpt-5.5"}),
+                original_request_body: &json!({"model":"gpt-5.5-xhigh"}),
+                upstream_is_stream: false,
+            })
+            .expect("headers should build");
+
+        assert_eq!(
+            resolved.headers.get("x-original-model-hit"),
+            Some(&"true".to_string())
+        );
+        assert_eq!(
+            resolved.headers.get("x-current-model-hit"),
+            Some(&"true".to_string())
+        );
+        assert_eq!(
+            resolved.headers.get("x-request-header-hit"),
+            Some(&"true".to_string())
+        );
+        assert!(!resolved.headers.contains_key("x-default-mapped-model-hit"));
+    }
+
+    #[test]
     fn builds_plan_fallback_headers_from_request_when_enabled() {
         let mut request_headers = HeaderMap::new();
         request_headers.insert("x-client", "demo".parse().expect("header"));


### PR DESCRIPTION
- Fall back to built-in reasoning suffix mappings when custom directive config only overrides part of an API format, so streamed requests such as gpt-5.5-xhigh can still select a compatible provider after format conversion.
- Add gateway candidate preselection coverage for default directive fallback and provider model mapping after request format conversion.
- Add standard and same-format body/header rule regression tests proving default model conditions read the original request model, while source=current reads the mapped provider body model.