### PR TITLE
Allow API key requests to use Kiro provider auth

### DIFF
--- a/apps/aether-gateway/src/ai_serving/planner/candidate_resolution.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/candidate_resolution.rs
@@ -399,6 +399,7 @@ pub(crate) fn candidate_auth_channel_skip_reason(
     let upstream_auth_channel = resolve_transport_request_auth_channel(transport)?;
     if request_auth_channel == upstream_auth_channel
         || allow_auth_channel_mismatch_for_format(transport)
+        || kiro_fixed_provider_auth_bridge_allows_auth_channel_mismatch(transport)
     {
         None
     } else {
@@ -470,6 +471,15 @@ fn allow_auth_channel_mismatch_for_format(transport: &GatewayProviderTransportSn
                 .filter_map(serde_json::Value::as_str)
                 .any(|item| crate::ai_serving::normalize_api_format_alias(item) == api_format)
         })
+}
+
+fn kiro_fixed_provider_auth_bridge_allows_auth_channel_mismatch(
+    transport: &GatewayProviderTransportSnapshot,
+) -> bool {
+    crate::ai_serving::transport::kiro::supports_kiro_fixed_provider_auth_bridge(
+        transport,
+        transport.endpoint.api_format.as_str(),
+    )
 }
 
 pub(crate) async fn read_candidate_transport_snapshot(
@@ -616,6 +626,70 @@ mod tests {
             candidate_auth_channel_skip_reason(&transport, Some("bearer_like")),
             None
         );
+        assert_eq!(
+            candidate_auth_channel_skip_reason(&transport, Some("api_key")),
+            Some("auth_channel_mismatch")
+        );
+    }
+
+    #[test]
+    fn auth_channel_gate_allows_claude_api_key_request_for_resolvable_kiro_oauth() {
+        let mut transport = sample_transport("oauth");
+        transport.provider.provider_type = "kiro".to_string();
+        transport.key.decrypted_api_key = "__placeholder__".to_string();
+        transport.key.decrypted_auth_config = Some(
+            r#"{
+                "access_token":"cached-kiro-access-token",
+                "expires_at":4102444800,
+                "machine_id":"123e4567-e89b-12d3-a456-426614174000"
+            }"#
+            .to_string(),
+        );
+
+        assert_eq!(
+            candidate_auth_channel_skip_reason(&transport, Some("api_key")),
+            None
+        );
+    }
+
+    #[test]
+    fn auth_channel_gate_keeps_custom_bearer_provider_blocked_for_api_key_request() {
+        let transport = sample_transport("bearer");
+
+        assert_eq!(
+            candidate_auth_channel_skip_reason(&transport, Some("api_key")),
+            Some("auth_channel_mismatch")
+        );
+    }
+
+    #[test]
+    fn auth_channel_gate_rejects_kiro_bridge_for_non_claude_messages_endpoint() {
+        let mut transport = sample_transport("oauth");
+        transport.provider.provider_type = "kiro".to_string();
+        transport.endpoint.api_format = "openai:responses".to_string();
+        transport.key.decrypted_api_key = "__placeholder__".to_string();
+        transport.key.decrypted_auth_config = Some(
+            r#"{
+                "access_token":"cached-kiro-access-token",
+                "expires_at":4102444800,
+                "machine_id":"123e4567-e89b-12d3-a456-426614174000"
+            }"#
+            .to_string(),
+        );
+
+        assert_eq!(
+            candidate_auth_channel_skip_reason(&transport, Some("api_key")),
+            Some("auth_channel_mismatch")
+        );
+    }
+
+    #[test]
+    fn auth_channel_gate_rejects_kiro_bridge_without_resolvable_auth() {
+        let mut transport = sample_transport("oauth");
+        transport.provider.provider_type = "kiro".to_string();
+        transport.key.decrypted_api_key = "__placeholder__".to_string();
+        transport.key.decrypted_auth_config = None;
+
         assert_eq!(
             candidate_auth_channel_skip_reason(&transport, Some("api_key")),
             Some("auth_channel_mismatch")

--- a/apps/aether-gateway/src/tests/ai_execute/stream_provider.rs
+++ b/apps/aether-gateway/src/tests/ai_execute/stream_provider.rs
@@ -578,6 +578,463 @@ async fn gateway_executes_kiro_claude_cli_stream_via_local_provider_catalog_cand
 }
 
 #[tokio::test]
+async fn gateway_executes_kiro_oauth_stream_for_api_key_request_via_local_provider_catalog_candidate(
+) {
+    use base64::Engine as _;
+
+    #[derive(Debug, Clone)]
+    struct SeenExecutionRuntimeStreamRequest {
+        trace_id: String,
+        url: String,
+        authorization: String,
+    }
+
+    fn crc32(data: &[u8]) -> u32 {
+        let mut crc = 0xffff_ffffu32;
+        for &byte in data {
+            crc ^= byte as u32;
+            for _ in 0..8 {
+                let mask = if crc & 1 == 1 { 0xedb8_8320 } else { 0 };
+                crc = (crc >> 1) ^ mask;
+            }
+        }
+        !crc
+    }
+
+    fn encode_string_header(name: &str, value: &str) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.push(name.len() as u8);
+        out.extend_from_slice(name.as_bytes());
+        out.push(7);
+        out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+        out.extend_from_slice(value.as_bytes());
+        out
+    }
+
+    fn encode_event_frame(
+        message_type: &str,
+        event_type: Option<&str>,
+        payload: serde_json::Value,
+    ) -> Vec<u8> {
+        let mut headers = encode_string_header(":message-type", message_type);
+        if let Some(event_type) = event_type {
+            headers.extend_from_slice(&encode_string_header(":event-type", event_type));
+        }
+        let payload = serde_json::to_vec(&payload).expect("payload should encode");
+        let total_len = 12 + headers.len() + payload.len() + 4;
+        let mut out = Vec::with_capacity(total_len);
+        out.extend_from_slice(&(total_len as u32).to_be_bytes());
+        out.extend_from_slice(&(headers.len() as u32).to_be_bytes());
+        let prelude_crc = crc32(&out[..8]);
+        out.extend_from_slice(&prelude_crc.to_be_bytes());
+        out.extend_from_slice(&headers);
+        out.extend_from_slice(&payload);
+        let message_crc = crc32(&out);
+        out.extend_from_slice(&message_crc.to_be_bytes());
+        out
+    }
+
+    fn hash_api_key(value: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(value.as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn sample_auth_snapshot(api_key_id: &str, user_id: &str) -> StoredAuthApiKeySnapshot {
+        StoredAuthApiKeySnapshot::new(
+            user_id.to_string(),
+            "alice".to_string(),
+            Some("alice@example.com".to_string()),
+            "user".to_string(),
+            "local".to_string(),
+            true,
+            false,
+            Some(serde_json::json!(["claude", "kiro"])),
+            Some(serde_json::json!(["claude:messages"])),
+            Some(serde_json::json!(["claude-sonnet-4"])),
+            api_key_id.to_string(),
+            Some("default".to_string()),
+            true,
+            false,
+            false,
+            Some(60),
+            Some(5),
+            Some(4_102_444_800),
+            Some(serde_json::json!(["claude", "kiro"])),
+            Some(serde_json::json!(["claude:messages"])),
+            Some(serde_json::json!(["claude-sonnet-4"])),
+        )
+        .expect("auth snapshot should build")
+    }
+
+    fn sample_candidate_row() -> StoredMinimalCandidateSelectionRow {
+        StoredMinimalCandidateSelectionRow {
+            provider_id: "provider-kiro-api-key-bridge-stream-1".to_string(),
+            provider_name: "kiro".to_string(),
+            provider_type: "kiro".to_string(),
+            provider_priority: 10,
+            provider_is_active: true,
+            endpoint_id: "endpoint-kiro-api-key-bridge-stream-1".to_string(),
+            endpoint_api_format: "claude:messages".to_string(),
+            endpoint_api_family: Some("claude".to_string()),
+            endpoint_kind: Some("cli".to_string()),
+            endpoint_is_active: true,
+            key_id: "key-kiro-api-key-bridge-stream-1".to_string(),
+            key_name: "prod".to_string(),
+            key_auth_type: "oauth".to_string(),
+            key_is_active: true,
+            key_api_formats: Some(vec!["claude:messages".to_string()]),
+            key_allowed_models: None,
+            key_capabilities: None,
+            key_internal_priority: 5,
+            key_global_priority_by_format: Some(serde_json::json!({"claude:messages": 1})),
+            model_id: "model-kiro-api-key-bridge-stream-1".to_string(),
+            global_model_id: "global-model-kiro-api-key-bridge-stream-1".to_string(),
+            global_model_name: "claude-sonnet-4".to_string(),
+            global_model_mappings: None,
+            global_model_supports_streaming: Some(true),
+            model_provider_model_name: "claude-sonnet-4-upstream".to_string(),
+            model_provider_model_mappings: Some(vec![StoredProviderModelMapping {
+                name: "claude-sonnet-4-upstream".to_string(),
+                priority: 1,
+                api_formats: Some(vec!["claude:messages".to_string()]),
+                endpoint_ids: None,
+            }]),
+            model_supports_streaming: Some(true),
+            model_is_active: true,
+            model_is_available: true,
+        }
+    }
+
+    fn sample_provider_catalog_provider() -> StoredProviderCatalogProvider {
+        StoredProviderCatalogProvider::new(
+            "provider-kiro-api-key-bridge-stream-1".to_string(),
+            "kiro".to_string(),
+            Some("https://example.com".to_string()),
+            "kiro".to_string(),
+        )
+        .expect("provider should build")
+        .with_transport_fields(
+            true,
+            false,
+            false,
+            None,
+            Some(2),
+            Some(serde_json::json!({"url":"http://provider-proxy.internal:8080"})),
+            Some(20.0),
+            None,
+            None,
+        )
+    }
+
+    fn sample_provider_catalog_endpoint() -> StoredProviderCatalogEndpoint {
+        StoredProviderCatalogEndpoint::new(
+            "endpoint-kiro-api-key-bridge-stream-1".to_string(),
+            "provider-kiro-api-key-bridge-stream-1".to_string(),
+            "claude:messages".to_string(),
+            Some("claude".to_string()),
+            Some("cli".to_string()),
+            true,
+        )
+        .expect("endpoint should build")
+        .with_transport_fields(
+            "https://kiro.{region}.example?tenant=demo".to_string(),
+            Some(serde_json::json!([
+                {"action":"set","key":"accept","value":"text/plain"}
+            ])),
+            None,
+            Some(2),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("endpoint transport should build")
+    }
+
+    fn sample_provider_catalog_key() -> StoredProviderCatalogKey {
+        let auth_config = serde_json::json!({
+            "provider_type": "kiro",
+            "access_token": "cached-kiro-access-token",
+            "expires_at": 4102444800_u64,
+            "refresh_token": "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+            "machine_id": "123e4567-e89b-12d3-a456-426614174000",
+            "api_region": "us-east-1",
+            "kiro_version": "0.8.0",
+            "system_version": "darwin#24.6.0",
+            "node_version": "22.21.1"
+        });
+
+        StoredProviderCatalogKey::new(
+            "key-kiro-api-key-bridge-stream-1".to_string(),
+            "provider-kiro-api-key-bridge-stream-1".to_string(),
+            "prod".to_string(),
+            "oauth".to_string(),
+            None,
+            true,
+        )
+        .expect("key should build")
+        .with_transport_fields(
+            Some(serde_json::json!(["claude:messages"])),
+            encrypt_python_fernet_plaintext(DEVELOPMENT_ENCRYPTION_KEY, "__placeholder__")
+                .expect("api key should encrypt"),
+            Some(
+                encrypt_python_fernet_plaintext(
+                    DEVELOPMENT_ENCRYPTION_KEY,
+                    auth_config.to_string().as_str(),
+                )
+                .expect("auth config should encrypt"),
+            ),
+            None,
+            Some(serde_json::json!({"claude:messages": 1})),
+            None,
+            None,
+            None,
+            Some(serde_json::json!({"transport_profile":"chrome_136"})),
+        )
+        .expect("key transport should build")
+    }
+
+    let seen_execution_runtime = Arc::new(Mutex::new(None::<SeenExecutionRuntimeStreamRequest>));
+    let seen_execution_runtime_clone = Arc::clone(&seen_execution_runtime);
+    let seen_report = Arc::new(Mutex::new(false));
+    let seen_report_clone = Arc::clone(&seen_report);
+    let decision_hits = Arc::new(Mutex::new(0usize));
+    let decision_hits_clone = Arc::clone(&decision_hits);
+    let plan_hits = Arc::new(Mutex::new(0usize));
+    let plan_hits_clone = Arc::clone(&plan_hits);
+    let public_hits = Arc::new(Mutex::new(0usize));
+    let public_hits_clone = Arc::clone(&public_hits);
+
+    let upstream = Router::new()
+        .route(
+            "/api/internal/gateway/resolve",
+            any(|_request: Request| async move {
+                Json(json!({
+                    "action": "proxy_public",
+                    "route_class": "ai_public",
+                    "route_family": "claude",
+                    "route_kind": "messages",
+                    "request_auth_channel": "api_key",
+                    "auth_endpoint_signature": "claude:messages",
+                    "execution_runtime_candidate": true,
+                    "auth_context": {
+                        "user_id": "user-kiro-api-key-bridge-stream-123",
+                        "api_key_id": "key-kiro-api-key-bridge-stream-123",
+                        "access_allowed": true
+                    },
+                    "public_path": "/v1/messages"
+                }))
+            }),
+        )
+        .route(
+            "/api/internal/gateway/decision-stream",
+            any(move |_request: Request| {
+                let decision_hits_inner = Arc::clone(&decision_hits_clone);
+                async move {
+                    *decision_hits_inner.lock().expect("mutex should lock") += 1;
+                    Json(json!({"action": "proxy_public"}))
+                }
+            }),
+        )
+        .route(
+            "/api/internal/gateway/plan-stream",
+            any(move |_request: Request| {
+                let plan_hits_inner = Arc::clone(&plan_hits_clone);
+                async move {
+                    *plan_hits_inner.lock().expect("mutex should lock") += 1;
+                    Json(json!({"action": "proxy_public"}))
+                }
+            }),
+        )
+        .route(
+            "/api/internal/gateway/report-stream",
+            any(move |request: Request| {
+                let seen_report_inner = Arc::clone(&seen_report_clone);
+                async move {
+                    let (_parts, body) = request.into_parts();
+                    let _raw_body = to_bytes(body, usize::MAX).await.expect("body should read");
+                    *seen_report_inner.lock().expect("mutex should lock") = true;
+                    Json(json!({"ok": true}))
+                }
+            }),
+        )
+        .route(
+            "/v1/messages",
+            any(move |_request: Request| {
+                let public_hits_inner = Arc::clone(&public_hits_clone);
+                async move {
+                    *public_hits_inner.lock().expect("mutex should lock") += 1;
+                    (StatusCode::IM_A_TEAPOT, Body::from("public-route-hit"))
+                }
+            }),
+        );
+
+    let execution_runtime = Router::new().route(
+        "/v1/execute/stream",
+        any(move |request: Request| {
+            let seen_execution_runtime_inner = Arc::clone(&seen_execution_runtime_clone);
+            async move {
+                let (parts, body) = request.into_parts();
+                let raw_body = to_bytes(body, usize::MAX).await.expect("body should read");
+                let payload: serde_json::Value =
+                    serde_json::from_slice(&raw_body).expect("execution runtime payload should parse");
+                *seen_execution_runtime_inner.lock().expect("mutex should lock") =
+                    Some(SeenExecutionRuntimeStreamRequest {
+                        trace_id: parts
+                            .headers
+                            .get(TRACE_ID_HEADER)
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or_default()
+                            .to_string(),
+                        url: payload
+                            .get("url")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        authorization: payload
+                            .get("headers")
+                            .and_then(|value| value.get("authorization"))
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                    });
+
+                let kiro_frames = [
+                    encode_event_frame(
+                        "event",
+                        Some("assistantResponseEvent"),
+                        json!({"content": "Hello from Kiro stream"}),
+                    ),
+                    encode_event_frame(
+                        "event",
+                        Some("contextUsageEvent"),
+                        json!({"contextUsagePercentage": 1.0}),
+                    ),
+                ]
+                .concat();
+                let frames = format!(
+                    concat!(
+                        "{{\"type\":\"headers\",\"payload\":{{\"kind\":\"headers\",\"status_code\":200,\"headers\":{{\"content-type\":\"application/vnd.amazon.eventstream\"}}}}}}\n",
+                        "{{\"type\":\"data\",\"payload\":{{\"kind\":\"data\",\"chunk_b64\":\"{}\"}}}}\n",
+                        "{{\"type\":\"telemetry\",\"payload\":{{\"kind\":\"telemetry\",\"telemetry\":{{\"elapsed_ms\":27,\"upstream_bytes\":64}}}}}}\n",
+                        "{{\"type\":\"eof\",\"payload\":{{\"kind\":\"eof\"}}}}\n"
+                    ),
+                    base64::engine::general_purpose::STANDARD.encode(kiro_frames)
+                );
+                let mut response = Response::builder()
+                    .status(StatusCode::OK)
+                    .body(Body::from(frames))
+                    .expect("response should build");
+                response.headers_mut().insert(
+                    http::header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/x-ndjson"),
+                );
+                response
+            }
+        }),
+    );
+
+    let auth_repository = Arc::new(InMemoryAuthApiKeySnapshotRepository::seed(vec![(
+        Some(hash_api_key("sk-client-kiro-api-key-bridge-stream")),
+        sample_auth_snapshot(
+            "key-kiro-api-key-bridge-stream-123",
+            "user-kiro-api-key-bridge-stream-123",
+        ),
+    )]));
+    let candidate_selection_repository =
+        Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed(vec![
+            sample_candidate_row(),
+        ]));
+    let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![sample_provider_catalog_provider()],
+        vec![sample_provider_catalog_endpoint()],
+        vec![sample_provider_catalog_key()],
+    ));
+
+    let (upstream_url, upstream_handle) = start_server(upstream).await;
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let gateway_state = build_state_with_execution_runtime_override(execution_runtime_url.clone())
+    .with_data_state_for_tests(
+        crate::data::GatewayDataState::with_auth_candidate_selection_provider_catalog_and_request_candidate_repository_for_tests(
+            auth_repository,
+            candidate_selection_repository,
+            provider_catalog_repository,
+            Arc::clone(&request_candidate_repository),
+            DEVELOPMENT_ENCRYPTION_KEY,
+        ),
+    );
+    let gateway = build_router_with_state(gateway_state);
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/messages"))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header("x-api-key", "sk-client-kiro-api-key-bridge-stream")
+        .header(TRACE_ID_HEADER, "trace-kiro-api-key-bridge-stream-123")
+        .body("{\"model\":\"claude-sonnet-4\",\"messages\":[{\"role\":\"user\",\"content\":\"hello stream\"}],\"stream\":true}")
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(http::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("text/event-stream")
+    );
+    let body = response.text().await.expect("body should read");
+    assert!(body.contains("Hello from Kiro stream"));
+    assert!(body.contains("event: message_start"));
+
+    let seen_execution_runtime_request = seen_execution_runtime
+        .lock()
+        .expect("mutex should lock")
+        .clone()
+        .expect("execution runtime stream should be captured");
+    assert_eq!(
+        seen_execution_runtime_request.trace_id,
+        "trace-kiro-api-key-bridge-stream-123"
+    );
+    assert_eq!(
+        seen_execution_runtime_request.url,
+        "https://kiro.us-east-1.example/generateAssistantResponse?tenant=demo"
+    );
+    assert_eq!(
+        seen_execution_runtime_request.authorization,
+        "Bearer cached-kiro-access-token"
+    );
+    assert_ne!(
+        seen_execution_runtime_request.authorization,
+        "Bearer sk-client-kiro-api-key-bridge-stream"
+    );
+
+    let stored_candidates = request_candidate_repository
+        .list_by_request_id("trace-kiro-api-key-bridge-stream-123")
+        .await
+        .expect("request candidate trace should read");
+    assert_eq!(stored_candidates.len(), 1);
+    assert_eq!(stored_candidates[0].status, RequestCandidateStatus::Success);
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert!(
+        !*seen_report.lock().expect("mutex should lock"),
+        "report-stream should stay local when request candidate persistence is available"
+    );
+
+    assert_eq!(*decision_hits.lock().expect("mutex should lock"), 0);
+    assert_eq!(*plan_hits.lock().expect("mutex should lock"), 0);
+    assert_eq!(*public_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_executes_claude_cli_stream_via_local_decision_gate_without_waiting_for_same_format_prefetch(
 ) {
     #[derive(Debug, Clone)]

--- a/apps/aether-gateway/src/tests/ai_execute/sync/claude/kiro.rs
+++ b/apps/aether-gateway/src/tests/ai_execute/sync/claude/kiro.rs
@@ -608,6 +608,449 @@ async fn gateway_executes_kiro_claude_cli_sync_via_local_provider_catalog_candid
 }
 
 #[test]
+fn gateway_executes_kiro_claude_cli_sync_with_api_key_request_auth_channel_via_oauth_catalog_key() {
+    run_kiro_claude_cli_sync_test(
+        "gateway_executes_kiro_claude_cli_sync_with_api_key_request_auth_channel_via_oauth_catalog_key",
+        gateway_executes_kiro_claude_cli_sync_with_api_key_request_auth_channel_via_oauth_catalog_key_impl,
+    );
+}
+
+async fn gateway_executes_kiro_claude_cli_sync_with_api_key_request_auth_channel_via_oauth_catalog_key_impl(
+) {
+    use base64::Engine as _;
+
+    #[derive(Debug, Clone)]
+    struct SeenExecutionRuntimeSyncRequest {
+        trace_id: String,
+        authorization: String,
+        mapped_model: String,
+        current_content: String,
+    }
+
+    fn crc32(data: &[u8]) -> u32 {
+        let mut crc = 0xffff_ffffu32;
+        for &byte in data {
+            crc ^= byte as u32;
+            for _ in 0..8 {
+                let mask = if crc & 1 == 1 { 0xedb8_8320 } else { 0 };
+                crc = (crc >> 1) ^ mask;
+            }
+        }
+        !crc
+    }
+
+    fn encode_string_header(name: &str, value: &str) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.push(name.len() as u8);
+        out.extend_from_slice(name.as_bytes());
+        out.push(7);
+        out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+        out.extend_from_slice(value.as_bytes());
+        out
+    }
+
+    fn encode_event_frame(
+        message_type: &str,
+        event_type: Option<&str>,
+        payload: serde_json::Value,
+    ) -> Vec<u8> {
+        let mut headers = encode_string_header(":message-type", message_type);
+        if let Some(event_type) = event_type {
+            headers.extend_from_slice(&encode_string_header(":event-type", event_type));
+        }
+        let payload = serde_json::to_vec(&payload).expect("payload should encode");
+        let total_len = 12 + headers.len() + payload.len() + 4;
+        let mut out = Vec::with_capacity(total_len);
+        out.extend_from_slice(&(total_len as u32).to_be_bytes());
+        out.extend_from_slice(&(headers.len() as u32).to_be_bytes());
+        let prelude_crc = crc32(&out[..8]);
+        out.extend_from_slice(&prelude_crc.to_be_bytes());
+        out.extend_from_slice(&headers);
+        out.extend_from_slice(&payload);
+        let message_crc = crc32(&out);
+        out.extend_from_slice(&message_crc.to_be_bytes());
+        out
+    }
+
+    fn hash_api_key(value: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(value.as_bytes());
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn sample_auth_snapshot(api_key_id: &str, user_id: &str) -> StoredAuthApiKeySnapshot {
+        StoredAuthApiKeySnapshot::new(
+            user_id.to_string(),
+            "alice".to_string(),
+            Some("alice@example.com".to_string()),
+            "user".to_string(),
+            "local".to_string(),
+            true,
+            false,
+            Some(serde_json::json!(["claude", "kiro"])),
+            Some(serde_json::json!(["claude:messages"])),
+            Some(serde_json::json!(["claude-sonnet-4"])),
+            api_key_id.to_string(),
+            Some("default".to_string()),
+            true,
+            false,
+            false,
+            Some(60),
+            Some(5),
+            Some(4_102_444_800),
+            Some(serde_json::json!(["claude", "kiro"])),
+            Some(serde_json::json!(["claude:messages"])),
+            Some(serde_json::json!(["claude-sonnet-4"])),
+        )
+        .expect("auth snapshot should build")
+    }
+
+    fn sample_candidate_row() -> StoredMinimalCandidateSelectionRow {
+        StoredMinimalCandidateSelectionRow {
+            provider_id: "provider-kiro-api-key-bridge-sync-1".to_string(),
+            provider_name: "kiro".to_string(),
+            provider_type: "kiro".to_string(),
+            provider_priority: 10,
+            provider_is_active: true,
+            endpoint_id: "endpoint-kiro-api-key-bridge-sync-1".to_string(),
+            endpoint_api_format: "claude:messages".to_string(),
+            endpoint_api_family: Some("claude".to_string()),
+            endpoint_kind: Some("cli".to_string()),
+            endpoint_is_active: true,
+            key_id: "key-kiro-api-key-bridge-sync-1".to_string(),
+            key_name: "prod".to_string(),
+            key_auth_type: "oauth".to_string(),
+            key_is_active: true,
+            key_api_formats: Some(vec!["claude:messages".to_string()]),
+            key_allowed_models: None,
+            key_capabilities: None,
+            key_internal_priority: 5,
+            key_global_priority_by_format: Some(serde_json::json!({"claude:messages": 1})),
+            model_id: "model-kiro-api-key-bridge-sync-1".to_string(),
+            global_model_id: "global-model-kiro-api-key-bridge-sync-1".to_string(),
+            global_model_name: "claude-sonnet-4".to_string(),
+            global_model_mappings: None,
+            global_model_supports_streaming: Some(true),
+            model_provider_model_name: "claude-sonnet-4-upstream".to_string(),
+            model_provider_model_mappings: Some(vec![StoredProviderModelMapping {
+                name: "claude-sonnet-4-upstream".to_string(),
+                priority: 1,
+                api_formats: Some(vec!["claude:messages".to_string()]),
+                endpoint_ids: None,
+            }]),
+            model_supports_streaming: Some(true),
+            model_is_active: true,
+            model_is_available: true,
+        }
+    }
+
+    fn sample_provider_catalog_provider() -> StoredProviderCatalogProvider {
+        StoredProviderCatalogProvider::new(
+            "provider-kiro-api-key-bridge-sync-1".to_string(),
+            "kiro".to_string(),
+            Some("https://example.com".to_string()),
+            "kiro".to_string(),
+        )
+        .expect("provider should build")
+        .with_transport_fields(
+            true,
+            false,
+            false,
+            None,
+            Some(2),
+            None,
+            Some(20.0),
+            None,
+            None,
+        )
+    }
+
+    fn sample_provider_catalog_endpoint() -> StoredProviderCatalogEndpoint {
+        StoredProviderCatalogEndpoint::new(
+            "endpoint-kiro-api-key-bridge-sync-1".to_string(),
+            "provider-kiro-api-key-bridge-sync-1".to_string(),
+            "claude:messages".to_string(),
+            Some("claude".to_string()),
+            Some("cli".to_string()),
+            true,
+        )
+        .expect("endpoint should build")
+        .with_transport_fields(
+            "https://kiro.{region}.example?tenant=demo".to_string(),
+            None,
+            None,
+            Some(2),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("endpoint transport should build")
+    }
+
+    fn sample_provider_catalog_key() -> StoredProviderCatalogKey {
+        let auth_config = serde_json::json!({
+            "provider_type": "kiro",
+            "access_token": "cached-kiro-access-token",
+            "expires_at": 4102444800_u64,
+            "refresh_token": "rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
+            "machine_id": "123e4567-e89b-12d3-a456-426614174000",
+            "api_region": "us-east-1",
+            "kiro_version": "0.8.0",
+            "system_version": "darwin#24.6.0",
+            "node_version": "22.21.1",
+            "profile_arn": "arn:aws:bedrock:us-east-1:123456789012:inference-profile/demo"
+        });
+
+        StoredProviderCatalogKey::new(
+            "key-kiro-api-key-bridge-sync-1".to_string(),
+            "provider-kiro-api-key-bridge-sync-1".to_string(),
+            "prod".to_string(),
+            "oauth".to_string(),
+            None,
+            true,
+        )
+        .expect("key should build")
+        .with_transport_fields(
+            Some(serde_json::json!(["claude:messages"])),
+            encrypt_python_fernet_plaintext(DEVELOPMENT_ENCRYPTION_KEY, "__placeholder__")
+                .expect("api key should encrypt"),
+            Some(
+                encrypt_python_fernet_plaintext(
+                    DEVELOPMENT_ENCRYPTION_KEY,
+                    auth_config.to_string().as_str(),
+                )
+                .expect("auth config should encrypt"),
+            ),
+            None,
+            Some(serde_json::json!({"claude:messages": 1})),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("key transport should build")
+    }
+
+    let seen_execution_runtime = Arc::new(Mutex::new(None::<SeenExecutionRuntimeSyncRequest>));
+    let seen_execution_runtime_clone = Arc::clone(&seen_execution_runtime);
+
+    let upstream = Router::new()
+        .route(
+            "/api/internal/gateway/resolve",
+            any(|_request: Request| async move {
+                Json(json!({
+                    "action": "proxy_public",
+                    "route_class": "ai_public",
+                    "route_family": "claude",
+                    "route_kind": "messages",
+                    "request_auth_channel": "api_key",
+                    "auth_endpoint_signature": "claude:messages",
+                    "execution_runtime_candidate": true,
+                    "auth_context": {
+                        "user_id": "user-kiro-api-key-bridge-sync-123",
+                        "api_key_id": "key-kiro-api-key-bridge-sync-123",
+                        "access_allowed": true
+                    },
+                    "public_path": "/v1/messages"
+                }))
+            }),
+        )
+        .route(
+            "/api/internal/gateway/decision-sync",
+            any(|_request: Request| async move { Json(json!({"action": "proxy_public"})) }),
+        )
+        .route(
+            "/api/internal/gateway/plan-sync",
+            any(|_request: Request| async move { Json(json!({"action": "proxy_public"})) }),
+        )
+        .route(
+            "/api/internal/gateway/report-sync",
+            any(|_request: Request| async move { Json(json!({"ok": true})) }),
+        )
+        .route(
+            "/v1/messages",
+            any(|_request: Request| async move {
+                (StatusCode::IM_A_TEAPOT, Body::from("public-route-hit"))
+            }),
+        );
+
+    let execution_runtime = Router::new().route(
+        "/v1/execute/sync",
+        any(move |request: Request| {
+            let seen_execution_runtime_inner = Arc::clone(&seen_execution_runtime_clone);
+            async move {
+                let (parts, body) = request.into_parts();
+                let raw_body = to_bytes(body, usize::MAX).await.expect("body should read");
+                let payload: serde_json::Value =
+                    serde_json::from_slice(&raw_body).expect("execution runtime payload should parse");
+                *seen_execution_runtime_inner.lock().expect("mutex should lock") =
+                    Some(SeenExecutionRuntimeSyncRequest {
+                        trace_id: parts
+                            .headers
+                            .get(TRACE_ID_HEADER)
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or_default()
+                            .to_string(),
+                        authorization: payload
+                            .get("headers")
+                            .and_then(|value| value.get("authorization"))
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        mapped_model: payload
+                            .get("body")
+                            .and_then(|value| value.get("json_body"))
+                            .and_then(|value| value.get("conversationState"))
+                            .and_then(|value| value.get("currentMessage"))
+                            .and_then(|value| value.get("userInputMessage"))
+                            .and_then(|value| value.get("modelId"))
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                        current_content: payload
+                            .get("body")
+                            .and_then(|value| value.get("json_body"))
+                            .and_then(|value| value.get("conversationState"))
+                            .and_then(|value| value.get("currentMessage"))
+                            .and_then(|value| value.get("userInputMessage"))
+                            .and_then(|value| value.get("content"))
+                            .and_then(|value| value.as_str())
+                            .unwrap_or_default()
+                            .to_string(),
+                    });
+
+                let kiro_frames = [
+                    encode_event_frame(
+                        "event",
+                        Some("assistantResponseEvent"),
+                        json!({"content": "Hello from Kiro api-key bridge"}),
+                    ),
+                    encode_event_frame(
+                        "event",
+                        Some("contextUsageEvent"),
+                        json!({"contextUsagePercentage": 1.0}),
+                    ),
+                ]
+                .concat();
+
+                Json(json!({
+                    "request_id": "trace-kiro-api-key-bridge-sync-123",
+                    "status_code": 200,
+                    "headers": {
+                        "content-type": "application/vnd.amazon.eventstream"
+                    },
+                    "body": {
+                        "body_bytes_b64": base64::engine::general_purpose::STANDARD.encode(kiro_frames)
+                    },
+                    "telemetry": {
+                        "elapsed_ms": 27
+                    }
+                }))
+            }
+        }),
+    );
+
+    let auth_repository = Arc::new(InMemoryAuthApiKeySnapshotRepository::seed(vec![(
+        Some(hash_api_key("sk-client-kiro-api-key-bridge-sync")),
+        sample_auth_snapshot(
+            "key-kiro-api-key-bridge-sync-123",
+            "user-kiro-api-key-bridge-sync-123",
+        ),
+    )]));
+    let candidate_selection_repository =
+        Arc::new(InMemoryMinimalCandidateSelectionReadRepository::seed(vec![
+            sample_candidate_row(),
+        ]));
+    let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![sample_provider_catalog_provider()],
+        vec![sample_provider_catalog_endpoint()],
+        vec![sample_provider_catalog_key()],
+    ));
+
+    let (upstream_url, upstream_handle) = start_server(upstream).await;
+    let (execution_runtime_url, execution_runtime_handle) = start_server(execution_runtime).await;
+    let gateway_state = build_state_with_execution_runtime_override(execution_runtime_url.clone())
+    .with_data_state_for_tests(
+        crate::data::GatewayDataState::with_auth_candidate_selection_provider_catalog_and_request_candidate_repository_for_tests(
+            auth_repository,
+            candidate_selection_repository,
+            provider_catalog_repository,
+            Arc::clone(&request_candidate_repository),
+            DEVELOPMENT_ENCRYPTION_KEY,
+        ),
+    );
+    let gateway = build_router_with_state(gateway_state);
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{gateway_url}/v1/messages"))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header("x-api-key", "sk-client-kiro-api-key-bridge-sync")
+        .header(TRACE_ID_HEADER, "trace-kiro-api-key-bridge-sync-123")
+        .body("{\"model\":\"claude-sonnet-4\",\"messages\":[{\"role\":\"user\",\"content\":\"hello api-key bridge\"}]}")
+        .send()
+        .await
+        .expect("request should succeed");
+
+    let status = response.status();
+    let response_body = response.text().await.expect("body should read");
+    assert!(
+        status == StatusCode::OK,
+        "unexpected status={status} body={response_body}"
+    );
+    let response_json: serde_json::Value =
+        serde_json::from_str(&response_body).expect("body should parse");
+    assert_eq!(response_json["model"], "claude-sonnet-4-upstream");
+    assert_eq!(
+        response_json["content"][0]["text"],
+        json!("Hello from Kiro api-key bridge")
+    );
+
+    let seen_execution_runtime_request = seen_execution_runtime
+        .lock()
+        .expect("mutex should lock")
+        .clone()
+        .expect("execution runtime sync should be captured");
+    assert_eq!(
+        seen_execution_runtime_request.trace_id,
+        "trace-kiro-api-key-bridge-sync-123"
+    );
+    assert_eq!(
+        seen_execution_runtime_request.authorization,
+        "Bearer cached-kiro-access-token"
+    );
+    assert_ne!(
+        seen_execution_runtime_request.authorization,
+        "Bearer sk-client-kiro-api-key-bridge-sync"
+    );
+    assert_ne!(
+        seen_execution_runtime_request.authorization,
+        "sk-client-kiro-api-key-bridge-sync"
+    );
+    assert_eq!(
+        seen_execution_runtime_request.mapped_model,
+        "claude-sonnet-4-upstream"
+    );
+    assert_eq!(
+        seen_execution_runtime_request.current_content,
+        "hello api-key bridge"
+    );
+
+    let stored_candidates = request_candidate_repository
+        .list_by_request_id("trace-kiro-api-key-bridge-sync-123")
+        .await
+        .expect("request candidate trace should read");
+    assert_eq!(stored_candidates.len(), 1);
+    assert_eq!(stored_candidates[0].status, RequestCandidateStatus::Success);
+
+    gateway_handle.abort();
+    execution_runtime_handle.abort();
+    upstream_handle.abort();
+}
+
+#[test]
 fn gateway_executes_kiro_claude_cli_sync_via_local_provider_catalog_candidate_after_refresh() {
     run_kiro_claude_cli_sync_test(
         "gateway_executes_kiro_claude_cli_sync_via_local_provider_catalog_candidate_after_refresh",

--- a/crates/aether-provider-transport/src/kiro.rs
+++ b/crates/aether-provider-transport/src/kiro.rs
@@ -10,8 +10,9 @@ mod url;
 pub use auth::{
     build_kiro_request_auth_from_config, is_kiro_claude_messages_transport,
     is_kiro_provider_transport, resolve_local_kiro_bearer_auth, resolve_local_kiro_request_auth,
-    supports_local_kiro_auth_prerequisites, supports_local_kiro_request_auth_resolution,
-    KiroBearerAuth, KiroRequestAuth, KIRO_AUTH_HEADER, PROVIDER_TYPE,
+    supports_kiro_fixed_provider_auth_bridge, supports_local_kiro_auth_prerequisites,
+    supports_local_kiro_request_auth_resolution, KiroBearerAuth, KiroRequestAuth, KIRO_AUTH_HEADER,
+    PROVIDER_TYPE,
 };
 pub use converter::convert_claude_messages_to_conversation_state;
 pub use credentials::{generate_machine_id, normalize_machine_id, KiroAuthConfig};

--- a/crates/aether-provider-transport/src/kiro/auth.rs
+++ b/crates/aether-provider-transport/src/kiro/auth.rs
@@ -34,6 +34,14 @@ pub fn is_kiro_claude_messages_transport(
         && aether_ai_formats::api_format_alias_matches(provider_api_format, "claude:messages")
 }
 
+pub fn supports_kiro_fixed_provider_auth_bridge(
+    transport: &GatewayProviderTransportSnapshot,
+    provider_api_format: &str,
+) -> bool {
+    is_kiro_claude_messages_transport(transport, provider_api_format)
+        && supports_local_kiro_request_auth_resolution(transport)
+}
+
 pub fn build_kiro_request_auth_from_config(
     auth_config: KiroAuthConfig,
     fallback_secret: Option<&str>,
@@ -154,8 +162,8 @@ mod tests {
     };
     use super::{
         resolve_local_kiro_bearer_auth, resolve_local_kiro_request_auth,
-        supports_local_kiro_auth_prerequisites, supports_local_kiro_request_auth_resolution,
-        KIRO_AUTH_HEADER,
+        supports_kiro_fixed_provider_auth_bridge, supports_local_kiro_auth_prerequisites,
+        supports_local_kiro_request_auth_resolution, KIRO_AUTH_HEADER,
     };
 
     fn sample_transport() -> GatewayProviderTransportSnapshot {
@@ -258,6 +266,50 @@ mod tests {
             .expect("request auth should resolve from legacy oauth auth_type");
         assert_eq!(auth.value, "Bearer cached-token");
         assert!(supports_local_kiro_request_auth_resolution(&transport));
+    }
+
+    #[test]
+    fn supports_fixed_provider_auth_bridge_for_claude_messages_with_resolvable_auth() {
+        let mut transport = sample_transport();
+        transport.key.auth_type = "oauth".to_string();
+        transport.key.decrypted_api_key = "__placeholder__".to_string();
+        transport.key.decrypted_auth_config = Some(
+            r#"{
+                "access_token":"cached-token",
+                "expires_at":4102444800,
+                "machine_id":"123e4567-e89b-12d3-a456-426614174000"
+            }"#
+            .to_string(),
+        );
+
+        assert!(supports_kiro_fixed_provider_auth_bridge(
+            &transport,
+            "claude:messages"
+        ));
+    }
+
+    #[test]
+    fn rejects_fixed_provider_auth_bridge_for_non_claude_messages_endpoint() {
+        let mut transport = sample_transport();
+        transport.endpoint.api_format = "openai:responses".to_string();
+
+        assert!(!supports_kiro_fixed_provider_auth_bridge(
+            &transport,
+            "openai:responses"
+        ));
+    }
+
+    #[test]
+    fn rejects_fixed_provider_auth_bridge_without_resolvable_auth() {
+        let mut transport = sample_transport();
+        transport.key.auth_type = "oauth".to_string();
+        transport.key.decrypted_api_key = "__placeholder__".to_string();
+        transport.key.decrypted_auth_config = None;
+
+        assert!(!supports_kiro_fixed_provider_auth_bridge(
+            &transport,
+            "claude:messages"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a Kiro-only fixed-provider auth bridge for Claude messages candidates
- Allow API-key gateway requests to route to resolvable Kiro OAuth/Bearer upstream auth without changing route classification
- Cover Kiro API-key sync/stream routing and keep custom bearer mismatch blocked

## Tests
- rtk cargo fmt
- rtk cargo test -p aether-provider-transport fixed_provider_auth_bridge --lib
- rtk cargo test -p aether-gateway auth_channel_gate --lib
- rtk cargo test -p aether-gateway tests::ai_execute::sync::claude::kiro::gateway_executes_kiro_claude_cli_sync_with_api_key_request_auth_channel_via_oauth_catalog_key -- --exact
- rtk cargo test -p aether-gateway tests::ai_execute::stream_provider::gateway_executes_kiro_oauth_stream_for_api_key_request_via_local_provider_catalog_candidate -- --exact
- rtk cargo test -p aether-gateway tests::ai_execute::sync::claude::kiro::gateway_executes_kiro_claude_cli_sync_via_local_provider_catalog_candidate -- --exact
- rtk cargo test -p aether-gateway tests::ai_execute::stream_provider::gateway_executes_kiro_claude_cli_stream_via_local_provider_catalog_candidate -- --exact
- rtk cargo test -p aether-gateway tests::architecture::ai_serving::ai_serving_routes_provider_transport_deps_through_facade -- --exact
- rtk git diff --check