### PR TITLE
Support Codex Spark model quota

### DIFF
--- a/apps/aether-gateway/src/ai_serving/planner/pool_scheduler.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/pool_scheduler.rs
@@ -381,6 +381,7 @@ async fn read_pool_catalog_key_contexts_by_id(
 ) -> BTreeMap<String, PoolCatalogKeyContext> {
     let mut key_ids = Vec::new();
     let mut provider_type_by_key_id = BTreeMap::<String, String>::new();
+    let mut requested_model_by_key_id = BTreeMap::<String, String>::new();
 
     for candidate in candidates {
         if pool_config_for_candidate(candidate).is_none() {
@@ -389,6 +390,10 @@ async fn read_pool_catalog_key_contexts_by_id(
         let key_id = candidate.candidate.key_id.clone();
         if let Entry::Vacant(entry) = provider_type_by_key_id.entry(key_id.clone()) {
             entry.insert(candidate.transport.provider.provider_type.clone());
+            requested_model_by_key_id.insert(
+                key_id.clone(),
+                pool_candidate_requested_model(&candidate.candidate).to_string(),
+            );
             key_ids.push(key_id);
         }
     }
@@ -419,18 +424,37 @@ async fn read_pool_catalog_key_contexts_by_id(
                 .get(&key.id)
                 .map(String::as_str)
                 .unwrap_or_default();
+            let requested_model = requested_model_by_key_id
+                .get(&key.id)
+                .map(String::as_str)
+                .unwrap_or_default();
             (
                 key.id.clone(),
-                build_pool_catalog_key_context(state, &key, provider_type),
+                build_pool_catalog_key_context(state, &key, provider_type, requested_model),
             )
         })
         .collect()
+}
+
+fn pool_candidate_requested_model(
+    candidate: &aether_scheduler_core::SchedulerMinimalCandidateSelectionCandidate,
+) -> &str {
+    let selected = candidate.selected_provider_model_name.trim();
+    if !selected.is_empty() {
+        return selected;
+    }
+    let global = candidate.global_model_name.trim();
+    if !global.is_empty() {
+        return global;
+    }
+    candidate.model_id.as_str()
 }
 
 fn build_pool_catalog_key_context(
     state: PlannerAppState<'_>,
     key: &StoredProviderCatalogKey,
     provider_type: &str,
+    requested_model: &str,
 ) -> PoolCatalogKeyContext {
     let status_snapshot = provider_key_status_snapshot_payload(key, provider_type);
     let quota_snapshot = status_snapshot
@@ -458,6 +482,17 @@ fn build_pool_catalog_key_context(
         })
         .filter(|value| value.is_finite() && *value >= 0.0);
 
+    let quota_exhausted = quota_snapshot
+        .and_then(|quota| quota.get("exhausted"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || aether_admin::provider::pool::admin_pool_key_model_quota_exhausted(
+            key,
+            provider_type,
+            requested_model,
+            crate::clock::current_unix_secs(),
+        );
+
     PoolCatalogKeyContext {
         oauth_plan_type: quota_snapshot
             .and_then(|quota| quota.get("plan_type"))
@@ -476,10 +511,7 @@ fn build_pool_catalog_key_context(
             .and_then(|account| account.get("blocked"))
             .and_then(Value::as_bool)
             .unwrap_or(false),
-        quota_exhausted: quota_snapshot
-            .and_then(|quota| quota.get("exhausted"))
-            .and_then(Value::as_bool)
-            .unwrap_or(false),
+        quota_exhausted,
         health_score,
         latency_avg_ms,
         catalog_lru_score: Some(key.last_used_at_unix_secs.unwrap_or(0) as f64),
@@ -1442,13 +1474,69 @@ mod tests {
                 )),
             ));
 
-        let context = build_pool_catalog_key_context(PlannerAppState::new(&app), &key, "codex");
+        let context =
+            build_pool_catalog_key_context(PlannerAppState::new(&app), &key, "codex", "gpt-5");
 
         assert_eq!(context.oauth_plan_type.as_deref(), Some("team"));
         assert_eq!(context.quota_usage_ratio, Some(0.25));
         assert_eq!(context.quota_reset_seconds, Some(3600.0));
         assert_eq!(context.latency_avg_ms, Some(50.0));
         assert_eq!(context.catalog_lru_score, Some(1_711_000_123.0));
+    }
+
+    #[test]
+    fn pool_catalog_context_marks_only_spark_model_quota_exhausted() {
+        let mut key = StoredProviderCatalogKey::new(
+            "key-1".to_string(),
+            "provider-1".to_string(),
+            "key-1".to_string(),
+            "oauth".to_string(),
+            None,
+            true,
+        )
+        .expect("key should build");
+        key.status_snapshot = Some(json!({
+            "account": {"blocked": false},
+            "quota": {
+                "version": 2,
+                "provider_type": "codex",
+                "exhausted": false,
+                "windows": [
+                    {
+                        "code": "weekly",
+                        "scope": "account",
+                        "used_ratio": 0.1,
+                        "remaining_ratio": 0.9
+                    },
+                    {
+                        "code": "model:gpt-5.3-codex-spark",
+                        "scope": "model",
+                        "model": "gpt-5.3-codex-spark",
+                        "used_ratio": 1.0,
+                        "remaining_ratio": 0.0,
+                        "reset_at": 4_000_000_000u64,
+                        "is_exhausted": true
+                    }
+                ]
+            }
+        }));
+        let app = AppState::new().expect("state should build");
+
+        let spark_context = build_pool_catalog_key_context(
+            PlannerAppState::new(&app),
+            &key,
+            "codex",
+            "gpt-5.3-codex-spark",
+        );
+        let regular_context = build_pool_catalog_key_context(
+            PlannerAppState::new(&app),
+            &key,
+            "codex",
+            "gpt-5.3-codex",
+        );
+
+        assert!(spark_context.quota_exhausted);
+        assert!(!regular_context.quota_exhausted);
     }
 
     fn sample_eligible_candidate(

--- a/apps/aether-gateway/src/handlers/admin/provider/pool_admin/payloads.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/pool_admin/payloads.rs
@@ -378,6 +378,11 @@ fn admin_pool_build_codex_account_quota_from_snapshot(
     ) {
         parts.push(part);
     }
+    if let Some(part) =
+        admin_pool_codex_spark_quota_part_from_snapshot(quota_snapshot, now_unix_secs)
+    {
+        parts.push(part);
+    }
 
     if !parts.is_empty() {
         return Some(parts.join(" | "));
@@ -401,6 +406,56 @@ fn admin_pool_build_codex_account_quota_from_snapshot(
     }
 
     None
+}
+
+fn admin_pool_codex_spark_quota_part_from_snapshot(
+    quota_snapshot: &serde_json::Map<String, serde_json::Value>,
+    now_unix_secs: u64,
+) -> Option<String> {
+    let window = admin_pool_quota_windows(quota_snapshot)
+        .into_iter()
+        .find(|window| {
+            let model_matches = window
+                .get("model")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|model| model.eq_ignore_ascii_case("gpt-5.3-codex-spark"));
+            let scope_matches = window
+                .get("scope")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|scope| scope.eq_ignore_ascii_case("model"));
+            model_matches && scope_matches
+        })?;
+    let reset_seconds =
+        admin_pool_quota_window_reset_seconds(quota_snapshot, window, now_unix_secs);
+    let exhausted = window
+        .get("is_exhausted")
+        .and_then(admin_provider_quota_pure::coerce_json_bool)
+        .or_else(|| {
+            admin_pool_json_to_f64(window.get("used_ratio")).map(|value| value >= 1.0 - 1e-6)
+        })
+        .unwrap_or(false);
+    if exhausted && reset_seconds.is_none_or(|value| value > 0.0) {
+        let mut part = "Spark 冷却中".to_string();
+        if let Some(reset_text) = reset_seconds.and_then(admin_pool_format_reset_after) {
+            part.push_str(&format!(" ({reset_text})"));
+        }
+        return Some(part);
+    }
+
+    let remaining_percent = admin_pool_json_to_f64(window.get("remaining_ratio"))
+        .map(|value| (value * 100.0).clamp(0.0, 100.0))
+        .or_else(|| {
+            admin_pool_json_to_f64(window.get("used_ratio"))
+                .map(|value| ((1.0 - value) * 100.0).clamp(0.0, 100.0))
+        })?;
+    let mut part = format!(
+        "Spark 剩余 {}",
+        admin_pool_format_percent(remaining_percent)
+    );
+    if let Some(reset_text) = reset_seconds.and_then(admin_pool_format_reset_after) {
+        part.push_str(&format!(" ({reset_text})"));
+    }
+    Some(part)
 }
 
 fn admin_pool_current_unix_secs() -> u64 {

--- a/apps/aether-gateway/src/handlers/shared/catalog.rs
+++ b/apps/aether-gateway/src/handlers/shared/catalog.rs
@@ -462,18 +462,43 @@ fn model_quota_window_snapshot(
     observed_at_unix_secs: Option<u64>,
 ) -> Option<Value> {
     let used_ratio = item
-        .get("used_percent")
+        .get("used_ratio")
         .and_then(admin_provider_quota_pure::coerce_json_f64)
-        .map(|value| (value / 100.0).clamp(0.0, 1.0))
+        .map(|value| value.clamp(0.0, 1.0))
+        .or_else(|| {
+            item.get("remaining_ratio")
+                .and_then(admin_provider_quota_pure::coerce_json_f64)
+                .map(|value| (1.0 - value.clamp(0.0, 1.0)).clamp(0.0, 1.0))
+        })
+        .or_else(|| {
+            item.get("remaining_percent")
+                .and_then(admin_provider_quota_pure::coerce_json_f64)
+                .map(|value| (1.0 - (value / 100.0).clamp(0.0, 1.0)).clamp(0.0, 1.0))
+        })
+        .or_else(|| {
+            item.get("used_percent")
+                .and_then(admin_provider_quota_pure::coerce_json_f64)
+                .map(|value| (value / 100.0).clamp(0.0, 1.0))
+        })
         .or_else(|| {
             item.get("remaining_fraction")
                 .and_then(admin_provider_quota_pure::coerce_json_f64)
                 .map(|value| (1.0 - value.clamp(0.0, 1.0)).clamp(0.0, 1.0))
         });
     let remaining_ratio = item
-        .get("remaining_fraction")
+        .get("remaining_ratio")
         .and_then(admin_provider_quota_pure::coerce_json_f64)
         .map(|value| value.clamp(0.0, 1.0))
+        .or_else(|| {
+            item.get("remaining_percent")
+                .and_then(admin_provider_quota_pure::coerce_json_f64)
+                .map(|value| (value / 100.0).clamp(0.0, 1.0))
+        })
+        .or_else(|| {
+            item.get("remaining_fraction")
+                .and_then(admin_provider_quota_pure::coerce_json_f64)
+                .map(|value| value.clamp(0.0, 1.0))
+        })
         .or_else(|| used_ratio.map(|value| (1.0 - value).max(0.0)));
     let reset_at = provider_quota_timestamp_unix_secs(
         item.get("reset_at").or_else(|| item.get("next_reset_at")),
@@ -2414,6 +2439,53 @@ mod tests {
             quota.get("windows").and_then(Value::as_array).map(Vec::len),
             Some(2usize)
         );
+    }
+
+    #[test]
+    fn codex_quota_snapshot_preserves_model_ratio_windows() {
+        let upstream_metadata = json!({
+            "codex": {
+                "updated_at": 1_775_553_285u64,
+                "primary_used_percent": 10.0,
+                "quota_by_model": {
+                    "gpt-5.3-codex-spark": {
+                        "windows": [
+                            {
+                                "code": "spark",
+                                "scope": "model",
+                                "model": "gpt-5.3-codex-spark",
+                                "used_ratio": 0.6,
+                                "remaining_ratio": 0.4,
+                                "reset_seconds": 300,
+                                "is_exhausted": false
+                            }
+                        ]
+                    }
+                }
+            }
+        });
+
+        let payload = sync_provider_key_quota_status_snapshot(
+            None,
+            "codex",
+            Some(&upstream_metadata),
+            "refresh_api",
+        )
+        .expect("quota snapshot should sync");
+        let spark = payload["quota"]["windows"]
+            .as_array()
+            .expect("windows should exist")
+            .iter()
+            .filter_map(Value::as_object)
+            .find(|window| window.get("model") == Some(&json!("gpt-5.3-codex-spark")))
+            .expect("Spark window should exist");
+
+        assert_eq!(spark.get("code"), Some(&json!("spark")));
+        assert_eq!(spark.get("scope"), Some(&json!("model")));
+        assert_eq!(spark.get("used_ratio"), Some(&json!(0.6)));
+        assert_eq!(spark.get("remaining_ratio"), Some(&json!(0.4)));
+        assert_eq!(spark.get("reset_seconds"), Some(&json!(300u64)));
+        assert_eq!(payload["quota"]["exhausted"], json!(false));
     }
 
     #[test]

--- a/apps/aether-gateway/src/handlers/shared/catalog.rs
+++ b/apps/aether-gateway/src/handlers/shared/catalog.rs
@@ -478,7 +478,11 @@ fn model_quota_window_snapshot(
     let reset_at = provider_quota_timestamp_unix_secs(
         item.get("reset_at").or_else(|| item.get("next_reset_at")),
     );
-    let reset_seconds = quota_window_reset_seconds(observed_at_unix_secs, reset_at);
+    let reset_seconds = item
+        .get("reset_seconds")
+        .or_else(|| item.get("reset_after_seconds"))
+        .and_then(admin_provider_quota_pure::coerce_json_u64)
+        .or_else(|| quota_window_reset_seconds(observed_at_unix_secs, reset_at));
     let is_exhausted = item
         .get("is_exhausted")
         .and_then(admin_provider_quota_pure::coerce_json_bool)
@@ -500,7 +504,14 @@ fn model_quota_window_snapshot(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or(model_name);
-    window.insert("code".to_string(), json!(format!("model:{model_name}")));
+    let code = item
+        .get("code")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("model:{model_name}"));
+    window.insert("code".to_string(), json!(code));
     window.insert("label".to_string(), json!(label));
     window.insert("scope".to_string(), json!("model"));
     window.insert("unit".to_string(), json!("percent"));
@@ -732,13 +743,43 @@ fn build_codex_quota_status_snapshot(
         .get("credits_unlimited")
         .and_then(admin_provider_quota_pure::coerce_json_bool);
 
-    let windows = [
+    let mut windows = [
         codex_quota_window_snapshot(metadata, "primary", "weekly", "周", observed_at_unix_secs),
         codex_quota_window_snapshot(metadata, "secondary", "5h", "5H", observed_at_unix_secs),
     ]
     .into_iter()
     .flatten()
     .collect::<Vec<_>>();
+    if let Some(model_windows) = provider_quota_model_bucket(metadata).map(|models| {
+        models
+            .iter()
+            .filter_map(|(model_name, item)| {
+                let item = item.as_object()?;
+                if let Some(nested_windows) = item.get("windows").and_then(Value::as_array) {
+                    let snapshots = nested_windows
+                        .iter()
+                        .filter_map(|window| {
+                            let mut merged = item.clone();
+                            if let Some(window) = window.as_object() {
+                                for (key, value) in window {
+                                    merged.insert(key.clone(), value.clone());
+                                }
+                            }
+                            model_quota_window_snapshot(model_name, &merged, observed_at_unix_secs)
+                        })
+                        .collect::<Vec<_>>();
+                    if !snapshots.is_empty() {
+                        return Some(snapshots);
+                    }
+                }
+                model_quota_window_snapshot(model_name, item, observed_at_unix_secs)
+                    .map(|window| vec![window])
+            })
+            .flatten()
+            .collect::<Vec<_>>()
+    }) {
+        windows.extend(model_windows);
+    }
 
     if windows.is_empty()
         && plan_type.is_none()
@@ -750,21 +791,32 @@ fn build_codex_quota_status_snapshot(
         return None;
     }
 
-    let usage_ratio = windows
+    let account_windows = windows
+        .iter()
+        .filter(|window| {
+            window
+                .get("scope")
+                .and_then(Value::as_str)
+                .is_none_or(|scope| scope.eq_ignore_ascii_case("account"))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let usage_ratio = account_windows
         .iter()
         .filter_map(Value::as_object)
         .filter_map(|window| window.get("used_ratio"))
         .filter_map(Value::as_f64)
         .max_by(f64::total_cmp);
-    let reset_seconds = windows
+    let reset_seconds = account_windows
         .iter()
         .filter_map(Value::as_object)
         .filter_map(|window| window.get("reset_seconds"))
         .filter_map(admin_provider_quota_pure::coerce_json_u64)
         .min();
-    let reset_at = quota_windows_min_reset_at(&windows);
-    let exhausted_by_credits =
-        windows.is_empty() && credits_unlimited != Some(true) && credits_has_credits == Some(false);
+    let reset_at = quota_windows_min_reset_at(&account_windows);
+    let exhausted_by_credits = account_windows.is_empty()
+        && credits_unlimited != Some(true)
+        && credits_has_credits == Some(false);
     let exhausted_by_window = usage_ratio.is_some_and(|value| value >= 1.0 - 1e-6);
     let exhausted = exhausted_by_credits || exhausted_by_window;
 

--- a/apps/aether-gateway/src/orchestration/effects.rs
+++ b/apps/aether-gateway/src/orchestration/effects.rs
@@ -10,7 +10,7 @@ use aether_usage_runtime::{
     build_stream_terminal_usage_outcome, build_sync_terminal_usage_outcome,
     GatewayStreamReportRequest, GatewaySyncReportRequest, TerminalUsageOutcome,
 };
-use serde_json::Value;
+use serde_json::{json, Value};
 use tracing::warn;
 
 use super::{
@@ -29,6 +29,7 @@ use crate::handlers::shared::provider_pool::{
     record_admin_provider_pool_stream_timeout, record_admin_provider_pool_success,
     AdminProviderPoolConfig,
 };
+use crate::handlers::shared::sync_provider_key_quota_status_snapshot;
 use crate::scheduler::affinity::SCHEDULER_AFFINITY_TTL;
 use crate::AppState;
 
@@ -670,6 +671,15 @@ async fn record_oauth_invalidation_effect(
         return;
     }
 
+    record_codex_spark_model_quota_fallback(
+        state,
+        context.plan,
+        transport.provider.provider_type.as_str(),
+        effect.status_code,
+        effect.response_text,
+    )
+    .await;
+
     let Some(invalid_reason) = resolve_local_oauth_invalid_reason(
         transport.provider.provider_type.as_str(),
         effect.status_code,
@@ -691,6 +701,136 @@ async fn record_oauth_invalidation_effect(
             plan.provider_id, plan.endpoint_id, plan.key_id, err
         );
     }
+}
+
+async fn record_codex_spark_model_quota_fallback(
+    state: &AppState,
+    plan: &ExecutionPlan,
+    provider_type: &str,
+    status_code: u16,
+    response_text: Option<&str>,
+) {
+    if !provider_type.trim().eq_ignore_ascii_case("codex") {
+        return;
+    }
+    let requested_model = plan.model_name.as_deref().unwrap_or_default().trim();
+    if !requested_model.eq_ignore_ascii_case(admin_provider_quota_pure::CODEX_SPARK_MODEL_ID) {
+        return;
+    }
+    if !codex_spark_error_clearly_quota_limited(status_code, response_text) {
+        return;
+    }
+
+    let now_unix_secs = current_unix_secs();
+    let reset_seconds = codex_spark_quota_fallback_reset_seconds(status_code, response_text);
+    let Some(mut updated_key) = state
+        .read_provider_catalog_keys_by_ids(std::slice::from_ref(&plan.key_id))
+        .await
+        .ok()
+        .and_then(|mut keys| keys.drain(..).next())
+    else {
+        return;
+    };
+    let mut upstream_metadata = updated_key
+        .upstream_metadata
+        .as_ref()
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let mut codex = upstream_metadata
+        .get("codex")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    codex.insert("schema_version".to_string(), json!(2));
+    codex
+        .entry("updated_at".to_string())
+        .or_insert_with(|| json!(now_unix_secs));
+    let mut quota_by_model = codex
+        .get("quota_by_model")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    quota_by_model.insert(
+        admin_provider_quota_pure::CODEX_SPARK_MODEL_ID.to_string(),
+        json!({
+            "updated_at": now_unix_secs,
+            "windows": [
+                {
+                    "code": "spark",
+                    "scope": "model",
+                    "model": admin_provider_quota_pure::CODEX_SPARK_MODEL_ID,
+                    "unit": "percent",
+                    "used_ratio": 1.0,
+                    "remaining_ratio": 0.0,
+                    "reset_seconds": reset_seconds,
+                    "reset_at": now_unix_secs.saturating_add(reset_seconds),
+                    "is_exhausted": true,
+                    "source": "runtime_fallback"
+                }
+            ]
+        }),
+    );
+    codex.insert("quota_by_model".to_string(), Value::Object(quota_by_model));
+    upstream_metadata.insert("codex".to_string(), Value::Object(codex));
+    updated_key.upstream_metadata = Some(Value::Object(upstream_metadata));
+    updated_key.status_snapshot = sync_provider_key_quota_status_snapshot(
+        updated_key.status_snapshot.as_ref(),
+        provider_type,
+        updated_key.upstream_metadata.as_ref(),
+        "runtime_fallback",
+    )
+    .or(updated_key.status_snapshot);
+    updated_key.updated_at_unix_secs = Some(now_unix_secs);
+
+    if let Err(err) = state.update_provider_catalog_key(&updated_key).await {
+        warn!(
+            "gateway orchestration effects: failed to persist Codex Spark quota fallback for provider {} endpoint {} key {}: {:?}",
+            plan.provider_id, plan.endpoint_id, plan.key_id, err
+        );
+    }
+}
+
+fn codex_spark_error_clearly_quota_limited(status_code: u16, response_text: Option<&str>) -> bool {
+    if !matches!(status_code, 402 | 429) {
+        return false;
+    }
+    let message = local_failover_error_message(response_text)
+        .or_else(|| response_text.map(str::to_string))
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if message.trim().is_empty() {
+        return status_code == 429;
+    }
+    [
+        "quota",
+        "rate limit",
+        "rate_limit",
+        "usage limit",
+        "usage_limit",
+        "capacity",
+        "cooldown",
+        "too many requests",
+        "额度",
+        "限额",
+        "冷却",
+    ]
+    .iter()
+    .any(|hint| message.contains(hint))
+}
+
+fn codex_spark_quota_fallback_reset_seconds(status_code: u16, response_text: Option<&str>) -> u64 {
+    let message = local_failover_error_message(response_text)
+        .or_else(|| response_text.map(str::to_string))
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if status_code == 429 && message.contains("5h") {
+        return 5 * 60 * 60;
+    }
+    if message.contains("weekly") || message.contains("week") || message.contains("周") {
+        return 7 * 24 * 60 * 60;
+    }
+    5 * 60
 }
 
 fn resolve_local_oauth_invalid_reason(

--- a/apps/aether-gateway/src/scheduler/candidate/runtime.rs
+++ b/apps/aether-gateway/src/scheduler/candidate/runtime.rs
@@ -465,6 +465,22 @@ fn oauth_account_state_code_is_hard_block(code: &str) -> bool {
     )
 }
 
+fn read_provider_key_rpm_reset_at_map(
+    state: &(impl SchedulerRuntimeState + ?Sized),
+    candidates: &[SchedulerMinimalCandidateSelectionCandidate],
+    now_unix_secs: u64,
+) -> BTreeMap<String, Option<u64>> {
+    candidates
+        .iter()
+        .map(|candidate| {
+            (
+                candidate.key_id.clone(),
+                state.provider_key_rpm_reset_at(candidate.key_id.as_str(), now_unix_secs),
+            )
+        })
+        .collect::<BTreeMap<_, _>>()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -558,20 +574,4 @@ mod tests {
             Some(false)
         );
     }
-}
-
-fn read_provider_key_rpm_reset_at_map(
-    state: &(impl SchedulerRuntimeState + ?Sized),
-    candidates: &[SchedulerMinimalCandidateSelectionCandidate],
-    now_unix_secs: u64,
-) -> BTreeMap<String, Option<u64>> {
-    candidates
-        .iter()
-        .map(|candidate| {
-            (
-                candidate.key_id.clone(),
-                state.provider_key_rpm_reset_at(candidate.key_id.as_str(), now_unix_secs),
-            )
-        })
-        .collect::<BTreeMap<_, _>>()
 }

--- a/apps/aether-gateway/src/scheduler/candidate/runtime.rs
+++ b/apps/aether-gateway/src/scheduler/candidate/runtime.rs
@@ -303,6 +303,11 @@ fn read_key_account_quota_exhaustion_map(
     provider_key_rpm_states: &BTreeMap<String, StoredProviderCatalogKey>,
     provider_skip_exhausted_accounts: &BTreeMap<String, bool>,
 ) -> BTreeMap<String, bool> {
+    let now_unix_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
     candidates
         .iter()
         .map(|candidate| {
@@ -316,11 +321,28 @@ fn read_key_account_quota_exhaustion_map(
                         admin_provider_pool_pure::admin_pool_key_account_quota_exhausted(
                             key,
                             candidate.provider_type.as_str(),
+                        ) || admin_provider_pool_pure::admin_pool_key_model_quota_exhausted(
+                            key,
+                            candidate.provider_type.as_str(),
+                            candidate_selected_model(candidate),
+                            now_unix_secs,
                         )
                     });
             (candidate.key_id.clone(), exhausted)
         })
         .collect()
+}
+
+fn candidate_selected_model(candidate: &SchedulerMinimalCandidateSelectionCandidate) -> &str {
+    let selected = candidate.selected_provider_model_name.trim();
+    if !selected.is_empty() {
+        return selected;
+    }
+    let global = candidate.global_model_name.trim();
+    if !global.is_empty() {
+        return global;
+    }
+    candidate.model_id.as_str()
 }
 
 fn read_key_oauth_invalid_map(

--- a/apps/aether-gateway/src/scheduler/candidate/runtime.rs
+++ b/apps/aether-gateway/src/scheduler/candidate/runtime.rs
@@ -25,7 +25,7 @@ pub(super) struct CandidateRuntimeSelectionSnapshot {
     pub(super) provider_key_rpm_states: BTreeMap<String, StoredProviderCatalogKey>,
     pub(super) pool_provider_ids: BTreeSet<String>,
     provider_quota_blocks_requests: BTreeMap<String, bool>,
-    key_account_quota_exhausted: BTreeMap<String, bool>,
+    candidate_quota_exhausted: BTreeMap<String, bool>,
     key_oauth_invalid: BTreeMap<String, bool>,
     provider_key_rpm_reset_ats: BTreeMap<String, Option<u64>>,
 }
@@ -47,7 +47,7 @@ pub(super) async fn read_candidate_runtime_selection_snapshot(
         .filter_map(|(provider_id, state)| state.pool_enabled.then_some(provider_id.clone()))
         .collect::<BTreeSet<_>>();
     let provider_key_rpm_states = read_provider_key_rpm_states(state, candidates).await?;
-    let key_account_quota_exhausted = read_key_account_quota_exhaustion_map(
+    let candidate_quota_exhausted = read_candidate_quota_exhaustion_map(
         candidates,
         &provider_key_rpm_states,
         &provider_skip_exhausted_accounts,
@@ -65,7 +65,7 @@ pub(super) async fn read_candidate_runtime_selection_snapshot(
         provider_key_rpm_states,
         pool_provider_ids,
         provider_quota_blocks_requests,
-        key_account_quota_exhausted,
+        candidate_quota_exhausted,
         key_oauth_invalid,
         provider_key_rpm_reset_ats,
     })
@@ -118,8 +118,8 @@ pub(super) fn is_candidate_selectable(
             .unwrap_or(false),
         account_quota_exhausted: !pool_group
             && snapshot
-                .key_account_quota_exhausted
-                .get(candidate.key_id.as_str())
+                .candidate_quota_exhausted
+                .get(candidate_quota_state_key(candidate).as_str())
                 .copied()
                 .unwrap_or(false),
         oauth_invalid: !pool_group
@@ -172,8 +172,8 @@ pub(super) fn current_candidate_runtime_skip_reason(
         provider_quota_blocks_requests,
         account_quota_exhausted: !pool_group
             && snapshot
-                .key_account_quota_exhausted
-                .get(candidate.key_id.as_str())
+                .candidate_quota_exhausted
+                .get(candidate_quota_state_key(candidate).as_str())
                 .copied()
                 .unwrap_or(false),
         oauth_invalid: !pool_group
@@ -298,7 +298,7 @@ async fn read_provider_pool_state_map(
         .collect())
 }
 
-fn read_key_account_quota_exhaustion_map(
+fn read_candidate_quota_exhaustion_map(
     candidates: &[SchedulerMinimalCandidateSelectionCandidate],
     provider_key_rpm_states: &BTreeMap<String, StoredProviderCatalogKey>,
     provider_skip_exhausted_accounts: &BTreeMap<String, bool>,
@@ -328,9 +328,18 @@ fn read_key_account_quota_exhaustion_map(
                             now_unix_secs,
                         )
                     });
-            (candidate.key_id.clone(), exhausted)
+            (candidate_quota_state_key(candidate), exhausted)
         })
         .collect()
+}
+
+fn candidate_quota_state_key(candidate: &SchedulerMinimalCandidateSelectionCandidate) -> String {
+    format!(
+        "{}\u{1f}{}\u{1f}{}",
+        candidate.provider_id,
+        candidate.key_id,
+        candidate_selected_model(candidate)
+    )
 }
 
 fn candidate_selected_model(candidate: &SchedulerMinimalCandidateSelectionCandidate) -> &str {
@@ -454,6 +463,101 @@ fn oauth_account_state_code_is_hard_block(code: &str) -> bool {
             | "account_blocked"
             | "account_verification"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        candidate_quota_state_key, read_candidate_quota_exhaustion_map,
+        SchedulerMinimalCandidateSelectionCandidate, StoredProviderCatalogKey,
+    };
+    use serde_json::json;
+    use std::collections::BTreeMap;
+
+    fn candidate(
+        key_id: &str,
+        selected_model: &str,
+    ) -> SchedulerMinimalCandidateSelectionCandidate {
+        SchedulerMinimalCandidateSelectionCandidate {
+            provider_id: "provider-1".to_string(),
+            provider_name: "provider".to_string(),
+            provider_type: "codex".to_string(),
+            provider_priority: 10,
+            endpoint_id: "endpoint-1".to_string(),
+            endpoint_api_format: "openai:chat".to_string(),
+            key_id: key_id.to_string(),
+            key_name: key_id.to_string(),
+            key_auth_type: "oauth".to_string(),
+            key_internal_priority: 0,
+            key_global_priority_for_format: None,
+            key_capabilities: None,
+            model_id: selected_model.to_string(),
+            global_model_id: selected_model.to_string(),
+            global_model_name: selected_model.to_string(),
+            selected_provider_model_name: selected_model.to_string(),
+            mapping_matched_model: None,
+        }
+    }
+
+    #[test]
+    fn candidate_quota_exhaustion_is_model_scoped() {
+        let spark = candidate("key-1", "gpt-5.3-codex-spark");
+        let regular = candidate("key-1", "gpt-5.3-codex");
+        let mut key = StoredProviderCatalogKey::new(
+            "key-1".to_string(),
+            "provider-1".to_string(),
+            "key-1".to_string(),
+            "oauth".to_string(),
+            None,
+            true,
+        )
+        .expect("key should build");
+        key.status_snapshot = Some(json!({
+            "quota": {
+                "version": 2,
+                "provider_type": "codex",
+                "exhausted": false,
+                "windows": [
+                    {
+                        "code": "weekly",
+                        "scope": "account",
+                        "used_ratio": 0.1,
+                        "remaining_ratio": 0.9
+                    },
+                    {
+                        "code": "model:gpt-5.3-codex-spark",
+                        "scope": "model",
+                        "model": "gpt-5.3-codex-spark",
+                        "used_ratio": 1.0,
+                        "remaining_ratio": 0.0,
+                        "reset_at": 4_000_000_000u64,
+                        "is_exhausted": true
+                    }
+                ]
+            }
+        }));
+        let provider_keys = BTreeMap::from([("key-1".to_string(), key)]);
+        let skip_exhausted = BTreeMap::from([("provider-1".to_string(), true)]);
+
+        let result = read_candidate_quota_exhaustion_map(
+            &[spark.clone(), regular.clone()],
+            &provider_keys,
+            &skip_exhausted,
+        );
+
+        assert_eq!(
+            result
+                .get(candidate_quota_state_key(&spark).as_str())
+                .copied(),
+            Some(true)
+        );
+        assert_eq!(
+            result
+                .get(candidate_quota_state_key(&regular).as_str())
+                .copied(),
+            Some(false)
+        );
+    }
 }
 
 fn read_provider_key_rpm_reset_at_map(

--- a/crates/aether-admin/src/provider/pool.rs
+++ b/crates/aether-admin/src/provider/pool.rs
@@ -212,6 +212,12 @@ pub fn admin_pool_key_account_quota_exhausted(
                         windows
                             .iter()
                             .filter_map(Value::as_object)
+                            .filter(|window| {
+                                window
+                                    .get("scope")
+                                    .and_then(Value::as_str)
+                                    .is_none_or(|scope| scope.eq_ignore_ascii_case("account"))
+                            })
                             .filter_map(|w| w.get("used_ratio"))
                             .filter_map(Value::as_f64)
                             .max_by(f64::total_cmp)
@@ -970,6 +976,37 @@ mod tests {
         }));
 
         assert!(!admin_pool_key_account_quota_exhausted(&key, "codex"));
+    }
+
+    #[test]
+    fn ignores_model_windows_when_preserving_codex_account_exhaustion() {
+        let mut key = sample_key(None);
+        key.status_snapshot = Some(json!({
+            "quota": {
+                "version": 2,
+                "provider_type": "codex",
+                "code": "exhausted",
+                "exhausted": true,
+                "windows": [
+                    {
+                        "code": "weekly",
+                        "scope": "account",
+                        "used_ratio": 1.0,
+                        "remaining_ratio": 0.0
+                    },
+                    {
+                        "code": "model:gpt-5.3-codex-spark",
+                        "scope": "model",
+                        "model": "gpt-5.3-codex-spark",
+                        "used_ratio": 0.2,
+                        "remaining_ratio": 0.8,
+                        "is_exhausted": false
+                    }
+                ]
+            }
+        }));
+
+        assert!(admin_pool_key_account_quota_exhausted(&key, "codex"));
     }
 
     #[test]

--- a/crates/aether-admin/src/provider/pool.rs
+++ b/crates/aether-admin/src/provider/pool.rs
@@ -8,6 +8,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use super::status as provider_status;
 
+const CODEX_SPARK_MODEL_ID: &str = super::quota::CODEX_SPARK_MODEL_ID;
+
 #[derive(Debug, Default, Clone, serde::Deserialize)]
 pub struct AdminPoolResolveSelectionRequest {
     #[serde(default)]
@@ -121,6 +123,21 @@ fn admin_pool_json_f64(value: Option<&Value>) -> Option<f64> {
         _ => None,
     }
     .filter(|value| value.is_finite())
+}
+
+fn admin_pool_json_u64(value: Option<&Value>) -> Option<u64> {
+    let mut parsed = match value {
+        Some(Value::Number(number)) => number.as_f64(),
+        Some(Value::String(value)) => value.trim().parse::<f64>().ok(),
+        _ => None,
+    }?;
+    if !parsed.is_finite() || parsed <= 0.0 {
+        return None;
+    }
+    if parsed > 1_000_000_000_000.0 {
+        parsed /= 1000.0;
+    }
+    Some(parsed.floor() as u64)
 }
 
 fn admin_pool_quota_snapshot_matches_provider(
@@ -266,6 +283,147 @@ pub fn admin_pool_key_account_quota_exhausted(
         }
         _ => false,
     }
+}
+
+fn admin_pool_model_matches_codex_spark(model: &str) -> bool {
+    model.trim().eq_ignore_ascii_case(CODEX_SPARK_MODEL_ID)
+}
+
+fn admin_pool_model_window_is_active(
+    quota_snapshot: Option<&serde_json::Map<String, Value>>,
+    window: &serde_json::Map<String, Value>,
+    now_unix_secs: u64,
+) -> bool {
+    if let Some(reset_at) = admin_pool_json_u64(window.get("reset_at")) {
+        return reset_at > now_unix_secs;
+    }
+    if let Some(reset_seconds) = admin_pool_json_u64(window.get("reset_seconds")) {
+        let observed_at = quota_snapshot
+            .and_then(|quota| admin_pool_json_u64(quota.get("observed_at")))
+            .or_else(|| {
+                quota_snapshot.and_then(|quota| admin_pool_json_u64(quota.get("updated_at")))
+            });
+        return observed_at
+            .map(|observed_at| observed_at.saturating_add(reset_seconds) > now_unix_secs)
+            .unwrap_or(reset_seconds > 0);
+    }
+    true
+}
+
+fn admin_pool_model_window_exhausted(
+    quota_snapshot: Option<&serde_json::Map<String, Value>>,
+    window: &serde_json::Map<String, Value>,
+    model: &str,
+    now_unix_secs: u64,
+) -> Option<bool> {
+    let scope_matches = window
+        .get("scope")
+        .and_then(Value::as_str)
+        .is_some_and(|scope| scope.eq_ignore_ascii_case("model"));
+    if !scope_matches {
+        return None;
+    }
+    let model_matches = window
+        .get("model")
+        .and_then(Value::as_str)
+        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(model));
+    if !model_matches {
+        return None;
+    }
+
+    let exhausted = admin_pool_json_bool(window.get("is_exhausted"))
+        .or_else(|| admin_pool_json_f64(window.get("used_ratio")).map(|value| value >= 1.0 - 1e-6))
+        .unwrap_or(false);
+    Some(exhausted && admin_pool_model_window_is_active(quota_snapshot, window, now_unix_secs))
+}
+
+fn admin_pool_model_quota_exhausted_from_snapshot(
+    quota_snapshot: &serde_json::Map<String, Value>,
+    model: &str,
+    now_unix_secs: u64,
+) -> Option<bool> {
+    let windows = quota_snapshot.get("windows")?.as_array()?;
+    let mut found = false;
+    for window in windows.iter().filter_map(Value::as_object) {
+        let Some(exhausted) =
+            admin_pool_model_window_exhausted(Some(quota_snapshot), window, model, now_unix_secs)
+        else {
+            continue;
+        };
+        found = true;
+        if exhausted {
+            return Some(true);
+        }
+    }
+    found.then_some(false)
+}
+
+fn admin_pool_model_quota_exhausted_from_metadata(
+    metadata: &serde_json::Map<String, Value>,
+    model: &str,
+    now_unix_secs: u64,
+) -> Option<bool> {
+    let model_bucket = metadata
+        .get("quota_by_model")
+        .or_else(|| metadata.get("models"))
+        .and_then(Value::as_object)?;
+    let item = model_bucket.get(model)?.as_object()?;
+    let windows = item.get("windows").and_then(Value::as_array);
+    let mut found = false;
+    if let Some(windows) = windows {
+        for window in windows.iter().filter_map(Value::as_object) {
+            let Some(exhausted) =
+                admin_pool_model_window_exhausted(None, window, model, now_unix_secs)
+            else {
+                continue;
+            };
+            found = true;
+            if exhausted {
+                return Some(true);
+            }
+        }
+    }
+    if found {
+        return Some(false);
+    }
+    let exhausted = admin_pool_json_bool(item.get("is_exhausted"))
+        .or_else(|| admin_pool_json_f64(item.get("used_ratio")).map(|value| value >= 1.0 - 1e-6))
+        .or_else(|| {
+            admin_pool_json_f64(item.get("used_percent")).map(|value| value >= 100.0 - 1e-6)
+        })?;
+    Some(exhausted)
+}
+
+pub fn admin_pool_key_model_quota_exhausted(
+    key: &StoredProviderCatalogKey,
+    provider_type: &str,
+    requested_model: &str,
+    now_unix_secs: u64,
+) -> bool {
+    if !provider_type.trim().eq_ignore_ascii_case("codex") {
+        return false;
+    }
+    if !admin_pool_model_matches_codex_spark(requested_model) {
+        return false;
+    }
+
+    if let Some(exhausted) =
+        admin_pool_key_quota_snapshot(key, provider_type).and_then(|quota_snapshot| {
+            admin_pool_model_quota_exhausted_from_snapshot(
+                quota_snapshot,
+                CODEX_SPARK_MODEL_ID,
+                now_unix_secs,
+            )
+        })
+    {
+        return exhausted;
+    }
+
+    let Some(bucket) = admin_pool_metadata_bucket(key.upstream_metadata.as_ref(), "codex") else {
+        return false;
+    };
+    admin_pool_model_quota_exhausted_from_metadata(bucket, CODEX_SPARK_MODEL_ID, now_unix_secs)
+        .unwrap_or(false)
 }
 
 fn admin_pool_has_proxy(key: &StoredProviderCatalogKey) -> bool {
@@ -674,7 +832,8 @@ pub fn build_admin_pool_selection_payload(keys: &[StoredProviderCatalogKey]) -> 
 mod tests {
     use super::{
         admin_pool_key_account_quota_exhausted, admin_pool_key_is_known_banned,
-        build_admin_pool_key_payload, AdminPoolKeyPayloadContext,
+        admin_pool_key_model_quota_exhausted, build_admin_pool_key_payload,
+        AdminPoolKeyPayloadContext,
     };
     use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogKey;
     use serde_json::json;
@@ -811,6 +970,70 @@ mod tests {
         }));
 
         assert!(!admin_pool_key_account_quota_exhausted(&key, "codex"));
+    }
+
+    #[test]
+    fn detects_codex_spark_model_quota_without_account_exhaustion() {
+        let mut key = sample_key(Some(json!({
+            "codex": {
+                "primary_used_percent": 10.0,
+                "secondary_used_percent": 20.0,
+                "quota_by_model": {
+                    "gpt-5.3-codex-spark": {
+                        "windows": [
+                            {
+                                "code": "spark",
+                                "scope": "model",
+                                "model": "gpt-5.3-codex-spark",
+                                "used_ratio": 1.0,
+                                "remaining_ratio": 0.0,
+                                "reset_at": 1_770_000_300u64,
+                                "is_exhausted": true
+                            }
+                        ]
+                    }
+                }
+            }
+        })));
+        key.status_snapshot = Some(json!({
+            "quota": {
+                "version": 2,
+                "provider_type": "codex",
+                "code": "ok",
+                "exhausted": false,
+                "windows": [
+                    {
+                        "code": "weekly",
+                        "scope": "account",
+                        "used_ratio": 0.1,
+                        "remaining_ratio": 0.9
+                    },
+                    {
+                        "code": "model:gpt-5.3-codex-spark",
+                        "scope": "model",
+                        "model": "gpt-5.3-codex-spark",
+                        "used_ratio": 1.0,
+                        "remaining_ratio": 0.0,
+                        "reset_at": 1_770_000_300u64,
+                        "is_exhausted": true
+                    }
+                ]
+            }
+        }));
+
+        assert!(!admin_pool_key_account_quota_exhausted(&key, "codex"));
+        assert!(admin_pool_key_model_quota_exhausted(
+            &key,
+            "codex",
+            "gpt-5.3-codex-spark",
+            1_770_000_000,
+        ));
+        assert!(!admin_pool_key_model_quota_exhausted(
+            &key,
+            "codex",
+            "gpt-5.3-codex",
+            1_770_000_000,
+        ));
     }
 
     #[test]

--- a/crates/aether-admin/src/provider/quota.rs
+++ b/crates/aether-admin/src/provider/quota.rs
@@ -5,6 +5,8 @@ use std::collections::BTreeMap;
 
 use super::status as provider_status;
 
+pub const CODEX_SPARK_MODEL_ID: &str = "gpt-5.3-codex-spark";
+
 const OAUTH_ACCOUNT_BLOCK_PREFIX: &str = "[ACCOUNT_BLOCK] ";
 const OAUTH_REFRESH_FAILED_PREFIX: &str = "[REFRESH_FAILED] ";
 const OAUTH_EXPIRED_PREFIX: &str = "[OAUTH_EXPIRED] ";
@@ -216,6 +218,150 @@ fn codex_write_window(
     }
 }
 
+fn codex_model_id_matches_spark(value: &str) -> bool {
+    value.trim().eq_ignore_ascii_case(CODEX_SPARK_MODEL_ID)
+}
+
+fn codex_model_source<'a>(
+    root: &'a serde_json::Map<String, serde_json::Value>,
+) -> Option<&'a serde_json::Value> {
+    for bucket_name in ["quota_by_model", "model_quotas", "model_usage", "models"] {
+        let Some(bucket) = root.get(bucket_name) else {
+            continue;
+        };
+        if let Some(item) = bucket
+            .as_object()
+            .and_then(|models| models.get(CODEX_SPARK_MODEL_ID))
+        {
+            return Some(item);
+        }
+        if let Some(item) = bucket.as_array().and_then(|items| {
+            items.iter().find(|item| {
+                item.as_object().is_some_and(|object| {
+                    ["model", "model_id", "id", "name"]
+                        .iter()
+                        .filter_map(|field| object.get(*field).and_then(serde_json::Value::as_str))
+                        .any(codex_model_id_matches_spark)
+                })
+            })
+        }) {
+            return Some(item);
+        }
+    }
+    None
+}
+
+fn codex_model_reset_seconds(window: &serde_json::Map<String, serde_json::Value>) -> Option<u64> {
+    for field in [
+        "reset_seconds",
+        "reset_after_seconds",
+        "reset_after",
+        "cooldown_seconds",
+        "retry_after_seconds",
+    ] {
+        if let Some(value) = window.get(field).and_then(coerce_json_u64) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn codex_model_reset_at(window: &serde_json::Map<String, serde_json::Value>) -> Option<u64> {
+    for field in ["reset_at", "next_reset_at", "resetTime", "reset_time"] {
+        if let Some(value) = window.get(field).and_then(coerce_json_u64) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn codex_model_remaining_ratio(window: &serde_json::Map<String, serde_json::Value>) -> Option<f64> {
+    for field in ["remaining_ratio", "remaining_fraction"] {
+        if let Some(value) = window.get(field).and_then(coerce_json_f64) {
+            return Some(value.clamp(0.0, 1.0));
+        }
+    }
+    window
+        .get("remaining_percent")
+        .and_then(coerce_json_f64)
+        .map(|value| (value / 100.0).clamp(0.0, 1.0))
+}
+
+fn codex_model_used_ratio(window: &serde_json::Map<String, serde_json::Value>) -> Option<f64> {
+    if let Some(value) = window.get("used_ratio").and_then(coerce_json_f64) {
+        return Some(value.clamp(0.0, 1.0));
+    }
+    if let Some(value) = window.get("used_percent").and_then(coerce_json_f64) {
+        return Some((value / 100.0).clamp(0.0, 1.0));
+    }
+    codex_model_remaining_ratio(window).map(|value| (1.0 - value).clamp(0.0, 1.0))
+}
+
+fn codex_model_window_payload(
+    source: &serde_json::Map<String, serde_json::Value>,
+    updated_at_unix_secs: u64,
+) -> Option<serde_json::Value> {
+    let used_ratio = codex_model_used_ratio(source);
+    let remaining_ratio = codex_model_remaining_ratio(source)
+        .or_else(|| used_ratio.map(|value| (1.0 - value).clamp(0.0, 1.0)));
+    let reset_seconds = codex_model_reset_seconds(source);
+    let reset_at = codex_model_reset_at(source)
+        .or_else(|| reset_seconds.map(|seconds| updated_at_unix_secs.saturating_add(seconds)));
+    let is_exhausted = source
+        .get("is_exhausted")
+        .or_else(|| source.get("exhausted"))
+        .or_else(|| source.get("cooldown"))
+        .or_else(|| source.get("cooling_down"))
+        .and_then(coerce_json_bool)
+        .or_else(|| used_ratio.map(|value| value >= 1.0 - 1e-6));
+
+    if used_ratio.is_none()
+        && remaining_ratio.is_none()
+        && reset_seconds.is_none()
+        && reset_at.is_none()
+        && is_exhausted.is_none()
+    {
+        return None;
+    }
+
+    Some(json!({
+        "code": "spark",
+        "scope": "model",
+        "model": CODEX_SPARK_MODEL_ID,
+        "unit": "percent",
+        "used_ratio": used_ratio,
+        "remaining_ratio": remaining_ratio,
+        "reset_seconds": reset_seconds,
+        "reset_at": reset_at,
+        "is_exhausted": is_exhausted,
+        "source": "codex_usage",
+    }))
+}
+
+fn codex_extract_spark_model_quota(
+    root: &serde_json::Map<String, serde_json::Value>,
+    updated_at_unix_secs: u64,
+) -> Option<serde_json::Value> {
+    let source = codex_model_source(root)?.as_object()?;
+    let mut windows = Vec::new();
+    if let Some(source_windows) = source.get("windows").and_then(serde_json::Value::as_array) {
+        windows.extend(source_windows.iter().filter_map(|window| {
+            codex_model_window_payload(window.as_object()?, updated_at_unix_secs)
+        }));
+    }
+    if let Some(window) = codex_model_window_payload(source, updated_at_unix_secs) {
+        windows.push(window);
+    }
+    if windows.is_empty() {
+        return None;
+    }
+
+    Some(json!({
+        "updated_at": updated_at_unix_secs,
+        "windows": windows,
+    }))
+}
+
 pub fn parse_codex_wham_usage_response(
     value: &serde_json::Value,
     updated_at_unix_secs: u64,
@@ -266,6 +412,17 @@ pub fn parse_codex_wham_usage_response(
         if let Some(value) = credits.get("unlimited").and_then(coerce_json_bool) {
             result.insert("credits_unlimited".to_string(), json!(value));
         }
+    }
+
+    if let Some(spark_quota) = codex_extract_spark_model_quota(root, updated_at_unix_secs) {
+        result.insert(
+            "schema_version".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(2)),
+        );
+        result.insert(
+            "quota_by_model".to_string(),
+            json!({ CODEX_SPARK_MODEL_ID: spark_quota }),
+        );
     }
 
     if result.is_empty() {
@@ -874,8 +1031,9 @@ pub fn parse_chatgpt_web_conversation_init_response(
 mod tests {
     use super::{
         codex_build_invalid_state, codex_runtime_invalid_reason,
-        parse_chatgpt_web_conversation_init_response, OAUTH_ACCOUNT_BLOCK_PREFIX,
-        OAUTH_EXPIRED_PREFIX, OAUTH_REFRESH_FAILED_PREFIX, OAUTH_REQUEST_FAILED_PREFIX,
+        parse_chatgpt_web_conversation_init_response, parse_codex_wham_usage_response,
+        CODEX_SPARK_MODEL_ID, OAUTH_ACCOUNT_BLOCK_PREFIX, OAUTH_EXPIRED_PREFIX,
+        OAUTH_REFRESH_FAILED_PREFIX, OAUTH_REQUEST_FAILED_PREFIX,
     };
     use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogKey;
     use serde_json::json;
@@ -967,6 +1125,46 @@ mod tests {
                     "{OAUTH_ACCOUNT_BLOCK_PREFIX}account has been deactivated"
                 ))
             )
+        );
+    }
+
+    #[test]
+    fn parses_codex_spark_model_quota_without_account_exhaustion() {
+        let parsed = parse_codex_wham_usage_response(
+            &json!({
+                "plan_type": "pro",
+                "rate_limit": {
+                    "primary_window": {"used_percent": 10.0},
+                    "secondary_window": {"used_percent": 20.0}
+                },
+                "quota_by_model": {
+                    CODEX_SPARK_MODEL_ID: {
+                        "windows": [
+                            {
+                                "remaining_ratio": 0.0,
+                                "reset_after_seconds": 300,
+                                "is_exhausted": true
+                            }
+                        ]
+                    }
+                }
+            }),
+            1_770_000_000,
+        )
+        .expect("codex metadata should parse");
+
+        assert_eq!(parsed.get("primary_used_percent"), Some(&json!(20.0)));
+        assert_eq!(parsed.get("secondary_used_percent"), Some(&json!(10.0)));
+        assert_eq!(parsed.get("schema_version"), Some(&json!(2)));
+        assert_eq!(
+            parsed
+                .get("quota_by_model")
+                .and_then(|value| value.get(CODEX_SPARK_MODEL_ID))
+                .and_then(|value| value.get("windows"))
+                .and_then(serde_json::Value::as_array)
+                .and_then(|windows| windows.first())
+                .and_then(|window| window.get("is_exhausted")),
+            Some(&json!(true))
         );
     }
 

--- a/crates/aether-admin/src/provider/quota.rs
+++ b/crates/aether-admin/src/provider/quota.rs
@@ -222,9 +222,9 @@ fn codex_model_id_matches_spark(value: &str) -> bool {
     value.trim().eq_ignore_ascii_case(CODEX_SPARK_MODEL_ID)
 }
 
-fn codex_model_source<'a>(
-    root: &'a serde_json::Map<String, serde_json::Value>,
-) -> Option<&'a serde_json::Value> {
+fn codex_model_source(
+    root: &serde_json::Map<String, serde_json::Value>,
+) -> Option<&serde_json::Value> {
     for bucket_name in ["quota_by_model", "model_quotas", "model_usage", "models"] {
         let Some(bucket) = root.get(bucket_name) else {
             continue;

--- a/frontend/src/views/admin/PoolManagement.vue
+++ b/frontend/src/views/admin/PoolManagement.vue
@@ -545,7 +545,7 @@
                   class="py-3 align-middle"
                 >
                   <div
-                    v-if="quotaProgressMap[key.key_id]?.length"
+                    v-if="quotaProgressMap[key.key_id]?.length || getCodexSparkQuotaItem(key)"
                     class="max-w-[208px] space-y-2"
                   >
                     <div
@@ -573,6 +573,50 @@
                           class="shrink-0 text-[10px] font-medium tabular-nums leading-none"
                           :class="getQuotaRemainingClassByRemaining(item.remainingPercent)"
                         >{{ item.remainingPercent.toFixed(1) }}%</span>
+                      </div>
+                    </div>
+                    <div
+                      v-if="getCodexSparkQuotaItem(key)"
+                      class="rounded-md border border-dashed border-border/70 bg-muted/20 px-2 py-1.5"
+                    >
+                      <button
+                        type="button"
+                        class="flex w-full items-center justify-between gap-2 text-[10px] leading-none text-muted-foreground transition-colors hover:text-foreground"
+                        :aria-expanded="isCodexSparkQuotaExpanded(key.key_id)"
+                        @click.stop="toggleCodexSparkQuota(key.key_id)"
+                      >
+                        <span class="font-medium">Spark 额度</span>
+                        <span class="ml-auto truncate tabular-nums">{{ getCodexSparkQuotaSummary(key) }}</span>
+                        <ChevronDown
+                          class="h-3 w-3 shrink-0 transition-transform duration-150"
+                          :class="isCodexSparkQuotaExpanded(key.key_id) ? 'rotate-180' : ''"
+                        />
+                      </button>
+                      <div
+                        v-if="isCodexSparkQuotaExpanded(key.key_id)"
+                        class="mt-2 flex flex-col gap-1"
+                      >
+                        <div class="flex items-center justify-between text-[10px] leading-none">
+                          <span class="font-medium text-muted-foreground">模型额度</span>
+                          <span
+                            v-if="getQuotaProgressDisplayText(getCodexSparkQuotaItem(key)!)"
+                            class="truncate tabular-nums text-muted-foreground/80"
+                            :title="getCodexSparkQuotaItem(key)?.detail"
+                          >{{ getQuotaProgressDisplayText(getCodexSparkQuotaItem(key)!) }}</span>
+                        </div>
+                        <div class="flex items-center gap-1.5">
+                          <div class="relative h-1.5 flex-1 overflow-hidden rounded-full bg-border">
+                            <div
+                              class="absolute left-0 top-0 h-full rounded-full transition-all duration-300"
+                              :class="getQuotaRemainingBarColorByRemaining(getCodexSparkQuotaItem(key)!.remainingPercent)"
+                              :style="{ width: `${getCodexSparkQuotaItem(key)!.remainingPercent}%` }"
+                            />
+                          </div>
+                          <span
+                            class="shrink-0 text-[10px] font-medium tabular-nums leading-none"
+                            :class="getQuotaRemainingClassByRemaining(getCodexSparkQuotaItem(key)!.remainingPercent)"
+                          >{{ getCodexSparkQuotaItem(key)!.remainingPercent.toFixed(1) }}%</span>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -939,7 +983,7 @@
                   配额
                 </div>
                 <div
-                  v-if="quotaProgressMap[key.key_id]?.length"
+                  v-if="quotaProgressMap[key.key_id]?.length || getCodexSparkQuotaItem(key)"
                   class="space-y-2"
                 >
                   <div
@@ -967,6 +1011,50 @@
                         class="shrink-0 text-[10px] font-medium tabular-nums leading-none"
                         :class="getQuotaRemainingClassByRemaining(item.remainingPercent)"
                       >{{ item.remainingPercent.toFixed(1) }}%</span>
+                    </div>
+                  </div>
+                  <div
+                    v-if="getCodexSparkQuotaItem(key)"
+                    class="rounded-md border border-dashed border-border/70 bg-background/70 px-2 py-1.5"
+                  >
+                    <button
+                      type="button"
+                      class="flex w-full items-center justify-between gap-2 text-[10px] leading-none text-muted-foreground transition-colors hover:text-foreground"
+                      :aria-expanded="isCodexSparkQuotaExpanded(key.key_id)"
+                      @click.stop="toggleCodexSparkQuota(key.key_id)"
+                    >
+                      <span class="font-medium">Spark 额度</span>
+                      <span class="ml-auto truncate tabular-nums">{{ getCodexSparkQuotaSummary(key) }}</span>
+                      <ChevronDown
+                        class="h-3 w-3 shrink-0 transition-transform duration-150"
+                        :class="isCodexSparkQuotaExpanded(key.key_id) ? 'rotate-180' : ''"
+                      />
+                    </button>
+                    <div
+                      v-if="isCodexSparkQuotaExpanded(key.key_id)"
+                      class="mt-2 flex flex-col gap-1"
+                    >
+                      <div class="flex items-center justify-between text-[10px] leading-none">
+                        <span class="font-medium text-muted-foreground">模型额度</span>
+                        <span
+                          v-if="getQuotaProgressDisplayText(getCodexSparkQuotaItem(key)!)"
+                          class="truncate tabular-nums text-muted-foreground/80"
+                          :title="getCodexSparkQuotaItem(key)?.detail"
+                        >{{ getQuotaProgressDisplayText(getCodexSparkQuotaItem(key)!) }}</span>
+                      </div>
+                      <div class="flex items-center gap-1.5">
+                        <div class="relative h-1.5 flex-1 overflow-hidden rounded-full bg-border">
+                          <div
+                            class="absolute left-0 top-0 h-full rounded-full transition-all duration-300"
+                            :class="getQuotaRemainingBarColorByRemaining(getCodexSparkQuotaItem(key)!.remainingPercent)"
+                            :style="{ width: `${getCodexSparkQuotaItem(key)!.remainingPercent}%` }"
+                          />
+                        </div>
+                        <span
+                          class="shrink-0 text-[10px] font-medium tabular-nums leading-none"
+                          :class="getQuotaRemainingClassByRemaining(getCodexSparkQuotaItem(key)!.remainingPercent)"
+                        >{{ getCodexSparkQuotaItem(key)!.remainingPercent.toFixed(1) }}%</span>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1914,6 +2002,7 @@ const CODEX_CYCLE_STAT_LABELS: Record<PoolStatsMetric['key'], string> = {
   total_tokens: 'Token',
   total_cost_usd: '费用',
 }
+const CODEX_SPARK_MODEL_ID = 'gpt-5.3-codex-spark'
 
 type PoolKeyUiState = {
   rowClass: string
@@ -1944,6 +2033,7 @@ const quotaProgressMap = computed<Record<string, QuotaProgressItem[]>>(() => {
   }
   return map
 })
+const expandedSparkQuotaKeyIds = ref<Set<string>>(new Set())
 
 const keyUiStateMap = computed<Record<string, PoolKeyUiState>>(() => {
   const map: Record<string, PoolKeyUiState> = {}
@@ -3134,7 +3224,7 @@ function getQuotaProgressLabel(label: string): string {
 }
 
 function getQuotaProgressCountdown(item: QuotaProgressItem) {
-  if (item.label !== '5H' && item.label !== '周') return null
+  if (item.label !== '5H' && item.label !== '周' && item.label !== 'Spark') return null
   if (item.resetAtSeconds == null && item.resetSeconds == null) return null
   return getCodexResetCountdown(
     item.resetAtSeconds,
@@ -3173,6 +3263,58 @@ function getQuotaProgressDisplayText(item: QuotaProgressItem): string {
 
 function getQuotaFallbackText(key: PoolKeyDetail): string | null {
   return getQuotaDisplayText(key, selectedProviderType.value)
+}
+
+function isCodexSparkQuotaExpanded(keyId: string): boolean {
+  return expandedSparkQuotaKeyIds.value.has(keyId)
+}
+
+function toggleCodexSparkQuota(keyId: string): void {
+  const next = new Set(expandedSparkQuotaKeyIds.value)
+  if (next.has(keyId)) {
+    next.delete(keyId)
+  } else {
+    next.add(keyId)
+  }
+  expandedSparkQuotaKeyIds.value = next
+}
+
+function getCodexSparkQuotaWindow(key: PoolKeyDetail): QuotaWindowSnapshot | null {
+  const quota = getCodexQuotaSnapshot(key)
+  if (!quota) return null
+  return getQuotaSnapshotWindowsByScope(quota, 'model').find((window) => {
+    return String(window.model || '').trim().toLowerCase() === CODEX_SPARK_MODEL_ID
+  }) ?? null
+}
+
+function isQuotaWindowActive(window: QuotaWindowSnapshot | null | undefined): boolean {
+  if (!window) return false
+  const resetAtSeconds = normalizeUnixSeconds(window.reset_at ?? null)
+  if (resetAtSeconds != null) return resetAtSeconds > Math.floor(Date.now() / 1000)
+  const resetSeconds = normalizeRemainingSeconds(window.reset_seconds ?? null)
+  return resetSeconds == null || resetSeconds > 0
+}
+
+function getCodexSparkQuotaItem(key: PoolKeyDetail): QuotaProgressItem | null {
+  const window = getCodexSparkQuotaWindow(key)
+  const remainingPercent = getQuotaWindowRemainingPercent(window)
+  if (!window || remainingPercent == null) return null
+  const exhausted = window.is_exhausted === true || (getQuotaWindowUsedPercent(window) ?? 0) >= 100 - 1e-6
+  return {
+    label: 'Spark',
+    remainingPercent,
+    detail: exhausted && isQuotaWindowActive(window) ? '冷却中' : undefined,
+    resetAtSeconds: normalizeUnixSeconds(window.reset_at ?? null),
+    resetSeconds: normalizeRemainingSeconds(window.reset_seconds ?? null),
+    updatedAtSeconds: getQuotaSnapshotUpdatedAtSeconds(getCodexQuotaSnapshot(key)),
+  }
+}
+
+function getCodexSparkQuotaSummary(key: PoolKeyDetail): string {
+  const item = getCodexSparkQuotaItem(key)
+  if (!item) return '未上报'
+  if (item.detail === '冷却中') return '冷却中'
+  return `剩余 ${item.remainingPercent.toFixed(1)}%`
 }
 
 


### PR DESCRIPTION
## Summary
- Add Codex Spark model-scoped quota parsing under the existing Codex metadata bucket.
- Surface Spark quota/cooldown in admin quota snapshots while keeping weekly/5H account quota semantics separate.
- Skip only Spark requests when Spark model quota is exhausted, while preserving existing Codex account-level scheduling gates.
- Keep Spark quota details folded by default in the pool UI to avoid crowding the account quota column.

## Verification
- cargo fmt --all
- cargo test -p aether-admin provider::quota::tests::parses_codex_spark_model_quota_without_account_exhaustion
- cargo test -p aether-admin provider::pool::tests::detects_codex_spark_model_quota_without_account_exhaustion
- cargo test -p aether-gateway ai_serving::planner::pool_scheduler::tests::pool_catalog_context_marks_only_spark_model_quota_exhausted
- cargo test -p aether-gateway scheduler::candidate::runtime::tests::candidate_quota_exhaustion_is_model_scoped
- cargo test -p aether-admin provider::pool::tests::ignores_model_windows_when_preserving_codex_account_exhaustion
- cargo test -p aether-gateway handlers::shared::catalog::tests::codex_quota_snapshot_preserves_model_ratio_windows
- cargo check -p aether-admin
- cargo check -p aether-gateway
- cargo test -p aether-gateway tests::control::admin::endpoints::quota
- cargo test -p aether-gateway tests::control::admin::pool
- npm run type-check (frontend)
- npm run test:run -- PoolManagement.codex-cycle-stats.spec.ts (frontend)

Fixes #400