### PR TITLE
feat: support client API key configuration

### DIFF
--- a/apps/aether-gateway/src/api/backend/public.rs
+++ b/apps/aether-gateway/src/api/backend/public.rs
@@ -1,4 +1,4 @@
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
 
 use crate::{handlers::proxy::proxy_request, state::AppState};
@@ -20,9 +20,11 @@ pub(crate) fn mount_public_support_routes(router: Router<AppState>) -> Router<Ap
         .route("/api/public/stats", get(proxy_request))
         .route("/api/public/global-models", get(proxy_request))
         .route("/api/public/health/api-formats", get(proxy_request))
+        .route("/api/client-provisioning/exchange", post(proxy_request))
         .route("/api/modules/auth-status", get(proxy_request))
         .route("/api/capabilities", get(proxy_request))
         .route("/api/capabilities/user-configurable", get(proxy_request))
         .route("/api/capabilities/model/{*model_path}", get(proxy_request))
+        .route("/install/client-config.sh", get(proxy_request))
         .route("/", get(proxy_request))
 }

--- a/apps/aether-gateway/src/control/route/public_support.rs
+++ b/apps/aether-gateway/src/control/route/public_support.rs
@@ -468,6 +468,23 @@ pub(super) fn classify_public_support_route(
             "user:self",
             false,
         ))
+    } else if method == http::Method::GET && normalized_path == "/install/client-config.sh" {
+        Some(classified(
+            "public_support",
+            "client_provisioning",
+            "install_script",
+            "public:client_provisioning",
+            false,
+        ))
+    } else if method == http::Method::POST && normalized_path == "/api/client-provisioning/exchange"
+    {
+        Some(classified(
+            "public_support",
+            "client_provisioning",
+            "exchange",
+            "public:client_provisioning",
+            false,
+        ))
     } else if method == http::Method::POST
         && normalized_path.starts_with("/api/me/management-tokens/")
         && normalized_path.ends_with("/regenerate")
@@ -556,6 +573,20 @@ pub(super) fn classify_public_support_route(
             "public_support",
             "users_me",
             route_kind,
+            "user:self",
+            false,
+        ))
+    } else if method == http::Method::POST
+        && has_single_nested_suffix_after_prefix(
+            normalized_path,
+            "/api/users/me/api-keys/",
+            "provisioning-token",
+        )
+    {
+        Some(classified(
+            "public_support",
+            "users_me",
+            "api_key_provisioning_token_create",
             "user:self",
             false,
         ))

--- a/apps/aether-gateway/src/control/tests/public_support.rs
+++ b/apps/aether-gateway/src/control/tests/public_support.rs
@@ -1,5 +1,8 @@
 use http::Uri;
 
+use crate::control::GatewayPublicRequestContext;
+use crate::handlers::shared::local_proxy_route_body_limit_bytes;
+
 use super::{classify_control_route, headers};
 
 #[test]
@@ -412,6 +415,11 @@ fn classifies_users_me_routes_as_public_support_route() {
             "management_tokens_create",
         ),
         (
+            http::Method::POST,
+            "/api/users/me/api-keys/key-1/provisioning-token",
+            "api_key_provisioning_token_create",
+        ),
+        (
             http::Method::GET,
             "/api/me/management-tokens/token-1",
             "management_token_detail",
@@ -450,6 +458,58 @@ fn classifies_users_me_routes_as_public_support_route() {
         );
         assert!(!decision.is_execution_runtime_candidate());
     }
+}
+
+#[test]
+fn classifies_client_provisioning_routes_as_public_support_route() {
+    let headers = headers(&[]);
+    for (method, uri, route_kind) in [
+        (
+            http::Method::GET,
+            "/install/client-config.sh",
+            "install_script",
+        ),
+        (
+            http::Method::POST,
+            "/api/client-provisioning/exchange",
+            "exchange",
+        ),
+    ] {
+        let uri: Uri = uri.parse().expect("uri should parse");
+        let decision =
+            classify_control_route(&method, &uri, &headers).expect("route should classify");
+
+        assert_eq!(decision.route_class.as_deref(), Some("public_support"));
+        assert_eq!(
+            decision.route_family.as_deref(),
+            Some("client_provisioning")
+        );
+        assert_eq!(decision.route_kind.as_deref(), Some(route_kind));
+        assert_eq!(
+            decision.auth_endpoint_signature.as_deref(),
+            Some("public:client_provisioning")
+        );
+        assert!(!decision.is_execution_runtime_candidate());
+    }
+}
+
+#[test]
+fn limits_client_provisioning_exchange_buffered_body() {
+    let headers = headers(&[]);
+    let uri: Uri = "/api/client-provisioning/exchange"
+        .parse()
+        .expect("uri should parse");
+    let decision =
+        classify_control_route(&http::Method::POST, &uri, &headers).expect("route should classify");
+    let context = GatewayPublicRequestContext::from_request_parts(
+        "trace-test",
+        &http::Method::POST,
+        &uri,
+        &headers,
+        Some(decision),
+    );
+
+    assert_eq!(local_proxy_route_body_limit_bytes(&context), 8 * 1024);
 }
 
 #[test]

--- a/apps/aether-gateway/src/handlers/proxy/mod.rs
+++ b/apps/aether-gateway/src/handlers/proxy/mod.rs
@@ -46,8 +46,9 @@ use crate::frontdoor_loop_guard::{
 };
 use crate::handlers::shared::{
     build_admin_proxy_auth_required_response, build_unhandled_admin_proxy_response,
-    local_proxy_route_requires_buffered_body, request_enables_control_execute,
-    should_strip_forwarded_provider_credential_header, should_strip_forwarded_trusted_admin_header,
+    local_proxy_route_body_limit_bytes, local_proxy_route_requires_buffered_body,
+    request_enables_control_execute, should_strip_forwarded_provider_credential_header,
+    should_strip_forwarded_trusted_admin_header,
 };
 use crate::headers::{
     extract_or_generate_trace_id, request_origin_from_headers_and_remote_addr,
@@ -822,16 +823,35 @@ pub(crate) async fn proxy_request(
     }
     let mut request_body = Some(body);
     let local_proxy_body = if local_proxy_route_requires_buffered_body(&request_context) {
-        Some(
-            to_bytes(
-                request_body
-                    .take()
-                    .expect("local proxy body buffering should own request body"),
-                usize::MAX,
-            )
-            .await
-            .map_err(|err| GatewayError::Internal(err.to_string()))?,
+        let body_limit = local_proxy_route_body_limit_bytes(&request_context);
+        let buffered = to_bytes(
+            request_body
+                .take()
+                .expect("local proxy body buffering should own request body"),
+            body_limit,
         )
+        .await;
+        match buffered {
+            Ok(value) => Some(value),
+            Err(_) if body_limit != usize::MAX => {
+                let response = build_local_http_error_response(
+                    &trace_id,
+                    None,
+                    http::StatusCode::PAYLOAD_TOO_LARGE,
+                    &format!("request body exceeds {body_limit} bytes"),
+                )?;
+                return Ok(finalize_gateway_response_with_context(
+                    &state,
+                    response,
+                    &remote_addr,
+                    &request_context,
+                    EXECUTION_PATH_PUBLIC_PROXY_PASSTHROUGH,
+                    &started_at,
+                    request_permit.take(),
+                ));
+            }
+            Err(err) => return Err(GatewayError::Internal(err.to_string())),
+        }
     } else {
         None
     };

--- a/apps/aether-gateway/src/handlers/public/support.rs
+++ b/apps/aether-gateway/src/handlers/public/support.rs
@@ -26,6 +26,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 mod support_announcements;
 #[path = "support/auth.rs"]
 mod support_auth;
+#[path = "support/client_provisioning.rs"]
+mod support_client_provisioning;
 #[path = "support/dashboard.rs"]
 mod support_dashboard;
 #[path = "support/models.rs"]
@@ -53,13 +55,14 @@ use self::support_auth::auth_registration::{
     auth_password_policy_level, validate_auth_register_password,
 };
 use self::support_auth::auth_session::{
-    build_auth_wallet_summary_payload, handle_auth_me, resolve_authenticated_local_user,
-    AuthenticatedLocalUserContext,
+    build_auth_wallet_summary_payload, create_auth_token, decode_auth_token, handle_auth_me,
+    resolve_authenticated_local_user, AuthenticatedLocalUserContext,
 };
 use self::support_auth::{
     build_auth_error_response, build_auth_json_response, build_auth_registration_settings_payload,
     build_auth_settings_payload, extract_client_device_id, maybe_build_local_auth_response,
 };
+use self::support_client_provisioning::maybe_build_local_client_provisioning_response;
 use self::support_dashboard::maybe_build_local_dashboard_response;
 use self::support_models::{
     build_models_auth_error_response, maybe_build_local_models_response, models_api_format,
@@ -144,6 +147,16 @@ pub(crate) async fn maybe_build_local_public_support_response(
     if decision.route_family.as_deref() == Some("users_me") {
         return maybe_build_local_users_me_response(state, request_context, headers, request_body)
             .await;
+    }
+
+    if decision.route_family.as_deref() == Some("client_provisioning") {
+        return maybe_build_local_client_provisioning_response(
+            state,
+            request_context,
+            headers,
+            request_body,
+        )
+        .await;
     }
 
     if decision.route_family.as_deref() == Some("payment_callback") {

--- a/apps/aether-gateway/src/handlers/public/support/client_provisioning.rs
+++ b/apps/aether-gateway/src/handlers/public/support/client_provisioning.rs
@@ -1,0 +1,367 @@
+use std::collections::HashMap;
+
+use axum::{
+    body::Body,
+    http,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Deserialize;
+use serde_json::json;
+
+use super::{
+    build_auth_error_response, decode_auth_token, decrypt_catalog_secret_with_fallbacks,
+    query_param_value, AppState, GatewayPublicRequestContext,
+};
+
+const CLIENT_PROVISIONING_TOKEN_TYPE: &str = "client_provisioning";
+const CLIENT_PROVISIONING_KV_PREFIX: &str = "client_provisioning:";
+const DEFAULT_CLIENT_BASE_URL: &str = "http://localhost:8084";
+
+#[derive(Debug, Deserialize)]
+struct ClientProvisioningExchangeJsonRequest {
+    token: String,
+    #[serde(default)]
+    base_url: Option<String>,
+}
+
+#[derive(Debug)]
+struct ClientProvisioningExchangeRequest {
+    token: String,
+    base_url: Option<String>,
+}
+
+pub(crate) async fn maybe_build_local_client_provisioning_response(
+    state: &AppState,
+    request_context: &GatewayPublicRequestContext,
+    _headers: &http::HeaderMap,
+    request_body: Option<&axum::body::Bytes>,
+) -> Option<Response<Body>> {
+    let decision = request_context.control_decision.as_ref()?;
+    match decision.route_kind.as_deref() {
+        Some("install_script") if request_context.request_path == "/install/client-config.sh" => {
+            Some(build_client_config_install_script_response())
+        }
+        Some("exchange") if request_context.request_path == "/api/client-provisioning/exchange" => {
+            Some(handle_client_provisioning_exchange(state, request_context, request_body).await)
+        }
+        _ => None,
+    }
+}
+
+fn build_client_config_install_script_response() -> Response<Body> {
+    let script = r#"#!/bin/sh
+set -eu
+
+info() { printf '%s\n' "[Aether] $*"; }
+fail() { printf '%s\n' "[Aether] ERROR: $*" >&2; exit 1; }
+
+if [ -z "${AETHER_PROVISIONING_TOKEN:-}" ]; then
+  fail "AETHER_PROVISIONING_TOKEN is required. Copy the full command from Aether."
+fi
+
+AETHER_BASE_URL="${AETHER_BASE_URL:-}"
+if [ -z "$AETHER_BASE_URL" ]; then
+  fail "AETHER_BASE_URL is required. Copy the full command from Aether."
+fi
+AETHER_BASE_URL="${AETHER_BASE_URL%/}"
+
+CONFIG_DIR="${AETHER_CLIENT_CONFIG_DIR:-$HOME/.aether}"
+CONFIG_FILE="${AETHER_CLIENT_CONFIG_FILE:-$CONFIG_DIR/client.env}"
+TMP_FILE="$CONFIG_FILE.tmp.$$"
+EXCHANGE_URL="$AETHER_BASE_URL/api/client-provisioning/exchange?format=env"
+
+cleanup() { rm -f "$TMP_FILE"; }
+trap cleanup EXIT HUP INT TERM
+
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+
+umask 077
+mkdir -p "$CONFIG_DIR"
+chmod 700 "$CONFIG_DIR" 2>/dev/null || true
+
+HTTP_STATUS=$(curl -sS -o "$TMP_FILE" -w '%{http_code}' \
+  -X POST "$EXCHANGE_URL" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode "token=$AETHER_PROVISIONING_TOKEN" \
+  --data-urlencode "base_url=$AETHER_BASE_URL") || fail "failed to contact Aether server"
+
+case "$HTTP_STATUS" in
+  200) ;;
+  *)
+    printf '%s\n' "[Aether] provisioning failed (HTTP $HTTP_STATUS):" >&2
+    sed 's/.*api_key.*/[redacted]/Ig' "$TMP_FILE" >&2 || true
+    exit 1
+    ;;
+esac
+
+mv "$TMP_FILE" "$CONFIG_FILE"
+chmod 600 "$CONFIG_FILE" 2>/dev/null || true
+trap - EXIT HUP INT TERM
+
+info "Client configuration written to $CONFIG_FILE"
+info "Load it with: . $CONFIG_FILE"
+info "Verify with: curl -fsS \"$AETHER_BASE_URL/v1/models\" -H \"Authorization: Bearer \\\${AETHER_API_KEY}\""
+"#;
+    let mut response = Response::new(Body::from(script));
+    response.headers_mut().insert(
+        http::header::CONTENT_TYPE,
+        http::HeaderValue::from_static("application/x-sh; charset=utf-8"),
+    );
+    response
+}
+
+async fn handle_client_provisioning_exchange(
+    state: &AppState,
+    request_context: &GatewayPublicRequestContext,
+    request_body: Option<&axum::body::Bytes>,
+) -> Response<Body> {
+    let Some(request_body) = request_body else {
+        return build_auth_error_response(
+            http::StatusCode::BAD_REQUEST,
+            "缺少 provisioning token",
+            false,
+        );
+    };
+    let request = match parse_exchange_request(request_body) {
+        Ok(value) => value,
+        Err(detail) => {
+            return build_auth_error_response(http::StatusCode::BAD_REQUEST, detail, false);
+        }
+    };
+    let token_payload = match decode_auth_token(&request.token, CLIENT_PROVISIONING_TOKEN_TYPE) {
+        Ok(value) => value,
+        Err(detail) => {
+            return build_auth_error_response(
+                http::StatusCode::UNAUTHORIZED,
+                format!("provisioning token 无效或已过期: {detail}"),
+                false,
+            );
+        }
+    };
+    let Some(jti) = token_payload.get("jti").and_then(serde_json::Value::as_str) else {
+        return build_auth_error_response(
+            http::StatusCode::UNAUTHORIZED,
+            "provisioning token 无效",
+            false,
+        );
+    };
+    match state
+        .runtime_state
+        .kv_take(&format!("{CLIENT_PROVISIONING_KV_PREFIX}{jti}"))
+        .await
+    {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return build_auth_error_response(
+                http::StatusCode::CONFLICT,
+                "provisioning token 已被使用或已失效，请重新生成客户端配置命令",
+                false,
+            );
+        }
+        Err(err) => {
+            return build_auth_error_response(
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("client provisioning token consume failed: {err:?}"),
+                false,
+            );
+        }
+    }
+    let Some(user_id) = token_payload
+        .get("user_id")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return build_auth_error_response(
+            http::StatusCode::UNAUTHORIZED,
+            "provisioning token 无效",
+            false,
+        );
+    };
+    let Some(api_key_id) = token_payload
+        .get("api_key_id")
+        .and_then(serde_json::Value::as_str)
+    else {
+        return build_auth_error_response(
+            http::StatusCode::UNAUTHORIZED,
+            "provisioning token 无效",
+            false,
+        );
+    };
+
+    let records = match state
+        .list_auth_api_key_export_records_by_user_ids(&[user_id.to_string()])
+        .await
+    {
+        Ok(value) => value,
+        Err(err) => {
+            return build_auth_error_response(
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("client provisioning api key lookup failed: {err:?}"),
+                false,
+            );
+        }
+    };
+    let Some(record) = records
+        .into_iter()
+        .find(|record| !record.is_standalone && record.api_key_id == api_key_id)
+    else {
+        return build_auth_error_response(
+            http::StatusCode::NOT_FOUND,
+            "API密钥不存在或已失效",
+            false,
+        );
+    };
+    if !record.is_active {
+        return build_auth_error_response(http::StatusCode::FORBIDDEN, "API密钥已停用", false);
+    }
+    let Some(ciphertext) = record
+        .key_encrypted
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return build_auth_error_response(
+            http::StatusCode::BAD_REQUEST,
+            "该密钥没有存储完整密钥信息",
+            false,
+        );
+    };
+    let Some(api_key) = decrypt_catalog_secret_with_fallbacks(state.encryption_key(), ciphertext)
+    else {
+        return build_auth_error_response(
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+            "解密密钥失败",
+            false,
+        );
+    };
+    let base_url = normalize_client_base_url(request.base_url.as_deref())
+        .unwrap_or_else(|| DEFAULT_CLIENT_BASE_URL.to_string());
+    let api_url = format!("{base_url}/v1");
+    let format = query_param_value(request_context.request_query_string.as_deref(), "format")
+        .unwrap_or_default();
+
+    if format.eq_ignore_ascii_case("env") {
+        return build_client_env_response(&base_url, &api_url, &api_key);
+    }
+
+    no_store_response(Json(json!({
+        "base_url": base_url,
+        "api_url": api_url,
+        "api_key": api_key,
+        "config_path": "~/.aether/client.env",
+        "message": "客户端配置凭证已签发，请妥善保存本地配置文件",
+        "verification": format!("curl -fsS {base_url}/v1/models -H 'Authorization: Bearer $AETHER_API_KEY'"),
+    }))
+    .into_response())
+}
+
+fn parse_exchange_request(
+    request_body: &[u8],
+) -> Result<ClientProvisioningExchangeRequest, String> {
+    if let Ok(payload) =
+        serde_json::from_slice::<ClientProvisioningExchangeJsonRequest>(request_body)
+    {
+        return normalize_exchange_request(payload.token, payload.base_url);
+    }
+    let decoded = url::form_urlencoded::parse(request_body)
+        .into_owned()
+        .collect::<HashMap<_, _>>();
+    normalize_exchange_request(
+        decoded.get("token").cloned().unwrap_or_default(),
+        decoded.get("base_url").cloned(),
+    )
+}
+
+fn normalize_exchange_request(
+    token: String,
+    base_url: Option<String>,
+) -> Result<ClientProvisioningExchangeRequest, String> {
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        return Err("缺少 provisioning token".to_string());
+    }
+    Ok(ClientProvisioningExchangeRequest { token, base_url })
+}
+
+fn normalize_client_base_url(value: Option<&str>) -> Option<String> {
+    let value = value?.trim().trim_end_matches('/');
+    if value.is_empty() {
+        return None;
+    }
+    let parsed = url::Url::parse(value).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return None;
+    }
+    Some(value.to_string())
+}
+
+fn build_client_env_response(base_url: &str, api_url: &str, api_key: &str) -> Response<Body> {
+    let body = format!(
+        "# Aether client configuration\nAETHER_BASE_URL={}\nAETHER_API_URL={}\nAETHER_API_KEY={}\nOPENAI_BASE_URL={}\nOPENAI_API_KEY={}\n",
+        shell_quote(base_url),
+        shell_quote(api_url),
+        shell_quote(api_key),
+        shell_quote(api_url),
+        shell_quote(api_key),
+    );
+    let mut response = Response::new(Body::from(body));
+    response.headers_mut().insert(
+        http::header::CONTENT_TYPE,
+        http::HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    no_store_response(response)
+}
+
+fn no_store_response(mut response: Response<Body>) -> Response<Body> {
+    response.headers_mut().insert(
+        http::header::CACHE_CONTROL,
+        http::HeaderValue::from_static("no-store"),
+    );
+    response.headers_mut().insert(
+        http::header::PRAGMA,
+        http::HeaderValue::from_static("no-cache"),
+    );
+    response
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_response_marks_credentials_no_store_and_quotes_values() {
+        let response = build_client_env_response(
+            "https://aether.example",
+            "https://aether.example/v1",
+            "sk-test'value",
+        );
+
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-store")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::PRAGMA)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-cache")
+        );
+    }
+
+    #[test]
+    fn normalizes_only_http_client_base_urls() {
+        assert_eq!(
+            normalize_client_base_url(Some("https://aether.example/")),
+            Some("https://aether.example".to_string())
+        );
+        assert!(normalize_client_base_url(Some("file:///tmp/aether")).is_none());
+    }
+}

--- a/apps/aether-gateway/src/handlers/public/support/user_me.rs
+++ b/apps/aether-gateway/src/handlers/public/support/user_me.rs
@@ -1,8 +1,9 @@
 use super::{
     auth_password_policy_level, build_auth_error_response, build_auth_wallet_summary_payload,
-    decrypt_catalog_secret_with_fallbacks, encrypt_catalog_secret_with_fallbacks, handle_auth_me,
-    query_param_optional_bool, query_param_value, resolve_authenticated_local_user,
-    unix_secs_to_rfc3339, validate_auth_register_password, AppState, AuthenticatedLocalUserContext,
+    create_auth_token, decrypt_catalog_secret_with_fallbacks,
+    encrypt_catalog_secret_with_fallbacks, handle_auth_me, query_param_optional_bool,
+    query_param_value, resolve_authenticated_local_user, unix_secs_to_rfc3339,
+    validate_auth_register_password, AppState, AuthenticatedLocalUserContext,
     GatewayPublicRequestContext, PUBLIC_CAPABILITY_DEFINITIONS,
 };
 use crate::admin_api::build_admin_endpoint_health_status_payload;

--- a/apps/aether-gateway/src/handlers/public/support/user_me_api_keys.rs
+++ b/apps/aether-gateway/src/handlers/public/support/user_me_api_keys.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
 
 use axum::{
     body::Body,
@@ -15,7 +16,7 @@ use crate::handlers::shared::{
 };
 
 use super::{
-    build_auth_error_response, decrypt_catalog_secret_with_fallbacks,
+    build_auth_error_response, create_auth_token, decrypt_catalog_secret_with_fallbacks,
     encrypt_catalog_secret_with_fallbacks, format_users_me_optional_unix_secs_iso8601,
     known_capability_names, normalize_user_model_capability_settings_input,
     query_param_optional_bool, resolve_authenticated_local_user,
@@ -23,6 +24,8 @@ use super::{
 };
 
 const USERS_ME_API_KEY_WRITE_UNAVAILABLE_DETAIL: &str = "用户 API 密钥写入暂不可用";
+const USERS_ME_API_KEY_PROVISIONING_TOKEN_TTL_SECS: i64 = 10 * 60;
+const USERS_ME_API_KEY_PROVISIONING_KV_PREFIX: &str = "client_provisioning:";
 
 #[derive(Debug, Deserialize)]
 struct UsersMeCreateApiKeyRequest {
@@ -116,6 +119,10 @@ pub(super) fn users_me_api_key_providers_path_matches(request_path: &str) -> boo
 
 pub(super) fn users_me_api_key_capabilities_path_matches(request_path: &str) -> bool {
     users_me_api_key_nested_id_from_path(request_path, "capabilities").is_some()
+}
+
+pub(super) fn users_me_api_key_provisioning_token_path_matches(request_path: &str) -> bool {
+    users_me_api_key_nested_id_from_path(request_path, "provisioning-token").is_some()
 }
 
 fn users_me_masked_api_key_display(state: &AppState, ciphertext: Option<&str>) -> String {
@@ -426,6 +433,113 @@ pub(super) async fn handle_users_me_api_key_detail_get(
     Json(build_users_me_api_key_detail_payload(
         state, &record, is_locked,
     ))
+    .into_response()
+}
+
+pub(super) async fn handle_users_me_api_key_provisioning_token_create(
+    state: &AppState,
+    request_context: &GatewayPublicRequestContext,
+    headers: &http::HeaderMap,
+) -> Response<Body> {
+    let auth = match resolve_authenticated_local_user(state, request_context, headers).await {
+        Ok(value) => value,
+        Err(response) => return response,
+    };
+    let Some(api_key_id) =
+        users_me_api_key_nested_id_from_path(&request_context.request_path, "provisioning-token")
+    else {
+        return build_auth_error_response(http::StatusCode::NOT_FOUND, "API密钥不存在", false);
+    };
+
+    let records = match state
+        .list_auth_api_key_export_records_by_user_ids(std::slice::from_ref(&auth.user.id))
+        .await
+    {
+        Ok(value) => value,
+        Err(err) => {
+            return build_auth_error_response(
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("user api key lookup failed: {err:?}"),
+                false,
+            )
+        }
+    };
+    let Some(record) = records
+        .into_iter()
+        .find(|record| !record.is_standalone && record.api_key_id == api_key_id)
+    else {
+        return build_auth_error_response(http::StatusCode::NOT_FOUND, "API密钥不存在", false);
+    };
+    if !record.is_active {
+        return build_auth_error_response(
+            http::StatusCode::BAD_REQUEST,
+            "API密钥已停用，无法生成客户端配置命令",
+            false,
+        );
+    }
+    let Some(ciphertext) = record.key_encrypted.as_deref().map(str::trim) else {
+        return build_auth_error_response(
+            http::StatusCode::BAD_REQUEST,
+            "该密钥没有存储完整密钥信息",
+            false,
+        );
+    };
+    if ciphertext.is_empty()
+        || decrypt_catalog_secret_with_fallbacks(state.encryption_key(), ciphertext).is_none()
+    {
+        return build_auth_error_response(
+            http::StatusCode::BAD_REQUEST,
+            "该密钥没有可用于客户端配置的完整密钥信息",
+            false,
+        );
+    }
+
+    let jti = uuid::Uuid::new_v4().to_string();
+    let expires_at = chrono::Utc::now()
+        + chrono::Duration::seconds(USERS_ME_API_KEY_PROVISIONING_TOKEN_TTL_SECS);
+    let mut token_payload = serde_json::Map::new();
+    token_payload.insert("jti".to_string(), json!(jti.clone()));
+    token_payload.insert("user_id".to_string(), json!(auth.user.id));
+    token_payload.insert("api_key_id".to_string(), json!(record.api_key_id));
+    token_payload.insert(
+        "api_key_name".to_string(),
+        json!(record.name.unwrap_or_else(|| "API Key".to_string())),
+    );
+    if let Err(err) = state
+        .runtime_state
+        .kv_set(
+            &format!("{USERS_ME_API_KEY_PROVISIONING_KV_PREFIX}{jti}"),
+            "pending",
+            Some(Duration::from_secs(
+                USERS_ME_API_KEY_PROVISIONING_TOKEN_TTL_SECS as u64,
+            )),
+        )
+        .await
+    {
+        return build_auth_error_response(
+            http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("client provisioning token store failed: {err:?}"),
+            false,
+        );
+    }
+    let provisioning_token =
+        match create_auth_token("client_provisioning", token_payload, expires_at) {
+            Ok(value) => value,
+            Err(detail) => {
+                return build_auth_error_response(
+                    http::StatusCode::INTERNAL_SERVER_ERROR,
+                    detail,
+                    false,
+                )
+            }
+        };
+
+    Json(json!({
+        "provisioning_token": provisioning_token,
+        "expires_at": expires_at.to_rfc3339(),
+        "ttl_seconds": USERS_ME_API_KEY_PROVISIONING_TOKEN_TTL_SECS,
+        "message": "客户端配置令牌已生成，请在过期前使用",
+    }))
     .into_response()
 }
 

--- a/apps/aether-gateway/src/handlers/public/support/user_me_routes.rs
+++ b/apps/aether-gateway/src/handlers/public/support/user_me_routes.rs
@@ -5,7 +5,8 @@ use super::{
     handle_auth_me, handle_users_me_api_key_capabilities_put, handle_users_me_api_key_create,
     handle_users_me_api_key_delete, handle_users_me_api_key_detail_get,
     handle_users_me_api_key_patch, handle_users_me_api_key_providers_put,
-    handle_users_me_api_key_update, handle_users_me_api_keys_get, handle_users_me_available_models,
+    handle_users_me_api_key_provisioning_token_create, handle_users_me_api_key_update,
+    handle_users_me_api_keys_get, handle_users_me_available_models,
     handle_users_me_delete_other_sessions, handle_users_me_delete_session,
     handle_users_me_detail_put, handle_users_me_endpoint_status_get,
     handle_users_me_management_token_create, handle_users_me_management_token_delete,
@@ -18,6 +19,7 @@ use super::{
     handle_users_me_usage_active_get, handle_users_me_usage_get, handle_users_me_usage_heatmap_get,
     handle_users_me_usage_interval_timeline_get, users_me_api_key_capabilities_path_matches,
     users_me_api_key_detail_path_matches, users_me_api_key_providers_path_matches,
+    users_me_api_key_provisioning_token_path_matches,
     users_me_management_token_detail_path_matches,
     users_me_management_token_regenerate_path_matches,
     users_me_management_token_toggle_path_matches, users_me_management_tokens_root,
@@ -152,6 +154,14 @@ pub(crate) async fn maybe_build_local_users_me_response(
                     request_body,
                 )
                 .await,
+            )
+        }
+        Some("api_key_provisioning_token_create")
+            if users_me_api_key_provisioning_token_path_matches(&request_context.request_path) =>
+        {
+            Some(
+                handle_users_me_api_key_provisioning_token_create(state, request_context, headers)
+                    .await,
             )
         }
         Some("api_key_capabilities_update")

--- a/apps/aether-gateway/src/handlers/shared/mod.rs
+++ b/apps/aether-gateway/src/handlers/shared/mod.rs
@@ -42,7 +42,7 @@ pub(crate) use self::payloads::{
 };
 pub(crate) use self::request_utils::{
     admin_proxy_local_requires_buffered_body, internal_proxy_local_requires_buffered_body,
-    json_string_list, local_proxy_route_requires_buffered_body,
+    json_string_list, local_proxy_route_body_limit_bytes, local_proxy_route_requires_buffered_body,
     mark_external_models_official_providers, public_support_local_requires_buffered_body,
     query_param_bool, query_param_optional_bool, query_param_value,
     request_enables_control_execute, rust_auth_terminates_provider_credentials,

--- a/apps/aether-gateway/src/handlers/shared/request_utils.rs
+++ b/apps/aether-gateway/src/handlers/shared/request_utils.rs
@@ -443,7 +443,15 @@ pub(crate) fn public_support_local_requires_buffered_body(
                 ) | (
                     Some("users_me"),
                     http::Method::POST,
-                    Some("api_keys_create" | "management_tokens_create"),
+                    Some(
+                        "api_keys_create"
+                            | "management_tokens_create"
+                            | "api_key_provisioning_token_create"
+                    ),
+                ) | (
+                    Some("client_provisioning"),
+                    http::Method::POST,
+                    Some("exchange"),
                 ) | (
                     Some("wallet"),
                     http::Method::POST,
@@ -463,4 +471,24 @@ pub(crate) fn local_proxy_route_requires_buffered_body(
     admin_proxy_local_requires_buffered_body(request_context)
         || internal_proxy_local_requires_buffered_body(request_context)
         || public_support_local_requires_buffered_body(request_context)
+}
+
+pub(crate) fn local_proxy_route_body_limit_bytes(
+    request_context: &GatewayPublicRequestContext,
+) -> usize {
+    const CLIENT_PROVISIONING_EXCHANGE_BODY_LIMIT_BYTES: usize = 8 * 1024;
+
+    if request_context
+        .control_decision
+        .as_ref()
+        .is_some_and(|decision| {
+            decision.route_class.as_deref() == Some("public_support")
+                && decision.route_family.as_deref() == Some("client_provisioning")
+                && decision.route_kind.as_deref() == Some("exchange")
+        })
+    {
+        CLIENT_PROVISIONING_EXCHANGE_BODY_LIMIT_BYTES
+    } else {
+        usize::MAX
+    }
 }

--- a/apps/aether-gateway/src/router.rs
+++ b/apps/aether-gateway/src/router.rs
@@ -86,6 +86,7 @@ fn frontend_path_bypasses_static(path: &str) -> bool {
         || path.starts_with("/v1/")
         || path.starts_with("/v1beta/")
         || path.starts_with("/upload/")
+        || path.starts_with("/install/")
         || path.starts_with("/_gateway/")
         || path.starts_with("/.well-known/")
 }

--- a/frontend/src/api/me.ts
+++ b/frontend/src/api/me.ts
@@ -171,6 +171,13 @@ export interface ApiKey {
   force_capabilities?: Record<string, boolean> | null  // 强制能力配置
 }
 
+export interface ApiKeyProvisioningTokenResponse {
+  provisioning_token: string
+  expires_at: string
+  ttl_seconds: number
+  message: string
+}
+
 // 不再需要 ProviderBinding 接口
 
 export interface ChangePasswordRequest {
@@ -245,6 +252,13 @@ export const meApi = {
     const response = await apiClient.get<{ key: string }>(
       `/api/users/me/api-keys/${keyId}`,
       { params: { include_key: true } }
+    )
+    return response.data
+  },
+
+  async createApiKeyProvisioningToken(keyId: string): Promise<ApiKeyProvisioningTokenResponse> {
+    const response = await apiClient.post<ApiKeyProvisioningTokenResponse>(
+      `/api/users/me/api-keys/${keyId}/provisioning-token`
     )
     return response.data
   },

--- a/frontend/src/views/user/MyApiKeys.vue
+++ b/frontend/src/views/user/MyApiKeys.vue
@@ -195,6 +195,23 @@
                     variant="ghost"
                     size="icon"
                     class="h-8 w-8"
+                    :title="apiKey.is_active ? '复制客户端一键配置命令' : '密钥已停用'"
+                    :disabled="!apiKey.is_active || provisioningLoadingId === apiKey.id"
+                    @click="openClientConfigCommand(apiKey)"
+                  >
+                    <Loader2
+                      v-if="provisioningLoadingId === apiKey.id"
+                      class="h-4 w-4 animate-spin"
+                    />
+                    <Terminal
+                      v-else
+                      class="h-4 w-4"
+                    />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="h-8 w-8"
                     :title="apiKey.is_locked ? '已锁定' : '编辑'"
                     :disabled="apiKey.is_locked"
                     @click="openEditApiKeyDialog(apiKey)"
@@ -273,6 +290,23 @@
                 </Badge>
               </div>
               <div class="flex items-center gap-0.5 flex-shrink-0">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  class="h-7 w-7"
+                  :title="apiKey.is_active ? '一键配置' : '密钥已停用'"
+                  :disabled="!apiKey.is_active || provisioningLoadingId === apiKey.id"
+                  @click="openClientConfigCommand(apiKey)"
+                >
+                  <Loader2
+                    v-if="provisioningLoadingId === apiKey.id"
+                    class="h-3.5 w-3.5 animate-spin"
+                  />
+                  <Terminal
+                    v-else
+                    class="h-3.5 w-3.5"
+                  />
+                </Button>
                 <Button
                   variant="ghost"
                   size="icon"
@@ -498,6 +532,30 @@
             </Button>
           </div>
         </div>
+        <div
+          v-if="clientConfigCommand"
+          class="space-y-2 rounded-lg border border-primary/20 bg-primary/5 p-3"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <Label class="text-sm font-medium">客户端一键配置命令</Label>
+              <p class="mt-1 text-xs text-muted-foreground">
+                命令中使用短期 provisioning token，不会暴露原始 API Key；过期时间 {{ clientConfigExpiresAtText }}。
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              @click="copyTextToClipboard(clientConfigCommand)"
+            >
+              <Copy class="mr-2 h-3.5 w-3.5" />
+              复制命令
+            </Button>
+          </div>
+          <code class="block whitespace-pre-wrap break-all rounded-md bg-background/80 px-3 py-2 font-mono text-xs text-foreground">
+            {{ clientConfigCommand }}
+          </code>
+        </div>
       </div>
 
       <template #footer>
@@ -506,6 +564,56 @@
           @click="showKeyDialog = false"
         >
           确定
+        </Button>
+      </template>
+    </Dialog>
+
+    <!-- 客户端配置命令对话框 -->
+    <Dialog
+      v-model="showClientConfigDialog"
+      size="lg"
+    >
+      <template #header>
+        <div class="border-b border-border px-6 py-4">
+          <div class="flex items-center gap-3">
+            <div class="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 flex-shrink-0">
+              <Terminal class="h-5 w-5 text-primary" />
+            </div>
+            <div class="flex-1 min-w-0">
+              <h3 class="text-lg font-semibold text-foreground leading-tight">
+                客户端一键配置
+              </h3>
+              <p class="text-xs text-muted-foreground">
+                {{ clientConfigKeyName }} · token 过期时间 {{ clientConfigExpiresAtText }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <div class="space-y-3">
+        <p class="text-sm text-muted-foreground">
+          在目标机器执行以下命令，会自动写入 <code class="rounded bg-muted px-1 py-0.5">~/.aether/client.env</code>，重复执行会安全覆盖同一配置文件。
+        </p>
+        <code class="block whitespace-pre-wrap break-all rounded-lg border bg-muted/40 px-3 py-3 font-mono text-xs text-foreground">
+          {{ clientConfigCommand }}
+        </code>
+      </div>
+
+      <template #footer>
+        <Button
+          variant="outline"
+          class="h-10 px-5"
+          @click="showClientConfigDialog = false"
+        >
+          关闭
+        </Button>
+        <Button
+          class="h-10 px-5"
+          @click="copyTextToClipboard(clientConfigCommand)"
+        >
+          <Copy class="mr-2 h-4 w-4" />
+          复制命令
         </Button>
       </template>
     </Dialog>
@@ -543,7 +651,7 @@ import {
   TableRow
 } from '@/components/ui'
 import RefreshButton from '@/components/ui/refresh-button.vue'
-import { Plus, Key, Copy, Trash2, Loader2, Activity, CheckCircle, Power, SquarePen } from 'lucide-vue-next'
+import { Plus, Key, Copy, Trash2, Loader2, Activity, CheckCircle, Power, SquarePen, Terminal } from 'lucide-vue-next'
 import { useToast } from '@/composables/useToast'
 import { log } from '@/utils/logger'
 import { parseApiError } from '@/utils/errorParser'
@@ -568,14 +676,26 @@ const paginatedApiKeys = computed(() => {
   return apiKeys.value.slice(start, start + pageSize.value)
 })
 
+const clientConfigExpiresAtText = computed(() => {
+  if (!clientConfigExpiresAt.value) return '未知'
+  const date = new Date(clientConfigExpiresAt.value)
+  if (Number.isNaN(date.getTime())) return clientConfigExpiresAt.value
+  return date.toLocaleString('zh-CN')
+})
+
 const showCreateDialog = ref(false)
 const showKeyDialog = ref(false)
+const showClientConfigDialog = ref(false)
 const showDeleteDialog = ref(false)
 
 const newKeyName = ref('')
 const newKeyRateLimit = ref<number | undefined>(undefined)
 const newKeyConcurrentLimit = ref<number | undefined>(undefined)
 const newKeyValue = ref('')
+const clientConfigCommand = ref('')
+const clientConfigExpiresAt = ref('')
+const clientConfigKeyName = ref('')
+const provisioningLoadingId = ref<string | null>(null)
 const keyToDelete = ref<ApiKey | null>(null)
 const editingApiKey = ref<ApiKey | null>(null)
 
@@ -615,6 +735,9 @@ function openCreateApiKeyDialog() {
   newKeyName.value = ''
   newKeyRateLimit.value = undefined
   newKeyConcurrentLimit.value = undefined
+  clientConfigCommand.value = ''
+  clientConfigExpiresAt.value = ''
+  clientConfigKeyName.value = ''
   showCreateDialog.value = true
 }
 
@@ -648,6 +771,12 @@ async function saveApiKey() {
         concurrent_limit: newKeyConcurrentLimit.value,
       })
       newKeyValue.value = newKey.key || ''
+      try {
+        await prepareClientConfigCommand(newKey)
+      } catch (error) {
+        log.warn('API 密钥已创建，但客户端配置命令生成失败:', error)
+        showError(parseApiError(error, 'API 密钥已创建，但客户端配置命令生成失败'))
+      }
       showKeyDialog.value = true
       success('API 密钥创建成功')
     }
@@ -708,6 +837,33 @@ async function copyApiKey(apiKey: ApiKey) {
     log.error('复制密钥失败:', error)
     showError('复制失败，请重试')
   }
+}
+
+async function openClientConfigCommand(apiKey: ApiKey) {
+  try {
+    await prepareClientConfigCommand(apiKey)
+    showClientConfigDialog.value = true
+  } catch (error) {
+    log.error('生成客户端配置命令失败:', error)
+    showError(parseApiError(error, '生成客户端配置命令失败'))
+  }
+}
+
+async function prepareClientConfigCommand(apiKey: ApiKey) {
+  provisioningLoadingId.value = apiKey.id
+  try {
+    const response = await meApi.createApiKeyProvisioningToken(apiKey.id)
+    const baseUrl = window.location.origin.replace(/\/$/, '')
+    clientConfigCommand.value = `curl -fsSL '${shellSingleQuote(baseUrl)}/install/client-config.sh' | AETHER_BASE_URL='${shellSingleQuote(baseUrl)}' AETHER_PROVISIONING_TOKEN='${shellSingleQuote(response.provisioning_token)}' sh`
+    clientConfigExpiresAt.value = response.expires_at
+    clientConfigKeyName.value = apiKey.name || 'API Key'
+  } finally {
+    provisioningLoadingId.value = null
+  }
+}
+
+function shellSingleQuote(value: string): string {
+  return value.replace(/'/g, `'\\''`)
 }
 
 async function copyTextToClipboard(text: string, showToast: boolean = true) {


### PR DESCRIPTION
## Summary
- Adds short-lived client provisioning tokens for user API keys and a public exchange endpoint that returns local client env config with no-store headers.
- Serves `/install/client-config.sh` so users can run a one-line command that writes `~/.aether/client.env` with restrictive permissions.
- Adds a user API key UI action/dialog to generate and copy the one-line client configuration command.

Closes #373

## Verification
- `cargo check -p aether-gateway`
- `cargo test -p aether-gateway control::tests::public_support::classifies_users_me_routes_as_public_support_route`
- `cargo test -p aether-gateway control::tests::public_support::classifies_client_provisioning_routes_as_public_support_route`
- `cargo test -p aether-gateway control::tests::public_support::limits_client_provisioning_exchange_buffered_body`
- `cargo test -p aether-gateway handlers::public::support::support_client_provisioning::tests`
- `npm run type-check`
- `npm run build`