### PR TITLE
Fix SSE stream handling and DeepSeek thinking compatibility

### DIFF
--- a/apps/aether-gateway/src/ai_serving/planner/standard/deepseek.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/deepseek.rs
@@ -1,0 +1,386 @@
+use serde_json::{json, Value};
+
+pub(crate) fn is_deepseek_provider(provider_type: &str, base_url: &str) -> bool {
+    let provider_type = provider_type.trim().to_ascii_lowercase();
+    if matches!(
+        provider_type.as_str(),
+        "deepseek" | "deepseek_openai" | "deepseek_anthropic" | "deepseek_compatible"
+    ) {
+        return true;
+    }
+
+    let host = base_url_host(base_url);
+    host == "deepseek.com" || host.ends_with(".deepseek.com")
+}
+
+pub(crate) fn apply_deepseek_tool_call_thinking_compat(
+    provider_request_body: &mut Value,
+    provider_type: &str,
+    base_url: &str,
+    provider_api_format: &str,
+    original_request_body: Option<&Value>,
+) {
+    if !is_deepseek_provider(provider_type, base_url) {
+        return;
+    }
+
+    match crate::ai_serving::normalize_api_format_alias(provider_api_format).as_str() {
+        "openai:chat" => {
+            apply_deepseek_openai_chat_thinking_compat(provider_request_body, original_request_body)
+        }
+        "claude:messages" => apply_deepseek_claude_messages_thinking_compat(
+            provider_request_body,
+            original_request_body,
+        ),
+        _ => {}
+    }
+}
+
+fn base_url_host(base_url: &str) -> String {
+    let lower = base_url.trim().to_ascii_lowercase();
+    let without_scheme = lower
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(lower.as_str());
+    let without_userinfo = without_scheme
+        .rsplit_once('@')
+        .map(|(_, host)| host)
+        .unwrap_or(without_scheme);
+    without_userinfo
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default()
+        .split(':')
+        .next()
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn source_disables_thinking(
+    original_request_body: Option<&Value>,
+    provider_request_body: &Value,
+) -> bool {
+    request_explicitly_disables_thinking(provider_request_body)
+        || original_request_body.is_some_and(request_explicitly_disables_thinking)
+}
+
+fn request_explicitly_disables_thinking(body: &Value) -> bool {
+    thinking_type(body).is_some_and(|value| value.eq_ignore_ascii_case("disabled"))
+        || reasoning_effort(body).is_some_and(|value| value.eq_ignore_ascii_case("none"))
+}
+
+fn thinking_type(body: &Value) -> Option<&str> {
+    body.get("thinking")
+        .and_then(Value::as_object)
+        .and_then(|thinking| thinking.get("type"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn reasoning_effort(body: &Value) -> Option<&str> {
+    body.get("reasoning_effort")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            body.get("reasoning")
+                .and_then(Value::as_object)
+                .and_then(|reasoning| reasoning.get("effort"))
+                .and_then(Value::as_str)
+        })
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn set_deepseek_thinking_type(body: &mut Value, thinking_type: &str) {
+    let Some(object) = body.as_object_mut() else {
+        return;
+    };
+
+    match object.get_mut("thinking") {
+        Some(Value::Object(thinking)) => {
+            thinking.insert("type".to_string(), Value::String(thinking_type.to_string()));
+        }
+        _ => {
+            object.insert(
+                "thinking".to_string(),
+                json!({
+                    "type": thinking_type,
+                }),
+            );
+        }
+    }
+}
+
+fn apply_deepseek_openai_chat_thinking_compat(
+    provider_request_body: &mut Value,
+    original_request_body: Option<&Value>,
+) {
+    let disabled = source_disables_thinking(original_request_body, provider_request_body);
+    set_deepseek_thinking_type(
+        provider_request_body,
+        if disabled { "disabled" } else { "enabled" },
+    );
+
+    let Some(object) = provider_request_body.as_object_mut() else {
+        return;
+    };
+    if disabled {
+        if reasoning_effort(&Value::Object(object.clone()))
+            .is_some_and(|value| value.eq_ignore_ascii_case("none"))
+        {
+            object.remove("reasoning_effort");
+        }
+        return;
+    }
+
+    let Some(messages) = object.get_mut("messages").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for message in messages {
+        let Some(message_object) = message.as_object_mut() else {
+            continue;
+        };
+        let is_assistant = message_object
+            .get("role")
+            .and_then(Value::as_str)
+            .is_some_and(|role| role.trim().eq_ignore_ascii_case("assistant"));
+        if !is_assistant {
+            continue;
+        }
+        if message_object
+            .get("reasoning_content")
+            .is_some_and(|value| !value.is_null())
+        {
+            continue;
+        }
+        message_object.insert(
+            "reasoning_content".to_string(),
+            Value::String(String::new()),
+        );
+    }
+}
+
+fn apply_deepseek_claude_messages_thinking_compat(
+    provider_request_body: &mut Value,
+    original_request_body: Option<&Value>,
+) {
+    if source_disables_thinking(original_request_body, provider_request_body) {
+        set_deepseek_thinking_type(provider_request_body, "disabled");
+        return;
+    }
+
+    let Some(messages) = provider_request_body
+        .get_mut("messages")
+        .and_then(Value::as_array_mut)
+    else {
+        return;
+    };
+    for message in messages {
+        let Some(message_object) = message.as_object_mut() else {
+            continue;
+        };
+        let is_assistant = message_object
+            .get("role")
+            .and_then(Value::as_str)
+            .is_some_and(|role| role.trim().eq_ignore_ascii_case("assistant"));
+        if !is_assistant {
+            continue;
+        }
+        ensure_claude_assistant_message_has_thinking_block(message_object);
+    }
+}
+
+fn ensure_claude_assistant_message_has_thinking_block(
+    message: &mut serde_json::Map<String, Value>,
+) {
+    let thinking_block = json!({
+        "type": "thinking",
+        "thinking": "",
+    });
+    match message.get_mut("content") {
+        Some(Value::Array(blocks)) => {
+            if blocks.iter().any(is_claude_thinking_block) {
+                return;
+            }
+            blocks.insert(0, thinking_block);
+        }
+        Some(Value::String(text)) => {
+            let text = std::mem::take(text);
+            message.insert(
+                "content".to_string(),
+                Value::Array(vec![
+                    thinking_block,
+                    json!({
+                        "type": "text",
+                        "text": text,
+                    }),
+                ]),
+            );
+        }
+        Some(Value::Null) | None => {
+            message.insert("content".to_string(), Value::Array(vec![thinking_block]));
+        }
+        Some(other) => {
+            let existing = std::mem::take(other);
+            message.insert(
+                "content".to_string(),
+                Value::Array(vec![thinking_block, existing]),
+            );
+        }
+    }
+}
+
+fn is_claude_thinking_block(block: &Value) -> bool {
+    block
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|block_type| block_type.trim().eq_ignore_ascii_case("thinking"))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{apply_deepseek_tool_call_thinking_compat, is_deepseek_provider};
+
+    #[test]
+    fn detects_deepseek_provider_by_type_or_host() {
+        assert!(is_deepseek_provider(
+            "deepseek",
+            "https://relay.example.com"
+        ));
+        assert!(is_deepseek_provider(
+            "custom",
+            "https://api.deepseek.com/v1"
+        ));
+        assert!(!is_deepseek_provider(
+            "custom",
+            "https://example.com/deepseek"
+        ));
+    }
+
+    #[test]
+    fn openai_chat_deepseek_adds_thinking_and_empty_reasoning_content() {
+        let mut body = json!({
+            "model": "deepseek-chat",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": null, "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"}
+                }]},
+                {"role": "tool", "tool_call_id": "call_1", "content": "{}"}
+            ]
+        });
+
+        apply_deepseek_tool_call_thinking_compat(
+            &mut body,
+            "deepseek",
+            "https://api.deepseek.com/v1",
+            "openai:chat",
+            None,
+        );
+
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["messages"][1]["reasoning_content"], "");
+    }
+
+    #[test]
+    fn openai_chat_deepseek_honors_disabled_thinking() {
+        let original = json!({"reasoning_effort": "none"});
+        let mut body = json!({
+            "model": "deepseek-chat",
+            "reasoning_effort": "none",
+            "messages": [
+                {"role": "assistant", "content": "hi"}
+            ]
+        });
+
+        apply_deepseek_tool_call_thinking_compat(
+            &mut body,
+            "deepseek",
+            "https://api.deepseek.com/v1",
+            "openai:chat",
+            Some(&original),
+        );
+
+        assert_eq!(body["thinking"]["type"], "disabled");
+        assert!(body.get("reasoning_effort").is_none());
+        assert!(body["messages"][0].get("reasoning_content").is_none());
+    }
+
+    #[test]
+    fn claude_messages_deepseek_prepends_empty_thinking_block() {
+        let mut body = json!({
+            "model": "deepseek-3.2",
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "call_1", "name": "lookup", "input": {}}
+                ]}
+            ]
+        });
+
+        apply_deepseek_tool_call_thinking_compat(
+            &mut body,
+            "deepseek",
+            "https://api.deepseek.com",
+            "claude:messages",
+            None,
+        );
+
+        assert_eq!(body["messages"][1]["content"][0]["type"], "thinking");
+        assert_eq!(body["messages"][1]["content"][0]["thinking"], "");
+        assert_eq!(body["messages"][1]["content"][1]["type"], "tool_use");
+    }
+
+    #[test]
+    fn claude_messages_deepseek_converts_string_assistant_content_to_blocks() {
+        let mut body = json!({
+            "model": "deepseek-3.2",
+            "messages": [{
+                "role": "assistant",
+                "content": "done"
+            }]
+        });
+
+        apply_deepseek_tool_call_thinking_compat(
+            &mut body,
+            "deepseek",
+            "https://api.deepseek.com",
+            "claude:messages",
+            None,
+        );
+
+        assert_eq!(body["messages"][0]["content"][0]["type"], "thinking");
+        assert_eq!(body["messages"][0]["content"][1]["type"], "text");
+        assert_eq!(body["messages"][0]["content"][1]["text"], "done");
+    }
+
+    #[test]
+    fn claude_messages_deepseek_preserves_existing_thinking_block() {
+        let mut body = json!({
+            "model": "deepseek-3.2",
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "plan", "signature": "sig"},
+                    {"type": "text", "text": "answer"}
+                ]
+            }]
+        });
+
+        apply_deepseek_tool_call_thinking_compat(
+            &mut body,
+            "deepseek",
+            "https://api.deepseek.com",
+            "claude:messages",
+            None,
+        );
+
+        assert_eq!(body["messages"][0]["content"].as_array().unwrap().len(), 2);
+        assert_eq!(body["messages"][0]["content"][0]["thinking"], "plan");
+        assert_eq!(body["messages"][0]["content"][0]["signature"], "sig");
+    }
+}

--- a/apps/aether-gateway/src/ai_serving/planner/standard/family/request.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/family/request.rs
@@ -14,7 +14,8 @@ use crate::ai_serving::planner::common::{
 };
 use crate::ai_serving::planner::spec_metadata::local_standard_spec_metadata;
 use crate::ai_serving::planner::standard::{
-    apply_codex_openai_responses_special_headers, request_body_build_failure_extra_data,
+    apply_codex_openai_responses_special_headers, apply_deepseek_tool_call_thinking_compat,
+    is_deepseek_provider, request_body_build_failure_extra_data,
 };
 use crate::ai_serving::transport::kiro::{
     build_kiro_provider_headers, build_kiro_provider_request_body,
@@ -77,6 +78,7 @@ fn provider_preserves_claude_thinking_signatures(provider_type: &str, base_url: 
         "anthropic" | "claude_code" | "bedrock" | "aws_bedrock" | "amazon_bedrock"
     ) || base_url.contains("api.anthropic.com")
         || is_bedrock_runtime_url
+        || is_deepseek_provider(provider_type.as_str(), base_url.as_str())
 }
 
 fn sanitize_claude_thinking_block(block: Value) -> (Option<Value>, bool) {
@@ -523,6 +525,13 @@ pub(crate) async fn resolve_local_standard_candidate_payload_parts(
         provider_api_format,
         transport,
     );
+    apply_deepseek_tool_call_thinking_compat(
+        &mut provider_request_body,
+        transport.provider.provider_type.as_str(),
+        transport.endpoint.base_url.as_str(),
+        provider_api_format,
+        Some(body_json),
+    );
     if let Some(mapping) =
         crate::system_features::reasoning_model_directive_mapping_for_api_format_and_model(
             state,
@@ -570,6 +579,13 @@ pub(crate) async fn resolve_local_standard_candidate_payload_parts(
             &mut provider_request_body,
             provider_api_format,
             transport,
+        );
+        apply_deepseek_tool_call_thinking_compat(
+            &mut provider_request_body,
+            transport.provider.provider_type.as_str(),
+            transport.endpoint.base_url.as_str(),
+            provider_api_format,
+            Some(body_json),
         );
     }
 
@@ -1166,6 +1182,14 @@ mod tests {
         assert!(provider_preserves_claude_thinking_signatures(
             "amazon_bedrock",
             "https://relay.example.com"
+        ));
+        assert!(provider_preserves_claude_thinking_signatures(
+            "deepseek",
+            "https://relay.example.com"
+        ));
+        assert!(provider_preserves_claude_thinking_signatures(
+            "custom",
+            "https://api.deepseek.com"
         ));
         assert!(!provider_preserves_claude_thinking_signatures(
             "openai",

--- a/apps/aether-gateway/src/ai_serving/planner/standard/mod.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/mod.rs
@@ -8,6 +8,7 @@ use crate::{AiExecutionDecision, AppState, GatewayError};
 
 mod claude;
 mod codex;
+mod deepseek;
 mod family;
 mod gemini;
 mod normalize;
@@ -16,6 +17,7 @@ mod openai;
 pub(crate) use self::codex::{
     apply_codex_openai_responses_special_body_edits, apply_codex_openai_responses_special_headers,
 };
+pub(crate) use self::deepseek::{apply_deepseek_tool_call_thinking_compat, is_deepseek_provider};
 pub(crate) use self::family::{
     build_local_stream_attempt_source, build_local_stream_plan_and_reports,
     build_local_sync_attempt_source, build_local_sync_plan_and_reports,

--- a/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/decision/request.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/decision/request.rs
@@ -17,9 +17,9 @@ use crate::ai_serving::planner::common::{
 };
 use crate::ai_serving::planner::standard::{
     apply_codex_openai_responses_special_body_edits, apply_codex_openai_responses_special_headers,
-    build_cross_format_openai_chat_request_body, build_cross_format_openai_chat_upstream_url,
-    build_local_openai_chat_request_body, build_local_openai_chat_upstream_url,
-    request_body_build_failure_extra_data,
+    apply_deepseek_tool_call_thinking_compat, build_cross_format_openai_chat_request_body,
+    build_cross_format_openai_chat_upstream_url, build_local_openai_chat_request_body,
+    build_local_openai_chat_upstream_url, request_body_build_failure_extra_data,
 };
 use crate::ai_serving::transport::auth::resolve_local_openai_bearer_auth;
 use crate::ai_serving::transport::kiro::{
@@ -403,7 +403,7 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             }
         };
 
-        let Some(provider_request_body) = build_local_openai_chat_request_body(
+        let Some(mut provider_request_body) = build_local_openai_chat_request_body(
             body_json,
             &prepared_candidate.mapped_model,
             upstream_is_stream,
@@ -429,6 +429,13 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             .await;
             return Ok(None);
         };
+        apply_deepseek_tool_call_thinking_compat(
+            &mut provider_request_body,
+            transport.provider.provider_type.as_str(),
+            transport.endpoint.base_url.as_str(),
+            "openai:chat",
+            Some(body_json),
+        );
 
         let Some(upstream_url) = build_local_openai_chat_upstream_url(parts, transport) else {
             mark_skipped_local_openai_chat_candidate_with_failure_diagnostic(
@@ -707,6 +714,13 @@ pub(crate) async fn resolve_local_openai_chat_candidate_payload_parts(
             request_requires_body_stream_field(body_json, force_body_stream_field),
         );
     }
+    apply_deepseek_tool_call_thinking_compat(
+        &mut provider_request_body,
+        transport.provider.provider_type.as_str(),
+        transport.endpoint.base_url.as_str(),
+        provider_api_format.as_str(),
+        Some(body_json),
+    );
 
     if let Some(kiro_auth) = kiro_auth.as_ref() {
         return Ok(build_kiro_openai_chat_cross_format_payload_parts(

--- a/apps/aether-gateway/src/ai_serving/planner/standard/openai/responses/decision/request.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/openai/responses/decision/request.rs
@@ -17,7 +17,7 @@ use crate::ai_serving::planner::common::{
 use crate::ai_serving::planner::spec_metadata::local_openai_responses_spec_metadata;
 use crate::ai_serving::planner::standard::{
     apply_codex_openai_responses_special_body_edits, apply_codex_openai_responses_special_headers,
-    build_cross_format_openai_responses_request_body,
+    apply_deepseek_tool_call_thinking_compat, build_cross_format_openai_responses_request_body,
     build_cross_format_openai_responses_upstream_url, build_local_openai_responses_request_body,
     build_local_openai_responses_upstream_url, request_body_build_failure_extra_data,
 };
@@ -375,6 +375,13 @@ pub(crate) async fn resolve_local_openai_responses_candidate_payload_parts(
             request_requires_body_stream_field(body_json, force_body_stream_field),
         );
     }
+    apply_deepseek_tool_call_thinking_compat(
+        &mut base_provider_request_body,
+        transport.provider.provider_type.as_str(),
+        transport.endpoint.base_url.as_str(),
+        provider_api_format,
+        Some(body_json),
+    );
     let antigravity_auth = if is_antigravity {
         match classify_local_antigravity_request_support(
             transport,

--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -5082,7 +5082,7 @@ mod tests {
         .expect("timeout failure should close the response body")
         .expect("response body should read");
         let text = String::from_utf8(body.to_vec()).expect("response body should be utf8");
-        assert!(text.contains(": aether-keepalive\n\n"));
+        assert!(!text.contains(": aether-keepalive\n\n"));
         assert!(text.contains("event: image_generation.failed"));
         assert!(text.contains("\"type\":\"image_stream_total_timeout\""));
     }

--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -1407,7 +1407,10 @@ fn should_limit_direct_finalize_prefetch(plan_kind: &str, has_local_stream_rewri
     plan_kind == OPENAI_IMAGE_STREAM_PLAN_KIND || has_local_stream_rewriter
 }
 
-fn should_emit_synthetic_sse_keepalive(plan: &ExecutionPlan) -> bool {
+fn client_format_allows_proxy_generated_sse_control_blocks(plan: &ExecutionPlan) -> bool {
+    // OpenAI-compatible clients commonly parse every client-visible SSE event as
+    // an OpenAI JSON payload or [DONE]. Keep the downstream wire format strict:
+    // do not inject proxy-generated comments, pings, or keepalives for openai:*.
     !plan
         .client_api_format
         .trim()
@@ -2723,8 +2726,8 @@ async fn execute_stream_from_frame_stream(
     let openai_image_stream_total_timeout_ms =
         resolve_openai_image_stream_total_timeout_ms(plan_kind, &plan);
     let response_headers_are_sse = response_headers_indicate_sse(&headers);
-    let emit_sse_keepalive_for_body =
-        response_headers_are_sse && should_emit_synthetic_sse_keepalive(&plan);
+    let emit_proxy_generated_sse_control_blocks =
+        response_headers_are_sse && client_format_allows_proxy_generated_sse_control_blocks(&plan);
     let plan_for_report = plan;
     let emit_passthrough_sse_terminal_error = skip_direct_finalize_prefetch
         && response_headers_indicate_sse(&upstream_headers)
@@ -3849,7 +3852,7 @@ async fn execute_stream_from_frame_stream(
         prefetched_chunks_for_body,
         rx,
         response_headers_are_sse,
-        emit_sse_keepalive_for_body,
+        emit_proxy_generated_sse_control_blocks,
         SSE_KEEPALIVE_INTERVAL,
     );
 
@@ -3901,13 +3904,13 @@ mod tests {
     use tokio::sync::{mpsc, watch, Notify};
 
     use super::{
-        build_sse_body_stream, ensure_stream_terminal_summary_for_missing_observed_finish,
+        build_sse_body_stream, client_format_allows_proxy_generated_sse_control_blocks,
+        ensure_stream_terminal_summary_for_missing_observed_finish,
         execute_execution_runtime_stream, execute_stream_from_frame_stream,
         maybe_apply_kiro_prompt_cache_usage_to_stream_summary, merge_stream_terminal_summary,
-        should_emit_synthetic_sse_keepalive, should_limit_direct_finalize_prefetch,
-        should_probe_success_failover_before_stream, should_skip_direct_finalize_prefetch,
-        stream_chunk_contains_sse_done, stream_requires_observed_terminal_event,
-        stream_terminal_summary_missing_observed_finish,
+        should_limit_direct_finalize_prefetch, should_probe_success_failover_before_stream,
+        should_skip_direct_finalize_prefetch, stream_chunk_contains_sse_done,
+        stream_requires_observed_terminal_event, stream_terminal_summary_missing_observed_finish,
         stream_terminal_summary_missing_observed_finish_with_requirement,
         stream_terminal_summary_represents_failure_with_requirement,
         ClientVisibleStreamCompletionTracker,
@@ -4769,7 +4772,7 @@ mod tests {
     }
 
     #[test]
-    fn disables_synthetic_sse_keepalive_for_openai_client_formats() {
+    fn openai_client_formats_disallow_proxy_generated_sse_control_blocks() {
         let mut plan = ExecutionPlan {
             request_id: "req-openai-keepalive".into(),
             candidate_id: Some("cand-openai-keepalive".into()),
@@ -4792,11 +4795,17 @@ mod tests {
             timeouts: None,
         };
 
-        assert!(!should_emit_synthetic_sse_keepalive(&plan));
+        assert!(!client_format_allows_proxy_generated_sse_control_blocks(
+            &plan
+        ));
         plan.client_api_format = "openai:responses".into();
-        assert!(!should_emit_synthetic_sse_keepalive(&plan));
+        assert!(!client_format_allows_proxy_generated_sse_control_blocks(
+            &plan
+        ));
         plan.client_api_format = "claude:messages".into();
-        assert!(should_emit_synthetic_sse_keepalive(&plan));
+        assert!(client_format_allows_proxy_generated_sse_control_blocks(
+            &plan
+        ));
     }
 
     #[tokio::test]

--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -1407,14 +1407,23 @@ fn should_limit_direct_finalize_prefetch(plan_kind: &str, has_local_stream_rewri
     plan_kind == OPENAI_IMAGE_STREAM_PLAN_KIND || has_local_stream_rewriter
 }
 
+fn should_emit_synthetic_sse_keepalive(plan: &ExecutionPlan) -> bool {
+    !plan
+        .client_api_format
+        .trim()
+        .to_ascii_lowercase()
+        .starts_with("openai:")
+}
+
 fn build_sse_body_stream(
     prefetched_chunks_for_body: Vec<Bytes>,
     mut rx: mpsc::Receiver<Result<Bytes, IoError>>,
+    filter_control_blocks: bool,
     emit_keepalive: bool,
     keepalive_interval: Duration,
 ) -> impl futures_util::Stream<Item = Result<Bytes, IoError>> + Send + 'static {
     stream! {
-        let mut upstream_control_filter = emit_keepalive.then(SseControlBlockFilter::default);
+        let mut upstream_control_filter = filter_control_blocks.then(SseControlBlockFilter::default);
         let mut sent_prefetched_chunk = false;
         for chunk in prefetched_chunks_for_body {
             if let Some(chunk) = filter_upstream_sse_control_chunk(&mut upstream_control_filter, chunk) {
@@ -1456,7 +1465,17 @@ fn build_sse_body_stream(
             }
         } else {
             while let Some(item) = rx.recv().await {
-                yield item;
+                match item {
+                    Ok(chunk) => {
+                        if let Some(chunk) = filter_upstream_sse_control_chunk(&mut upstream_control_filter, chunk) {
+                            yield Ok(chunk);
+                        }
+                    }
+                    Err(err) => yield Err(err),
+                }
+            }
+            if let Some(chunk) = flush_upstream_sse_control_filter(&mut upstream_control_filter) {
+                yield Ok(chunk);
             }
         }
     }
@@ -2703,6 +2722,9 @@ async fn execute_stream_from_frame_stream(
     let is_openai_image_stream_for_report = plan_kind == OPENAI_IMAGE_STREAM_PLAN_KIND;
     let openai_image_stream_total_timeout_ms =
         resolve_openai_image_stream_total_timeout_ms(plan_kind, &plan);
+    let response_headers_are_sse = response_headers_indicate_sse(&headers);
+    let emit_sse_keepalive_for_body =
+        response_headers_are_sse && should_emit_synthetic_sse_keepalive(&plan);
     let plan_for_report = plan;
     let emit_passthrough_sse_terminal_error = skip_direct_finalize_prefetch
         && response_headers_indicate_sse(&upstream_headers)
@@ -3820,14 +3842,14 @@ async fn execute_stream_from_frame_stream(
         );
     }
 
-    let emit_sse_keepalive = response_headers_indicate_sse(&headers);
-    if emit_sse_keepalive {
+    if response_headers_are_sse {
         headers.remove("content-length");
     }
     let body_stream = build_sse_body_stream(
         prefetched_chunks_for_body,
         rx,
-        emit_sse_keepalive,
+        response_headers_are_sse,
+        emit_sse_keepalive_for_body,
         SSE_KEEPALIVE_INTERVAL,
     );
 
@@ -3882,9 +3904,10 @@ mod tests {
         build_sse_body_stream, ensure_stream_terminal_summary_for_missing_observed_finish,
         execute_execution_runtime_stream, execute_stream_from_frame_stream,
         maybe_apply_kiro_prompt_cache_usage_to_stream_summary, merge_stream_terminal_summary,
-        should_limit_direct_finalize_prefetch, should_probe_success_failover_before_stream,
-        should_skip_direct_finalize_prefetch, stream_chunk_contains_sse_done,
-        stream_requires_observed_terminal_event, stream_terminal_summary_missing_observed_finish,
+        should_emit_synthetic_sse_keepalive, should_limit_direct_finalize_prefetch,
+        should_probe_success_failover_before_stream, should_skip_direct_finalize_prefetch,
+        stream_chunk_contains_sse_done, stream_requires_observed_terminal_event,
+        stream_terminal_summary_missing_observed_finish,
         stream_terminal_summary_missing_observed_finish_with_requirement,
         stream_terminal_summary_represents_failure_with_requirement,
         ClientVisibleStreamCompletionTracker,
@@ -4745,12 +4768,44 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn disables_synthetic_sse_keepalive_for_openai_client_formats() {
+        let mut plan = ExecutionPlan {
+            request_id: "req-openai-keepalive".into(),
+            candidate_id: Some("cand-openai-keepalive".into()),
+            provider_name: Some("openai".into()),
+            provider_id: "prov-1".into(),
+            endpoint_id: "ep-1".into(),
+            key_id: "key-1".into(),
+            method: "POST".into(),
+            url: "https://example.com/v1/chat/completions".into(),
+            headers: BTreeMap::new(),
+            content_type: Some("application/json".into()),
+            content_encoding: None,
+            body: RequestBody::from_json(json!({"stream": true})),
+            stream: true,
+            client_api_format: "openai:chat".into(),
+            provider_api_format: "openai:chat".into(),
+            model_name: Some("gpt-5.4".into()),
+            proxy: None,
+            transport_profile: None,
+            timeouts: None,
+        };
+
+        assert!(!should_emit_synthetic_sse_keepalive(&plan));
+        plan.client_api_format = "openai:responses".into();
+        assert!(!should_emit_synthetic_sse_keepalive(&plan));
+        plan.client_api_format = "claude:messages".into();
+        assert!(should_emit_synthetic_sse_keepalive(&plan));
+    }
+
     #[tokio::test]
     async fn sse_body_stream_emits_initial_and_periodic_keepalive_without_business_chunks() {
         let (_tx, rx) = mpsc::channel::<Result<Bytes, std::io::Error>>(1);
         let mut body_stream = Box::pin(build_sse_body_stream(
             Vec::new(),
             rx,
+            true,
             true,
             Duration::from_millis(10),
         ));
@@ -4771,6 +4826,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sse_body_stream_filters_control_blocks_without_synthetic_keepalive() {
+        let (tx, rx) = mpsc::channel::<Result<Bytes, std::io::Error>>(1);
+        let mut body_stream = Box::pin(build_sse_body_stream(
+            vec![Bytes::from_static(b": upstream-keepalive\n\n")],
+            rx,
+            true,
+            false,
+            Duration::from_millis(10),
+        ));
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(30), body_stream.next())
+                .await
+                .is_err(),
+            "control-only prefetched blocks should not produce client-visible chunks"
+        );
+
+        tx.send(Ok(Bytes::from_static(
+            b"data: {\"id\":\"chatcmpl-no-keepalive\"}\n\n",
+        )))
+        .await
+        .expect("business chunk should send");
+        let chunk = tokio::time::timeout(Duration::from_millis(50), body_stream.next())
+            .await
+            .expect("business chunk should arrive")
+            .expect("stream should yield business chunk")
+            .expect("business chunk should be ok");
+        assert_eq!(
+            chunk.as_ref(),
+            b"data: {\"id\":\"chatcmpl-no-keepalive\"}\n\n"
+        );
+    }
+
+    #[tokio::test]
     async fn sse_body_stream_drops_upstream_control_only_blocks() {
         let (_tx, rx) = mpsc::channel::<Result<Bytes, std::io::Error>>(1);
         let mut body_stream = Box::pin(build_sse_body_stream(
@@ -4782,6 +4871,7 @@ mod tests {
                 ),
             ],
             rx,
+            true,
             true,
             Duration::from_secs(60),
         ));
@@ -4811,6 +4901,7 @@ mod tests {
             ],
             rx,
             true,
+            true,
             Duration::from_secs(60),
         ));
 
@@ -4832,6 +4923,7 @@ mod tests {
         let mut body_stream = Box::pin(build_sse_body_stream(
             Vec::new(),
             rx,
+            true,
             true,
             Duration::from_secs(60),
         ));
@@ -4887,6 +4979,7 @@ mod tests {
         let mut body_stream = Box::pin(build_sse_body_stream(
             vec![Bytes::from_static(b": upstream-keepalive\n\n")],
             rx,
+            true,
             true,
             Duration::from_secs(60),
         ));

--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -117,6 +117,7 @@ const OPENAI_IMAGE_STREAM_PLAN_KIND: &str = "openai_image_stream";
 const SSE_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
 const SSE_KEEPALIVE_BYTES: &[u8] = b": aether-keepalive\n\n";
 const SSE_CONTROL_FILTER_MAX_BUFFER_BYTES: usize = 1024 * 1024;
+const SSE_TERMINAL_DETECTOR_MAX_LINE_BYTES: usize = 1024 * 1024;
 const STREAM_IDLE_LOG_INTERVAL: Duration = Duration::from_secs(60);
 const STREAM_IDLE_LOG_INTERVAL_MS: u64 = 60_000;
 const REWRITTEN_STREAM_PREFETCH_TIMEOUT: Duration = Duration::from_millis(750);
@@ -1588,42 +1589,120 @@ fn sse_buffer_has_data_line(buffer: &[u8]) -> bool {
         .any(|line| line.trim_start().starts_with("data:"))
 }
 
-fn stream_chunk_contains_sse_done(chunk: &[u8]) -> bool {
-    std::str::from_utf8(chunk).ok().is_some_and(|text| {
-        text.lines().any(|line| {
-            let line = line.trim();
-            if matches!(
-                line,
-                "data: [DONE]"
-                    | "event: message_stop"
-                    | "event: response.completed"
-                    | "event: response.failed"
-                    | "event: response.incomplete"
-                    | "event: error"
-            ) {
-                return true;
+#[derive(Default)]
+struct ClientVisibleStreamCompletionTracker {
+    line_buffer: Vec<u8>,
+    event_type: Option<String>,
+    data_payload: String,
+    has_data_payload: bool,
+    skip_next_lf: bool,
+    completed: bool,
+}
+
+impl ClientVisibleStreamCompletionTracker {
+    fn observe_chunk(&mut self, chunk: &[u8]) -> bool {
+        if self.completed {
+            return true;
+        }
+        if chunk.is_empty() {
+            return false;
+        }
+
+        for byte in chunk {
+            if self.skip_next_lf {
+                self.skip_next_lf = false;
+                if *byte == b'\n' {
+                    continue;
+                }
             }
-            let Some(data) = line.strip_prefix("data:").map(str::trim) else {
-                return false;
-            };
-            data == "[DONE]"
-                || serde_json::from_str::<serde_json::Value>(data).is_ok_and(|value| {
-                    value
-                        .get("type")
-                        .and_then(serde_json::Value::as_str)
-                        .is_some_and(|event_type| {
-                            matches!(
-                                event_type,
-                                "message_stop"
-                                    | "response.completed"
-                                    | "response.failed"
-                                    | "response.incomplete"
-                                    | "error"
-                            )
-                        })
-                })
+
+            match *byte {
+                b'\n' => self.finish_line(),
+                b'\r' => {
+                    self.finish_line();
+                    self.skip_next_lf = true;
+                }
+                _ => {
+                    self.line_buffer.push(*byte);
+                    if self.line_buffer.len() > SSE_TERMINAL_DETECTOR_MAX_LINE_BYTES {
+                        self.line_buffer.clear();
+                    }
+                }
+            }
+
+            if self.completed {
+                break;
+            }
+        }
+
+        self.completed
+    }
+
+    fn finish_line(&mut self) {
+        let line = std::mem::take(&mut self.line_buffer);
+        let Ok(line) = std::str::from_utf8(&line) else {
+            self.reset_current_event();
+            return;
+        };
+        let line = line.trim();
+
+        if line.is_empty() {
+            self.completed = self.current_event_is_terminal();
+            self.reset_current_event();
+            return;
+        }
+
+        if let Some(event_type) = line.strip_prefix("event:").map(str::trim) {
+            self.event_type = Some(event_type.to_string());
+            return;
+        }
+
+        if let Some(data) = line.strip_prefix("data:").map(str::trim) {
+            if data.is_empty() {
+                return;
+            }
+            if self.has_data_payload {
+                self.data_payload.push('\n');
+            }
+            self.data_payload.push_str(data);
+            self.has_data_payload = true;
+        }
+    }
+
+    fn current_event_is_terminal(&self) -> bool {
+        self.event_type
+            .as_deref()
+            .is_some_and(is_terminal_sse_event_type)
+            || (self.has_data_payload && sse_data_payload_is_terminal(&self.data_payload))
+    }
+
+    fn reset_current_event(&mut self) {
+        self.event_type = None;
+        self.data_payload.clear();
+        self.has_data_payload = false;
+    }
+}
+
+fn is_terminal_sse_event_type(event_type: &str) -> bool {
+    matches!(
+        event_type,
+        "message_stop" | "response.completed" | "response.failed" | "response.incomplete" | "error"
+    )
+}
+
+fn sse_data_payload_is_terminal(data: &str) -> bool {
+    data == "[DONE]"
+        || serde_json::from_str::<serde_json::Value>(data).is_ok_and(|value| {
+            value
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(is_terminal_sse_event_type)
         })
-    })
+}
+
+fn stream_chunk_contains_sse_done(chunk: &[u8]) -> bool {
+    let mut tracker = ClientVisibleStreamCompletionTracker::default();
+    tracker.observe_chunk(chunk)
 }
 
 async fn next_stream_frame<R>(
@@ -2699,8 +2778,9 @@ async fn execute_stream_from_frame_stream(
             max_stream_body_buffer_bytes,
             &mut client_body_truncated,
         );
+        let mut client_stream_completion_tracker = ClientVisibleStreamCompletionTracker::default();
         let mut client_visible_stream_completed =
-            stream_chunk_contains_sse_done(&prefetched_body_for_report);
+            client_stream_completion_tracker.observe_chunk(&prefetched_body_for_report);
         let mut usage_stream_telemetry: Option<ExecutionTelemetry> = initial_telemetry.clone();
         let mut telemetry: Option<ExecutionTelemetry> = initial_telemetry;
         let reached_eof = initial_reached_eof;
@@ -3147,12 +3227,11 @@ async fn execute_stream_from_frame_stream(
                         );
                         let rewritten_chunk_len =
                             u64::try_from(rewritten_chunk.len()).unwrap_or(u64::MAX);
-                        let chunk_completed_stream =
-                            stream_chunk_contains_sse_done(&rewritten_chunk);
                         if downstream_dropped {
                             continue;
                         }
-                        if tx.send(Ok(Bytes::from(rewritten_chunk))).await.is_err() {
+                        let rewritten_chunk = Bytes::from(rewritten_chunk);
+                        if tx.send(Ok(rewritten_chunk.clone())).await.is_err() {
                             warn!(
                                 event_name = "stream_execution_downstream_disconnected",
                                 log_type = "ops",
@@ -3163,7 +3242,8 @@ async fn execute_stream_from_frame_stream(
                             );
                             downstream_dropped = true;
                         } else {
-                            client_visible_stream_completed |= chunk_completed_stream;
+                            client_visible_stream_completed |= client_stream_completion_tracker
+                                .observe_chunk(rewritten_chunk.as_ref());
                             client_stream_bytes.fetch_add(rewritten_chunk_len, Ordering::Relaxed);
                             last_client_chunk_elapsed_ms.store(
                                 stream_started_at_for_report
@@ -3292,9 +3372,8 @@ async fn execute_stream_from_frame_stream(
                             );
                             let rewritten_chunk_len =
                                 u64::try_from(rewritten_chunk.len()).unwrap_or(u64::MAX);
-                            let chunk_completed_stream =
-                                stream_chunk_contains_sse_done(&rewritten_chunk);
-                            if tx.send(Ok(Bytes::from(rewritten_chunk))).await.is_err() {
+                            let rewritten_chunk = Bytes::from(rewritten_chunk);
+                            if tx.send(Ok(rewritten_chunk.clone())).await.is_err() {
                                 warn!(
                                     event_name = "stream_execution_downstream_flush_disconnected",
                                     log_type = "ops",
@@ -3305,7 +3384,8 @@ async fn execute_stream_from_frame_stream(
                                 );
                                 downstream_dropped = true;
                             } else {
-                                client_visible_stream_completed |= chunk_completed_stream;
+                                client_visible_stream_completed |= client_stream_completion_tracker
+                                    .observe_chunk(rewritten_chunk.as_ref());
                                 client_stream_bytes
                                     .fetch_add(rewritten_chunk_len, Ordering::Relaxed);
                                 last_client_chunk_elapsed_ms.store(
@@ -3363,8 +3443,8 @@ async fn execute_stream_from_frame_stream(
                         );
                         let flushed_chunk_len =
                             u64::try_from(flushed_chunk.len()).unwrap_or(u64::MAX);
-                        let chunk_completed_stream = stream_chunk_contains_sse_done(&flushed_chunk);
-                        if tx.send(Ok(Bytes::from(flushed_chunk))).await.is_err() {
+                        let flushed_chunk = Bytes::from(flushed_chunk);
+                        if tx.send(Ok(flushed_chunk.clone())).await.is_err() {
                             warn!(
                                 event_name = "stream_execution_downstream_rewrite_flush_disconnected",
                                 log_type = "ops",
@@ -3375,7 +3455,8 @@ async fn execute_stream_from_frame_stream(
                             );
                             downstream_dropped = true;
                         } else {
-                            client_visible_stream_completed |= chunk_completed_stream;
+                            client_visible_stream_completed |= client_stream_completion_tracker
+                                .observe_chunk(flushed_chunk.as_ref());
                             client_stream_bytes.fetch_add(flushed_chunk_len, Ordering::Relaxed);
                             last_client_chunk_elapsed_ms.store(
                                 stream_started_at_for_report
@@ -3806,6 +3887,7 @@ mod tests {
         stream_requires_observed_terminal_event, stream_terminal_summary_missing_observed_finish,
         stream_terminal_summary_missing_observed_finish_with_requirement,
         stream_terminal_summary_represents_failure_with_requirement,
+        ClientVisibleStreamCompletionTracker,
     };
     use crate::control::GatewayControlDecision;
     use crate::tunnel::{tunnel_protocol, TunnelProxyConn};
@@ -3837,6 +3919,20 @@ mod tests {
         assert!(!stream_chunk_contains_sse_done(
             b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\"}\n\n"
         ));
+    }
+
+    #[test]
+    fn detects_client_visible_sse_terminal_events_across_chunks() {
+        let mut tracker = ClientVisibleStreamCompletionTracker::default();
+        assert!(!tracker.observe_chunk(b"data: [DO"));
+        assert!(!tracker.observe_chunk(b"NE]\n"));
+        assert!(tracker.observe_chunk(b"\n"));
+
+        let mut tracker = ClientVisibleStreamCompletionTracker::default();
+        assert!(!tracker.observe_chunk(b"event: response.comp"));
+        assert!(!tracker.observe_chunk(b"leted\r\n"));
+        assert!(tracker
+            .observe_chunk(b"data: {\"type\":\"response.completed\",\"response\":{}}\r\n\r\n"));
     }
 
     fn tunnel_proxy_snapshot(base_url: String) -> aether_contracts::ProxySnapshot {
@@ -5316,6 +5412,155 @@ mod tests {
             response_time_ms > first_byte_time_ms,
             "terminal duration should include time after the first byte"
         );
+    }
+
+    #[tokio::test]
+    async fn split_done_then_downstream_close_is_recorded_success() {
+        let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
+        let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
+        let state = AppState::new()
+            .expect("app state should build")
+            .with_data_state_for_tests(
+                crate::data::GatewayDataState::with_request_candidate_and_usage_repository_for_tests(
+                    Arc::clone(&request_candidate_repository),
+                    Arc::clone(&usage_repository),
+                ),
+            )
+            .with_usage_runtime_for_tests(UsageRuntimeConfig {
+                enabled: true,
+                ..UsageRuntimeConfig::default()
+            });
+        let plan = ExecutionPlan {
+            request_id: "req-split-done-close-success".into(),
+            candidate_id: Some("cand-split-done-close-success".into()),
+            provider_name: Some("openai".into()),
+            provider_id: "prov-1".into(),
+            endpoint_id: "ep-1".into(),
+            key_id: "key-1".into(),
+            method: "POST".into(),
+            url: "https://example.com/v1/chat/completions".into(),
+            headers: BTreeMap::from([
+                ("content-type".into(), "application/json".into()),
+                ("accept".into(), "text/event-stream".into()),
+            ]),
+            content_type: Some("application/json".into()),
+            content_encoding: None,
+            body: RequestBody::from_json(json!({
+                "model": "gpt-5.4",
+                "messages": [],
+                "stream": true
+            })),
+            stream: true,
+            client_api_format: "openai:chat".into(),
+            provider_api_format: "openai:chat".into(),
+            model_name: Some("gpt-5.4".into()),
+            proxy: None,
+            transport_profile: None,
+            timeouts: None,
+        };
+        let release_eof = Arc::new(Notify::new());
+        let release_eof_for_stream = Arc::clone(&release_eof);
+        let frame_stream = stream! {
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"{\"type\":\"headers\",\"payload\":{\"kind\":\"headers\",\"status_code\":200,\"headers\":{\"content-type\":\"text/event-stream\"}}}\n",
+            ));
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"{\"type\":\"data\",\"payload\":{\"kind\":\"data\",\"text\":\"data: {\\\"id\\\":\\\"first\\\",\\\"object\\\":\\\"chat.completion.chunk\\\",\\\"model\\\":\\\"gpt-5.4\\\",\\\"choices\\\":[{\\\"index\\\":0,\\\"delta\\\":{\\\"content\\\":\\\"hi\\\"},\\\"finish_reason\\\":null}]}\\n\\n\"}}\n",
+            ));
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"{\"type\":\"data\",\"payload\":{\"kind\":\"data\",\"text\":\"data: {\\\"id\\\":\\\"terminal\\\",\\\"object\\\":\\\"chat.completion.chunk\\\",\\\"model\\\":\\\"gpt-5.4\\\",\\\"choices\\\":[{\\\"index\\\":0,\\\"delta\\\":{},\\\"finish_reason\\\":\\\"stop\\\"}],\\\"usage\\\":{\\\"prompt_tokens\\\":7,\\\"completion_tokens\\\":11,\\\"total_tokens\\\":18}}\\n\\n\"}}\n",
+            ));
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"{\"type\":\"data\",\"payload\":{\"kind\":\"data\",\"text\":\"data: [DO\"}}\n",
+            ));
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"{\"type\":\"data\",\"payload\":{\"kind\":\"data\",\"text\":\"NE]\\n\\n\"}}\n",
+            ));
+            release_eof_for_stream.notified().await;
+        }
+        .boxed();
+
+        let response = execute_stream_from_frame_stream(
+            &state,
+            plan,
+            "trace-split-done-close-success",
+            &test_decision(),
+            "openai_chat_stream",
+            None,
+            Some(json!({
+                "request_id": "req-split-done-close-success",
+                "candidate_id": "cand-split-done-close-success",
+                "candidate_index": 0,
+                "retry_index": 0,
+                "provider_api_format": "openai:chat",
+                "client_api_format": "openai:chat"
+            })),
+            crate::clock::current_unix_ms(),
+            Instant::now(),
+            frame_stream,
+            None,
+        )
+        .await
+        .expect("execution should succeed")
+        .expect("execution should return a client response");
+
+        let mut body_stream = response.into_body().into_data_stream();
+        let mut body = Vec::new();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !String::from_utf8_lossy(&body).contains("data: [DONE]") {
+                let chunk = body_stream
+                    .next()
+                    .await
+                    .expect("body should yield until done")
+                    .expect("chunk should be ok");
+                body.extend_from_slice(&chunk);
+            }
+        })
+        .await
+        .expect("final DONE should arrive");
+        drop(body_stream);
+        release_eof.notify_one();
+
+        let candidates = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let candidates = request_candidate_repository
+                    .list_by_request_id("req-split-done-close-success")
+                    .await
+                    .expect("request candidates should read");
+                if candidates
+                    .first()
+                    .is_some_and(|candidate| candidate.status == RequestCandidateStatus::Success)
+                {
+                    break candidates;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("candidate should be marked success");
+        assert_eq!(candidates[0].status_code, Some(200));
+
+        let stored_usage = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let usage = usage_repository
+                    .find_by_request_id("req-split-done-close-success")
+                    .await
+                    .expect("usage should read");
+                if usage
+                    .as_ref()
+                    .is_some_and(|usage| usage.status == "completed")
+                {
+                    break usage.expect("completed usage should exist");
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("usage should be marked completed");
+        assert_eq!(stored_usage.status_code, Some(200));
+        assert_eq!(stored_usage.input_tokens, 7);
+        assert_eq!(stored_usage.output_tokens, 11);
+        assert_eq!(stored_usage.total_tokens, 18);
     }
 
     #[tokio::test]

--- a/crates/aether-ai-formats/src/formats/claude/messages/stream.rs
+++ b/crates/aether-ai-formats/src/formats/claude/messages/stream.rs
@@ -410,6 +410,7 @@ enum ClaudeOpenBlock {
 struct ClaudeClientToolState {
     call_id: String,
     name: String,
+    buffered_arguments: String,
 }
 
 #[derive(Default)]
@@ -460,18 +461,47 @@ impl ClaudeClientEmitter {
         let Some(open_block) = self.open_block.take() else {
             return Ok(Vec::new());
         };
+        let mut out = Vec::new();
         let block_index = match open_block {
             ClaudeOpenBlock::Text { block_index } => block_index,
             ClaudeOpenBlock::Thinking { block_index } => block_index,
-            ClaudeOpenBlock::Tool { block_index, .. } => block_index,
+            ClaudeOpenBlock::Tool {
+                tool_index,
+                block_index,
+            } => {
+                if let Some(state) = self.tool_states.get_mut(&tool_index) {
+                    if state.name == "Read" && !state.buffered_arguments.is_empty() {
+                        let arguments = remove_empty_pages_from_tool_arguments(
+                            &state.name,
+                            &state.buffered_arguments,
+                        );
+                        state.buffered_arguments.clear();
+                        if !arguments.is_empty() {
+                            out.extend(encode_json_sse(
+                                Some("content_block_delta"),
+                                &json!({
+                                    "type": "content_block_delta",
+                                    "index": block_index,
+                                    "delta": {
+                                        "type": "input_json_delta",
+                                        "partial_json": arguments,
+                                    }
+                                }),
+                            )?);
+                        }
+                    }
+                }
+                block_index
+            }
         };
-        encode_json_sse(
+        out.extend(encode_json_sse(
             Some("content_block_stop"),
             &json!({
                 "type": "content_block_stop",
                 "index": block_index,
             }),
-        )
+        )?);
+        Ok(out)
     }
 
     fn ensure_text_block(&mut self) -> Result<Vec<u8>, AiSurfaceFinalizeError> {
@@ -688,23 +718,33 @@ impl ClaudeClientEmitter {
                 Ok(out)
             }
             CanonicalStreamEvent::ToolCallArgumentsDelta { index, arguments } => {
-                let arguments = remove_empty_pages_from_tool_arguments(&arguments);
+                let (call_id, name) = {
+                    let state = self.tool_states.entry(index).or_default();
+                    let call_id = if state.call_id.is_empty() {
+                        format!("tool_{index}")
+                    } else {
+                        state.call_id.clone()
+                    };
+                    let name = if state.name.is_empty() {
+                        "unknown".to_string()
+                    } else {
+                        state.name.clone()
+                    };
+                    (call_id, name)
+                };
                 if arguments.is_empty() {
                     return Ok(Vec::new());
                 }
                 let mut out = self.ensure_started()?;
-                let state = self.tool_states.entry(index).or_default();
-                let call_id = if state.call_id.is_empty() {
-                    format!("tool_{index}")
-                } else {
-                    state.call_id.clone()
-                };
-                let name = if state.name.is_empty() {
-                    "unknown".to_string()
-                } else {
-                    state.name.clone()
-                };
                 out.extend(self.ensure_tool_block(index, &call_id, &name)?);
+                if name == "Read" {
+                    self.tool_states
+                        .entry(index)
+                        .or_default()
+                        .buffered_arguments
+                        .push_str(&arguments);
+                    return Ok(out);
+                }
                 let block_index = match self.open_block {
                     Some(ClaudeOpenBlock::Tool { block_index, .. }) => block_index,
                     _ => return Ok(out),
@@ -1230,7 +1270,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_client_emitter_removes_empty_pages_from_tool_arguments() {
+    fn claude_client_emitter_removes_empty_pages_from_read_tool_arguments() {
         let mut emitter = ClaudeClientEmitter::default();
         let mut bytes = emitter
             .emit(CanonicalStreamFrame {
@@ -1257,9 +1297,58 @@ mod tests {
                 .expect("tool delta should encode"),
         );
 
+        let pending_sse = String::from_utf8(bytes.clone()).expect("sse should be utf8");
+        assert!(!pending_sse.contains("\\\"pages\\\":\\\"\\\""));
+
+        bytes.extend(
+            emitter
+                .emit(CanonicalStreamFrame {
+                    id: "msg_123".to_string(),
+                    model: "claude-sonnet-4-5".to_string(),
+                    event: CanonicalStreamEvent::Finish {
+                        finish_reason: Some("tool_calls".to_string()),
+                        usage: None,
+                    },
+                })
+                .expect("finish should close read tool block"),
+        );
+
         let sse = String::from_utf8(bytes).expect("sse should be utf8");
         assert!(sse.contains("\"partial_json\":\"{\\\"file_path\\\":\\\"/tmp/a.txt\\\",\\\"offset\\\":1,\\\"limit\\\":20}\""));
         assert!(!sse.contains("\\\"pages\\\":\\\"\\\""));
+    }
+
+    #[test]
+    fn claude_client_emitter_preserves_empty_pages_for_other_tool_arguments() {
+        let mut emitter = ClaudeClientEmitter::default();
+        let mut bytes = emitter
+            .emit(CanonicalStreamFrame {
+                id: "msg_123".to_string(),
+                model: "claude-sonnet-4-5".to_string(),
+                event: CanonicalStreamEvent::ToolCallStart {
+                    index: 0,
+                    call_id: "toolu_search".to_string(),
+                    name: "Search".to_string(),
+                },
+            })
+            .expect("tool start should encode");
+        bytes.extend(
+            emitter
+                .emit(CanonicalStreamFrame {
+                    id: "msg_123".to_string(),
+                    model: "claude-sonnet-4-5".to_string(),
+                    event: CanonicalStreamEvent::ToolCallArgumentsDelta {
+                        index: 0,
+                        arguments: r#"{"query":"","pages":""}"#.to_string(),
+                    },
+                })
+                .expect("tool delta should encode"),
+        );
+
+        let sse = String::from_utf8(bytes).expect("sse should be utf8");
+        assert!(
+            sse.contains("\"partial_json\":\"{\\\"query\\\":\\\"\\\",\\\"pages\\\":\\\"\\\"}\"")
+        );
     }
 
     #[test]

--- a/crates/aether-ai-formats/src/formats/shared/response.rs
+++ b/crates/aether-ai-formats/src/formats/shared/response.rs
@@ -29,7 +29,10 @@ pub fn canonicalize_tool_arguments(value: Option<Value>) -> String {
     }
 }
 
-pub fn remove_empty_pages_from_tool_arguments(arguments: &str) -> String {
+pub fn remove_empty_pages_from_tool_arguments(tool_name: &str, arguments: &str) -> String {
+    if tool_name != "Read" {
+        return arguments.to_string();
+    }
     let Ok(mut value) = serde_json::from_str::<Value>(arguments) else {
         return arguments.to_string();
     };
@@ -153,16 +156,21 @@ mod tests {
     fn removes_empty_pages_from_tool_arguments() {
         assert_eq!(
             remove_empty_pages_from_tool_arguments(
+                "Read",
                 r#"{"file_path":"/tmp/a.txt","offset":1,"limit":20,"pages":""}"#
             ),
             r#"{"file_path":"/tmp/a.txt","offset":1,"limit":20}"#
         );
         assert_eq!(
-            remove_empty_pages_from_tool_arguments(r#"{"pages":"1-2"}"#),
+            remove_empty_pages_from_tool_arguments("Search", r#"{"query":"","pages":""}"#),
+            r#"{"query":"","pages":""}"#
+        );
+        assert_eq!(
+            remove_empty_pages_from_tool_arguments("Read", r#"{"pages":"1-2"}"#),
             r#"{"pages":"1-2"}"#
         );
         assert_eq!(
-            remove_empty_pages_from_tool_arguments(r#"{"pages":"#),
+            remove_empty_pages_from_tool_arguments("Read", r#"{"pages":"#),
             r#"{"pages":"#
         );
     }

--- a/crates/aether-ai-formats/src/formats/shared/sync_products.rs
+++ b/crates/aether-ai-formats/src/formats/shared/sync_products.rs
@@ -2531,7 +2531,12 @@ pub fn aggregate_claude_stream_sync_response(body: &[u8]) -> Option<Value> {
             }
             "tool_use" => {
                 if !state.partial_json.is_empty() {
-                    let arguments = remove_empty_pages_from_tool_arguments(&state.partial_json);
+                    let tool_name = block
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    let arguments =
+                        remove_empty_pages_from_tool_arguments(tool_name, &state.partial_json);
                     let input = serde_json::from_str::<Value>(&arguments)
                         .unwrap_or(Value::String(arguments));
                     block.insert("input".to_string(), input);
@@ -3110,6 +3115,34 @@ mod tests {
                 "file_path": "/tmp/a.txt",
                 "offset": 1,
                 "limit": 20,
+            })
+        );
+    }
+
+    #[test]
+    fn aggregates_claude_stream_preserves_empty_pages_for_non_read_tool_input() {
+        let body = concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-sonnet-4-5\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null}}\n\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_search\",\"name\":\"Search\",\"input\":{}}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"query\\\":\\\"\\\",\\\"pages\\\":\\\"\\\"}\"}}\n\n",
+            "event: content_block_stop\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\"}\n\n",
+        );
+
+        let aggregated =
+            aggregate_claude_stream_sync_response(body.as_bytes()).expect("body should aggregate");
+
+        assert_eq!(aggregated["content"][0]["type"], "tool_use");
+        assert_eq!(
+            aggregated["content"][0]["input"],
+            json!({
+                "query": "",
+                "pages": "",
             })
         );
     }

--- a/crates/aether-ai-formats/src/protocol/canonical.rs
+++ b/crates/aether-ai-formats/src/protocol/canonical.rs
@@ -3825,6 +3825,7 @@ pub(crate) fn canonical_block_to_claude(
             input,
             extensions,
         } => {
+            let input = claude_tool_use_input_without_empty_read_pages(name, input);
             let mut out = Map::new();
             out.insert("type".to_string(), Value::String("tool_use".to_string()));
             out.insert(
@@ -3832,7 +3833,7 @@ pub(crate) fn canonical_block_to_claude(
                 Value::String(claude_compatible_tool_use_id(id)),
             );
             out.insert("name".to_string(), Value::String(name.clone()));
-            out.insert("input".to_string(), input.clone());
+            out.insert("input".to_string(), input);
             out.extend(namespace_extension_object(extensions, "claude", &out));
             Some(Some(Value::Object(out)))
         }
@@ -3865,6 +3866,18 @@ pub(crate) fn canonical_block_to_claude(
         }
         CanonicalContentBlock::Unknown { .. } => Some(None),
     }
+}
+
+fn claude_tool_use_input_without_empty_read_pages(name: &str, input: &Value) -> Value {
+    if name != "Read" || input.get("pages").and_then(Value::as_str) != Some("") {
+        return input.clone();
+    }
+    let Some(object) = input.as_object() else {
+        return input.clone();
+    };
+    let mut object = object.clone();
+    object.remove("pages");
+    Value::Object(object)
 }
 
 fn canonical_tool_result_content_to_claude(
@@ -5594,6 +5607,74 @@ mod tests {
             1
         );
         assert_eq!(rebuilt["service_tier"], "flex");
+    }
+
+    #[test]
+    fn openai_responses_to_claude_response_drops_empty_pages_only_for_read_tool() {
+        let response = json!({
+            "id": "resp_read_pages",
+            "object": "response",
+            "status": "completed",
+            "model": "gpt-5.5",
+            "output": [
+                {
+                    "type": "function_call",
+                    "id": "call_read",
+                    "call_id": "call_read",
+                    "name": "Read",
+                    "arguments": "{\"file_path\":\"/tmp/a.txt\",\"offset\":0,\"limit\":20,\"pages\":\"\"}"
+                },
+                {
+                    "type": "function_call",
+                    "id": "call_search",
+                    "call_id": "call_search",
+                    "name": "Search",
+                    "arguments": "{\"query\":\"\",\"pages\":\"\"}"
+                }
+            ],
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "total_tokens": 2
+            }
+        });
+
+        let canonical =
+            from_openai_responses_to_canonical_response(&response).expect("canonical response");
+        let claude = canonical_to_claude_response(&canonical);
+
+        assert_eq!(
+            claude["content"][0]["input"],
+            json!({
+                "file_path": "/tmp/a.txt",
+                "offset": 0,
+                "limit": 20,
+            })
+        );
+        assert_eq!(
+            claude["content"][1]["input"],
+            json!({
+                "query": "",
+                "pages": "",
+            })
+        );
+
+        let rebuilt_responses = canonical_to_openai_responses_response(&canonical, &json!({}));
+        let read_arguments = serde_json::from_str::<Value>(
+            rebuilt_responses["output"][0]["arguments"]
+                .as_str()
+                .expect("arguments should be a string"),
+        )
+        .expect("arguments should be json");
+        assert_eq!(
+            read_arguments,
+            json!({
+                "file_path": "/tmp/a.txt",
+                "offset": 0,
+                "limit": 20,
+                "pages": "",
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
  - 修复 split streaming terminal events：新增客户端可见的 SSE completion tracker，支持跨 chunk 识别 [DONE]、message_stop、response.completed/
    failed/incomplete 和 error。
  - 修复 OpenAI stream keepalive：OpenAI 客户端不再收到代理生成的 SSE keepalive/control block，但仍过滤上游 control-only block。
  - 重构并澄清 OpenAI SSE control policy：命名和注释明确 OpenAI 流不应注入代理控制块。
  - 增加 DeepSeek thinking compatibility：按 provider type 或 *.deepseek.com 检测 DeepSeek；OpenAI Chat 仅在 thinking 启用且历史 assistant 缺少
    reasoning 时补空 reasoning_content；Claude Messages 仅在不存在 thinking block 时补空 block，已有 thinking block/signature 不会被覆盖。
  - 对齐 OpenAI image stream timeout 测试：断言不包含代理 keepalive，同时保留失败事件和 image_stream_total_timeout 校验。
  - 对openai渠道在claude code中使用时出现的read工具报错问题进行适配