### PR TITLE
feat(kiro): add per-key overage toggle for Pro+ subscriptions

### DIFF
--- a/apps/aether-gateway/src/control/route/oauth.rs
+++ b/apps/aether-gateway/src/control/route/oauth.rs
@@ -191,6 +191,17 @@ pub(super) fn classify_oauth_route(
         ))
     } else if method == http::Method::POST
         && normalized_path.starts_with("/api/admin/provider-oauth/keys/")
+        && normalized_path.ends_with("/kiro/overage")
+    {
+        Some(classified(
+            "admin_proxy",
+            "provider_oauth_manage",
+            "set_kiro_overage",
+            "admin:provider_oauth",
+            false,
+        ))
+    } else if method == http::Method::POST
+        && normalized_path.starts_with("/api/admin/provider-oauth/keys/")
         && normalized_path.ends_with("/refresh")
     {
         Some(classified(

--- a/apps/aether-gateway/src/control/tests/admin_oauth.rs
+++ b/apps/aether-gateway/src/control/tests/admin_oauth.rs
@@ -120,6 +120,11 @@ fn classifies_admin_provider_oauth_maintenance_routes_as_admin_proxy_route() {
             "/api/admin/provider-oauth/providers/provider-123/device-poll",
             "device_poll",
         ),
+        (
+            http::Method::POST,
+            "/api/admin/provider-oauth/keys/key-123/kiro/overage",
+            "set_kiro_overage",
+        ),
     ] {
         let uri: Uri = path.parse().expect("uri should parse");
         let decision =

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/mod.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/mod.rs
@@ -6,8 +6,9 @@ use crate::handlers::admin::provider::shared::paths::{
     admin_provider_oauth_batch_import_provider_id,
     admin_provider_oauth_batch_import_task_provider_id, admin_provider_oauth_complete_key_id,
     admin_provider_oauth_complete_provider_id, admin_provider_oauth_device_authorize_provider_id,
-    admin_provider_oauth_import_provider_id, admin_provider_oauth_refresh_key_id,
-    admin_provider_oauth_start_key_id, admin_provider_oauth_start_provider_id,
+    admin_provider_oauth_import_provider_id, admin_provider_oauth_kiro_overage_key_id,
+    admin_provider_oauth_refresh_key_id, admin_provider_oauth_start_key_id,
+    admin_provider_oauth_start_provider_id,
 };
 use crate::handlers::admin::request::{AdminAppState, AdminRequestContext};
 use crate::GatewayError;
@@ -108,6 +109,19 @@ pub(crate) async fn maybe_build_local_admin_provider_oauth_response(
             "refresh_provider_oauth_for_key",
             "provider_key",
             admin_provider_oauth_refresh_key_id(request_context.path()),
+        )));
+    }
+
+    if route_kind == Some("set_kiro_overage") && *method == http::Method::POST {
+        let response =
+            super::quota::kiro::handle_admin_kiro_overage(state, request_context, request_body)
+                .await?;
+        return Ok(Some(helpers::attach_admin_provider_oauth_audit_response(
+            response,
+            "admin_provider_oauth_kiro_overage_updated",
+            "update_kiro_overage_preference",
+            "provider_key",
+            admin_provider_oauth_kiro_overage_key_id(request_context.path()),
         )));
     }
 

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/kiro/mod.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/kiro/mod.rs
@@ -1,6 +1,8 @@
+mod overage;
 mod parse;
 mod plan;
 
+pub(crate) use self::overage::handle_admin_kiro_overage;
 use self::parse::parse_kiro_usage_response;
 use self::plan::execute_kiro_quota_plan;
 use super::shared::{

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/kiro/overage.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/kiro/overage.rs
@@ -1,0 +1,379 @@
+use super::super::shared::{
+    default_provider_quota_execution_timeouts, execute_provider_quota_plan,
+    extract_execution_error_message, persist_provider_quota_refresh_state,
+    quota_refresh_success_invalid_state, ProviderQuotaExecutionOutcome,
+};
+use super::parse::parse_kiro_usage_response;
+use super::plan::{build_kiro_usage_headers, execute_kiro_quota_plan};
+use super::{
+    kiro_auth_from_refreshed_entry, kiro_quota_error_is_account_banned,
+    kiro_quota_error_is_token_invalid,
+};
+use crate::handlers::admin::provider::oauth::errors::build_internal_control_error_response;
+use crate::handlers::admin::provider::oauth::runtime::provider_oauth_runtime_endpoint_for_provider;
+use crate::handlers::admin::provider::shared::paths::admin_provider_oauth_kiro_overage_key_id;
+use crate::handlers::admin::request::{
+    AdminAppState, AdminGatewayProviderTransportSnapshot, AdminKiroRequestAuth, AdminRequestContext,
+};
+use crate::GatewayError;
+use aether_contracts::{ExecutionPlan, ProxySnapshot, RequestBody};
+use aether_provider_transport::LocalResolvedOAuthRequestAuth;
+use axum::{
+    body::{Body, Bytes},
+    http,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::{json, Value};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn build_kiro_overage_url(auth: &AdminKiroRequestAuth) -> String {
+    format!(
+        "https://q.{}.amazonaws.com/setUserPreference",
+        auth.auth_config.effective_api_region()
+    )
+}
+
+fn build_kiro_overage_body(auth: &AdminKiroRequestAuth, enabled: bool) -> Value {
+    let status = if enabled { "ENABLED" } else { "DISABLED" };
+    let mut object = serde_json::Map::new();
+    object.insert(
+        "overageConfiguration".to_string(),
+        json!({ "overageStatus": status }),
+    );
+    if let Some(profile_arn) = auth.auth_config.profile_arn_for_payload() {
+        object.insert("profileArn".to_string(), json!(profile_arn));
+    }
+    Value::Object(object)
+}
+
+async fn execute_kiro_overage_plan(
+    state: &AdminAppState<'_>,
+    transport: &AdminGatewayProviderTransportSnapshot,
+    auth: &AdminKiroRequestAuth,
+    enabled: bool,
+    proxy_override: Option<&ProxySnapshot>,
+) -> Result<ProviderQuotaExecutionOutcome, GatewayError> {
+    let proxy = match proxy_override {
+        Some(proxy) => Some(proxy.clone()),
+        None => {
+            state
+                .resolve_transport_proxy_snapshot_with_tunnel_affinity(transport)
+                .await
+        }
+    };
+    let timeouts = state
+        .resolve_transport_execution_timeouts(transport)
+        .or(Some(default_provider_quota_execution_timeouts(
+            proxy.as_ref(),
+        )));
+    let body_json = build_kiro_overage_body(auth, enabled);
+    let plan = ExecutionPlan {
+        request_id: format!("kiro-overage:{}", transport.key.id),
+        candidate_id: None,
+        provider_name: Some("kiro".to_string()),
+        provider_id: transport.provider.id.clone(),
+        endpoint_id: transport.endpoint.id.clone(),
+        key_id: transport.key.id.clone(),
+        method: "POST".to_string(),
+        url: build_kiro_overage_url(auth),
+        headers: build_kiro_usage_headers(auth),
+        content_type: Some("application/json".to_string()),
+        content_encoding: None,
+        body: RequestBody {
+            json_body: Some(body_json),
+            body_bytes_b64: None,
+            body_ref: None,
+        },
+        stream: false,
+        client_api_format: "claude:messages".to_string(),
+        provider_api_format: "kiro:set_user_preference".to_string(),
+        model_name: Some("kiro-set-user-preference".to_string()),
+        proxy,
+        transport_profile: state.resolve_transport_profile(transport),
+        timeouts,
+    };
+
+    execute_provider_quota_plan(state, transport, plan, "kiro_overage").await
+}
+
+async fn resolve_kiro_request_auth(
+    state: &AdminAppState<'_>,
+    transport: &AdminGatewayProviderTransportSnapshot,
+) -> Result<(AdminKiroRequestAuth, bool), GatewayError> {
+    match state.force_local_oauth_refresh_entry(transport).await {
+        Ok(Some(entry)) => match kiro_auth_from_refreshed_entry(&entry) {
+            Some(LocalResolvedOAuthRequestAuth::Kiro(auth)) => Ok((auth, true)),
+            _ => Err(GatewayError::Internal(
+                "Kiro Token 刷新成功但认证信息解析失败".to_string(),
+            )),
+        },
+        Ok(None) => match state
+            .resolve_local_oauth_kiro_request_auth(transport)
+            .await?
+        {
+            Some(auth) => Ok((auth, false)),
+            None => Err(GatewayError::Internal(
+                "缺少 Kiro 认证配置 (auth_config)".to_string(),
+            )),
+        },
+        Err(err) => Err(GatewayError::Internal(format!(
+            "Kiro Token 刷新失败: {err}"
+        ))),
+    }
+}
+
+fn encode_refreshed_auth_config(
+    state: &AdminAppState<'_>,
+    transport: &AdminGatewayProviderTransportSnapshot,
+    auth: &AdminKiroRequestAuth,
+) -> Option<String> {
+    let mut auth_config_object = transport
+        .key
+        .decrypted_auth_config
+        .as_deref()
+        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    if let Some(refreshed_auth_config) = auth.auth_config.to_json_value().as_object() {
+        for (key, value) in refreshed_auth_config {
+            auth_config_object.insert(key.clone(), value.clone());
+        }
+    }
+    auth_config_object
+        .entry("provider_type".to_string())
+        .or_insert_with(|| json!("kiro"));
+    let auth_config_json = Value::Object(auth_config_object).to_string();
+    state.encrypt_catalog_secret_with_fallbacks(auth_config_json.as_str())
+}
+
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn bad_request(message: impl Into<String>) -> Response<Body> {
+    build_internal_control_error_response(http::StatusCode::BAD_REQUEST, message)
+}
+
+fn not_found(message: impl Into<String>) -> Response<Body> {
+    build_internal_control_error_response(http::StatusCode::NOT_FOUND, message)
+}
+
+fn forbidden(message: impl Into<String>) -> Response<Body> {
+    build_internal_control_error_response(http::StatusCode::FORBIDDEN, message)
+}
+
+fn upstream_failure(status_code: u16, detail: &str) -> Response<Body> {
+    build_internal_control_error_response(
+        http::StatusCode::BAD_GATEWAY,
+        format!("setUserPreference 返回状态码 {status_code}: {detail}"),
+    )
+}
+
+pub(crate) async fn handle_admin_kiro_overage(
+    state: &AdminAppState<'_>,
+    request_context: &AdminRequestContext<'_>,
+    request_body: Option<&Bytes>,
+) -> Result<Response<Body>, GatewayError> {
+    let Some(key_id) = admin_provider_oauth_kiro_overage_key_id(request_context.path()) else {
+        return Ok(not_found("Key 不存在"));
+    };
+
+    let Some(request_body) = request_body else {
+        return Ok(bad_request(
+            "请求体必须是合法的 JSON 对象，且包含 enabled 字段",
+        ));
+    };
+    let payload = match serde_json::from_slice::<Value>(request_body) {
+        Ok(Value::Object(map)) => map,
+        _ => {
+            return Ok(bad_request(
+                "请求体必须是合法的 JSON 对象，且包含 enabled 字段",
+            ));
+        }
+    };
+    let Some(enabled) = payload.get("enabled").and_then(Value::as_bool) else {
+        return Ok(bad_request("enabled 字段必须是布尔值"));
+    };
+
+    let Some(key) = state
+        .read_provider_catalog_keys_by_ids(std::slice::from_ref(&key_id))
+        .await?
+        .into_iter()
+        .next()
+    else {
+        return Ok(not_found("Key 不存在"));
+    };
+
+    let Some(provider) = state
+        .read_provider_catalog_providers_by_ids(std::slice::from_ref(&key.provider_id))
+        .await?
+        .into_iter()
+        .next()
+    else {
+        return Ok(not_found("Provider 不存在"));
+    };
+    if !provider.provider_type.trim().eq_ignore_ascii_case("kiro") {
+        return Ok(bad_request("该 Provider 不是 Kiro 类型"));
+    }
+
+    let overage_capable = key
+        .upstream_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("kiro"))
+        .and_then(|kiro| kiro.get("overage_capable"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !overage_capable {
+        return Ok(forbidden("该订阅不支持超额"));
+    }
+
+    let endpoints = state
+        .list_provider_catalog_endpoints_by_provider_ids(std::slice::from_ref(&provider.id))
+        .await?;
+    let Some(endpoint) = provider_oauth_runtime_endpoint_for_provider("kiro", &endpoints) else {
+        return Ok(bad_request("找不到有效的 Kiro 端点"));
+    };
+
+    let Some(transport) = state
+        .read_provider_transport_snapshot(&provider.id, &endpoint.id, &key.id)
+        .await?
+    else {
+        return Ok(bad_request("Provider transport snapshot unavailable"));
+    };
+
+    let (auth, token_refreshed) = match resolve_kiro_request_auth(state, &transport).await {
+        Ok(result) => result,
+        Err(GatewayError::Internal(message)) => {
+            return Ok(build_internal_control_error_response(
+                http::StatusCode::SERVICE_UNAVAILABLE,
+                message,
+            ));
+        }
+        Err(err) => return Err(err),
+    };
+
+    let proxy_override = None::<ProxySnapshot>;
+    let toggle_outcome =
+        execute_kiro_overage_plan(state, &transport, &auth, enabled, proxy_override.as_ref())
+            .await?;
+
+    let toggle_result = match toggle_outcome {
+        ProviderQuotaExecutionOutcome::Response(result) => result,
+        ProviderQuotaExecutionOutcome::Failure(detail) => {
+            return Ok(build_internal_control_error_response(
+                http::StatusCode::BAD_GATEWAY,
+                format!("setUserPreference 请求执行失败: {detail}"),
+            ));
+        }
+    };
+
+    if toggle_result.status_code != 200 {
+        let now = now_unix_secs();
+        let err_msg = extract_execution_error_message(&toggle_result);
+        let detail = err_msg
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .unwrap_or("unknown error");
+        let (mut oauth_invalid_at_unix_secs, mut oauth_invalid_reason) =
+            quota_refresh_success_invalid_state(&key);
+        let mut metadata_update = None::<Value>;
+        match toggle_result.status_code {
+            401 => {
+                oauth_invalid_at_unix_secs = Some(now);
+                oauth_invalid_reason = Some("Kiro Token 无效或已过期".to_string());
+            }
+            403 | 423 => {
+                if kiro_quota_error_is_token_invalid(err_msg.as_deref()) {
+                    oauth_invalid_at_unix_secs = Some(now);
+                    oauth_invalid_reason = Some("Kiro Token 无效或已过期".to_string());
+                } else if kiro_quota_error_is_account_banned(err_msg.as_deref()) {
+                    oauth_invalid_at_unix_secs = Some(now);
+                    oauth_invalid_reason = Some(format!("账户已封禁: {detail}"));
+                    metadata_update = Some(json!({
+                        "kiro": {
+                            "is_banned": true,
+                            "ban_reason": detail,
+                            "banned_at": now,
+                            "updated_at": now,
+                        }
+                    }));
+                }
+            }
+            _ => {}
+        }
+        let _ = persist_provider_quota_refresh_state(
+            state,
+            &key_id,
+            metadata_update.as_ref(),
+            oauth_invalid_at_unix_secs,
+            oauth_invalid_reason,
+            None,
+        )
+        .await?;
+        return Ok(upstream_failure(toggle_result.status_code, detail));
+    }
+
+    // Upstream accepted the toggle. Refetch authoritative state via
+    // getUsageLimits and persist the merged metadata so any concurrent
+    // quota refresh sees consistent data.
+    let usage_outcome =
+        execute_kiro_quota_plan(state, &transport, &auth, proxy_override.as_ref()).await?;
+    let usage_result = match usage_outcome {
+        ProviderQuotaExecutionOutcome::Response(result) => result,
+        ProviderQuotaExecutionOutcome::Failure(detail) => {
+            return Ok(build_internal_control_error_response(
+                http::StatusCode::BAD_GATEWAY,
+                format!("getUsageLimits 请求执行失败: {detail}"),
+            ));
+        }
+    };
+    if usage_result.status_code != 200 {
+        let err_msg = extract_execution_error_message(&usage_result);
+        return Ok(upstream_failure(
+            usage_result.status_code,
+            err_msg.as_deref().unwrap_or("unknown error"),
+        ));
+    }
+    let Some(usage_body) = usage_result
+        .body
+        .as_ref()
+        .and_then(|body| body.json_body.as_ref())
+    else {
+        return Ok(build_internal_control_error_response(
+            http::StatusCode::BAD_GATEWAY,
+            "getUsageLimits 响应中未包含限额信息",
+        ));
+    };
+    let now = now_unix_secs();
+    let Some(metadata) = parse_kiro_usage_response(usage_body, now) else {
+        return Ok(build_internal_control_error_response(
+            http::StatusCode::BAD_GATEWAY,
+            "getUsageLimits 响应无法解析",
+        ));
+    };
+
+    let metadata_update = json!({ "kiro": metadata.clone() });
+    let encrypted_auth_config = if token_refreshed {
+        encode_refreshed_auth_config(state, &transport, &auth)
+    } else {
+        None
+    };
+    let (oauth_invalid_at_unix_secs, oauth_invalid_reason) =
+        quota_refresh_success_invalid_state(&key);
+    let _ = persist_provider_quota_refresh_state(
+        state,
+        &key_id,
+        Some(&metadata_update),
+        oauth_invalid_at_unix_secs,
+        oauth_invalid_reason,
+        encrypted_auth_config,
+    )
+    .await?;
+
+    Ok(Json(metadata).into_response())
+}

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/kiro/plan.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/kiro/plan.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 use url::form_urlencoded;
 use uuid::Uuid;
 
-fn build_kiro_usage_headers(auth: &AdminKiroRequestAuth) -> BTreeMap<String, String> {
+pub(super) fn build_kiro_usage_headers(auth: &AdminKiroRequestAuth) -> BTreeMap<String, String> {
     let kiro_version = auth.auth_config.effective_kiro_version();
     let machine_id = auth.machine_id.trim();
     let ide_tag = if machine_id.is_empty() {

--- a/apps/aether-gateway/src/handlers/admin/provider/shared/paths/mod.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/shared/paths/mod.rs
@@ -24,8 +24,8 @@ pub(crate) use self::oauth::{
     admin_provider_oauth_batch_import_task_provider_id, admin_provider_oauth_complete_key_id,
     admin_provider_oauth_complete_provider_id, admin_provider_oauth_device_authorize_provider_id,
     admin_provider_oauth_device_poll_provider_id, admin_provider_oauth_import_provider_id,
-    admin_provider_oauth_refresh_key_id, admin_provider_oauth_start_key_id,
-    admin_provider_oauth_start_provider_id,
+    admin_provider_oauth_kiro_overage_key_id, admin_provider_oauth_refresh_key_id,
+    admin_provider_oauth_start_key_id, admin_provider_oauth_start_provider_id,
 };
 pub(crate) use self::ops::{
     admin_provider_id_for_provider_ops_balance, admin_provider_id_for_provider_ops_checkin,

--- a/apps/aether-gateway/src/handlers/admin/provider/shared/paths/oauth.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/shared/paths/oauth.rs
@@ -72,6 +72,14 @@ pub(crate) fn admin_provider_oauth_device_poll_provider_id(request_path: &str) -
     provider_oauth_provider_id_for_suffix(request_path, "/device-poll")
 }
 
+pub(crate) fn admin_provider_oauth_kiro_overage_key_id(request_path: &str) -> Option<String> {
+    request_path
+        .strip_prefix("/api/admin/provider-oauth/keys/")?
+        .strip_suffix("/kiro/overage")
+        .filter(|key_id| !key_id.is_empty() && !key_id.contains('/'))
+        .map(ToOwned::to_owned)
+}
+
 fn provider_oauth_provider_id_for_suffix(request_path: &str, suffix: &str) -> Option<String> {
     request_path
         .strip_prefix("/api/admin/provider-oauth/providers/")?

--- a/apps/aether-gateway/src/handlers/shared/request_utils.rs
+++ b/apps/aether-gateway/src/handlers/shared/request_utils.rs
@@ -247,6 +247,7 @@ pub(crate) fn admin_proxy_local_requires_buffered_body(
                 )
                 | (Some("provider_oauth_manage"), http::Method::POST, Some("device_authorize"))
                 | (Some("provider_oauth_manage"), http::Method::POST, Some("device_poll"))
+                | (Some("provider_oauth_manage"), http::Method::POST, Some("set_kiro_overage"))
                 | (Some("system_manage"), http::Method::POST, Some("config_import"))
                 | (Some("system_manage"), http::Method::POST, Some("users_import"))
                 | (Some("system_manage"), http::Method::PUT, Some("settings_set"))

--- a/crates/aether-admin/src/provider/quota.rs
+++ b/crates/aether-admin/src/provider/quota.rs
@@ -692,6 +692,57 @@ pub fn parse_kiro_usage_response(
         result.insert("email".to_string(), json!(email));
     }
 
+    // Overage configuration / subscription capability / breakdown charges.
+    // Values mirror the raw Kiro `getUsageLimits` response — do not insert
+    // defaults or nulls when upstream fields are missing.
+    let overage_configuration = root
+        .get("overageConfiguration")
+        .and_then(serde_json::Value::as_object);
+    if let Some(overage_status) = overage_configuration
+        .and_then(|object| object.get("overageStatus"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let enabled = overage_status.eq_ignore_ascii_case("ENABLED");
+        result.insert("overage_enabled".to_string(), json!(enabled));
+    }
+
+    if let Some(overage_capability) = root
+        .get("subscriptionInfo")
+        .and_then(|value| value.get("overageCapability"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let capable = overage_capability.eq_ignore_ascii_case("OVERAGE_CAPABLE");
+        result.insert("overage_capable".to_string(), json!(capable));
+    }
+
+    if let Some(overage_cap) = breakdown
+        .get("overageCapWithPrecision")
+        .and_then(coerce_json_f64)
+        .or_else(|| breakdown.get("overageCap").and_then(coerce_json_f64))
+    {
+        result.insert("overage_cap".to_string(), json!(overage_cap));
+    }
+
+    if let Some(overage_rate) = breakdown.get("overageRate").and_then(coerce_json_f64) {
+        result.insert("overage_rate".to_string(), json!(overage_rate));
+    }
+
+    if let Some(current_overages) = breakdown
+        .get("currentOveragesWithPrecision")
+        .and_then(coerce_json_f64)
+        .or_else(|| breakdown.get("currentOverages").and_then(coerce_json_f64))
+    {
+        result.insert("current_overages".to_string(), json!(current_overages));
+    }
+
+    if let Some(overage_charges) = breakdown.get("overageCharges").and_then(coerce_json_f64) {
+        result.insert("overage_charges".to_string(), json!(overage_charges));
+    }
+
     Some(serde_json::Value::Object(result))
 }
 
@@ -914,8 +965,8 @@ mod tests {
     use super::{
         codex_build_invalid_state, codex_runtime_invalid_reason,
         parse_chatgpt_web_conversation_init_response, parse_codex_wham_usage_response,
-        OAUTH_ACCOUNT_BLOCK_PREFIX, OAUTH_EXPIRED_PREFIX, OAUTH_REFRESH_FAILED_PREFIX,
-        OAUTH_REQUEST_FAILED_PREFIX,
+        parse_kiro_usage_response, OAUTH_ACCOUNT_BLOCK_PREFIX, OAUTH_EXPIRED_PREFIX,
+        OAUTH_REFRESH_FAILED_PREFIX, OAUTH_REQUEST_FAILED_PREFIX,
     };
     use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogKey;
     use serde_json::json;
@@ -1106,5 +1157,94 @@ mod tests {
 
         assert_eq!(parsed.get("image_quota_blocked"), Some(&json!(true)));
         assert_eq!(parsed.get("image_quota_remaining"), Some(&json!(0.0)));
+    }
+
+    #[test]
+    fn parses_kiro_overage_fields_from_har_shaped_response() {
+        // Shape taken from `kiro超额开关.har` entry 3 (GET /getUsageLimits after
+        // toggling overageStatus=DISABLED). Fields asserted below match the
+        // six new outputs added for the overage switch feature.
+        let parsed = parse_kiro_usage_response(
+            &json!({
+                "daysUntilReset": 0,
+                "limits": [],
+                "nextDateReset": 1_780_272_000u64,
+                "overageConfiguration": {
+                    "overageLimit": null,
+                    "overageStatus": "DISABLED"
+                },
+                "subscriptionInfo": {
+                    "overageCapability": "OVERAGE_CAPABLE",
+                    "subscriptionManagementTarget": "MANAGE",
+                    "subscriptionTitle": "KIRO PRO",
+                    "type": "Q_DEVELOPER_STANDALONE_PRO",
+                    "upgradeCapability": "UPGRADE_CAPABLE"
+                },
+                "usageBreakdownList": [{
+                    "bonuses": [],
+                    "currency": "USD",
+                    "currentOverages": 0,
+                    "currentOveragesWithPrecision": 0.0,
+                    "currentUsage": 7,
+                    "currentUsageWithPrecision": 7.13,
+                    "displayName": "Credit",
+                    "displayNamePlural": "Credits",
+                    "freeTrialInfo": null,
+                    "nextDateReset": 1_780_272_000u64,
+                    "overageCap": 10000,
+                    "overageCapWithPrecision": 10000.0,
+                    "overageCharges": 0.0,
+                    "overageRate": 0.04,
+                    "resourceType": "CREDIT",
+                    "unit": "INVOCATIONS",
+                    "usageLimit": 1000,
+                    "usageLimitWithPrecision": 1000.0
+                }],
+                "userInfo": {"email": "sample@example.com", "userId": "d-abc"}
+            }),
+            1_778_067_246,
+        )
+        .expect("kiro usage response should parse");
+
+        assert_eq!(parsed.get("overage_enabled"), Some(&json!(false)));
+        assert_eq!(parsed.get("overage_capable"), Some(&json!(true)));
+        assert_eq!(parsed.get("overage_cap"), Some(&json!(10000.0)));
+        assert_eq!(parsed.get("overage_rate"), Some(&json!(0.04)));
+        assert_eq!(parsed.get("current_overages"), Some(&json!(0.0)));
+        assert_eq!(parsed.get("overage_charges"), Some(&json!(0.0)));
+        assert_eq!(parsed.get("subscription_title"), Some(&json!("KIRO PRO")));
+    }
+
+    #[test]
+    fn parses_kiro_response_without_overage_fields_skips_them() {
+        // Minimal response: no overageConfiguration, no subscription-level
+        // overageCapability, no overage-related breakdown fields. The six
+        // overage keys MUST NOT appear in the output (no null stubs).
+        let parsed = parse_kiro_usage_response(
+            &json!({
+                "usageBreakdownList": [{
+                    "currentUsage": 1,
+                    "currentUsageWithPrecision": 1.5,
+                    "usageLimit": 100,
+                    "usageLimitWithPrecision": 100.0
+                }]
+            }),
+            1_778_000_000,
+        )
+        .expect("minimal kiro response should parse");
+
+        for key in [
+            "overage_enabled",
+            "overage_capable",
+            "overage_cap",
+            "overage_rate",
+            "current_overages",
+            "overage_charges",
+        ] {
+            assert!(
+                parsed.get(key).is_none(),
+                "key `{key}` should be absent when upstream omits overage fields"
+            );
+        }
     }
 }

--- a/frontend/src/api/endpoints/provider_oauth.ts
+++ b/frontend/src/api/endpoints/provider_oauth.ts
@@ -1,4 +1,5 @@
 import client from '../client'
+import type { KiroUpstreamMetadata } from './types/provider'
 
 export interface ProviderOAuthStartResponse {
   authorization_url: string
@@ -81,6 +82,17 @@ export interface OAuthBatchImportTaskStatusResponse {
 
 export async function refreshProviderOAuth(keyId: string): Promise<ProviderOAuthCompleteResponse> {
   const resp = await client.post(`/api/admin/provider-oauth/keys/${keyId}/refresh`)
+  return resp.data
+}
+
+export async function setKiroOverage(
+  keyId: string,
+  enabled: boolean,
+): Promise<KiroUpstreamMetadata> {
+  const resp = await client.post(
+    `/api/admin/provider-oauth/keys/${keyId}/kiro/overage`,
+    { enabled },
+  )
   return resp.data
 }
 

--- a/frontend/src/api/endpoints/types/provider.ts
+++ b/frontend/src/api/endpoints/types/provider.ts
@@ -356,6 +356,13 @@ export interface KiroUpstreamMetadata {
   is_banned?: boolean  // 账户是否被封禁
   ban_reason?: string  // 封禁原因
   banned_at?: number  // 封禁时间（Unix 时间戳，秒）
+  // 超额配置（来自 Kiro getUsageLimits 响应）
+  overage_enabled?: boolean  // 当前是否已开启超额
+  overage_capable?: boolean  // 订阅是否支持超额（Pro 及以上为 true）
+  overage_cap?: number  // 超额上限（最多可超出的 invocations）
+  overage_rate?: number  // 超额单价（USD / invocation）
+  current_overages?: number  // 本期已超出使用量
+  overage_charges?: number  // 本期已产生的超额费用（USD）
 }
 
 export interface ChatGPTWebUpstreamMetadata {

--- a/frontend/src/features/providers/components/ProviderDetailDrawer.vue
+++ b/frontend/src/features/providers/components/ProviderDetailDrawer.vue
@@ -658,7 +658,9 @@
                         v-if="hasCodexSparkQuotaDisplayData(key)"
                         class="mt-3 border-t border-border/60 pt-2"
                       >
-                        <div class="mb-1 text-[10px] text-muted-foreground">GPT-5.3 Codex Spark</div>
+                        <div class="mb-1 text-[10px] text-muted-foreground">
+                          GPT-5.3 Codex Spark
+                        </div>
                         <div class="grid gap-3 grid-cols-2">
                           <div v-if="getCodexQuotaDisplay(key)?.spark_secondary_used_percent !== undefined">
                             <div class="flex items-center justify-between text-[10px] mb-0.5">
@@ -858,7 +860,21 @@
                       <template v-else>
                         <div class="flex items-center justify-between mb-1">
                           <span class="text-[10px] text-muted-foreground">账号配额</span>
-                          <div class="flex items-center gap-1">
+                          <div class="flex items-center gap-2">
+                            <!-- 超额开关（仅 overage_capable 时渲染） -->
+                            <div
+                              v-if="key.upstream_metadata?.kiro?.overage_capable === true"
+                              class="flex items-center gap-1.5"
+                              :title="(key.upstream_metadata?.kiro?.overage_enabled ?? false) ? '已开启超额使用' : '开启超额使用'"
+                            >
+                              <span class="text-[10px] text-muted-foreground">超额</span>
+                              <Switch
+                                :model-value="key.upstream_metadata?.kiro?.overage_enabled ?? false"
+                                :disabled="togglingOverageKeyId === key.id"
+                                class="scale-75 origin-right"
+                                @update:model-value="(v: boolean) => handleToggleKiroOverage(key, v)"
+                              />
+                            </div>
                             <RefreshCw
                               v-if="refreshingQuota"
                               class="w-3 h-3 text-muted-foreground/70 animate-spin"
@@ -871,9 +887,12 @@
                             </span>
                           </div>
                         </div>
-                        <!-- Kiro 额度显示：使用进度 -->
-                        <div>
-                          <!-- 使用额度进度条 -->
+                        <!-- 双列进度条：使用额度 + 超额用量（超额开启且有容量时切到两列） -->
+                        <div
+                          class="grid gap-3"
+                          :class="showKiroOverageBar(key) ? 'grid-cols-2' : 'grid-cols-1'"
+                        >
+                          <!-- 使用额度 -->
                           <div>
                             <div class="flex items-center justify-between text-[10px] mb-0.5">
                               <span class="text-muted-foreground">使用额度</span>
@@ -896,6 +915,26 @@
                               <span v-if="getKiroQuotaDisplay(key)?.next_reset_at">
                                 {{ formatKiroResetTime(getKiroQuotaDisplay(key)?.next_reset_at) }}重置
                               </span>
+                            </div>
+                          </div>
+                          <!-- 超额用量（仅开启且有额度时渲染） -->
+                          <div v-if="showKiroOverageBar(key)">
+                            <div class="flex items-center justify-between text-[10px] mb-0.5">
+                              <span class="text-muted-foreground">超额用量</span>
+                              <span :class="getQuotaRemainingClass(getKiroOverageUsedPercent(key))">
+                                {{ (100 - getKiroOverageUsedPercent(key)).toFixed(1) }}%
+                              </span>
+                            </div>
+                            <div class="relative w-full h-1.5 bg-border rounded-full overflow-hidden">
+                              <div
+                                class="absolute left-0 top-0 h-full transition-all duration-300"
+                                :class="getQuotaRemainingBarColor(getKiroOverageUsedPercent(key))"
+                                :style="{ width: `${Math.max(100 - getKiroOverageUsedPercent(key), 0)}%` }"
+                              />
+                            </div>
+                            <div class="text-[9px] text-muted-foreground/70 mt-0.5">
+                              {{ formatKiroUsage(key.upstream_metadata?.kiro?.current_overages) }} /
+                              {{ formatKiroUsage(key.upstream_metadata?.kiro?.overage_cap) }}
                             </div>
                           </div>
                         </div>
@@ -1241,6 +1280,7 @@ import { useEscapeKey } from '@/composables/useEscapeKey'
 import Button from '@/components/ui/button.vue'
 import Badge from '@/components/ui/badge.vue'
 import Card from '@/components/ui/card.vue'
+import Switch from '@/components/ui/switch.vue'
 import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui'
 import { useToast } from '@/composables/useToast'
 import { useConfirm } from '@/composables/useConfirm'
@@ -1281,6 +1321,7 @@ import {
   exportKey,
   refreshProviderOAuth,
   refreshProviderQuota,
+  setKiroOverage,
   clearOAuthInvalid,
   type ProviderEndpoint,
   type EndpointAPIKey,
@@ -1403,6 +1444,7 @@ const prioritySaving = ref(false)
 
 // OAuth 刷新状态
 const refreshingOAuthKeyId = ref<string | null>(null)
+const togglingOverageKeyId = ref<string | null>(null)
 
 // OAuth 失效清除状态
 const clearingOAuthInvalidKeyId = ref<string | null>(null)
@@ -1886,6 +1928,27 @@ async function handleRefreshOAuth(key: EndpointAPIKey) {
   }
 }
 
+async function handleToggleKiroOverage(key: EndpointAPIKey, enabled: boolean) {
+  if (togglingOverageKeyId.value) return
+  togglingOverageKeyId.value = key.id
+  try {
+    const metadata = await setKiroOverage(key.id, enabled)
+    const keyInList = providerKeys.value.find(k => k.id === key.id)
+    if (keyInList) {
+      const existing = (keyInList.upstream_metadata ?? {}) as UpstreamMetadata
+      keyInList.upstream_metadata = {
+        ...existing,
+        kiro: metadata,
+      }
+    }
+    showSuccess(enabled ? '已开启超额使用' : '已关闭超额使用')
+  } catch (err: unknown) {
+    showError(parseApiError(err, enabled ? '开启超额失败' : '关闭超额失败'), '错误')
+  } finally {
+    togglingOverageKeyId.value = null
+  }
+}
+
 // 判断是否为账号级别的封禁（刷新 token 无法修复）
 function isAccountLevelBlock(key: EndpointAPIKey): boolean {
   const account = getAccountStatusDisplay(key)
@@ -2295,6 +2358,24 @@ function formatKiroUsage(value: number | undefined): string {
     return `${(value / 1000).toFixed(1)}K`
   }
   return value.toFixed(1)
+}
+
+// 计算 Kiro 超额已用百分比 (0-100)，cap <= 0 时返回 0
+function getKiroOverageUsedPercent(key: EndpointAPIKey): number {
+  const kiro = key.upstream_metadata?.kiro
+  const cap = kiro?.overage_cap ?? 0
+  if (cap <= 0) return 0
+  const used = kiro?.current_overages ?? 0
+  return Math.max(0, Math.min(100, (used / cap) * 100))
+}
+
+// 是否渲染 Kiro 超额用量进度条：订阅支持 + 已开启 + 有容量
+function showKiroOverageBar(key: EndpointAPIKey): boolean {
+  const kiro = key.upstream_metadata?.kiro
+  if (!kiro) return false
+  if (kiro.overage_capable !== true) return false
+  if (!kiro.overage_enabled) return false
+  return (kiro.overage_cap ?? 0) > 0
 }
 
 // 格式化 Kiro 重置时间


### PR DESCRIPTION
## 变更内容

* 新增 Kiro 账号的"超额使用"开关，Pro 及以上订阅可在 Provider 详情抽屉中一键开启 / 关闭
* 新增 `POST /api/admin/provider-oauth/keys/{id}/kiro/overage` 接口，代理 Kiro 上游 `setUserPreference` 并立即回读 `getUsageLimits` 拿到状态
* Kiro 的 `upstream_metadata` 解析额外提取 `overage_enabled`、`overage_capable`、`overage_cap`、`overage_rate`、`current_overages`、`overage_charges` 六个字段
* 前端抽屉增加超额 Switch 和双列进度条（基础额度 + 超额用量）
<img width="728" height="438" alt="image" src="https://github.com/user-attachments/assets/2677b5f6-a610-41a7-a766-1a6a03c94219" />
