### PR TITLE
fix: capture pending usage request payloads

### DIFF
--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -16,10 +16,10 @@ use aether_scheduler_core::{
     parse_request_candidate_report_context, SchedulerRequestCandidateStatusUpdate,
 };
 use aether_usage_runtime::{
-    build_lifecycle_usage_seed, build_stream_terminal_usage_payload_seed,
-    build_sync_terminal_usage_payload_seed, build_terminal_usage_context_seed,
-    UsageBodyCapturePolicy, UsageRequestRecordLevel, UsageRuntimeAccess,
-    DEFAULT_USAGE_RESPONSE_BODY_CAPTURE_LIMIT_BYTES,
+    build_lifecycle_usage_seed_with_options, build_stream_terminal_usage_payload_seed,
+    build_sync_terminal_usage_payload_seed, build_terminal_usage_context_seed_with_options,
+    LifecycleUsageSeed, UsageBodyCapturePolicy, UsageRequestRecordLevel, UsageRuntimeAccess,
+    UsageSeedBuildOptions, DEFAULT_USAGE_RESPONSE_BODY_CAPTURE_LIMIT_BYTES,
 };
 use async_stream::stream;
 use axum::body::{Body, Bytes};
@@ -107,13 +107,41 @@ const STREAM_IDLE_LOG_INTERVAL_MS: u64 = 60_000;
 const REWRITTEN_STREAM_PREFETCH_TIMEOUT: Duration = Duration::from_millis(750);
 const OPENAI_IMAGE_STREAM_DEFAULT_TOTAL_TIMEOUT_MS: u64 = 900_000;
 
-fn record_sync_terminal_usage(
+async fn usage_seed_build_options(state: &AppState, request_id: &str) -> UsageSeedBuildOptions {
+    if !state.usage_runtime.is_enabled() {
+        return UsageSeedBuildOptions::without_request_payloads();
+    }
+
+    match UsageRuntimeAccess::request_record_level(state.data.as_ref()).await {
+        Ok(UsageRequestRecordLevel::Basic) => UsageSeedBuildOptions::without_request_payloads(),
+        Ok(UsageRequestRecordLevel::Full) => UsageSeedBuildOptions::full(),
+        Err(err) => {
+            warn!(
+                event_name = "usage_seed_policy_read_failed",
+                log_type = "ops",
+                request_id = %short_request_id(request_id),
+                error = %err,
+                fallback = "full",
+                "gateway failed to read usage request record level while building usage seed"
+            );
+            UsageSeedBuildOptions::full()
+        }
+    }
+}
+
+async fn record_sync_terminal_usage(
     state: &AppState,
     plan: &ExecutionPlan,
     report_context: Option<&serde_json::Value>,
     payload: &GatewaySyncReportRequest,
 ) {
-    let context_seed = build_terminal_usage_context_seed(plan, report_context);
+    if !state.usage_runtime.is_enabled() {
+        return;
+    }
+
+    let seed_options = usage_seed_build_options(state, plan.request_id.as_str()).await;
+    let context_seed =
+        build_terminal_usage_context_seed_with_options(plan, report_context, seed_options);
     let payload_seed = build_sync_terminal_usage_payload_seed(payload);
     state
         .usage_runtime
@@ -189,14 +217,20 @@ fn build_stream_error_sync_payload(
     }
 }
 
-fn record_stream_terminal_usage(
+async fn record_stream_terminal_usage(
     state: &AppState,
     plan: &ExecutionPlan,
     report_context: Option<&serde_json::Value>,
     payload: &GatewayStreamReportRequest,
     cancelled: bool,
 ) {
-    let context_seed = build_terminal_usage_context_seed(plan, report_context);
+    if !state.usage_runtime.is_enabled() {
+        return;
+    }
+
+    let seed_options = usage_seed_build_options(state, plan.request_id.as_str()).await;
+    let context_seed =
+        build_terminal_usage_context_seed_with_options(plan, report_context, seed_options);
     let payload_seed = build_stream_terminal_usage_payload_seed(payload);
     state.usage_runtime.record_stream_terminal(
         state.data.as_ref(),
@@ -476,15 +510,21 @@ pub(crate) async fn execute_execution_runtime_stream(
 ) -> Result<Option<Response<Body>>, GatewayError> {
     let stream_started_at = Instant::now();
     ensure_execution_request_candidate_slot(state, &mut plan, &mut report_context).await;
-    let lifecycle_seed = std::sync::Arc::new(build_lifecycle_usage_seed(
-        &plan,
-        report_context.as_ref(),
-    ));
+    let seed_options = usage_seed_build_options(state, plan.request_id.as_str()).await;
+    let lifecycle_seed = state.usage_runtime.is_enabled().then(|| {
+        Arc::new(build_lifecycle_usage_seed_with_options(
+            &plan,
+            report_context.as_ref(),
+            seed_options,
+        ))
+    });
     let request_candidate_status_snapshot =
         snapshot_local_request_candidate_status(&plan, report_context.as_ref());
-    state
-        .usage_runtime
-        .record_pending(state.data.as_ref(), lifecycle_seed.clone());
+    if let Some(lifecycle_seed) = lifecycle_seed.as_ref() {
+        state
+            .usage_runtime
+            .record_pending(state.data.as_ref(), lifecycle_seed.clone());
+    }
     let candidate_started_unix_secs = current_request_candidate_unix_ms();
     if let Some(snapshot) = request_candidate_status_snapshot.clone() {
         let state_bg = state.clone();
@@ -519,6 +559,12 @@ pub(crate) async fn execute_execution_runtime_stream(
         .unwrap_or_else(|| "-".to_string());
     match maybe_execute_kiro_web_search_stream(state, &plan, report_context.as_ref()).await {
         Ok(Some(kiro_web_search)) => {
+            let has_report_context_override = kiro_web_search.report_context.is_some();
+            let stream_lifecycle_seed = if has_report_context_override {
+                None
+            } else {
+                lifecycle_seed.clone()
+            };
             return execute_stream_from_frame_stream(
                 state,
                 plan,
@@ -530,6 +576,8 @@ pub(crate) async fn execute_execution_runtime_stream(
                 candidate_started_unix_secs,
                 stream_started_at,
                 kiro_web_search.frame_stream,
+                stream_lifecycle_seed,
+                seed_options,
             )
             .await;
         }
@@ -570,6 +618,12 @@ pub(crate) async fn execute_execution_runtime_stream(
     }
     match maybe_execute_chatgpt_web_image_stream(state, &plan, report_context.as_ref()).await {
         Ok(Some(chatgpt_web_image)) => {
+            let has_report_context_override = chatgpt_web_image.report_context.is_some();
+            let stream_lifecycle_seed = if has_report_context_override {
+                None
+            } else {
+                lifecycle_seed.clone()
+            };
             return execute_stream_from_frame_stream(
                 state,
                 plan,
@@ -581,6 +635,8 @@ pub(crate) async fn execute_execution_runtime_stream(
                 candidate_started_unix_secs,
                 stream_started_at,
                 chatgpt_web_image.frame_stream,
+                stream_lifecycle_seed,
+                seed_options,
             )
             .await;
         }
@@ -676,6 +732,8 @@ pub(crate) async fn execute_execution_runtime_stream(
             candidate_started_unix_secs,
             stream_started_at,
             frame_stream,
+            lifecycle_seed.clone(),
+            seed_options,
         )
         .await;
     }
@@ -740,6 +798,8 @@ pub(crate) async fn execute_execution_runtime_stream(
                 candidate_started_unix_secs,
                 stream_started_at,
                 frame_stream,
+                lifecycle_seed.clone(),
+                seed_options,
             )
             .await;
         }
@@ -825,6 +885,8 @@ pub(crate) async fn execute_execution_runtime_stream(
             candidate_started_unix_secs,
             stream_started_at,
             frame_stream,
+            lifecycle_seed.clone(),
+            seed_options,
         )
         .await;
     }
@@ -1092,16 +1154,23 @@ async fn execute_stream_from_frame_stream(
     candidate_started_unix_secs: u64,
     stream_started_at: Instant,
     frame_stream: BoxStream<'static, Result<Bytes, IoError>>,
+    lifecycle_seed: Option<Arc<LifecycleUsageSeed>>,
+    seed_options: UsageSeedBuildOptions,
 ) -> Result<Option<Response<Body>>, GatewayError> {
     let request_id = plan.request_id.as_str();
     let request_id_for_log = short_request_id(request_id);
     let candidate_id = plan.candidate_id.as_deref();
     let provider_name = plan.provider_name.as_deref().unwrap_or("-");
     let model_name = plan.model_name.as_deref().unwrap_or("-");
-    let lifecycle_seed = std::sync::Arc::new(build_lifecycle_usage_seed(
-        &plan,
-        report_context.as_ref(),
-    ));
+    let lifecycle_seed = lifecycle_seed.or_else(|| {
+        state.usage_runtime.is_enabled().then(|| {
+            Arc::new(build_lifecycle_usage_seed_with_options(
+                &plan,
+                report_context.as_ref(),
+                seed_options,
+            ))
+        })
+    });
     let request_candidate_status_snapshot =
         snapshot_local_request_candidate_status(&plan, report_context.as_ref());
     let candidate_index = parse_request_candidate_report_context(report_context.as_ref())
@@ -1419,7 +1488,7 @@ async fn execute_stream_from_frame_stream(
             client_body_json,
             None,
         );
-        record_sync_terminal_usage(state, &plan, payload.report_context.as_ref(), &payload);
+        record_sync_terminal_usage(state, &plan, payload.report_context.as_ref(), &payload).await;
         let terminal_unix_secs = current_request_candidate_unix_ms();
         record_local_request_candidate_status(
             state,
@@ -1652,7 +1721,8 @@ async fn execute_stream_from_frame_stream(
                                 &plan,
                                 payload.report_context.as_ref(),
                                 &payload,
-                            );
+                            )
+                            .await;
                             let response = submit_local_core_error_or_sync_finalize(
                                 state, trace_id, decision, payload,
                             )
@@ -1839,12 +1909,14 @@ async fn execute_stream_from_frame_stream(
     drop(private_stream_normalizer);
     drop(local_stream_rewriter);
 
-    state.usage_runtime.record_stream_started(
-        state.data.as_ref(),
-        lifecycle_seed.clone(),
-        status_code,
-        prefetched_telemetry.as_ref(),
-    );
+    if let Some(lifecycle_seed) = lifecycle_seed.as_ref() {
+        state.usage_runtime.record_stream_started(
+            state.data.as_ref(),
+            lifecycle_seed.clone(),
+            status_code,
+            prefetched_telemetry.as_ref(),
+        );
+    }
     if let Some(snapshot) = request_candidate_status_snapshot {
         let state_bg = state.clone();
         let latency_ms = prefetched_telemetry
@@ -2365,12 +2437,14 @@ async fn execute_stream_from_frame_stream(
                                     .as_ref()
                                     .and_then(|telemetry| telemetry.upstream_bytes),
                             };
-                            state_for_report.usage_runtime.record_stream_started(
-                                state_for_report.data.as_ref(),
-                                lifecycle_seed_for_report.clone(),
-                                status_code,
-                                Some(&first_data_telemetry),
-                            );
+                            if let Some(lifecycle_seed) = lifecycle_seed_for_report.as_ref() {
+                                state_for_report.usage_runtime.record_stream_started(
+                                    state_for_report.data.as_ref(),
+                                    lifecycle_seed.clone(),
+                                    status_code,
+                                    Some(&first_data_telemetry),
+                                );
+                            }
                             usage_stream_telemetry = Some(first_data_telemetry);
                         }
 
@@ -2413,12 +2487,14 @@ async fn execute_stream_from_frame_stream(
                             &frame_telemetry,
                         );
                         if should_refresh_stream_usage {
-                            state_for_report.usage_runtime.record_stream_started(
-                                state_for_report.data.as_ref(),
-                                lifecycle_seed_for_report.clone(),
-                                status_code,
-                                Some(&frame_telemetry),
-                            );
+                            if let Some(lifecycle_seed) = lifecycle_seed_for_report.as_ref() {
+                                state_for_report.usage_runtime.record_stream_started(
+                                    state_for_report.data.as_ref(),
+                                    lifecycle_seed.clone(),
+                                    status_code,
+                                    Some(&frame_telemetry),
+                                );
+                            }
                             usage_stream_telemetry = Some(frame_telemetry.clone());
                         }
                         telemetry = Some(frame_telemetry);
@@ -2713,7 +2789,8 @@ async fn execute_stream_from_frame_stream(
                 usage_payload.report_context.as_ref(),
                 &usage_payload,
                 true,
-            );
+            )
+            .await;
             record_local_request_candidate_status(
                 &state_for_report,
                 &plan_for_report,
@@ -2802,7 +2879,8 @@ async fn execute_stream_from_frame_stream(
             usage_payload.report_context.as_ref(),
             &usage_payload,
             false,
-        );
+        )
+        .await;
         record_local_request_candidate_status(
             &state_for_report,
             &plan_for_report,
@@ -2895,7 +2973,7 @@ mod tests {
     use aether_data::repository::usage::InMemoryUsageReadRepository;
     use aether_data_contracts::repository::candidates::RequestCandidateReadRepository;
     use aether_data_contracts::repository::usage::UsageReadRepository;
-    use aether_usage_runtime::UsageRuntimeConfig;
+    use aether_usage_runtime::{UsageRuntimeConfig, UsageSeedBuildOptions};
     use async_stream::stream;
     use axum::body::{to_bytes, Body, Bytes};
     use axum::extract::ws::Message;
@@ -3142,6 +3220,8 @@ mod tests {
             crate::clock::current_unix_ms(),
             Instant::now(),
             frame_stream,
+            None,
+            UsageSeedBuildOptions::full(),
         )
         .await
         .expect("execution should succeed")

--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -476,7 +476,10 @@ pub(crate) async fn execute_execution_runtime_stream(
 ) -> Result<Option<Response<Body>>, GatewayError> {
     let stream_started_at = Instant::now();
     ensure_execution_request_candidate_slot(state, &mut plan, &mut report_context).await;
-    let lifecycle_seed = build_lifecycle_usage_seed(&plan, report_context.as_ref());
+    let lifecycle_seed = std::sync::Arc::new(build_lifecycle_usage_seed(
+        &plan,
+        report_context.as_ref(),
+    ));
     let request_candidate_status_snapshot =
         snapshot_local_request_candidate_status(&plan, report_context.as_ref());
     state
@@ -1095,7 +1098,10 @@ async fn execute_stream_from_frame_stream(
     let candidate_id = plan.candidate_id.as_deref();
     let provider_name = plan.provider_name.as_deref().unwrap_or("-");
     let model_name = plan.model_name.as_deref().unwrap_or("-");
-    let lifecycle_seed = build_lifecycle_usage_seed(&plan, report_context.as_ref());
+    let lifecycle_seed = std::sync::Arc::new(build_lifecycle_usage_seed(
+        &plan,
+        report_context.as_ref(),
+    ));
     let request_candidate_status_snapshot =
         snapshot_local_request_candidate_status(&plan, report_context.as_ref());
     let candidate_index = parse_request_candidate_report_context(report_context.as_ref())
@@ -1835,7 +1841,7 @@ async fn execute_stream_from_frame_stream(
 
     state.usage_runtime.record_stream_started(
         state.data.as_ref(),
-        &lifecycle_seed,
+        lifecycle_seed.clone(),
         status_code,
         prefetched_telemetry.as_ref(),
     );
@@ -2361,7 +2367,7 @@ async fn execute_stream_from_frame_stream(
                             };
                             state_for_report.usage_runtime.record_stream_started(
                                 state_for_report.data.as_ref(),
-                                &lifecycle_seed_for_report,
+                                lifecycle_seed_for_report.clone(),
                                 status_code,
                                 Some(&first_data_telemetry),
                             );
@@ -2409,7 +2415,7 @@ async fn execute_stream_from_frame_stream(
                         if should_refresh_stream_usage {
                             state_for_report.usage_runtime.record_stream_started(
                                 state_for_report.data.as_ref(),
-                                &lifecycle_seed_for_report,
+                                lifecycle_seed_for_report.clone(),
                                 status_code,
                                 Some(&frame_telemetry),
                             );

--- a/apps/aether-gateway/src/execution_runtime/stream/execution_failures.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution_failures.rs
@@ -2,7 +2,7 @@ use aether_contracts::{ExecutionError, ExecutionPlan, ExecutionTelemetry};
 use aether_data_contracts::repository::candidates::RequestCandidateStatus;
 use aether_scheduler_core::SchedulerRequestCandidateStatusUpdate;
 use aether_usage_runtime::{
-    build_sync_terminal_usage_payload_seed, build_terminal_usage_context_seed,
+    build_sync_terminal_usage_payload_seed, build_terminal_usage_context_seed_with_options,
 };
 use axum::body::Body;
 use axum::http::Response;
@@ -271,11 +271,15 @@ async fn record_stream_sync_failure(
         }),
     )
     .await;
-    let context_seed = build_terminal_usage_context_seed(plan, report_context);
-    let payload_seed = build_sync_terminal_usage_payload_seed(payload);
-    state
-        .usage_runtime
-        .record_sync_terminal(state.data.as_ref(), context_seed, payload_seed);
+    if state.usage_runtime.is_enabled() {
+        let seed_options = super::usage_seed_build_options(state, plan.request_id.as_str()).await;
+        let context_seed =
+            build_terminal_usage_context_seed_with_options(plan, report_context, seed_options);
+        let payload_seed = build_sync_terminal_usage_payload_seed(payload);
+        state
+            .usage_runtime
+            .record_sync_terminal(state.data.as_ref(), context_seed, payload_seed);
+    }
     let terminal_unix_secs = current_request_candidate_unix_ms();
     record_report_request_candidate_status(
         state,

--- a/apps/aether-gateway/src/execution_runtime/sync/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/sync/execution.rs
@@ -1047,7 +1047,10 @@ async fn execute_execution_runtime_sync_impl(
         .map(|value| value.to_string())
         .unwrap_or_else(|| "-".to_string());
     let candidate_started_unix_secs = current_request_candidate_unix_ms();
-    let lifecycle_seed = build_lifecycle_usage_seed(&plan, report_context.as_ref());
+    let lifecycle_seed = std::sync::Arc::new(build_lifecycle_usage_seed(
+        &plan,
+        report_context.as_ref(),
+    ));
     state
         .usage_runtime
         .record_pending(state.data.as_ref(), lifecycle_seed);

--- a/apps/aether-gateway/src/execution_runtime/sync/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/sync/execution.rs
@@ -10,8 +10,9 @@ use aether_scheduler_core::{
     SchedulerRequestCandidateStatusUpdate,
 };
 use aether_usage_runtime::{
-    build_lifecycle_usage_seed, build_sync_terminal_usage_payload_seed,
-    build_terminal_usage_context_seed,
+    build_lifecycle_usage_seed_with_options, build_sync_terminal_usage_payload_seed,
+    build_terminal_usage_context_seed_with_options, UsageRequestRecordLevel, UsageRuntimeAccess,
+    UsageSeedBuildOptions,
 };
 use async_stream::stream;
 use axum::body::{to_bytes, Body, Bytes};
@@ -122,13 +123,41 @@ struct ImplicitSyncFinalizeOutcome {
     outcome: LocalCoreSyncFinalizeOutcome,
 }
 
-fn record_sync_terminal_usage(
+async fn usage_seed_build_options(state: &AppState, request_id: &str) -> UsageSeedBuildOptions {
+    if !state.usage_runtime.is_enabled() {
+        return UsageSeedBuildOptions::without_request_payloads();
+    }
+
+    match UsageRuntimeAccess::request_record_level(state.data.as_ref()).await {
+        Ok(UsageRequestRecordLevel::Basic) => UsageSeedBuildOptions::without_request_payloads(),
+        Ok(UsageRequestRecordLevel::Full) => UsageSeedBuildOptions::full(),
+        Err(err) => {
+            warn!(
+                event_name = "usage_seed_policy_read_failed",
+                log_type = "ops",
+                request_id = %short_request_id(request_id),
+                error = %err,
+                fallback = "full",
+                "gateway failed to read usage request record level while building usage seed"
+            );
+            UsageSeedBuildOptions::full()
+        }
+    }
+}
+
+async fn record_sync_terminal_usage(
     state: &AppState,
     plan: &ExecutionPlan,
     report_context: Option<&serde_json::Value>,
     payload: &GatewaySyncReportRequest,
 ) {
-    let context_seed = build_terminal_usage_context_seed(plan, report_context);
+    if !state.usage_runtime.is_enabled() {
+        return;
+    }
+
+    let seed_options = usage_seed_build_options(state, plan.request_id.as_str()).await;
+    let context_seed =
+        build_terminal_usage_context_seed_with_options(plan, report_context, seed_options);
     let payload_seed = build_sync_terminal_usage_payload_seed(payload);
     state
         .usage_runtime
@@ -1047,13 +1076,17 @@ async fn execute_execution_runtime_sync_impl(
         .map(|value| value.to_string())
         .unwrap_or_else(|| "-".to_string());
     let candidate_started_unix_secs = current_request_candidate_unix_ms();
-    let lifecycle_seed = std::sync::Arc::new(build_lifecycle_usage_seed(
-        &plan,
-        report_context.as_ref(),
-    ));
-    state
-        .usage_runtime
-        .record_pending(state.data.as_ref(), lifecycle_seed);
+    if state.usage_runtime.is_enabled() {
+        let seed_options = usage_seed_build_options(state, plan.request_id.as_str()).await;
+        let lifecycle_seed = std::sync::Arc::new(build_lifecycle_usage_seed_with_options(
+            &plan,
+            report_context.as_ref(),
+            seed_options,
+        ));
+        state
+            .usage_runtime
+            .record_pending(state.data.as_ref(), lifecycle_seed);
+    }
     record_local_request_candidate_status(
         state,
         &plan,
@@ -1657,7 +1690,8 @@ async fn execute_execution_runtime_sync_impl(
             &plan,
             implicit_finalize.payload.report_context.as_ref(),
             usage_payload,
-        );
+        )
+        .await;
         if let Some(report_payload) = implicit_finalize.outcome.background_report {
             spawn_sync_report(state.clone(), report_payload);
         } else {
@@ -1709,7 +1743,8 @@ async fn execute_execution_runtime_sync_impl(
                 &plan,
                 payload.report_context.as_ref(),
                 usage_payload,
-            );
+            )
+            .await;
             if let Some(report_payload) = outcome.background_report {
                 spawn_sync_report(state.clone(), report_payload);
             } else {
@@ -1754,7 +1789,8 @@ async fn execute_execution_runtime_sync_impl(
                     &plan,
                     original_report_context.as_ref(),
                     &report_payload,
-                );
+                )
+                .await;
                 if let Some(snapshot) = local_task_snapshot {
                     let _ = state.upsert_video_task_snapshot(&snapshot).await?;
                     state.video_tasks.record_snapshot(snapshot);
@@ -1782,7 +1818,8 @@ async fn execute_execution_runtime_sync_impl(
                 resolve_local_sync_success_background_report_kind(payload.report_kind.as_str());
             apply_sync_success_effects(state, &plan, payload.report_context.as_ref(), &payload)
                 .await;
-            record_sync_terminal_usage(state, &plan, payload.report_context.as_ref(), &payload);
+            record_sync_terminal_usage(state, &plan, payload.report_context.as_ref(), &payload)
+                .await;
             state
                 .video_tasks
                 .apply_finalize_mutation(request_path, payload.report_kind.as_str());
@@ -1822,7 +1859,8 @@ async fn execute_execution_runtime_sync_impl(
             if let Some(error_report_kind) = background_error_report_kind {
                 payload.report_kind = error_report_kind.to_string();
             }
-            record_sync_terminal_usage(state, &plan, payload.report_context.as_ref(), &payload);
+            record_sync_terminal_usage(state, &plan, payload.report_context.as_ref(), &payload)
+                .await;
             if background_error_report_kind.is_some() {
                 spawn_sync_report(state.clone(), payload);
             } else {
@@ -1842,7 +1880,7 @@ async fn execute_execution_runtime_sync_impl(
                 candidate_id,
             )?));
         }
-        record_sync_terminal_usage(state, &plan, payload.report_context.as_ref(), &payload);
+        record_sync_terminal_usage(state, &plan, payload.report_context.as_ref(), &payload).await;
         let response =
             submit_local_core_error_or_sync_finalize(state, trace_id, decision, payload).await?;
         return Ok(Some(attach_control_metadata_headers(
@@ -1876,7 +1914,8 @@ async fn execute_execution_runtime_sync_impl(
         &plan,
         usage_payload.report_context.as_ref(),
         &usage_payload,
-    );
+    )
+    .await;
     let response = attach_control_metadata_headers(
         build_client_response_from_parts(
             status_code,

--- a/apps/aether-gateway/src/tests/usage/direct.rs
+++ b/apps/aether-gateway/src/tests/usage/direct.rs
@@ -8,6 +8,7 @@ use super::{
     Router, StatusCode, UsageReadRepository, UsageRuntimeConfig, DEVELOPMENT_ENCRYPTION_KEY,
     TRACE_ID_HEADER,
 };
+use aether_data_contracts::repository::usage::{StoredRequestUsageAudit, UsageBodyCaptureState};
 
 fn large_request_body(stream: bool) -> String {
     let large_message = "x".repeat(128 * 1024);
@@ -17,6 +18,43 @@ fn large_request_body(stream: bool) -> String {
         "stream": stream
     }))
     .expect("request body should encode")
+}
+
+fn assert_usage_has_openai_chat_request_body(
+    usage: &StoredRequestUsageAudit,
+    expected_stream: Option<bool>,
+) {
+    let request_body = usage
+        .request_body
+        .as_ref()
+        .expect("usage should capture the client request body");
+    assert_eq!(request_body["model"], "gpt-5");
+    assert!(request_body["messages"].is_array());
+    if let Some(expected_stream) = expected_stream {
+        assert_eq!(request_body["stream"], json!(expected_stream));
+    }
+
+    let provider_request_body = usage
+        .provider_request_body
+        .as_ref()
+        .expect("usage should capture the provider request body");
+    assert!(provider_request_body
+        .get("model")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|model| !model.is_empty()));
+    assert!(provider_request_body["messages"].is_array());
+    if let Some(expected_stream) = expected_stream {
+        assert_eq!(provider_request_body["stream"], json!(expected_stream));
+    }
+
+    assert_eq!(
+        usage.request_body_state,
+        Some(UsageBodyCaptureState::Inline)
+    );
+    assert_eq!(
+        usage.provider_request_body_state,
+        Some(UsageBodyCaptureState::Inline)
+    );
 }
 
 #[tokio::test]
@@ -258,6 +296,7 @@ async fn gateway_records_pending_usage_before_execution_runtime_sync_result_arri
     assert_eq!(pending.status, "pending");
     assert_eq!(pending.billing_status, "pending");
     assert_eq!(pending.response_time_ms, None);
+    assert_usage_has_openai_chat_request_body(&pending, None);
 
     allow_execution_response.notify_one();
 
@@ -278,6 +317,7 @@ async fn gateway_records_pending_usage_before_execution_runtime_sync_result_arri
     let stored = stored.expect("usage should be finalized");
     assert_eq!(stored.status, "completed");
     assert_eq!(stored.response_time_ms, Some(45));
+    assert_usage_has_openai_chat_request_body(&stored, None);
 
     gateway_handle.abort();
     execution_runtime_handle.abort();
@@ -285,7 +325,7 @@ async fn gateway_records_pending_usage_before_execution_runtime_sync_result_arri
 }
 
 #[tokio::test]
-async fn gateway_keeps_pending_sync_usage_lightweight_for_large_request_body() {
+async fn gateway_records_pending_sync_usage_body_for_large_request_body() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
     let execution_request_started = Arc::new(tokio::sync::Notify::new());
@@ -408,10 +448,9 @@ async fn gateway_keeps_pending_sync_usage_lightweight_for_large_request_body() {
     }
     let pending = pending.expect("pending usage should be recorded before sync result resolves");
     assert_eq!(pending.status, "pending");
-    assert!(pending.request_headers.is_none());
-    assert!(pending.request_body.is_none());
-    assert!(pending.provider_request_headers.is_none());
-    assert!(pending.provider_request_body.is_none());
+    assert!(pending.request_headers.is_some());
+    assert_usage_has_openai_chat_request_body(&pending, Some(false));
+    assert!(pending.provider_request_headers.is_some());
     assert!(pending.response_headers.is_none());
     assert!(pending.client_response_headers.is_none());
 
@@ -669,6 +708,7 @@ async fn gateway_records_pending_usage_before_execution_runtime_stream_headers_a
     assert_eq!(pending.billing_status, "pending");
     assert_eq!(pending.first_byte_time_ms, None);
     assert_eq!(pending.response_time_ms, None);
+    assert_usage_has_openai_chat_request_body(&pending, Some(true));
 
     allow_execution_response.notify_one();
 
@@ -689,6 +729,7 @@ async fn gateway_records_pending_usage_before_execution_runtime_stream_headers_a
     let stored = stored.expect("usage should be finalized");
     assert_eq!(stored.status, "completed");
     assert_eq!(stored.first_byte_time_ms, Some(19));
+    assert_usage_has_openai_chat_request_body(&stored, Some(true));
 
     gateway_handle.abort();
     execution_runtime_handle.abort();
@@ -696,7 +737,7 @@ async fn gateway_records_pending_usage_before_execution_runtime_stream_headers_a
 }
 
 #[tokio::test]
-async fn gateway_keeps_pending_stream_usage_lightweight_for_large_request_body() {
+async fn gateway_records_pending_stream_usage_body_for_large_request_body() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
     let execution_request_started = Arc::new(tokio::sync::Notify::new());
@@ -814,10 +855,9 @@ async fn gateway_keeps_pending_stream_usage_lightweight_for_large_request_body()
     }
     let pending = pending.expect("pending usage should be recorded before stream headers arrive");
     assert_eq!(pending.status, "pending");
-    assert!(pending.request_headers.is_none());
-    assert!(pending.request_body.is_none());
-    assert!(pending.provider_request_headers.is_none());
-    assert!(pending.provider_request_body.is_none());
+    assert!(pending.request_headers.is_some());
+    assert_usage_has_openai_chat_request_body(&pending, Some(true));
+    assert!(pending.provider_request_headers.is_some());
     assert!(pending.response_headers.is_none());
     assert!(pending.client_response_headers.is_none());
 

--- a/crates/aether-data/src/repository/usage/postgres/queries/upsert_usage_body_blob_sql.sql
+++ b/crates/aether-data/src/repository/usage/postgres/queries/upsert_usage_body_blob_sql.sql
@@ -13,3 +13,4 @@ ON CONFLICT (body_ref)
 DO UPDATE SET
   payload_gzip = EXCLUDED.payload_gzip,
   updated_at = NOW()
+WHERE usage_body_blobs.payload_gzip IS DISTINCT FROM EXCLUDED.payload_gzip

--- a/crates/aether-usage-runtime/src/lib.rs
+++ b/crates/aether-usage-runtime/src/lib.rs
@@ -48,14 +48,16 @@ pub use worker::{
     UsageEventRecorder, UsageQueueWorker, UsageRecordWriter,
 };
 pub use write::{
-    build_lifecycle_usage_seed, build_pending_usage_record, build_pending_usage_record_from_seed,
+    build_lifecycle_usage_seed, build_lifecycle_usage_seed_with_options,
+    build_pending_usage_record, build_pending_usage_record_from_seed,
     build_stream_terminal_usage_event, build_stream_terminal_usage_outcome,
     build_stream_terminal_usage_payload_seed, build_stream_terminal_usage_seed,
     build_streaming_usage_record, build_streaming_usage_record_from_seed,
     build_sync_terminal_usage_event, build_sync_terminal_usage_outcome,
     build_sync_terminal_usage_payload_seed, build_sync_terminal_usage_seed,
-    build_terminal_usage_context_seed, build_terminal_usage_event_from_outcome,
-    build_terminal_usage_event_from_seed, build_usage_event_data_seed, LifecycleUsageSeed,
-    StreamTerminalUsagePayloadSeed, SyncTerminalUsagePayloadSeed, TerminalUsageContextSeed,
-    TerminalUsageOutcome, TerminalUsageSeed, UsageTerminalState,
+    build_terminal_usage_context_seed, build_terminal_usage_context_seed_with_options,
+    build_terminal_usage_event_from_outcome, build_terminal_usage_event_from_seed,
+    build_usage_event_data_seed, LifecycleUsageSeed, StreamTerminalUsagePayloadSeed,
+    SyncTerminalUsagePayloadSeed, TerminalUsageContextSeed, TerminalUsageOutcome,
+    TerminalUsageSeed, UsageSeedBuildOptions, UsageTerminalState,
 };

--- a/crates/aether-usage-runtime/src/runtime.rs
+++ b/crates/aether-usage-runtime/src/runtime.rs
@@ -119,7 +119,7 @@ impl UsageRuntime {
         Some(worker.spawn())
     }
 
-    pub fn record_pending<T>(&self, data: &T, seed: LifecycleUsageSeed)
+    pub fn record_pending<T>(&self, data: &T, seed: Arc<LifecycleUsageSeed>)
     where
         T: UsageRuntimeAccess + Clone + 'static,
     {
@@ -159,7 +159,7 @@ impl UsageRuntime {
     pub fn record_stream_started<T>(
         &self,
         data: &T,
-        seed: &LifecycleUsageSeed,
+        seed: Arc<LifecycleUsageSeed>,
         status_code: u16,
         telemetry: Option<&ExecutionTelemetry>,
     ) where
@@ -169,7 +169,6 @@ impl UsageRuntime {
             return;
         }
         let data = T::clone(data);
-        let seed = seed.clone();
         let telemetry = telemetry.cloned();
         let request_id = seed.request_id.clone();
         spawn_on_usage_background_runtime(boxed_usage_task(async move {
@@ -425,10 +424,11 @@ impl UsageRuntime {
 }
 
 async fn build_pending_usage_record_offthread(
-    seed: LifecycleUsageSeed,
+    seed: Arc<LifecycleUsageSeed>,
     now_unix_secs: u64,
 ) -> Result<UpsertUsageRecord, DataLayerError> {
     tokio::task::spawn_blocking(move || {
+        let seed = Arc::try_unwrap(seed).unwrap_or_else(|shared| (*shared).clone());
         crate::write::build_pending_usage_record_from_owned_seed(seed, now_unix_secs)
     })
     .await
@@ -436,12 +436,13 @@ async fn build_pending_usage_record_offthread(
 }
 
 async fn build_streaming_usage_record_offthread(
-    seed: LifecycleUsageSeed,
+    seed: Arc<LifecycleUsageSeed>,
     status_code: u16,
     telemetry: Option<ExecutionTelemetry>,
     now_unix_secs: u64,
 ) -> Result<UpsertUsageRecord, DataLayerError> {
     tokio::task::spawn_blocking(move || {
+        let seed = Arc::try_unwrap(seed).unwrap_or_else(|shared| (*shared).clone());
         crate::write::build_streaming_usage_record_from_owned_seed(
             seed,
             status_code,

--- a/crates/aether-usage-runtime/src/write.rs
+++ b/crates/aether-usage-runtime/src/write.rs
@@ -88,6 +88,11 @@ pub struct LifecycleUsageSeed {
     pub provider_endpoint_kind: Option<String>,
     pub has_format_conversion: Option<bool>,
     pub is_stream: bool,
+    pub request_headers: Option<Value>,
+    pub request_body: Option<Value>,
+    pub provider_request_headers: Option<Value>,
+    pub provider_request: Option<Value>,
+    body_refs: UsageBodyRefsSeed,
     routing: UsageRoutingSeed,
     body_states: UsageBodyStatesSeed,
     pub request_metadata: Option<Value>,
@@ -233,6 +238,7 @@ pub fn build_lifecycle_usage_seed(
     report_context: Option<&Value>,
 ) -> LifecycleUsageSeed {
     let context = report_context.and_then(Value::as_object);
+    let request_capture = build_runtime_request_capture_seed(plan, context);
     let api_format = context_string(context, "client_api_format")
         .or_else(|| non_empty_str(Some(plan.client_api_format.as_str())));
     let endpoint_api_format = context_string(context, "provider_api_format")
@@ -292,8 +298,24 @@ pub fn build_lifecycle_usage_seed(
         provider_endpoint_kind,
         has_format_conversion: context_bool(context, "needs_conversion"),
         is_stream: plan.stream,
+        request_headers: mask_sensitive_headers_in_json_value(context_value(
+            context,
+            "original_headers",
+        )),
+        request_body: request_capture.request_body,
+        provider_request_headers: mask_sensitive_headers_in_json_value(
+            context_usage_value(context, "provider_request_headers")
+                .or_else(|| headers_to_json(&plan.headers)),
+        ),
+        provider_request: request_capture.provider_request,
+        body_refs: UsageBodyRefsSeed {
+            request_body_ref: request_capture.request_body_ref,
+            provider_request_body_ref: request_capture.provider_request_body_ref,
+            response_body_ref: context_string(context, "response_body_ref"),
+            client_response_body_ref: context_string(context, "client_response_body_ref"),
+        },
         routing: build_runtime_routing_seed(plan, context),
-        body_states: build_runtime_body_states_seed(plan, context),
+        body_states: request_capture.body_states,
         request_metadata: build_runtime_request_metadata_seed(plan, context),
     }
 }
@@ -1025,16 +1047,18 @@ fn build_lifecycle_usage_record_owned(
         provider_endpoint_kind,
         has_format_conversion,
         is_stream,
+        request_headers,
+        request_body,
+        provider_request_headers,
+        provider_request,
+        body_refs,
         routing,
         body_states,
         request_metadata,
         ..
     } = seed;
     let routing = merge_routing_seed_with_metadata_owned(routing, request_metadata.as_ref());
-    let body_refs = merge_body_refs_seed_with_metadata_owned(
-        UsageBodyRefsSeed::default(),
-        request_metadata.as_ref(),
-    );
+    let body_refs = merge_body_refs_seed_with_metadata_owned(body_refs, request_metadata.as_ref());
     let request_metadata = if trusted_request_metadata {
         request_metadata
     } else {
@@ -1081,12 +1105,12 @@ fn build_lifecycle_usage_record_owned(
         first_byte_time_ms,
         status: status.to_string(),
         billing_status: billing_status.to_string(),
-        request_headers: None,
-        request_body: None,
+        request_headers: sanitize_usage_header_capture(request_headers),
+        request_body,
         request_body_ref: body_refs.request_body_ref,
         request_body_state: body_states.request_body_state,
-        provider_request_headers: None,
-        provider_request_body: None,
+        provider_request_headers: sanitize_usage_header_capture(provider_request_headers),
+        provider_request_body: provider_request,
         provider_request_body_ref: body_refs.provider_request_body_ref,
         provider_request_body_state: body_states.provider_request_body_state,
         response_headers: sanitize_usage_header_capture(response_headers),
@@ -1128,10 +1152,8 @@ fn build_lifecycle_usage_record_impl(
     } = options;
     let (status, billing_status) = lifecycle_status_and_billing(lifecycle_state);
     let routing = merge_routing_seed_with_metadata(&seed.routing, seed.request_metadata.as_ref());
-    let body_refs = merge_body_refs_seed_with_metadata(
-        &UsageBodyRefsSeed::default(),
-        seed.request_metadata.as_ref(),
-    );
+    let body_refs =
+        merge_body_refs_seed_with_metadata(&seed.body_refs, seed.request_metadata.as_ref());
     let request_metadata = if trusted_request_metadata {
         seed.request_metadata.clone()
     } else {
@@ -1178,12 +1200,14 @@ fn build_lifecycle_usage_record_impl(
         first_byte_time_ms,
         status: status.to_string(),
         billing_status: billing_status.to_string(),
-        request_headers: None,
-        request_body: None,
+        request_headers: sanitize_usage_header_capture(seed.request_headers.clone()),
+        request_body: seed.request_body.clone(),
         request_body_ref: body_refs.request_body_ref,
         request_body_state: seed.body_states.request_body_state,
-        provider_request_headers: None,
-        provider_request_body: None,
+        provider_request_headers: sanitize_usage_header_capture(
+            seed.provider_request_headers.clone(),
+        ),
+        provider_request_body: seed.provider_request.clone(),
         provider_request_body_ref: body_refs.provider_request_body_ref,
         provider_request_body_state: seed.body_states.provider_request_body_state,
         response_headers: sanitize_usage_header_capture(response_headers),
@@ -1624,23 +1648,6 @@ fn capture_usage_storage_value(value: Value) -> Value {
         "max_bytes": MAX_USAGE_CAPTURE_BYTES,
         "value_kind": usage_value_kind(&value),
     })
-}
-
-fn build_runtime_body_states_seed(
-    plan: &ExecutionPlan,
-    context: Option<&Map<String, Value>>,
-) -> UsageBodyStatesSeed {
-    let request_body_ref = context_string(context, "request_body_ref");
-    let provider_request_body_ref = context_string(context, "provider_request_body_ref")
-        .or_else(|| non_empty_str(plan.body.body_ref.as_deref()));
-    build_runtime_body_states_seed_from_parts(
-        context_has_inline_body(context, "original_request_body"),
-        request_body_ref.as_deref(),
-        context_has_inline_body(context, "provider_request_body")
-            || plan_has_inline_json_body_for_usage(plan),
-        provider_request_body_ref.as_deref(),
-        plan.body.body_bytes_b64.is_some(),
-    )
 }
 
 fn build_runtime_body_states_seed_from_parts(
@@ -2474,7 +2481,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_usage_records_stay_lightweight() {
+    fn pending_usage_records_capture_request_payloads() {
         let plan = ExecutionPlan {
             request_id: "req-pending-usage-1".to_string(),
             candidate_id: Some("cand-pending-usage-1".to_string()),
@@ -2515,9 +2522,9 @@ mod tests {
                 "execution_path": "local_execution_runtime_miss",
                 "local_execution_runtime_miss_reason": "all_candidates_skipped",
                 "original_headers": {"authorization": "Bearer upstream-secret"},
-                "original_request_body": {"messages": [{"content": "should not be persisted in pending"}]},
+                "original_request_body": {"messages": [{"content": "visible before response"}]},
                 "provider_request_headers": {"authorization": "Bearer provider-secret"},
-                "provider_request_body": {"input": "should not be persisted in pending"}
+                "provider_request_body": {"input": "visible before response"}
             })),
             1_700_000_000,
         )
@@ -2525,10 +2532,30 @@ mod tests {
 
         assert_eq!(record.status, "pending");
         assert_eq!(record.billing_status, "pending");
-        assert!(record.request_headers.is_none());
-        assert!(record.request_body.is_none());
-        assert!(record.provider_request_headers.is_none());
-        assert!(record.provider_request_body.is_none());
+        assert_eq!(
+            record.request_headers,
+            Some(json!({"authorization": "Bear****cret"}))
+        );
+        assert_eq!(
+            record.request_body,
+            Some(json!({"messages": [{"content": "visible before response"}]}))
+        );
+        assert_eq!(
+            record.provider_request_headers,
+            Some(json!({"authorization": "Bear****cret"}))
+        );
+        assert_eq!(
+            record.provider_request_body,
+            Some(json!({"input": "visible before response"}))
+        );
+        assert_eq!(
+            record.request_body_state,
+            Some(UsageBodyCaptureState::Inline)
+        );
+        assert_eq!(
+            record.provider_request_body_state,
+            Some(UsageBodyCaptureState::Inline)
+        );
         assert_eq!(record.candidate_id.as_deref(), Some("cand-pending-usage-1"));
         assert_eq!(record.candidate_index, Some(0));
         assert_eq!(record.key_name.as_deref(), Some("codex-upstream"));
@@ -2592,7 +2619,7 @@ mod tests {
     }
 
     #[test]
-    fn streaming_usage_records_stay_lightweight_by_default() {
+    fn streaming_usage_records_capture_request_payloads_by_default() {
         let plan = ExecutionPlan {
             request_id: "req-streaming-usage-1".to_string(),
             candidate_id: Some("cand-streaming-usage-1".to_string()),
@@ -2619,8 +2646,10 @@ mod tests {
             &plan,
             Some(&json!({
                 "candidate_id": "cand-streaming-usage-1",
-                "original_request_body": {"messages": [{"content": "omit me"}]},
-                "provider_request_body": {"input": "omit me too"}
+                "original_headers": {"authorization": "Bearer stream-secret"},
+                "original_request_body": {"messages": [{"content": "visible while streaming"}]},
+                "provider_request_headers": {"x-api-key": "provider-stream-secret"},
+                "provider_request_body": {"input": "visible while streaming"}
             })),
             200,
             None,
@@ -2631,10 +2660,22 @@ mod tests {
         assert_eq!(record.status, "streaming");
         assert_eq!(record.billing_status, "pending");
         assert_eq!(record.status_code, Some(200));
-        assert!(record.request_headers.is_none());
-        assert!(record.request_body.is_none());
-        assert!(record.provider_request_headers.is_none());
-        assert!(record.provider_request_body.is_none());
+        assert_eq!(
+            record.request_headers,
+            Some(json!({"authorization": "Bear****cret"}))
+        );
+        assert_eq!(
+            record.request_body,
+            Some(json!({"messages": [{"content": "visible while streaming"}]}))
+        );
+        assert_eq!(
+            record.provider_request_headers,
+            Some(json!({"x-api-key": "prov****cret"}))
+        );
+        assert_eq!(
+            record.provider_request_body,
+            Some(json!({"input": "visible while streaming"}))
+        );
         assert!(record.response_headers.is_none());
         assert!(record.client_response_headers.is_none());
     }
@@ -3955,6 +3996,11 @@ mod tests {
                 provider_endpoint_kind: Some("chat".to_string()),
                 has_format_conversion: Some(false),
                 is_stream: false,
+                request_headers: None,
+                request_body: None,
+                provider_request_headers: None,
+                provider_request: None,
+                body_refs: UsageBodyRefsSeed::default(),
                 body_states: UsageBodyStatesSeed::default(),
                 routing: UsageRoutingSeed {
                     candidate_id: Some("cand-1".to_string()),

--- a/crates/aether-usage-runtime/src/write.rs
+++ b/crates/aether-usage-runtime/src/write.rs
@@ -229,6 +229,31 @@ struct LifecycleUsageRecordOptions {
     trusted_request_metadata: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UsageSeedBuildOptions {
+    pub capture_request_payloads: bool,
+}
+
+impl UsageSeedBuildOptions {
+    pub const fn full() -> Self {
+        Self {
+            capture_request_payloads: true,
+        }
+    }
+
+    pub const fn without_request_payloads() -> Self {
+        Self {
+            capture_request_payloads: false,
+        }
+    }
+}
+
+impl Default for UsageSeedBuildOptions {
+    fn default() -> Self {
+        Self::full()
+    }
+}
+
 const MAX_USAGE_CAPTURE_DEPTH: usize = 64;
 const MAX_USAGE_CAPTURE_NODES: usize = 20_000;
 const MAX_USAGE_CAPTURE_BYTES: usize = 64 * 1024;
@@ -237,8 +262,16 @@ pub fn build_lifecycle_usage_seed(
     plan: &ExecutionPlan,
     report_context: Option<&Value>,
 ) -> LifecycleUsageSeed {
+    build_lifecycle_usage_seed_with_options(plan, report_context, UsageSeedBuildOptions::full())
+}
+
+pub fn build_lifecycle_usage_seed_with_options(
+    plan: &ExecutionPlan,
+    report_context: Option<&Value>,
+    options: UsageSeedBuildOptions,
+) -> LifecycleUsageSeed {
     let context = report_context.and_then(Value::as_object);
-    let request_capture = build_runtime_request_capture_seed(plan, context);
+    let request_capture = build_runtime_request_capture_seed(plan, context, options);
     let api_format = context_string(context, "client_api_format")
         .or_else(|| non_empty_str(Some(plan.client_api_format.as_str())));
     let endpoint_api_format = context_string(context, "provider_api_format")
@@ -316,7 +349,7 @@ pub fn build_lifecycle_usage_seed(
         },
         routing: build_runtime_routing_seed(plan, context),
         body_states: request_capture.body_states,
-        request_metadata: build_runtime_request_metadata_seed(plan, context),
+        request_metadata: build_runtime_request_metadata_seed(plan, context, options),
     }
 }
 
@@ -653,8 +686,20 @@ pub fn build_terminal_usage_context_seed(
     plan: &ExecutionPlan,
     report_context: Option<&Value>,
 ) -> TerminalUsageContextSeed {
+    build_terminal_usage_context_seed_with_options(
+        plan,
+        report_context,
+        UsageSeedBuildOptions::full(),
+    )
+}
+
+pub fn build_terminal_usage_context_seed_with_options(
+    plan: &ExecutionPlan,
+    report_context: Option<&Value>,
+    options: UsageSeedBuildOptions,
+) -> TerminalUsageContextSeed {
     let context = report_context.and_then(Value::as_object);
-    let request_capture = build_runtime_request_capture_seed(plan, context);
+    let request_capture = build_runtime_request_capture_seed(plan, context, options);
     let client_contract = context_string(context, "client_contract")
         .or_else(|| context_string(context, "client_api_format"))
         .or_else(|| non_empty_str(Some(plan.client_api_format.as_str())))
@@ -715,8 +760,11 @@ pub fn build_terminal_usage_context_seed(
         },
         body_states: request_capture.body_states,
         request_metadata: merge_usage_request_metadata_owned(
-            build_usage_request_metadata_seed(plan, context),
-            build_plan_body_capture_metadata(plan.body.body_bytes_b64.as_deref()),
+            build_usage_request_metadata_seed_with_options(plan, context, options),
+            options
+                .capture_request_payloads
+                .then(|| build_plan_body_capture_metadata(plan.body.body_bytes_b64.as_deref()))
+                .flatten(),
         ),
     }
 }
@@ -1246,7 +1294,8 @@ fn build_usage_event_data_seed_with_detail(
 ) -> UsageEventData {
     let context = report_context.and_then(Value::as_object);
     let routing = build_runtime_routing_seed(plan, context);
-    let request_capture = build_runtime_request_capture_seed(plan, context);
+    let request_capture =
+        build_runtime_request_capture_seed(plan, context, UsageSeedBuildOptions::full());
     let api_format = context_string(context, "client_api_format")
         .or_else(|| non_empty_str(Some(plan.client_api_format.as_str())));
     let endpoint_api_format = context_string(context, "provider_api_format")
@@ -1512,7 +1561,18 @@ fn plan_has_inline_json_body_for_usage(plan: &ExecutionPlan) -> bool {
 fn build_runtime_request_capture_seed(
     plan: &ExecutionPlan,
     context: Option<&Map<String, Value>>,
+    options: UsageSeedBuildOptions,
 ) -> RuntimeRequestCaptureSeed {
+    if !options.capture_request_payloads {
+        return RuntimeRequestCaptureSeed {
+            request_body: None,
+            request_body_ref: None,
+            provider_request: None,
+            provider_request_body_ref: None,
+            body_states: build_runtime_body_states_seed_from_parts(false, None, false, None, false),
+        };
+    }
+
     let request_body = context_body_value(context, "original_request_body");
     let request_body_ref = context_string(context, "request_body_ref");
     let provider_request = context_body_value(context, "provider_request_body")
@@ -1539,21 +1599,34 @@ fn build_runtime_request_capture_seed(
 fn build_runtime_request_metadata_seed(
     plan: &ExecutionPlan,
     context: Option<&Map<String, Value>>,
+    options: UsageSeedBuildOptions,
 ) -> Option<Value> {
-    let request_body_ref = context_string(context, "request_body_ref");
-    let provider_request_body_ref = context_string(context, "provider_request_body_ref")
-        .or_else(|| non_empty_str(plan.body.body_ref.as_deref()));
-    let request_has_inline_body = context_has_inline_body(context, "original_request_body");
-    let provider_request_has_inline_body =
-        context_has_inline_body(context, "provider_request_body")
-            || plan_has_inline_json_body_for_usage(plan);
+    let request_body_ref = options
+        .capture_request_payloads
+        .then(|| context_string(context, "request_body_ref"))
+        .flatten();
+    let provider_request_body_ref = options
+        .capture_request_payloads
+        .then(|| {
+            context_string(context, "provider_request_body_ref")
+                .or_else(|| non_empty_str(plan.body.body_ref.as_deref()))
+        })
+        .flatten();
+    let request_has_inline_body = options.capture_request_payloads
+        && context_has_inline_body(context, "original_request_body");
+    let provider_request_has_inline_body = options.capture_request_payloads
+        && (context_has_inline_body(context, "provider_request_body")
+            || plan_has_inline_json_body_for_usage(plan));
     let mut metadata = build_runtime_request_metadata_seed_from_parts(
         context,
         request_has_inline_body,
         request_body_ref.as_deref(),
         provider_request_has_inline_body,
         provider_request_body_ref.as_deref(),
-        plan.body.body_bytes_b64.as_deref(),
+        options
+            .capture_request_payloads
+            .then_some(plan.body.body_bytes_b64.as_deref())
+            .flatten(),
     );
     if let Some(proxy) = plan.proxy.as_ref() {
         if let Some(node_id) = proxy
@@ -1575,6 +1648,28 @@ fn build_runtime_request_metadata_seed(
         }
     }
     metadata
+}
+
+fn build_usage_request_metadata_seed_with_options(
+    plan: &ExecutionPlan,
+    context: Option<&Map<String, Value>>,
+    options: UsageSeedBuildOptions,
+) -> Option<Value> {
+    if options.capture_request_payloads {
+        return build_usage_request_metadata_seed(plan, context);
+    }
+
+    let mut metadata = build_usage_request_metadata_seed(plan, context)?;
+    if let Some(object) = metadata.as_object_mut() {
+        object.remove("request_body_ref");
+        object.remove("provider_request_body_ref");
+        object.remove("provider_request_body_base64_bytes");
+        object.remove("body_capture");
+        if object.is_empty() {
+            return None;
+        }
+    }
+    Some(metadata)
 }
 
 fn build_runtime_request_metadata_seed_from_parts(
@@ -2303,16 +2398,17 @@ fn empty_to_none(value: Option<String>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_pending_usage_record, build_pending_usage_record_from_seed,
-        build_stream_terminal_usage_event, build_streaming_usage_record,
-        build_sync_terminal_usage_event, build_sync_terminal_usage_payload_seed,
-        build_sync_terminal_usage_seed, build_terminal_usage_context_seed,
+        build_lifecycle_usage_seed_with_options, build_pending_usage_record,
+        build_pending_usage_record_from_seed, build_stream_terminal_usage_event,
+        build_streaming_usage_record, build_sync_terminal_usage_event,
+        build_sync_terminal_usage_payload_seed, build_sync_terminal_usage_seed,
+        build_terminal_usage_context_seed, build_terminal_usage_context_seed_with_options,
         build_terminal_usage_event_from_seed, build_usage_event_data_seed,
         extract_token_counts_from_json, extract_token_counts_from_value, headers_to_json,
         mask_header_value, mask_sensitive_headers_in_json_value, parse_sse_body_for_storage,
         resolve_error_message, trim_owned_non_empty_string, LifecycleUsageSeed, TerminalUsageSeed,
-        UsageBodyRefsSeed, UsageBodyStatesSeed, UsageRoutingSeed, UsageTerminalState,
-        MAX_USAGE_CAPTURE_BYTES, MAX_USAGE_CAPTURE_DEPTH,
+        UsageBodyRefsSeed, UsageBodyStatesSeed, UsageRoutingSeed, UsageSeedBuildOptions,
+        UsageTerminalState, MAX_USAGE_CAPTURE_BYTES, MAX_USAGE_CAPTURE_DEPTH,
     };
     use crate::{
         build_upsert_usage_record_from_event, GatewayStreamReportRequest, GatewaySyncReportRequest,
@@ -3564,6 +3660,107 @@ mod tests {
             .request_metadata
             .as_ref()
             .is_none_or(|value| { value.get("provider_request_body_ref").is_none() }));
+    }
+
+    #[test]
+    fn usage_seed_build_options_can_skip_request_payload_capture() {
+        let plan = ExecutionPlan {
+            request_id: "req-skip-request-payloads-1".to_string(),
+            candidate_id: Some("cand-skip-request-payloads-1".to_string()),
+            provider_name: Some("OpenAI".to_string()),
+            provider_id: "provider-1".to_string(),
+            endpoint_id: "endpoint-1".to_string(),
+            key_id: "key-1".to_string(),
+            method: "POST".to_string(),
+            url: "https://example.com/v1/responses".to_string(),
+            headers: BTreeMap::new(),
+            content_type: Some("application/json".to_string()),
+            content_encoding: None,
+            body: RequestBody {
+                json_body: Some(json!({
+                    "model": "gpt-5.4",
+                    "input": "provider secret"
+                })),
+                body_bytes_b64: Some(
+                    base64::engine::general_purpose::STANDARD.encode(b"provider secret"),
+                ),
+                body_ref: Some("blob://provider-request".to_string()),
+            },
+            stream: false,
+            client_api_format: "openai:responses".to_string(),
+            provider_api_format: "openai:responses".to_string(),
+            model_name: Some("gpt-5.4".to_string()),
+            proxy: None,
+            transport_profile: None,
+            timeouts: None,
+        };
+        let report_context = json!({
+            "trace_id": "trace-skip-request-payloads-1",
+            "client_api_format": "openai:responses",
+            "provider_api_format": "openai:responses",
+            "original_request_body": {"input": "client secret"},
+            "provider_request_body": {"input": "provider secret"},
+            "request_body_ref": "blob://client-request",
+            "provider_request_body_ref": "blob://provider-request-context",
+            "provider_request_body_base64_bytes": 15
+        });
+        let options = UsageSeedBuildOptions::without_request_payloads();
+
+        let lifecycle_seed =
+            build_lifecycle_usage_seed_with_options(&plan, Some(&report_context), options);
+
+        assert!(lifecycle_seed.request_body.is_none());
+        assert!(lifecycle_seed.provider_request.is_none());
+        assert!(lifecycle_seed.body_refs.request_body_ref.is_none());
+        assert!(lifecycle_seed.body_refs.provider_request_body_ref.is_none());
+        assert_eq!(
+            lifecycle_seed
+                .request_metadata
+                .as_ref()
+                .and_then(|value| value.get("trace_id"))
+                .and_then(Value::as_str),
+            Some("trace-skip-request-payloads-1")
+        );
+        assert!(lifecycle_seed
+            .request_metadata
+            .as_ref()
+            .is_none_or(|value| value.get("provider_request_body_base64_bytes").is_none()));
+
+        let payload = GatewaySyncReportRequest {
+            trace_id: "trace-skip-request-payloads-1".to_string(),
+            report_kind: "openai_responses_sync_success".to_string(),
+            report_context: Some(report_context),
+            status_code: 200,
+            headers: BTreeMap::new(),
+            body_json: Some(json!({"id": "resp_123"})),
+            client_body_json: None,
+            body_base64: None,
+            telemetry: None,
+        };
+        let context_seed = build_terminal_usage_context_seed_with_options(
+            &plan,
+            payload.report_context.as_ref(),
+            options,
+        );
+        assert!(context_seed.request_body.is_none());
+        assert!(context_seed.provider_request.is_none());
+        assert!(context_seed.body_refs.request_body_ref.is_none());
+        assert!(context_seed.body_refs.provider_request_body_ref.is_none());
+        assert!(context_seed
+            .request_metadata
+            .as_ref()
+            .is_none_or(|value| value.get("provider_request_body_base64_bytes").is_none()));
+
+        let event = build_terminal_usage_event_from_seed(build_sync_terminal_usage_seed(
+            context_seed,
+            build_sync_terminal_usage_payload_seed(&payload),
+        ))
+        .expect("usage event should build from bodyless seed");
+
+        assert!(event.data.request_body.is_none());
+        assert!(event.data.provider_request_body.is_none());
+        assert!(event.data.request_body_ref.is_none());
+        assert!(event.data.provider_request_body_ref.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- capture request payloads in pending usage records before execution completes
- avoid building request payload seeds when usage runtime is disabled or request_record_level is basic
- reuse the stream lifecycle usage seed instead of rebuilding it in the stream handler

## Verification
- cargo fmt -p aether-usage-runtime -p aether-gateway
- cargo test -p aether-usage-runtime
- cargo check -p aether-gateway