### PR TITLE
feat(compose): add solo sqlite compose deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ git pull
 ./deploy.sh
 ```
 
+### Docker Compose（单容器 SQLite / solo）
+
+```bash
+# 1. 克隆代码
+git clone https://github.com/fawney19/Aether.git
+cd Aether
+
+# 2. 配置环境变量
+cp .env.example .env
+./generate_keys.sh
+# 编辑 .env 设置 ADMIN_PASSWORD
+
+# 3. 启动单容器 SQLite 版本
+docker compose -f docker-compose.solo.yml up -d
+
+# 4. 升级前备份（可选）
+cp -a data/aether.db backup_$(date +%Y%m%d_%H%M%S).db
+```
+
 ### 一键安装（可选部署方式）
 
 安装脚本先从 `aether-rust-pioneer` 分支下载，不依赖 GitHub Release 的 `latest` 脚本地址。运行后会先选择语言，再选择版本和部署方式。Linux 单机 / 集群服务使用 systemd，macOS 单机 / 集群服务使用系统级 launchd；脚本会按当前系统自动下载 `linux-*` 或 `macos-*` Release 压缩包。
@@ -106,6 +125,7 @@ curl -fsSL https://raw.githubusercontent.com/fawney19/Aether/aether-rust-pioneer
   1) Docker Compose: 应用 + Postgres + Redis
   2) 单机服务: systemd/launchd + SQLite + 进程内运行时
   3) 集群节点服务: systemd/launchd + 共享数据库 + Redis
+  4) Docker Compose: 应用 + SQLite
 
 请输入选项 [2]:
 

--- a/docker-compose.solo.yml
+++ b/docker-compose.solo.yml
@@ -1,0 +1,28 @@
+services:
+  app:
+    image: ${APP_IMAGE:-ghcr.io/fawney19/aether:pre}
+    container_name: aether-app
+    env_file:
+      - .env
+    environment:
+      TZ: Asia/Shanghai
+      AETHER_LOG_DESTINATION: ${AETHER_LOG_DESTINATION:-both}
+      AETHER_LOG_FORMAT: ${AETHER_LOG_FORMAT:-pretty}
+      AETHER_LOG_DIR: ${AETHER_LOG_DIR:-/app/logs}
+      AETHER_LOG_ROTATION: ${AETHER_LOG_ROTATION:-daily}
+      AETHER_LOG_RETENTION_DAYS: ${AETHER_LOG_RETENTION_DAYS:-7}
+      AETHER_LOG_MAX_FILES: ${AETHER_LOG_MAX_FILES:-30}
+      APP_PORT: ${APP_PORT:-8084}
+      AETHER_GATEWAY_AUTO_PREPARE_DATABASE: ${AETHER_GATEWAY_AUTO_PREPARE_DATABASE:-true}
+    ports:
+      - "${APP_PORT:-8084}:${APP_PORT:-8084}"
+    volumes:
+      - ./data:/app/data
+      - ./logs:/app/logs
+    healthcheck:
+      test: ["CMD", "aether-gateway", "--healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped

--- a/install.sh
+++ b/install.sh
@@ -49,8 +49,9 @@ Usage: install.sh [options]
 Install Aether Gateway.
 
 Options:
-  --mode MODE          Deployment mode: compose, single, or cluster
+  --mode MODE          Deployment mode: compose, compose-solo, single, or cluster
                       compose: Docker Compose app + Postgres + Redis
+                      compose-solo: Docker Compose app + SQLite
                       single: system service with SQLite + in-process runtime
                       cluster: system service connected to shared database + Redis
                       Linux services use systemd; macOS services use launchd
@@ -424,6 +425,10 @@ select_mode() {
             MODE="compose"
             return
             ;;
+        compose-solo|solo|docker-solo|docker-solo-compose)
+            MODE="compose-solo"
+            return
+            ;;
         single|service|systemd|launchd|sqlite)
             MODE="single"
             return
@@ -435,7 +440,7 @@ select_mode() {
         auto|"")
             ;;
         *)
-            die "unsupported install mode: ${MODE}; expected compose, single, or cluster"
+            die "unsupported install mode: ${MODE}; expected compose, compose-solo, single, or cluster"
             ;;
     esac
 
@@ -449,6 +454,7 @@ select_mode() {
   1) Docker Compose: 应用 + Postgres + Redis
   2) 单机服务: ${service_manager} + SQLite + 进程内运行时
   3) 集群节点服务: ${service_manager} + 共享数据库 + Redis
+  4) Docker Compose: 应用 + SQLite
 
 请输入选项 [2]:
 EOF
@@ -459,6 +465,7 @@ Choose Aether deployment mode:
   1) Docker Compose: app + Postgres + Redis
   2) Single-node service: ${service_manager} + SQLite + in-process runtime
   3) Cluster node service: ${service_manager} + shared database + Redis
+  4) Docker Compose: app + SQLite
 
 Enter choice [2]:
 EOF
@@ -474,6 +481,9 @@ EOF
                 ;;
             3)
                 MODE="cluster"
+                ;;
+            4)
+                MODE="compose-solo"
                 ;;
             *)
                 if ui_is_zh; then
@@ -1024,6 +1034,46 @@ generate_compose_env() {
     replace_or_append_env "${output}" "AETHER_GATEWAY_AUTO_PREPARE_DATABASE" "true"
 }
 
+generate_compose_solo_env() {
+    local output="$1"
+    local jwt_key encryption_key
+    prompt_admin_password
+    jwt_key="$(urlsafe_rand 32)"
+    encryption_key="$(urlsafe_rand 32)"
+
+    cat > "${output}" <<EOF
+ENVIRONMENT=production
+TZ=Asia/Shanghai
+RUST_LOG=aether_gateway=info
+AETHER_LOG_DESTINATION=both
+AETHER_LOG_FORMAT=pretty
+AETHER_LOG_DIR=/app/logs
+AETHER_LOG_ROTATION=daily
+AETHER_LOG_RETENTION_DAYS=7
+AETHER_LOG_MAX_FILES=30
+
+APP_IMAGE=$(compose_image)
+APP_PORT=${APP_PORT:-8084}
+AETHER_GATEWAY_DEPLOYMENT_TOPOLOGY=single-node
+AETHER_GATEWAY_NODE_ROLE=all
+AETHER_GATEWAY_STATIC_DIR=/srv/frontend
+AETHER_GATEWAY_VIDEO_TASK_TRUTH_SOURCE_MODE=rust-authoritative
+AETHER_GATEWAY_AUTO_PREPARE_DATABASE=true
+AETHER_RUNTIME_BACKEND=memory
+API_KEY_PREFIX=sk
+
+AETHER_DATABASE_DRIVER=sqlite
+AETHER_DATABASE_URL=sqlite:///app/data/aether.db
+
+JWT_SECRET_KEY=${JWT_SECRET_KEY:-${jwt_key}}
+ENCRYPTION_KEY=${ENCRYPTION_KEY:-${encryption_key}}
+
+ADMIN_EMAIL=${ADMIN_EMAIL:-admin@example.local}
+ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
+ADMIN_PASSWORD=${ADMIN_PASSWORD}
+EOF
+}
+
 install_config_dir() {
     if is_darwin; then
         install -d -o root -g "${SERVICE_GROUP}" -m 0750 "${CONFIG_DIR}"
@@ -1409,6 +1459,43 @@ Docker Compose files are ready:
 Next steps:
   cd ${COMPOSE_DIR}
   docker compose pull
+  docker compose up -d
+  docker compose logs -f app
+
+Generate a fresh key set any time:
+  cd ${COMPOSE_DIR}
+  ./generate_keys.sh
+EOF
+}
+
+install_compose_solo_mode() {
+    info "preparing Docker Compose solo deployment in ${COMPOSE_DIR}"
+    install -d -m 0755 "${COMPOSE_DIR}" "${COMPOSE_DIR}/logs" "${COMPOSE_DIR}/data"
+
+    install_project_file "docker-compose.solo.yml" "${COMPOSE_DIR}/docker-compose.yml" "0644"
+    install_project_file ".env.example" "${COMPOSE_DIR}/.env.example" "0644"
+    write_generate_keys_script "${COMPOSE_DIR}/generate_keys.sh"
+
+    if [[ -f "${COMPOSE_DIR}/.env" ]]; then
+        warn "keeping existing ${COMPOSE_DIR}/.env"
+    else
+        info "generating ${COMPOSE_DIR}/.env"
+        generate_compose_solo_env "${COMPOSE_DIR}/.env"
+        chmod 0600 "${COMPOSE_DIR}/.env"
+    fi
+
+    cat <<EOF
+
+Docker Compose solo files are ready:
+  ${COMPOSE_DIR}/docker-compose.yml
+  ${COMPOSE_DIR}/.env
+  ${COMPOSE_DIR}/.env.example
+  ${COMPOSE_DIR}/generate_keys.sh
+  ${COMPOSE_DIR}/data
+  ${COMPOSE_DIR}/logs
+
+Next steps:
+  cd ${COMPOSE_DIR}
   docker compose up -d
   docker compose logs -f app
 
@@ -1834,6 +1921,8 @@ main() {
 
     if [[ "${MODE}" == "compose" ]]; then
         install_compose_mode
+    elif [[ "${MODE}" == "compose-solo" ]]; then
+        install_compose_solo_mode
     else
         require_root
         require_service_manager


### PR DESCRIPTION
## Summary

- Add a single-container Docker Compose solo deployment for SQLite-based installs.
- New `docker-compose.solo.yml` runs only the app container with `./data` and `./logs` volumes, no Postgres/Redis.
- `install.sh` now supports `--mode compose-solo` (and aliases), generates a solo env, and installs the solo compose template.
- README documents the solo Docker Compose path alongside the existing full compose and native install flows.

## Verification

- `bash -n install.sh`
- `ruby -e 'require "yaml"; YAML.load_file("docker-compose.solo.yml")'`
- `install.sh --mode compose-solo --version v0.0.0` against a temp compose dir
- `docker compose -f docker-compose.solo.yml` config validation with a temp `.env`

## Behavior Changes

- Existing full compose mode remains unchanged.
- New solo mode keeps the same `app` service/image conventions but uses SQLite and local data/log volumes only.