### PR TITLE
修复负载均衡模式下提供商优先级越级

### DIFF
--- a/crates/aether-scheduler-core/src/ranking/mod.rs
+++ b/crates/aether-scheduler-core/src/ranking/mod.rs
@@ -399,7 +399,7 @@ mod tests {
     }
 
     #[test]
-    fn load_balance_provider_mode_randomizes_providers_then_uses_internal_key_priority() {
+    fn load_balance_provider_mode_keeps_provider_priority_slots_and_uses_internal_key_priority() {
         let mut provider_a_primary = candidate("a-primary", 0, 0, Some(0));
         provider_a_primary.provider_id = "provider-a".to_string();
         provider_a_primary.key_id = "key-a-primary".to_string();
@@ -411,33 +411,17 @@ mod tests {
         provider_b.key_id = "key-b".to_string();
         let candidates = vec![provider_a_secondary, provider_b, provider_a_primary];
 
-        let seed = (0..512)
-            .find(|seed| {
-                ranked_keys(
-                    &candidates,
-                    SchedulerRankingContext {
-                        priority_mode: SchedulerPriorityMode::Provider,
-                        ranking_mode: SchedulerRankingMode::LoadBalance,
-                        include_health: false,
-                        load_balance_seed: *seed,
-                    },
-                )
-                .first()
-                .is_some_and(|key| key == "key-b")
-            })
-            .expect("test seed should put provider-b first");
-
         let order = ranked_keys(
             &candidates,
             SchedulerRankingContext {
                 priority_mode: SchedulerPriorityMode::Provider,
                 ranking_mode: SchedulerRankingMode::LoadBalance,
                 include_health: false,
-                load_balance_seed: seed,
+                load_balance_seed: 0,
             },
         );
 
-        assert_eq!(order[0], "key-b");
+        assert_eq!(order[2], "key-b");
         let primary_index = order
             .iter()
             .position(|key| key == "key-a-primary")
@@ -450,26 +434,10 @@ mod tests {
     }
 
     #[test]
-    fn load_balance_global_key_mode_randomizes_keys_ignoring_global_priority() {
+    fn load_balance_global_key_mode_keeps_global_priority_slots() {
         let high_priority = candidate("high", 100, 0, Some(0));
         let low_priority = candidate("low", 0, 0, Some(100));
         let candidates = vec![high_priority, low_priority];
-
-        let seed = (0..512)
-            .find(|seed| {
-                ranked_ids(
-                    &candidates,
-                    SchedulerRankingContext {
-                        priority_mode: SchedulerPriorityMode::GlobalKey,
-                        ranking_mode: SchedulerRankingMode::LoadBalance,
-                        include_health: false,
-                        load_balance_seed: *seed,
-                    },
-                )
-                .first()
-                .is_some_and(|provider| provider == "provider-low")
-            })
-            .expect("test seed should put lower global-priority key first");
 
         assert_eq!(
             ranked_ids(
@@ -478,10 +446,10 @@ mod tests {
                     priority_mode: SchedulerPriorityMode::GlobalKey,
                     ranking_mode: SchedulerRankingMode::LoadBalance,
                     include_health: false,
-                    load_balance_seed: seed,
+                    load_balance_seed: 0,
                 },
             ),
-            vec!["provider-low", "provider-high"]
+            vec!["provider-high", "provider-low"]
         );
     }
 }

--- a/crates/aether-scheduler-core/src/ranking/modes.rs
+++ b/crates/aether-scheduler-core/src/ranking/modes.rs
@@ -6,7 +6,7 @@ use super::compare_candidate_identity_for_ranking;
 use super::format::{
     compare_cross_format_demotion, compare_demoted_format_preference, compare_format_preference,
 };
-use super::priority::compare_candidate_priority_slot;
+use super::priority::{candidate_priority_slot, compare_candidate_priority_slot};
 use super::types::{SchedulerRankableCandidate, SchedulerRankingContext, SchedulerRankingMode};
 
 pub(super) fn compare_rankable_candidates(
@@ -65,10 +65,20 @@ fn compare_load_balance_base(
         .cmp(&right.capability_priority)
         .then_with(|| compare_cross_format_demotion(left, right))
         .then_with(|| compare_demoted_format_preference(left, right))
+        .then_with(|| compare_load_balance_priority_slot(left, right, context))
         .then_with(|| compare_format_preference(left, right))
         .then_with(|| compare_load_balance_distribution(left, right, context))
         .then_with(|| compare_candidate_identity_for_ranking(left, right))
         .then(left.original_index.cmp(&right.original_index))
+}
+
+fn compare_load_balance_priority_slot(
+    left: &SchedulerRankableCandidate,
+    right: &SchedulerRankableCandidate,
+    context: SchedulerRankingContext,
+) -> Ordering {
+    candidate_priority_slot(left, context.priority_mode)
+        .cmp(&candidate_priority_slot(right, context.priority_mode))
 }
 
 fn compare_load_balance_distribution(


### PR DESCRIPTION
## 摘要
- 修复负载均衡模式在提供商优先级下跨优先级随机 provider 的问题
- 调度现在会先按 provider/global key 优先级槽位排序，再只在同槽位内做负载均衡
- 更新调度测试，覆盖 provider 与 global key 两种优先级模式

## 验证
- cargo fmt --check
- cargo test -p aether-scheduler-core load_balance_
- cargo test -p aether-scheduler-core