### PR TITLE
refactor: prepare frontend i18n architecture

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onErrorCaptured, onUnmounted } from 'vue'
+import { onMounted, onErrorCaptured, onUnmounted, watch } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import ToastContainer from '@/components/ToastContainer.vue'
 import ConfirmContainer from '@/components/ConfirmContainer.vue'
@@ -14,6 +14,7 @@ import { NETWORK_CONFIG, AUTH_CONFIG } from '@/config/constants'
 import router from '@/router'
 import { hasAuthIdentityChanged } from '@/utils/authToken'
 import { log } from '@/utils/logger'
+import { applyPreferredLocale, t } from '@/i18n'
 
 const authStore = useAuthStore()
 
@@ -22,6 +23,14 @@ const storedToken = apiClient.getToken()
 if (storedToken) {
   authStore.token = storedToken
 }
+
+watch(
+  () => authStore.user?.preferences?.language,
+  (language) => {
+    applyPreferredLocale(language)
+  },
+  { immediate: true },
+)
 
 // 全局错误处理器 - 只处理特定错误,避免完全吞掉所有错误
 onErrorCaptured((error: Error) => {
@@ -48,7 +57,7 @@ if (typeof window !== 'undefined') {
         window.location.reload()
       } else {
         // 超过最大重试次数,显示友好提示
-        alert('页面加载失败,请手动刷新浏览器。如问题持续,请清除浏览器缓存后重试。')
+        alert(t('errors.moduleLoadFailed', '页面加载失败,请手动刷新浏览器。如问题持续,请清除浏览器缓存后重试。'))
       }
       return
     }

--- a/frontend/src/components/PlatformSelect.vue
+++ b/frontend/src/components/PlatformSelect.vue
@@ -16,10 +16,10 @@
       />
       <div class="platform-select__text">
         <p class="platform-select__label">
-          {{ currentOption.label }}
+          {{ resolveText(currentOption.label) }}
         </p>
         <p class="platform-select__hint">
-          {{ currentOption.hint }}
+          {{ resolveText(currentOption.hint) }}
         </p>
       </div>
     </div>
@@ -43,10 +43,10 @@
           />
           <div class="platform-select__option-copy">
             <p class="platform-select__option-label">
-              {{ option.label }}
+              {{ resolveText(option.label) }}
             </p>
             <p class="platform-select__option-hint">
-              {{ option.hint }}
+              {{ resolveText(option.hint) }}
             </p>
           </div>
           <Check
@@ -62,11 +62,12 @@
 <script lang="ts">
 import { Apple, Box, Monitor, Terminal } from 'lucide-vue-next'
 import type { Component } from 'vue'
+import { resolveText, type TextValue } from '@/i18n'
 
 export interface PlatformOption {
   value: string
-  label: string
-  hint: string
+  label: TextValue
+  hint: TextValue
   icon: Component
   command: string
 }

--- a/frontend/src/components/common/AlertDialog.vue
+++ b/frontend/src/components/common/AlertDialog.vue
@@ -14,7 +14,7 @@
           />
           <div class="flex-1 min-w-0">
             <h3 class="text-lg font-semibold text-foreground leading-tight">
-              {{ title }}
+              {{ resolvedTitle }}
             </h3>
           </div>
         </div>
@@ -44,7 +44,7 @@
         class="h-10 px-5"
         @click="handleCancel"
       >
-        {{ cancelText }}
+        {{ resolvedCancelText }}
       </Button>
 
       <!-- 确认按钮 -->
@@ -58,7 +58,7 @@
           v-if="loading"
           class="animate-spin h-4 w-4 mr-2"
         />
-        {{ confirmText }}
+        {{ resolvedConfirmText }}
       </Button>
     </template>
   </Dialog>
@@ -69,16 +69,17 @@ import { computed } from 'vue'
 import { Dialog } from '@/components/ui'
 import Button from '@/components/ui/button.vue'
 import { AlertTriangle, AlertCircle, Info, Trash2, HelpCircle, Loader2 } from 'lucide-vue-next'
+import { i18nText, resolveText, type TextValue } from '@/i18n'
 
 export type AlertType = 'danger' | 'destructive' | 'warning' | 'info' | 'question'
 
 interface Props {
   modelValue: boolean
-  title: string
-  description: string
+  title: TextValue
+  description: TextValue
   type?: AlertType
-  confirmText?: string
-  cancelText?: string
+  confirmText?: TextValue
+  cancelText?: TextValue
   loading?: boolean
 }
 
@@ -90,16 +91,24 @@ interface Emits {
 
 const props = withDefaults(defineProps<Props>(), {
   type: 'warning',
-  confirmText: '确认',
-  cancelText: '取消',
   loading: false
 })
 
 const emit = defineEmits<Emits>()
 
+const alertText = {
+  cancel: i18nText('common.actions.cancel', '取消'),
+  confirm: i18nText('common.actions.confirm', '确认'),
+}
+
 // 解析描述文本为多行
+const resolvedTitle = computed(() => resolveText(props.title))
+const resolvedDescription = computed(() => resolveText(props.description))
+const resolvedConfirmText = computed(() => resolveText(props.confirmText ?? alertText.confirm))
+const resolvedCancelText = computed(() => resolveText(props.cancelText ?? alertText.cancel))
+
 const descriptionLines = computed(() => {
-  return props.description.split('\n').filter(line => line.trim())
+  return resolvedDescription.value.split('\n').filter(line => line.trim())
 })
 
 function escapeHtml(raw: string): string {

--- a/frontend/src/components/common/EmptyState.vue
+++ b/frontend/src/components/common/EmptyState.vue
@@ -16,18 +16,18 @@
 
     <!-- 标题 -->
     <h3
-      v-if="title"
+      v-if="resolvedTitle"
       :class="titleClasses"
     >
-      {{ title }}
+      {{ resolvedTitle }}
     </h3>
 
     <!-- 描述 -->
     <p
-      v-if="description"
+      v-if="resolvedDescription"
       :class="descriptionClasses"
     >
-      {{ description }}
+      {{ resolvedDescription }}
     </p>
 
     <!-- 自定义内容插槽 -->
@@ -40,12 +40,12 @@
 
     <!-- 操作按钮 -->
     <div
-      v-if="$slots.actions || actionText"
+      v-if="$slots.actions || resolvedActionText"
       class="mt-6 flex flex-wrap items-center justify-center gap-3"
     >
       <slot name="actions">
         <Button
-          v-if="actionText"
+          v-if="resolvedActionText"
           :variant="actionVariant"
           :size="actionSize"
           @click="handleAction"
@@ -55,7 +55,7 @@
             v-if="actionIcon"
             class="mr-2 h-4 w-4"
           />
-          {{ actionText }}
+          {{ resolvedActionText }}
         </Button>
       </slot>
     </div>
@@ -82,6 +82,7 @@ import {
   Filter
 } from 'lucide-vue-next'
 import type { Component } from 'vue'
+import { i18nText, resolveText, type TextValue } from '@/i18n'
 
 type EmptyStateType = 'default' | 'search' | 'filter' | 'error' | 'empty' | 'notFound'
 type ButtonVariant = 'default' | 'outline' | 'secondary' | 'ghost' | 'link' | 'destructive'
@@ -93,11 +94,11 @@ interface Props {
   /** 自定义图标组件 */
   icon?: Component
   /** 标题 */
-  title?: string
+  title?: TextValue
   /** 描述文本 */
-  description?: string
+  description?: TextValue
   /** 操作按钮文本 */
-  actionText?: string
+  actionText?: TextValue
   /** 操作按钮图标 */
   actionIcon?: Component
   /** 操作按钮变体 */
@@ -134,38 +135,42 @@ const typeConfig = computed(() => {
   const configs = {
     default: {
       icon: Inbox,
-      title: '暂无数据',
-      description: '当前没有可显示的内容'
+      title: i18nText('common.empty.default.title', '暂无数据'),
+      description: i18nText('common.empty.default.description', '当前没有可显示的内容')
     },
     search: {
       icon: Search,
-      title: '未找到结果',
-      description: '尝试使用不同的关键词搜索'
+      title: i18nText('common.empty.search.title', '未找到结果'),
+      description: i18nText('common.empty.search.description', '尝试使用不同的关键词搜索')
     },
     filter: {
       icon: Filter,
-      title: '无匹配结果',
-      description: '没有符合当前筛选条件的数据'
+      title: i18nText('common.empty.filter.title', '无匹配结果'),
+      description: i18nText('common.empty.filter.description', '没有符合当前筛选条件的数据')
     },
     error: {
       icon: AlertCircle,
-      title: '加载失败',
-      description: '数据加载过程中出现错误'
+      title: i18nText('common.empty.error.title', '加载失败'),
+      description: i18nText('common.empty.error.description', '数据加载过程中出现错误')
     },
     empty: {
       icon: PackageOpen,
-      title: '这里空空如也',
-      description: '还没有任何内容'
+      title: i18nText('common.empty.empty.title', '这里空空如也'),
+      description: i18nText('common.empty.empty.description', '还没有任何内容')
     },
     notFound: {
       icon: FileQuestion,
-      title: '未找到',
-      description: '请求的资源不存在'
+      title: i18nText('common.empty.notFound.title', '未找到'),
+      description: i18nText('common.empty.notFound.description', '请求的资源不存在')
     }
   }
 
   return configs[props.type]
 })
+
+const resolvedTitle = computed(() => resolveText(props.title ?? typeConfig.value.title))
+const resolvedDescription = computed(() => resolveText(props.description ?? typeConfig.value.description))
+const resolvedActionText = computed(() => resolveText(props.actionText))
 
 // 默认图标
 const defaultIcon = computed(() => typeConfig.value.icon)

--- a/frontend/src/components/common/LoadingState.vue
+++ b/frontend/src/components/common/LoadingState.vue
@@ -26,10 +26,10 @@
       </div>
 
       <div
-        v-if="message"
+        v-if="resolvedMessage"
         class="text-sm text-muted-foreground"
       >
-        {{ message }}
+        {{ resolvedMessage }}
       </div>
     </div>
   </div>
@@ -38,10 +38,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import Skeleton from '@/components/ui/skeleton.vue'
+import { resolveText, type TextValue } from '@/i18n'
 
 interface Props {
   variant?: 'skeleton' | 'spinner' | 'pulse'
-  message?: string
+  message?: TextValue
   size?: 'sm' | 'md' | 'lg'
   fullHeight?: boolean
 }
@@ -52,6 +53,8 @@ const props = withDefaults(defineProps<Props>(), {
   size: 'md',
   fullHeight: false,
 })
+
+const resolvedMessage = computed(() => resolveText(props.message))
 
 const containerClasses = computed(() => {
   const classes = ['flex items-center justify-center']

--- a/frontend/src/components/common/UpdateDialog.vue
+++ b/frontend/src/components/common/UpdateDialog.vue
@@ -13,13 +13,13 @@
 
       <!-- Title -->
       <h2 class="text-xl font-semibold text-foreground mt-4 mb-2">
-        发现新版本
+        {{ resolveText(updateText.foundNewVersion) }}
       </h2>
 
       <!-- Version Info -->
       <div class="mx-auto mb-2 w-full max-w-sm rounded-lg bg-muted/20 px-4 py-3 text-center">
         <p class="text-xs text-muted-foreground">
-          最新版本
+          {{ resolveText(updateText.latestVersion) }}
         </p>
         <p class="mt-1 break-all font-mono text-base font-semibold text-primary">
           {{ formatDisplayVersion(latestVersion) }}
@@ -35,10 +35,10 @@
           v-if="publishedAt"
           class="text-left text-xs text-muted-foreground mb-2"
         >
-          发布于 {{ formattedPublishedAt }}
+          {{ publishedAtLabel }}
         </div>
         <div class="text-left text-xs font-medium text-muted-foreground mb-2">
-          更新内容
+          {{ resolveText(updateText.releaseNotes) }}
         </div>
         <!-- eslint-disable vue/no-v-html -->
         <div
@@ -53,7 +53,7 @@
         v-else
         class="text-sm text-muted-foreground max-w-xs mt-2 mb-4"
       >
-        新版本已发布，建议更新以获得最新功能和安全修复
+        {{ resolveText(updateText.defaultDescription) }}
       </p>
     </div>
 
@@ -64,13 +64,13 @@
           class="flex-1"
           @click="handleLater"
         >
-          稍后提醒
+          {{ resolveText(updateText.later) }}
         </Button>
         <Button
           class="flex-1"
           @click="handleViewRelease"
         >
-          查看更新
+          {{ resolveText(updateText.viewRelease) }}
         </Button>
       </div>
     </template>
@@ -85,6 +85,17 @@ import HeaderLogo from '@/components/HeaderLogo.vue'
 import { formatDisplayVersion } from '@/utils/version'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
+import { getCurrentLocale, i18nText, resolveText } from '@/i18n'
+
+const updateText = {
+  defaultDescription: i18nText('common.update.defaultDescription', '新版本已发布，建议更新以获得最新功能和安全修复'),
+  foundNewVersion: i18nText('common.update.foundNewVersion', '发现新版本'),
+  later: i18nText('common.actions.later', '稍后提醒'),
+  latestVersion: i18nText('common.update.latestVersion', '最新版本'),
+  publishedAt: i18nText('common.update.publishedAt', '发布于 {date}'),
+  releaseNotes: i18nText('common.update.releaseNotes', '更新内容'),
+  viewRelease: i18nText('common.actions.viewRelease', '查看更新'),
+}
 
 const props = defineProps<{
   modelValue: boolean
@@ -114,15 +125,19 @@ const formattedPublishedAt = computed(() => {
   if (!props.publishedAt) return ''
   try {
     const date = new Date(props.publishedAt)
-    return date.toLocaleDateString('zh-CN', {
+    return new Intl.DateTimeFormat(getCurrentLocale(), {
       year: 'numeric',
       month: 'long',
       day: 'numeric'
-    })
+    }).format(date)
   } catch {
     return props.publishedAt
   }
 })
+
+const publishedAtLabel = computed(() => resolveText(updateText.publishedAt, {
+  date: formattedPublishedAt.value,
+}))
 
 // 渲染 Markdown 格式的 Release Notes（使用 DOMPurify 防止 XSS）
 const renderedReleaseNotes = computed(() => {

--- a/frontend/src/components/layout/CardSection.vue
+++ b/frontend/src/components/layout/CardSection.vue
@@ -1,23 +1,23 @@
 <template>
   <Card :class="cardClasses">
     <div
-      v-if="title || description || $slots.header"
+      v-if="resolvedTitle || resolvedDescription || $slots.header"
       :class="headerClasses"
     >
       <slot name="header">
         <div class="flex items-center justify-between">
           <div>
             <h3
-              v-if="title"
+              v-if="resolvedTitle"
               class="text-lg font-medium leading-6 text-foreground"
             >
-              {{ title }}
+              {{ resolvedTitle }}
             </h3>
             <p
-              v-if="description"
+              v-if="resolvedDescription"
               class="mt-1 text-sm text-muted-foreground"
             >
-              {{ description }}
+              {{ resolvedDescription }}
             </p>
           </div>
           <div v-if="$slots.actions">
@@ -43,10 +43,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import Card from '@/components/ui/card.vue'
+import { resolveText, type TextValue } from '@/i18n'
 
 interface Props {
-  title?: string
-  description?: string
+  title?: TextValue
+  description?: TextValue
   variant?: 'default' | 'elevated' | 'glass'
   padding?: 'none' | 'sm' | 'md' | 'lg'
 }
@@ -57,6 +58,9 @@ const props = withDefaults(defineProps<Props>(), {
   variant: 'default',
   padding: 'md',
 })
+
+const resolvedTitle = computed(() => resolveText(props.title))
+const resolvedDescription = computed(() => resolveText(props.description))
 
 const cardClasses = computed(() => {
   const classes = []

--- a/frontend/src/components/layout/PageHeader.vue
+++ b/frontend/src/components/layout/PageHeader.vue
@@ -16,13 +16,13 @@
 
         <div>
           <h1 class="text-2xl font-semibold text-foreground sm:text-3xl">
-            {{ title }}
+            {{ resolvedTitle }}
           </h1>
           <p
-            v-if="description"
+            v-if="resolvedDescription"
             class="mt-1 text-sm text-muted-foreground"
           >
-            {{ description }}
+            {{ resolvedDescription }}
           </p>
         </div>
       </div>
@@ -38,13 +38,17 @@
 </template>
 
 <script setup lang="ts">
-import type { Component } from 'vue'
+import { computed, type Component } from 'vue'
+import { resolveText, type TextValue } from '@/i18n'
 
 interface Props {
-  title: string
-  description?: string
+  title: TextValue
+  description?: TextValue
   icon?: Component
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
+
+const resolvedTitle = computed(() => resolveText(props.title))
+const resolvedDescription = computed(() => resolveText(props.description))
 </script>

--- a/frontend/src/components/layout/Section.vue
+++ b/frontend/src/components/layout/Section.vue
@@ -1,23 +1,23 @@
 <template>
   <section :class="sectionClasses">
     <div
-      v-if="title || description || $slots.header"
+      v-if="resolvedTitle || resolvedDescription || $slots.header"
       class="mb-6"
     >
       <slot name="header">
         <div class="flex items-center justify-between">
           <div>
             <h2
-              v-if="title"
+              v-if="resolvedTitle"
               class="text-lg font-medium text-foreground"
             >
-              {{ title }}
+              {{ resolvedTitle }}
             </h2>
             <p
-              v-if="description"
+              v-if="resolvedDescription"
               class="mt-1 text-sm text-muted-foreground"
             >
-              {{ description }}
+              {{ resolvedDescription }}
             </p>
           </div>
           <div v-if="$slots.actions">
@@ -33,10 +33,11 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { resolveText, type TextValue } from '@/i18n'
 
 interface Props {
-  title?: string
-  description?: string
+  title?: TextValue
+  description?: TextValue
   spacing?: 'none' | 'sm' | 'md' | 'lg'
 }
 
@@ -45,6 +46,9 @@ const props = withDefaults(defineProps<Props>(), {
   description: undefined,
   spacing: 'md',
 })
+
+const resolvedTitle = computed(() => resolveText(props.title))
+const resolvedDescription = computed(() => resolveText(props.description))
 
 const sectionClasses = computed(() => {
   const classes = []

--- a/frontend/src/components/layout/SidebarNav.vue
+++ b/frontend/src/components/layout/SidebarNav.vue
@@ -7,12 +7,12 @@
     >
       <!-- Section Header -->
       <div
-        v-if="group.title"
+        v-if="resolveText(group.title)"
         class="px-2.5 pb-1 flex items-center gap-2"
         :class="index > 0 ? 'pt-1' : ''"
       >
         <span class="text-[10px] font-medium text-muted-foreground/50 font-mono tabular-nums">{{ String(index + 1).padStart(2, '0') }}</span>
-        <span class="text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-[0.1em]">{{ group.title }}</span>
+        <span class="text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-[0.1em]">{{ resolveText(group.title) }}</span>
       </div>
 
       <!-- Links -->
@@ -41,7 +41,7 @@
                 :class="isItemActive(item.href) ? 'text-primary' : 'text-muted-foreground/70 group-hover:text-foreground'"
                 :stroke-width="isItemActive(item.href) ? 2 : 1.75"
               />
-              <span class="text-[13px] tracking-tight">{{ item.name }}</span>
+              <span class="text-[13px] tracking-tight">{{ resolveText(item.name) }}</span>
             </div>
 
             <!-- Active Indicator -->
@@ -58,16 +58,17 @@
 
 <script setup lang="ts">
 import type { Component } from 'vue'
+import { resolveText, type TextValue } from '@/i18n'
 
 export interface NavigationItem {
-  name: string
+  name: TextValue
   href: string
   icon: Component
-  description?: string
+  description?: TextValue
 }
 
 export interface NavigationGroup {
-  title?: string
+  title?: TextValue
   items: NavigationItem[]
 }
 

--- a/frontend/src/config/builtin-tools.ts
+++ b/frontend/src/config/builtin-tools.ts
@@ -1,35 +1,36 @@
 import { Mail, Shield, AlertTriangle } from 'lucide-vue-next'
 import type { LucideIcon } from 'lucide-vue-next'
+import { i18nText, type TextValue } from '@/i18n'
 
 export interface BuiltinTool {
-  name: string
-  description: string
+  name: TextValue
+  description: TextValue
   href: string
   icon: LucideIcon
 }
 
 export const BUILTIN_TOOLS: BuiltinTool[] = [
   {
-    name: '邮件配置',
-    description: '配置 SMTP 邮件服务，管理邮件模板和发送设置',
+    name: i18nText('builtinTools.email.name', '邮件配置'),
+    description: i18nText('builtinTools.email.description', '配置 SMTP 邮件服务，管理邮件模板和发送设置'),
     href: '/admin/email',
     icon: Mail,
   },
   {
-    name: 'IP 安全',
-    description: '管理 IP 黑白名单，控制系统访问权限',
+    name: i18nText('builtinTools.ipSecurity.name', 'IP 安全'),
+    description: i18nText('builtinTools.ipSecurity.description', '管理 IP 黑白名单，控制系统访问权限'),
     href: '/admin/ip-security',
     icon: Shield,
   },
   {
-    name: '审计日志',
-    description: '查看系统操作日志，追踪安全事件与变更记录',
+    name: i18nText('builtinTools.auditLogs.name', '审计日志'),
+    description: i18nText('builtinTools.auditLogs.description', '查看系统操作日志，追踪安全事件与变更记录'),
     href: '/admin/audit-logs',
     icon: AlertTriangle,
   },
 ]
 
 /** href → display name mapping for breadcrumbs */
-export const BUILTIN_TOOL_BREADCRUMBS: Record<string, string> = Object.fromEntries(
+export const BUILTIN_TOOL_BREADCRUMBS: Record<string, TextValue> = Object.fromEntries(
   BUILTIN_TOOLS.map(t => [t.href, t.name])
 )

--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -1,0 +1,129 @@
+import {
+  Activity,
+  BarChart3,
+  Box,
+  Cog,
+  Database,
+  FileUp,
+  FolderTree,
+  Gauge,
+  Home,
+  Key,
+  KeyRound,
+  Layers,
+  Megaphone,
+  Puzzle,
+  Server,
+  Shield,
+  SlidersHorizontal,
+  Users,
+  Wallet,
+  Zap,
+  type LucideIcon,
+} from 'lucide-vue-next'
+import { i18nText, type TextValue } from '@/i18n'
+
+export interface NavigationItemDescriptor {
+  name: TextValue
+  href: string
+  icon: LucideIcon
+  description?: TextValue
+}
+
+export interface NavigationGroupDescriptor {
+  title?: TextValue
+  items: NavigationItemDescriptor[]
+}
+
+export const userNavigationGroups: NavigationGroupDescriptor[] = [
+  {
+    title: i18nText('layout.nav.groups.overview', '概览'),
+    items: [
+      { name: i18nText('layout.nav.items.dashboard', '仪表盘'), href: '/dashboard', icon: Home },
+      { name: i18nText('layout.nav.items.healthMonitor', '健康监控'), href: '/dashboard/endpoint-status', icon: Activity },
+    ],
+  },
+  {
+    title: i18nText('layout.nav.groups.resources', '资源'),
+    items: [
+      { name: i18nText('layout.nav.items.modelCatalog', '模型目录'), href: '/dashboard/models', icon: Box },
+      { name: i18nText('layout.nav.items.apiKeys', 'API 密钥'), href: '/dashboard/api-keys', icon: Key },
+    ],
+  },
+  {
+    title: i18nText('layout.nav.groups.account', '账户'),
+    items: [
+      { name: i18nText('layout.nav.items.walletCenter', '钱包中心'), href: '/dashboard/wallet', icon: Wallet },
+      { name: i18nText('layout.nav.items.usageRecords', '使用记录'), href: '/dashboard/usage', icon: Activity },
+      { name: i18nText('layout.nav.items.asyncTasks', '异步任务'), href: '/dashboard/async-tasks', icon: Zap },
+    ],
+  },
+]
+
+const adminSystemPrefixItems: NavigationItemDescriptor[] = [
+  { name: i18nText('layout.nav.items.announcementManagement', '公告管理'), href: '/admin/announcements', icon: Megaphone },
+  { name: i18nText('layout.nav.items.cacheMonitoring', '缓存监控'), href: '/admin/cache-monitoring', icon: Gauge },
+]
+
+const adminSystemSuffixItems: NavigationItemDescriptor[] = [
+  { name: i18nText('layout.nav.items.moduleManagement', '模块管理'), href: '/admin/modules', icon: Puzzle },
+  { name: i18nText('layout.nav.items.systemSettings', '系统设置'), href: '/admin/system', icon: Cog },
+]
+
+export const moduleNavigationIconMap: Record<string, LucideIcon> = {
+  FileUp,
+  Key,
+  KeyRound,
+  Puzzle,
+  Server,
+  Shield,
+  SlidersHorizontal,
+}
+
+export function createModuleNavigationItem(input: {
+  displayName: string
+  href: string
+  iconName?: string | null
+}): NavigationItemDescriptor {
+  return {
+    name: input.displayName,
+    href: input.href,
+    icon: moduleNavigationIconMap[input.iconName || ''] || Puzzle,
+  }
+}
+
+export function createAdminNavigationGroups(moduleItems: NavigationItemDescriptor[]): NavigationGroupDescriptor[] {
+  return [
+    {
+      title: i18nText('layout.nav.groups.overview', '概览'),
+      items: [
+        { name: i18nText('layout.nav.items.dashboard', '仪表盘'), href: '/admin/dashboard', icon: Home },
+        { name: i18nText('layout.nav.items.healthMonitor', '健康监控'), href: '/admin/health-monitor', icon: Activity },
+        { name: i18nText('layout.nav.items.userStats', '用户统计'), href: '/admin/user-stats', icon: BarChart3 },
+        { name: i18nText('layout.nav.items.costAnalysis', '成本分析'), href: '/admin/cost-analysis', icon: Gauge },
+        { name: i18nText('layout.nav.items.performanceAnalysis', '性能分析'), href: '/admin/performance-analysis', icon: Activity },
+      ],
+    },
+    {
+      title: i18nText('layout.nav.groups.management', '管理'),
+      items: [
+        { name: i18nText('layout.nav.items.users', '用户管理'), href: '/admin/users', icon: Users },
+        { name: i18nText('layout.nav.items.providers', '提供商'), href: '/admin/providers', icon: FolderTree },
+        { name: i18nText('layout.nav.items.modelManagement', '模型管理'), href: '/admin/models', icon: Layers },
+        { name: i18nText('layout.nav.items.poolManagement', '号池管理'), href: '/admin/pool', icon: Database },
+        { name: i18nText('layout.nav.items.standaloneKeys', '独立密钥'), href: '/admin/keys', icon: Key },
+        { name: i18nText('layout.nav.items.walletsManagement', '钱包管理'), href: '/admin/wallets', icon: Wallet },
+        { name: i18nText('layout.nav.items.asyncTasks', '异步任务'), href: '/admin/async-tasks', icon: Zap },
+        { name: i18nText('layout.nav.items.usageRecords', '使用记录'), href: '/admin/usage', icon: BarChart3 },
+      ],
+    },
+    {
+      title: i18nText('layout.nav.groups.system', '系统'),
+      items: [
+        ...adminSystemPrefixItems,
+        ...moduleItems,
+        ...adminSystemSuffixItems,
+      ],
+    },
+  ]
+}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,134 @@
+import { readonly, ref } from 'vue'
+import { messages, type AppLocale } from './messages'
+
+const STORAGE_KEY = 'aether_locale'
+const DEFAULT_LOCALE: AppLocale = 'zh-CN'
+
+export const supportedLocales = Object.keys(messages) as AppLocale[]
+
+export type TextParams = Record<string, string | number | boolean | null | undefined>
+
+export interface LocalizedText {
+  key: string
+  defaultValue: string
+  params?: TextParams
+}
+
+export type TextValue = string | LocalizedText | null | undefined
+
+const currentLocale = ref<AppLocale>(resolveInitialLocale())
+
+export function i18nText(key: string, defaultValue: string, params?: TextParams): LocalizedText {
+  return { key, defaultValue, params }
+}
+
+export function normalizeLocale(value: string | null | undefined): AppLocale {
+  if (!value) {
+    return DEFAULT_LOCALE
+  }
+
+  const normalized = value.trim().replace('_', '-').toLowerCase()
+  if (normalized === 'zh' || normalized.startsWith('zh-')) {
+    return 'zh-CN'
+  }
+  if (normalized === 'en' || normalized.startsWith('en-')) {
+    return 'en'
+  }
+
+  return DEFAULT_LOCALE
+}
+
+export function initAppLocale(): void {
+  applyDocumentLocale(currentLocale.value)
+}
+
+export function getCurrentLocale(): AppLocale {
+  return currentLocale.value
+}
+
+export function setAppLocale(locale: string | null | undefined, options: { persist?: boolean } = {}): AppLocale {
+  const nextLocale = normalizeLocale(locale)
+  currentLocale.value = nextLocale
+  applyDocumentLocale(nextLocale)
+
+  if (options.persist !== false && typeof window !== 'undefined') {
+    window.localStorage.setItem(STORAGE_KEY, nextLocale)
+  }
+
+  return nextLocale
+}
+
+export function applyPreferredLocale(locale: string | null | undefined): void {
+  if (!locale) {
+    return
+  }
+  setAppLocale(locale)
+}
+
+export function t(key: string, defaultValue = key, params?: TextParams): string {
+  const translated = lookupMessage(currentLocale.value, key) ?? lookupMessage(DEFAULT_LOCALE, key) ?? defaultValue
+  return interpolate(translated, params)
+}
+
+export function resolveText(value: TextValue, params?: TextParams): string {
+  if (!value) {
+    return ''
+  }
+  if (typeof value === 'string') {
+    return interpolate(value, params)
+  }
+
+  return t(value.key, value.defaultValue, { ...value.params, ...params })
+}
+
+export function useAppI18n() {
+  return {
+    locale: readonly(currentLocale),
+    resolveText,
+    setLocale: setAppLocale,
+    supportedLocales,
+    t,
+  }
+}
+
+function resolveInitialLocale(): AppLocale {
+  if (typeof window === 'undefined') {
+    return DEFAULT_LOCALE
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  if (stored) {
+    return normalizeLocale(stored)
+  }
+
+  return normalizeLocale(window.navigator.language)
+}
+
+function lookupMessage(locale: AppLocale, key: string): string | undefined {
+  const catalog = messages[locale] as unknown as Record<string, unknown>
+  const value = key.split('.').reduce<unknown>((current, segment) => {
+    if (!current || typeof current !== 'object') {
+      return undefined
+    }
+    return (current as Record<string, unknown>)[segment]
+  }, catalog)
+
+  return typeof value === 'string' ? value : undefined
+}
+
+function interpolate(template: string, params?: TextParams): string {
+  if (!params) {
+    return template
+  }
+
+  return template.replace(/\{(\w+)\}/g, (match, key) => {
+    const value = params[key]
+    return value === undefined || value === null ? match : String(value)
+  })
+}
+
+function applyDocumentLocale(locale: AppLocale): void {
+  if (typeof document !== 'undefined') {
+    document.documentElement.lang = locale
+  }
+}

--- a/frontend/src/i18n/messages.ts
+++ b/frontend/src/i18n/messages.ts
@@ -1,0 +1,273 @@
+export const messages = {
+  'zh-CN': {
+    common: {
+      actions: {
+        cancel: '取消',
+        confirm: '确认',
+        configure: '配置',
+        manage: '管理',
+        refresh: '刷新',
+        later: '稍后提醒',
+        viewRelease: '查看更新',
+        retry: '重试',
+      },
+      update: {
+        defaultDescription: '新版本已发布，建议更新以获得最新功能和安全修复',
+        foundNewVersion: '发现新版本',
+        latestVersion: '最新版本',
+        publishedAt: '发布于 {date}',
+        releaseNotes: '更新内容',
+      },
+      empty: {
+        default: {
+          title: '暂无数据',
+          description: '当前没有可显示的内容',
+        },
+        search: {
+          title: '未找到结果',
+          description: '尝试使用不同的关键词搜索',
+        },
+        filter: {
+          title: '无匹配结果',
+          description: '没有符合当前筛选条件的数据',
+        },
+        error: {
+          title: '加载失败',
+          description: '数据加载过程中出现错误',
+        },
+        empty: {
+          title: '这里空空如也',
+          description: '还没有任何内容',
+        },
+        notFound: {
+          title: '未找到',
+          description: '请求的资源不存在',
+        },
+      },
+      status: {
+        loading: '加载中...',
+        unknown: '未知',
+        unavailable: '不可用',
+      },
+    },
+    layout: {
+      actions: {
+        dashboard: '控制台',
+        login: '登录',
+        logout: '退出登录',
+        relogin: '重新登录',
+        settings: '个人设置',
+      },
+      breadcrumbs: {
+        account: '账户',
+        dashboard: '仪表盘',
+        moduleManagement: '模块管理',
+        personalSettings: '个人设置',
+        system: '系统',
+      },
+      nav: {
+        groups: {
+          account: '账户',
+          management: '管理',
+          overview: '概览',
+          resources: '资源',
+          system: '系统',
+        },
+        items: {
+          analytics: '数据分析',
+          announcementManagement: '公告管理',
+          apiKeys: 'API 密钥',
+          asyncTasks: '异步任务',
+          cacheMonitoring: '缓存监控',
+          costAnalysis: '成本分析',
+          dashboard: '仪表盘',
+          healthMonitor: '健康监控',
+          modelCatalog: '模型目录',
+          modelManagement: '模型管理',
+          moduleManagement: '模块管理',
+          performanceAnalysis: '性能分析',
+          poolManagement: '号池管理',
+          providers: '提供商',
+          reports: '综合报表',
+          standaloneKeys: '独立密钥',
+          systemSettings: '系统设置',
+          usageRecords: '使用记录',
+          userStats: '用户统计',
+          users: '用户管理',
+          walletCenter: '钱包中心',
+          walletsManagement: '钱包管理',
+        },
+      },
+      notice: {
+        authExpired: '认证已过期，请重新登录',
+      },
+      roles: {
+        admin: '管理员',
+        auditAdmin: '审计管理员',
+        user: '用户',
+      },
+      theme: {
+        dark: '深色模式',
+        light: '浅色模式',
+        system: '跟随系统',
+      },
+      titles: {
+        github: 'GitHub 仓库',
+      },
+    },
+    builtinTools: {
+      auditLogs: {
+        name: '审计日志',
+        description: '查看系统操作日志，追踪安全事件与变更记录',
+      },
+      email: {
+        name: '邮件配置',
+        description: '配置 SMTP 邮件服务，管理邮件模板和发送设置',
+      },
+      ipSecurity: {
+        name: 'IP 安全',
+        description: '管理 IP 黑白名单，控制系统访问权限',
+      },
+    },
+    errors: {
+      moduleLoadFailed: '页面加载失败,请手动刷新浏览器。如问题持续,请清除浏览器缓存后重试。',
+    },
+  },
+  en: {
+    common: {
+      actions: {
+        cancel: 'Cancel',
+        confirm: 'Confirm',
+        configure: 'Configure',
+        manage: 'Manage',
+        refresh: 'Refresh',
+        later: 'Remind me later',
+        viewRelease: 'View release',
+        retry: 'Retry',
+      },
+      update: {
+        defaultDescription: 'A new version is available. Update to get the latest features and security fixes.',
+        foundNewVersion: 'New version found',
+        latestVersion: 'Latest version',
+        publishedAt: 'Published on {date}',
+        releaseNotes: 'Release notes',
+      },
+      empty: {
+        default: {
+          title: 'No data',
+          description: 'There is nothing to display right now.',
+        },
+        search: {
+          title: 'No results',
+          description: 'Try searching with different keywords.',
+        },
+        filter: {
+          title: 'No matching results',
+          description: 'No data matches the current filters.',
+        },
+        error: {
+          title: 'Failed to load',
+          description: 'Something went wrong while loading data.',
+        },
+        empty: {
+          title: 'Nothing here yet',
+          description: 'No content has been added yet.',
+        },
+        notFound: {
+          title: 'Not found',
+          description: 'The requested resource does not exist.',
+        },
+      },
+      status: {
+        loading: 'Loading...',
+        unknown: 'Unknown',
+        unavailable: 'Unavailable',
+      },
+    },
+    layout: {
+      actions: {
+        dashboard: 'Dashboard',
+        login: 'Log in',
+        logout: 'Log out',
+        relogin: 'Log in again',
+        settings: 'Profile settings',
+      },
+      breadcrumbs: {
+        account: 'Account',
+        dashboard: 'Dashboard',
+        moduleManagement: 'Modules',
+        personalSettings: 'Profile settings',
+        system: 'System',
+      },
+      nav: {
+        groups: {
+          account: 'Account',
+          management: 'Management',
+          overview: 'Overview',
+          resources: 'Resources',
+          system: 'System',
+        },
+        items: {
+          analytics: 'Analytics',
+          announcementManagement: 'Announcements',
+          apiKeys: 'API Keys',
+          asyncTasks: 'Async Tasks',
+          cacheMonitoring: 'Cache Monitor',
+          costAnalysis: 'Cost Analysis',
+          dashboard: 'Dashboard',
+          healthMonitor: 'Health Monitor',
+          modelCatalog: 'Model Catalog',
+          modelManagement: 'Models',
+          moduleManagement: 'Modules',
+          performanceAnalysis: 'Performance Analysis',
+          poolManagement: 'Pool Management',
+          providers: 'Providers',
+          reports: 'Reports',
+          standaloneKeys: 'Standalone Keys',
+          systemSettings: 'System Settings',
+          usageRecords: 'Usage Records',
+          userStats: 'User Stats',
+          users: 'Users',
+          walletCenter: 'Wallet',
+          walletsManagement: 'Wallets',
+        },
+      },
+      notice: {
+        authExpired: 'Your session has expired. Please log in again.',
+      },
+      roles: {
+        admin: 'Admin',
+        auditAdmin: 'Audit Admin',
+        user: 'User',
+      },
+      theme: {
+        dark: 'Dark mode',
+        light: 'Light mode',
+        system: 'Use system theme',
+      },
+      titles: {
+        github: 'GitHub repository',
+      },
+    },
+    builtinTools: {
+      auditLogs: {
+        name: 'Audit Logs',
+        description: 'Review system operations and track security events or configuration changes.',
+      },
+      email: {
+        name: 'Email Settings',
+        description: 'Configure SMTP, email templates, and sending behavior.',
+      },
+      ipSecurity: {
+        name: 'IP Security',
+        description: 'Manage IP allowlists and blocklists for system access control.',
+      },
+    },
+    errors: {
+      moduleLoadFailed: 'The page failed to load. Refresh the browser manually. If the issue continues, clear the browser cache and try again.',
+    },
+  },
+} as const
+
+export type MessageCatalogs = typeof messages
+export type AppLocale = keyof MessageCatalogs

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -15,7 +15,7 @@
       <div class="flex w-full max-w-3xl items-center justify-between rounded-3xl bg-orange-500 px-6 py-3 text-white shadow-2xl ring-1 ring-white/30">
         <div class="flex items-center gap-3">
           <AlertTriangle class="h-5 w-5" />
-          <span>认证已过期，请重新登录</span>
+          <span>{{ resolveText(layoutText.notice.authExpired) }}</span>
         </div>
         <Button
           variant="outline"
@@ -23,7 +23,7 @@
           class="border-white/60 text-white hover:bg-white/10"
           @click="handleRelogin"
         >
-          重新登录
+          {{ resolveText(layoutText.actions.relogin) }}
         </Button>
       </div>
     </template>
@@ -66,7 +66,7 @@
             </div>
             <div class="flex flex-col min-w-0">
               <span class="text-xs font-semibold leading-none truncate opacity-90 text-foreground">{{ authStore.user?.username }}</span>
-              <span class="text-[10px] opacity-50 leading-none mt-1.5 text-muted-foreground">{{ currentRoleLabel }}</span>
+              <span class="text-[10px] opacity-50 leading-none mt-1.5 text-muted-foreground">{{ profileRoleLabel }}</span>
             </div>
           </div>
 
@@ -74,13 +74,13 @@
             <RouterLink
               to="/dashboard/settings"
               class="p-1.5 hover:bg-muted/50 rounded-md text-muted-foreground hover:text-foreground transition-colors"
-              title="个人设置"
+              :title="resolveText(layoutText.actions.settings)"
             >
               <Settings class="w-4 h-4" />
             </RouterLink>
             <button
               class="p-1.5 rounded-md text-muted-foreground hover:text-red-500 transition-colors"
-              title="退出登录"
+              :title="resolveText(layoutText.actions.logout)"
               @click="handleLogout"
             >
               <LogOut class="w-4 h-4" />
@@ -123,7 +123,7 @@
               />
               <button
                 class="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition"
-                :title="themeMode === 'system' ? '跟随系统' : themeMode === 'dark' ? '深色模式' : '浅色模式'"
+                :title="themeButtonTitle"
                 @click="toggleDarkMode"
               >
                 <SunMoon
@@ -227,7 +227,7 @@
                     </div>
                     <div class="flex flex-col min-w-0">
                       <span class="text-sm font-semibold leading-none truncate text-[#191919] dark:text-white">{{ authStore.user?.username }}</span>
-                      <span class="text-[10px] text-[#91918d] dark:text-muted-foreground leading-none mt-1">{{ currentRoleLabel }}</span>
+                      <span class="text-[10px] text-[#91918d] dark:text-muted-foreground leading-none mt-1">{{ profileRoleLabel }}</span>
                     </div>
                   </div>
                   <div class="flex items-center gap-1">
@@ -307,7 +307,7 @@
           <!-- Theme Toggle -->
           <button
             class="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition"
-            :title="themeMode === 'system' ? '跟随系统' : themeMode === 'dark' ? '深色模式' : '浅色模式'"
+            :title="themeButtonTitle"
             @click="toggleDarkMode"
           >
             <SunMoon
@@ -329,7 +329,7 @@
             target="_blank"
             rel="noopener noreferrer"
             class="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition"
-            title="GitHub 仓库"
+            :title="resolveText(layoutText.titles.github)"
           >
             <GithubIcon class="h-4 w-4" />
           </a>
@@ -369,41 +369,27 @@ import UpdateDialog from '@/components/common/UpdateDialog.vue'
 import VersionButton from '@/components/common/VersionButton.vue'
 import { buildUpdateErrorStatus } from '@/utils/updateStatus'
 import {
-  Home,
-  Users,
-  Key,
-  KeyRound,
-  BarChart3,
-  Cog,
   Settings,
-  Activity,
-  Shield,
   AlertTriangle,
   SunMedium,
   Moon,
-  Gauge,
-  Layers,
-  FolderTree,
-  Database,
-  Box,
   LogOut,
   SunMoon,
   ChevronRight,
-  Megaphone,
-  Wallet,
   Menu,
   X,
-  Puzzle,
-  Zap,
-  FileUp,
-  Server,
-  SlidersHorizontal,
-  type LucideIcon,
 } from 'lucide-vue-next'
 
 import GithubIcon from '@/components/icons/GithubIcon.vue'
 import { BUILTIN_TOOL_BREADCRUMBS } from '@/config/builtin-tools'
 import { prefetchAdminNavigationTarget } from '@/utils/adminNavigationPrefetch'
+import {
+  createAdminNavigationGroups,
+  createModuleNavigationItem,
+  userNavigationGroups,
+  type NavigationGroupDescriptor,
+} from '@/config/navigation'
+import { i18nText, resolveText } from '@/i18n'
 
 const router = useRouter()
 const route = useRoute()
@@ -413,6 +399,53 @@ const { themeMode, toggleDarkMode } = useDarkMode()
 const { siteName, siteSubtitle } = useSiteInfo()
 const isDemo = computed(() => isDemoMode())
 const isAdmin = computed(() => authStore.user?.role === 'admin')
+
+const layoutText = {
+  actions: {
+    logout: i18nText('layout.actions.logout', '退出登录'),
+    relogin: i18nText('layout.actions.relogin', '重新登录'),
+    settings: i18nText('layout.actions.settings', '个人设置'),
+  },
+  breadcrumbs: {
+    account: i18nText('layout.breadcrumbs.account', '账户'),
+    dashboard: i18nText('layout.breadcrumbs.dashboard', '仪表盘'),
+    moduleManagement: i18nText('layout.breadcrumbs.moduleManagement', '模块管理'),
+    personalSettings: i18nText('layout.breadcrumbs.personalSettings', '个人设置'),
+    system: i18nText('layout.breadcrumbs.system', '系统'),
+  },
+  notice: {
+    authExpired: i18nText('layout.notice.authExpired', '认证已过期，请重新登录'),
+  },
+  roles: {
+    admin: i18nText('layout.roles.admin', '管理员'),
+    auditAdmin: i18nText('layout.roles.auditAdmin', '审计管理员'),
+    user: i18nText('layout.roles.user', '用户'),
+  },
+  theme: {
+    dark: i18nText('layout.theme.dark', '深色模式'),
+    light: i18nText('layout.theme.light', '浅色模式'),
+    system: i18nText('layout.theme.system', '跟随系统'),
+  },
+  titles: {
+    github: i18nText('layout.titles.github', 'GitHub 仓库'),
+  },
+}
+
+const themeButtonTitle = computed(() => {
+  if (themeMode.value === 'system') {
+    return resolveText(layoutText.theme.system)
+  }
+  if (themeMode.value === 'dark') {
+    return resolveText(layoutText.theme.dark)
+  }
+  return resolveText(layoutText.theme.light)
+})
+
+const profileRoleLabel = computed(() => {
+  if (authStore.isAdmin) return resolveText(layoutText.roles.admin)
+  if (authStore.isAuditAdmin) return resolveText(layoutText.roles.auditAdmin)
+  return resolveText(layoutText.roles.user)
+})
 
 const showAuthError = ref(false)
 const mobileMenuOpen = ref(false)
@@ -618,102 +651,28 @@ function prefetchNavigationItem(href: string) {
 
 // Navigation Data
 const navigation = computed(() => {
-  const baseNavigation = [
-    {
-      title: '概览',
-      items: [
-        { name: '仪表盘', href: '/dashboard', icon: Home },
-        { name: '健康监控', href: '/dashboard/endpoint-status', icon: Activity },
-      ]
-    },
-    {
-      title: '资源',
-      items: [
-        { name: '模型目录', href: '/dashboard/models', icon: Box },
-        { name: 'API 密钥', href: '/dashboard/api-keys', icon: Key },
-      ]
-    },
-    {
-      title: '账户',
-      items: [
-         { name: '钱包中心', href: '/dashboard/wallet', icon: Wallet },
-         { name: '使用统计', href: '/dashboard/usage', icon: BarChart3 },
-         { name: '异步任务', href: '/dashboard/async-tasks', icon: Zap },
-      ]
-    }
-  ]
-
-  // 系统菜单项（静态部分）
-  const systemItems: { name: string; href: string; icon: LucideIcon }[] = [
-    { name: '公告管理', href: '/admin/announcements', icon: Megaphone },
-    { name: '缓存监控', href: '/admin/cache-monitoring', icon: Gauge },
-  ]
-
-  // 动态添加已激活模块的菜单项
-  // 图标映射
-  const iconMap: Record<string, LucideIcon> = {
-    Key,
-    KeyRound,
-    FileUp,
-    Shield,
-    Puzzle,
-    Server,
-    SlidersHorizontal,
-  }
-
-  // 添加模块菜单项（按 admin_menu_order 排序，只显示已激活的）
   const moduleMenuItems = Object.values(moduleStore.modules)
     .filter(m => m.active && m.admin_route && m.admin_menu_group === 'system')
     .sort((a, b) => a.admin_menu_order - b.admin_menu_order)
-    .map(m => ({
-      name: m.display_name,
+    .map(m => createModuleNavigationItem({
+      displayName: m.display_name,
       href: m.admin_route ?? '',
-      icon: iconMap[m.admin_menu_icon || ''] || Puzzle
+      iconName: m.admin_menu_icon,
     }))
 
-  systemItems.push(...moduleMenuItems)
+  const groups: NavigationGroupDescriptor[] = authStore.canAccessAdmin
+    ? createAdminNavigationGroups(moduleMenuItems)
+    : userNavigationGroups
 
-  // 模块管理和系统设置放在最后
-  systemItems.push({ name: '模块管理', href: '/admin/modules', icon: Puzzle })
-  systemItems.push({ name: '系统设置', href: '/admin/system', icon: Cog })
-
-  const adminNavigation = [
-     {
-      title: '概览',
-      items: [
-        { name: '仪表盘', href: '/admin/dashboard', icon: Home },
-        { name: '健康监控', href: '/admin/health-monitor', icon: Activity },
-        { name: '用户统计', href: '/admin/user-stats', icon: BarChart3 },
-        { name: '成本分析', href: '/admin/cost-analysis', icon: Gauge },
-        { name: '性能分析', href: '/admin/performance-analysis', icon: Activity },
-      ]
-    },
-    {
-      title: '管理',
-      items: [
-        { name: '用户管理', href: '/admin/users', icon: Users },
-        { name: '提供商', href: '/admin/providers', icon: FolderTree },
-        { name: '模型管理', href: '/admin/models', icon: Layers },
-        { name: '号池管理', href: '/admin/pool', icon: Database },
-        { name: '独立密钥', href: '/admin/keys', icon: Key },
-        { name: '钱包管理', href: '/admin/wallets', icon: Wallet },
-        { name: '异步任务', href: '/admin/async-tasks', icon: Zap },
-        { name: '使用记录', href: '/admin/usage', icon: BarChart3 },
-      ]
-    },
-    {
-      title: '系统',
-      items: systemItems
-    }
-  ]
-
-  return authStore.canAccessAdmin ? adminNavigation : baseNavigation
-})
-
-const currentRoleLabel = computed(() => {
-  if (authStore.isAdmin) return '管理员'
-  if (authStore.isAuditAdmin) return '审计管理员'
-  return '用户'
+  return groups.map(group => ({
+    title: resolveText(group.title),
+    items: group.items.map(item => ({
+      name: resolveText(item.name),
+      href: item.href,
+      icon: item.icon,
+      description: item.description ? resolveText(item.description) : undefined,
+    })),
+  }))
 })
 
 // Breadcrumbs
@@ -726,8 +685,8 @@ const breadcrumbs = computed((): BreadcrumbItem[] => {
   // Special case: personal settings page accessed by admin
   if (route.path === '/dashboard/settings') {
     return [
-      { label: '账户' },
-      { label: '个人设置' }
+      { label: resolveText(layoutText.breadcrumbs.account) },
+      { label: resolveText(layoutText.breadcrumbs.personalSettings) }
     ]
   }
 
@@ -737,8 +696,8 @@ const breadcrumbs = computed((): BreadcrumbItem[] => {
     const moduleStatus = moduleStore.modules[moduleName]
     const displayName = moduleStatus?.display_name || moduleName
     return [
-      { label: '系统' },
-      { label: '模块管理', href: '/admin/modules' },
+      { label: resolveText(layoutText.breadcrumbs.system) },
+      { label: resolveText(layoutText.breadcrumbs.moduleManagement), href: '/admin/modules' },
       { label: displayName }
     ]
   }
@@ -746,9 +705,9 @@ const breadcrumbs = computed((): BreadcrumbItem[] => {
   // Special case: built-in tools under module management
   if (BUILTIN_TOOL_BREADCRUMBS[route.path]) {
     return [
-      { label: '系统' },
-      { label: '模块管理', href: '/admin/modules' },
-      { label: BUILTIN_TOOL_BREADCRUMBS[route.path] }
+      { label: resolveText(layoutText.breadcrumbs.system) },
+      { label: resolveText(layoutText.breadcrumbs.moduleManagement), href: '/admin/modules' },
+      { label: resolveText(BUILTIN_TOOL_BREADCRUMBS[route.path]) }
     ]
   }
 
@@ -770,12 +729,12 @@ const breadcrumbs = computed((): BreadcrumbItem[] => {
   )
   if (currentModule) {
     return [
-      { label: '模块管理', href: '/admin/modules' },
+      { label: resolveText(layoutText.breadcrumbs.moduleManagement), href: '/admin/modules' },
       { label: currentModule.display_name }
     ]
   }
 
-  return [{ label: '仪表盘' }]
+  return [{ label: resolveText(layoutText.breadcrumbs.dashboard) }]
 })
 
 // Styling Classes (Editorial)

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,6 +4,9 @@ import router from './router'
 import './style.css'
 import App from './App.vue'
 import { preloadCriticalModules } from './utils/importRetry'
+import { initAppLocale } from './i18n'
+
+initAppLocale()
 
 const app = createApp(App)
 const pinia = createPinia()

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,17 +1,36 @@
+import { getCurrentLocale, t } from '@/i18n'
+
+function toFiniteNumber(value: number | string | undefined | null): number | null {
+  if (value === undefined || value === null) return null
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+
+  const normalized = value
+    .trim()
+    .replace(/[$,\s]/g, '')
+
+  if (!normalized) return null
+
+  const parsed = Number(normalized)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
 // Token formatting - intelligent display based on value size
-export function formatTokens(num: number | undefined | null): string {
-  if (num === undefined || num === null || num === 0) {
+export function formatTokens(num: number | string | undefined | null): string {
+  const normalized = toFiniteNumber(num)
+  if (normalized === null || normalized === 0) {
     return '0'
   }
 
   // For very small values (< 1000), show as is without unit
-  if (num < 1000) {
-    return num.toString()
+  if (normalized < 1000) {
+    return normalized.toString()
   }
 
   // For values 1K-999K, show in thousands
-  if (num < 1000000) {
-    const thousands = num / 1000
+  if (normalized < 1000000) {
+    const thousands = normalized / 1000
     if (thousands >= 100) {
       return `${Math.round(thousands)  }K`
     } else if (thousands >= 10) {
@@ -22,7 +41,7 @@ export function formatTokens(num: number | undefined | null): string {
   }
 
   // For values >= 1M, show in millions
-  const millions = num / 1000000
+  const millions = normalized / 1000000
   if (millions >= 100) {
     return `${Math.round(millions)  }M`
   } else if (millions >= 10) {
@@ -33,53 +52,54 @@ export function formatTokens(num: number | undefined | null): string {
 }
 
 // Currency formatting with high precision for small values
-export function formatCurrency(amount: number | undefined | null): string {
-  if (amount === undefined || amount === null || amount === 0) {
+export function formatCurrency(amount: number | string | undefined | null): string {
+  const normalized = toFiniteNumber(amount)
+  if (normalized === null || normalized === 0) {
     return '$0.00'
   }
 
   // For very small amounts (< $0.00001), show up to 8 decimal places
-  if (amount > 0 && amount < 0.00001) {
-    const formatted = amount.toFixed(8)
+  if (normalized > 0 && normalized < 0.00001) {
+    const formatted = normalized.toFixed(8)
     // Remove trailing zeros but keep at least 2 decimal places
     const trimmed = formatted.replace(/(\.\d\d)0+$/, '$1')
     return `$${  trimmed}`
   }
 
   // For small amounts (< $0.0001), show up to 6 decimal places
-  if (amount < 0.0001) {
-    const formatted = amount.toFixed(6)
+  if (normalized < 0.0001) {
+    const formatted = normalized.toFixed(6)
     // Remove trailing zeros but keep at least 2 decimal places
     const trimmed = formatted.replace(/(\.\d\d)0+$/, '$1')
     return `$${  trimmed}`
   }
 
   // For small amounts (< $0.01), show up to 5 decimal places
-  if (amount < 0.01) {
-    const formatted = amount.toFixed(5)
+  if (normalized < 0.01) {
+    const formatted = normalized.toFixed(5)
     // Remove trailing zeros but keep at least 2 decimal places
     const trimmed = formatted.replace(/(\.\d\d)0+$/, '$1')
     return `$${  trimmed}`
   }
 
   // For amounts less than $1, show 4 decimal places
-  if (amount < 1) {
-    const formatted = amount.toFixed(4)
+  if (normalized < 1) {
+    const formatted = normalized.toFixed(4)
     // Remove trailing zeros but keep at least 2 decimal places
     const trimmed = formatted.replace(/(\.\d\d)0+$/, '$1')
     return `$${  trimmed}`
   }
 
   // For amounts $1-$100, show 2-3 decimal places
-  if (amount < 100) {
-    const formatted = amount.toFixed(3)
+  if (normalized < 100) {
+    const formatted = normalized.toFixed(3)
     // Remove trailing zeros but keep at least 2 decimal places
     const trimmed = formatted.replace(/(\.\d\d)0+$/, '$1')
     return `$${  trimmed}`
   }
 
   // For larger amounts, show 2 decimal places
-  return `$${  amount.toFixed(2)}`
+  return `$${  normalized.toFixed(2)}`
 }
 
 // Number formatting with locale support
@@ -87,20 +107,20 @@ export function formatNumber(num: number | undefined | null): string {
   if (num === undefined || num === null) {
     return '0'
   }
-  return num.toLocaleString('zh-CN')
+  return num.toLocaleString(getCurrentLocale())
 }
 
 // Date formatting
 export function formatDate(dateString: string | undefined | null): string {
-  if (!dateString) return '未知'
+  if (!dateString) return t('common.status.unknown', '未知')
 
-  return new Date(dateString).toLocaleDateString('zh-CN', {
+  return new Intl.DateTimeFormat(getCurrentLocale(), {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit'
-  })
+  }).format(new Date(dateString))
 }
 
 // Model price formatting (already in per 1M tokens)
@@ -157,7 +177,8 @@ export function formatRemainingTime(expireAt: number | undefined, currentTime: n
 // Cache hit rate formatting
 export function formatHitRate(rate: number | undefined): string {
   if (typeof rate !== 'number' || Number.isNaN(rate)) return '-'
-  return `${rate.toFixed(2)}%`
+  const normalized = rate <= 1 ? rate * 100 : rate
+  return `${normalized.toFixed(2)}%`
 }
 
 // Rate limit formatting (supports "inherit" semantics: null = inherit system default)

--- a/frontend/src/views/admin/ModuleManagement.vue
+++ b/frontend/src/views/admin/ModuleManagement.vue
@@ -43,7 +43,7 @@
         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
           <div
             v-for="tool in filteredBuiltinTools"
-            :key="tool.name"
+            :key="tool.href"
             class="group relative border rounded-2xl p-6 transition-all duration-200 hover:shadow-lg border-border bg-card hover:border-primary/20 cursor-pointer"
             @click="router.push(tool.href)"
           >
@@ -56,12 +56,12 @@
               </div>
               <div class="flex-1 min-w-0 pt-1">
                 <h4 class="font-semibold text-base truncate">
-                  {{ tool.name }}
+                  {{ resolveText(tool.name) }}
                 </h4>
               </div>
             </div>
             <p class="text-sm text-muted-foreground leading-relaxed line-clamp-2 min-h-[2.5rem]">
-              {{ tool.description }}
+              {{ resolveText(tool.description) }}
             </p>
             <div class="mt-5 pt-4 border-t border-border/50 flex items-center justify-end">
               <Button
@@ -220,6 +220,7 @@ import Switch from '@/components/ui/switch.vue'
 import Input from '@/components/ui/input.vue'
 import { PageHeader, PageContainer } from '@/components/layout'
 import { useToast } from '@/composables/useToast'
+import { resolveText } from '@/i18n'
 import { useModuleStore } from '@/stores/modules'
 import { BUILTIN_TOOLS } from '@/config/builtin-tools'
 import { log } from '@/utils/logger'
@@ -238,7 +239,7 @@ const filteredBuiltinTools = computed(() => {
   if (!searchQuery.value.trim()) return BUILTIN_TOOLS
   const query = searchQuery.value.toLowerCase()
   return BUILTIN_TOOLS.filter(
-    t => t.name.toLowerCase().includes(query) || t.description.toLowerCase().includes(query)
+    t => resolveText(t.name).toLowerCase().includes(query) || resolveText(t.description).toLowerCase().includes(query)
   )
 })
 

--- a/frontend/src/views/public/guide/GuideLayout.vue
+++ b/frontend/src/views/public/guide/GuideLayout.vue
@@ -54,7 +54,7 @@
                     :class="isNavActive(item.path) ? 'text-primary' : 'text-muted-foreground/70 group-hover:text-foreground'"
                     :stroke-width="isNavActive(item.path) ? 2 : 1.75"
                   />
-                  <span class="text-[13px] tracking-tight">{{ item.name }}</span>
+                  <span class="text-[13px] tracking-tight">{{ resolveText(item.name) }}</span>
                 </div>
                 <div
                   v-if="isNavActive(item.path)"
@@ -81,7 +81,7 @@
                     class="w-1 h-1 rounded-full flex-shrink-0"
                     :class="activeHash === sub.hash ? 'bg-primary' : 'bg-muted-foreground/30'"
                   />
-                  {{ sub.name }}
+                  {{ resolveText(sub.name) }}
                 </a>
               </div>
             </template>
@@ -127,7 +127,7 @@
             <div class="flex items-center gap-3">
               <button
                 class="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition"
-                :title="themeMode === 'system' ? '跟随系统' : themeMode === 'dark' ? '深色模式' : '浅色模式'"
+                :title="themeMode === 'system' ? resolveText(themeLabels.system) : themeMode === 'dark' ? resolveText(themeLabels.dark) : resolveText(themeLabels.light)"
                 @click="toggleDarkMode"
               >
                 <SunMoon
@@ -230,12 +230,12 @@
               to="/guide"
               class="hover:text-foreground transition-colors"
             >
-              教程文档
+              {{ resolveText(guideText.docs) }}
             </RouterLink>
             <template v-if="currentNavItem && currentNavItem.id !== 'overview'">
               <ChevronRight class="w-3 h-3 opacity-50" />
               <span class="text-foreground font-medium">
-                {{ currentNavItem.name }}
+                {{ resolveText(currentNavItem.name) }}
               </span>
             </template>
           </div>
@@ -244,7 +244,7 @@
         <div class="flex items-center gap-2">
           <button
             class="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition"
-            :title="themeMode === 'system' ? '跟随系统' : themeMode === 'dark' ? '深色模式' : '浅色模式'"
+            :title="themeMode === 'system' ? resolveText(themeLabels.system) : themeMode === 'dark' ? resolveText(themeLabels.dark) : resolveText(themeLabels.light)"
             @click="toggleDarkMode"
           >
             <SunMoon
@@ -336,11 +336,22 @@ import HeaderLogo from '@/components/HeaderLogo.vue'
 import AppShell from '@/components/layout/AppShell.vue'
 import { useDarkMode } from '@/composables/useDarkMode'
 import { useSiteInfo } from '@/composables/useSiteInfo'
+import { i18nText, resolveText } from '@/i18n'
 import { guideNavItems } from './guide-config'
 
 const route = useRoute()
 const { themeMode, toggleDarkMode } = useDarkMode()
 const { siteName, siteSubtitle } = useSiteInfo()
+
+const guideText = {
+  docs: i18nText('guide.docs', '教程文档'),
+}
+
+const themeLabels = {
+  dark: i18nText('layout.theme.dark', '深色模式'),
+  light: i18nText('layout.theme.light', '浅色模式'),
+  system: i18nText('layout.theme.system', '跟随系统'),
+}
 
 const mobileMenuOpen = ref(false)
 const baseUrl = ref(typeof window !== 'undefined' ? window.location.origin : 'https://your-aether.com')
@@ -452,7 +463,7 @@ const navigation = computed(() => [
   {
     title: '',
     items: guideNavItems.map(item => ({
-      name: item.name,
+      name: resolveText(item.name),
       href: item.path,
       icon: item.icon
     }))

--- a/frontend/src/views/public/guide/guide-config.ts
+++ b/frontend/src/views/public/guide/guide-config.ts
@@ -8,108 +8,109 @@ import {
   Blocks,
   HelpCircle
 } from 'lucide-vue-next'
+import { i18nText, type TextValue } from '@/i18n'
 
 // 导航配置
 export interface GuideNavItem {
   id: string
-  name: string
+  name: TextValue
   path: string
   icon: Component
-  description?: string
-  subItems?: { name: string; hash: string }[]
+  description?: TextValue
+  subItems?: { name: TextValue; hash: string }[]
 }
 
 export const guideNavItems: GuideNavItem[] = [
   {
     id: 'overview',
-    name: '快速开始',
+    name: i18nText('guide.nav.overview', '快速开始'),
     path: '/guide',
     icon: Rocket,
-    description: '部署后的配置指南',
+    description: i18nText('guide.nav.overviewDescription', '部署后的配置指南'),
     subItems: [
-      { name: '部署', hash: '#production' },
-      { name: '配置流程', hash: '#config-steps' },
-      { name: '反向代理', hash: '#reverse-proxy' },
-      { name: '异步任务', hash: '#async-tasks' },
-      { name: '代理配置', hash: '#proxy-config' }
+      { name: i18nText('guide.nav.production', '部署'), hash: '#production' },
+      { name: i18nText('guide.nav.configSteps', '配置流程'), hash: '#config-steps' },
+      { name: i18nText('guide.nav.reverseProxy', '反向代理'), hash: '#reverse-proxy' },
+      { name: i18nText('guide.nav.asyncTasks', '异步任务'), hash: '#async-tasks' },
+      { name: i18nText('guide.nav.proxyConfig', '代理配置'), hash: '#proxy-config' }
     ]
   },
   {
     id: 'architecture',
-    name: '架构说明',
+    name: i18nText('guide.nav.architecture', '架构说明'),
     path: '/guide/architecture',
     icon: Network,
-    description: '系统架构'
+    description: i18nText('guide.nav.architectureDescription', '系统架构')
   },
   {
     id: 'concepts',
-    name: '相关概念',
+    name: i18nText('guide.nav.concepts', '相关概念'),
     path: '/guide/concepts',
     icon: BookOpen,
-    description: '核心概念',
+    description: i18nText('guide.nav.conceptsDescription', '核心概念'),
     subItems: [
-      { name: '创建统一模型', hash: '#create-model' },
-      { name: '添加提供商', hash: '#add-provider' },
-      { name: '添加端点', hash: '#add-endpoint' },
-      { name: '添加密钥', hash: '#add-key' },
-      { name: '模型权限', hash: '#model-permission' },
-      { name: '关联模型', hash: '#link-model' },
-      { name: '模型映射', hash: '#model-mapping' },
-      { name: '反向代理', hash: '#reverse-proxy' },
-      { name: '优先级管理', hash: '#priority-management' }
+      { name: i18nText('guide.nav.createModel', '创建统一模型'), hash: '#create-model' },
+      { name: i18nText('guide.nav.addProvider', '添加提供商'), hash: '#add-provider' },
+      { name: i18nText('guide.nav.addEndpoint', '添加端点'), hash: '#add-endpoint' },
+      { name: i18nText('guide.nav.addKey', '添加密钥'), hash: '#add-key' },
+      { name: i18nText('guide.nav.modelPermission', '模型权限'), hash: '#model-permission' },
+      { name: i18nText('guide.nav.linkModel', '关联模型'), hash: '#link-model' },
+      { name: i18nText('guide.nav.modelMapping', '模型映射'), hash: '#model-mapping' },
+      { name: i18nText('guide.nav.reverseProxy', '反向代理'), hash: '#reverse-proxy' },
+      { name: i18nText('guide.nav.priorityManagement', '优先级管理'), hash: '#priority-management' }
     ]
   },
   {
     id: 'strategy',
-    name: '关键策略',
+    name: i18nText('guide.nav.strategy', '关键策略'),
     path: '/guide/strategy',
     icon: Target,
-    description: '关键策略',
+    description: i18nText('guide.nav.strategyDescription', '关键策略'),
     subItems: [
-      { name: '请求体记录', hash: '#request-logging' },
-      { name: '调度模式', hash: '#scheduling' },
-      { name: '访问限制', hash: '#rate-limit' },
-      { name: '请求体清理', hash: '#payload-cleanup' },
-      { name: '定时任务', hash: '#cron-tasks' }
+      { name: i18nText('guide.nav.requestLogging', '请求体记录'), hash: '#request-logging' },
+      { name: i18nText('guide.nav.scheduling', '调度模式'), hash: '#scheduling' },
+      { name: i18nText('guide.nav.rateLimit', '访问限制'), hash: '#rate-limit' },
+      { name: i18nText('guide.nav.payloadCleanup', '请求体清理'), hash: '#payload-cleanup' },
+      { name: i18nText('guide.nav.cronTasks', '定时任务'), hash: '#cron-tasks' }
     ]
   },
   {
     id: 'advanced',
-    name: '高级功能',
+    name: i18nText('guide.nav.advanced', '高级功能'),
     path: '/guide/advanced',
     icon: Settings,
-    description: '高级功能',
+    description: i18nText('guide.nav.advancedDescription', '高级功能'),
     subItems: [
-      { name: '格式转换', hash: '#format-conversion' },
-      { name: '流式/非流式', hash: '#stream-policy' },
-      { name: '请求头/体编辑', hash: '#header-body-edit' },
-      { name: '模型映射', hash: '#model-mapping' },
-      { name: '正则映射', hash: '#regex-mapping' },
-      { name: '能力标签', hash: '#capabilities' },
-      { name: '余额监控', hash: '#balance-monitor' },
-      { name: '配置导入/出', hash: '#config-export' },
-      { name: '锁定用户密钥', hash: '#lock-key' }
+      { name: i18nText('guide.nav.formatConversion', '格式转换'), hash: '#format-conversion' },
+      { name: i18nText('guide.nav.streamPolicy', '流式/非流式'), hash: '#stream-policy' },
+      { name: i18nText('guide.nav.headerBodyEdit', '请求头/体编辑'), hash: '#header-body-edit' },
+      { name: i18nText('guide.nav.modelMapping', '模型映射'), hash: '#model-mapping' },
+      { name: i18nText('guide.nav.regexMapping', '正则映射'), hash: '#regex-mapping' },
+      { name: i18nText('guide.nav.capabilities', '能力标签'), hash: '#capabilities' },
+      { name: i18nText('guide.nav.balanceMonitor', '余额监控'), hash: '#balance-monitor' },
+      { name: i18nText('guide.nav.configExport', '配置导入/出'), hash: '#config-export' },
+      { name: i18nText('guide.nav.lockKey', '锁定用户密钥'), hash: '#lock-key' }
     ]
   },
   {
     id: 'modules',
-    name: '模块管理',
+    name: i18nText('guide.nav.modules', '模块管理'),
     path: '/guide/modules',
     icon: Blocks,
-    description: '模块管理',
+    description: i18nText('guide.nav.modulesDescription', '模块管理'),
     subItems: [
-      { name: '访问令牌', hash: '#management-tokens' },
-      { name: '邮件配置', hash: '#email-config' },
-      { name: 'OAuth登录', hash: '#oauth-login' },
-      { name: 'LDAP认证', hash: '#ldap-auth' }
+      { name: i18nText('guide.nav.managementTokens', '访问令牌'), hash: '#management-tokens' },
+      { name: i18nText('guide.nav.emailConfig', '邮件配置'), hash: '#email-config' },
+      { name: i18nText('guide.nav.oauthLogin', 'OAuth登录'), hash: '#oauth-login' },
+      { name: i18nText('guide.nav.ldapAuth', 'LDAP认证'), hash: '#ldap-auth' }
     ]
   },
   {
     id: 'faq',
-    name: '常见问题',
+    name: i18nText('guide.nav.faq', '常见问题'),
     path: '/guide/faq',
     icon: HelpCircle,
-    description: '常见问题'
+    description: i18nText('guide.nav.faqDescription', '常见问题')
   }
 ]
 

--- a/frontend/src/views/user/Settings.vue
+++ b/frontend/src/views/user/Settings.vue
@@ -665,6 +665,7 @@ import SelectContent from '@/components/ui/select-content.vue'
 import SelectItem from '@/components/ui/select-item.vue'
 import Switch from '@/components/ui/switch.vue'
 import { useToast } from '@/composables/useToast'
+import { applyPreferredLocale, setAppLocale } from '@/i18n'
 import { formatCurrency } from '@/utils/format'
 import { getApiUrl } from '@/utils/url'
 import { log } from '@/utils/logger'
@@ -787,6 +788,7 @@ function handleThemeChange(value: string) {
 function handleLanguageChange(value: string) {
   preferencesForm.value.language = value
   languageSelectOpen.value = false
+  setAppLocale(value)
   updatePreferences()
 }
 
@@ -997,6 +999,8 @@ async function loadPreferences() {
         // 静默失败，不影响用户体验
       })
     }
+
+    applyPreferredLocale(preferencesForm.value.language)
   } catch (error) {
     log.error('加载偏好设置失败:', error)
   }
@@ -1148,6 +1152,7 @@ async function updatePreferences() {
       }
     })
     success('设置已保存')
+    setAppLocale(preferencesForm.value.language)
   } catch (error) {
     log.error('更新偏好设置失败:', error)
     showError('保存设置失败')


### PR DESCRIPTION
## Summary
- add a lightweight frontend i18n facade and message catalog with locale initialization and preference sync
- move main navigation/breadcrumb definitions into config and make shared layout/common components accept translatable text values
- wire locale-aware formatting and prepare guide/module UI configuration for future message migration

## Testing
- git diff --check
- npm run type-check (fails locally: vue-tsc not found because frontend dependencies are not installed)