### PR TITLE
fix: strip include from codex compact requests

### DIFF
--- a/apps/aether-gateway/src/ai_serving/planner/standard/normalize/tests.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/normalize/tests.rs
@@ -207,7 +207,10 @@ fn local_openai_responses_compact_wrapper_strips_include_for_codex_requests() {
     assert!(provider_request_body.get("store").is_none());
     assert!(provider_request_body.get("stream").is_none());
     assert_eq!(provider_request_body["instructions"], "");
-    assert_eq!(provider_request_body["prompt_cache_key"], "172c39e6-c0a0-5a70-8b63-e0f8e0d185a3");
+    assert_eq!(
+        provider_request_body["prompt_cache_key"],
+        "172c39e6-c0a0-5a70-8b63-e0f8e0d185a3"
+    );
 }
 
 #[test]

--- a/apps/aether-gateway/src/ai_serving/planner/standard/normalize/tests.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/normalize/tests.rs
@@ -180,6 +180,37 @@ fn local_openai_responses_compact_wrapper_strips_store_for_same_format_requests(
 }
 
 #[test]
+fn local_openai_responses_compact_wrapper_strips_include_for_codex_requests() {
+    let body_json = json!({
+        "model": "gpt-5.4",
+        "input": [],
+        "include": ["reasoning.encrypted_content"],
+        "store": true,
+        "stream": true
+    });
+
+    let provider_request_body = build_local_openai_responses_request_body(
+        &body_json,
+        "gpt-5.4",
+        false,
+        false,
+        "codex",
+        "openai:responses:compact",
+        None,
+        Some("key-123"),
+        &http::HeaderMap::new(),
+        false,
+    )
+    .expect("local codex compact body should build");
+
+    assert!(provider_request_body.get("include").is_none());
+    assert!(provider_request_body.get("store").is_none());
+    assert!(provider_request_body.get("stream").is_none());
+    assert_eq!(provider_request_body["instructions"], "");
+    assert_eq!(provider_request_body["prompt_cache_key"], "172c39e6-c0a0-5a70-8b63-e0f8e0d185a3");
+}
+
+#[test]
 fn local_openai_responses_wrapper_applies_model_directive_before_body_rules() {
     let body_json = json!({
         "model": "gpt-5.4-max",

--- a/crates/aether-ai-formats/src/formats/openai/responses/codex.rs
+++ b/crates/aether-ai-formats/src/formats/openai/responses/codex.rs
@@ -514,9 +514,9 @@ pub fn apply_codex_openai_responses_special_headers(
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_openai_responses_compact_special_body_edits,
         apply_codex_openai_responses_chat_body_edits,
-        apply_codex_openai_responses_special_body_edits, CODEX_OPENAI_IMAGE_INTERNAL_MODEL,
+        apply_codex_openai_responses_special_body_edits,
+        apply_openai_responses_compact_special_body_edits, CODEX_OPENAI_IMAGE_INTERNAL_MODEL,
     };
     use serde_json::json;
 

--- a/crates/aether-ai-formats/src/formats/openai/responses/codex.rs
+++ b/crates/aether-ai-formats/src/formats/openai/responses/codex.rs
@@ -284,7 +284,8 @@ pub fn apply_openai_responses_compact_special_body_edits(
         return;
     };
 
-    // `/v1/responses/compact` does not accept `store` or body-level `stream`.
+    // `/v1/responses/compact` does not accept `include`, `store`, or body-level `stream`.
+    body_object.remove("include");
     body_object.remove("store");
     body_object.remove("stream");
 }
@@ -513,6 +514,7 @@ pub fn apply_codex_openai_responses_special_headers(
 #[cfg(test)]
 mod tests {
     use super::{
+        apply_openai_responses_compact_special_body_edits,
         apply_codex_openai_responses_chat_body_edits,
         apply_codex_openai_responses_special_body_edits, CODEX_OPENAI_IMAGE_INTERNAL_MODEL,
     };
@@ -591,6 +593,27 @@ mod tests {
             ])
         );
         assert_eq!(provider_request_body["parallel_tool_calls"], json!(false));
+    }
+
+    #[test]
+    fn compact_body_edits_strip_include_store_and_stream() {
+        let mut provider_request_body = json!({
+            "input": [],
+            "model": "gpt-5.4",
+            "include": ["reasoning.encrypted_content"],
+            "store": true,
+            "stream": true,
+        });
+
+        apply_openai_responses_compact_special_body_edits(
+            &mut provider_request_body,
+            "openai:responses:compact",
+        );
+
+        assert!(provider_request_body.get("include").is_none());
+        assert!(provider_request_body.get("store").is_none());
+        assert!(provider_request_body.get("stream").is_none());
+        assert_eq!(provider_request_body["model"], json!("gpt-5.4"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- strip `include` alongside `store` and body-level `stream` when normalizing `/v1/responses/compact` requests
- add regressions for the compact body helper and the gateway Codex compact normalization path from issue #455
- fixes #455

## Validation
- `cargo test -p aether-ai-formats compact_body_edits_strip_include_store_and_stream`
- `cargo test -p aether-ai-formats codex`
- `cargo test -p aether-gateway local_openai_responses_compact_wrapper_strips_include_for_codex_requests`
- `cargo test -p aether-gateway local_openai_responses_compact_wrapper_strips_store_for_same_format_requests`