### PR TITLE
fix(usage): prevent detail view from overriding active request status

### DIFF
--- a/frontend/src/features/usage/components/__tests__/HorizontalRequestTimeline.spec.ts
+++ b/frontend/src/features/usage/components/__tests__/HorizontalRequestTimeline.spec.ts
@@ -350,6 +350,35 @@ describe('HorizontalRequestTimeline', () => {
     expect(nodeDot?.classList.contains('status-success')).toBe(false)
   })
 
+  it('keeps emitted trace state active while the request lifecycle is still streaming', async () => {
+    const onTraceState = vi.fn()
+    const trace = buildTrace([
+      buildCandidate({
+        id: 'cand-stale-failed',
+        provider_id: 'provider-stale',
+        provider_name: 'Provider Stale',
+        key_id: 'key-stale',
+        key_name: 'Stale Key',
+        candidate_index: 0,
+        status: 'failed',
+        status_code: 503,
+      }),
+    ])
+    trace.final_status = 'failed'
+
+    mountTimeline(trace, {
+      requestStatus: 'streaming',
+      overrideStatusCode: 200,
+      onTraceState,
+    })
+    await nextTick()
+
+    const lastCall = onTraceState.mock.calls.at(-1)?.[0]
+    expect(lastCall).toMatchObject({
+      finalStatus: 'streaming',
+    })
+  })
+
   it('shows request path from request metadata', async () => {
     const trace = buildTrace([
       buildCandidate({

--- a/frontend/src/features/usage/utils/__tests__/status.spec.ts
+++ b/frontend/src/features/usage/utils/__tests__/status.spec.ts
@@ -141,6 +141,25 @@ describe('usage status helpers', () => {
     })).toBe('failed')
   })
 
+  it('keeps active request lifecycle status authoritative over detail status code inference', () => {
+    expect(resolveTimelineFinalStatus({
+      requestStatus: 'streaming',
+      statusCode: 200,
+    })).toBe('streaming')
+
+    expect(resolveTimelineFinalStatus({
+      requestStatus: 'streaming',
+      statusCode: 503,
+      traceFinalStatus: 'failed',
+    })).toBe('streaming')
+
+    expect(resolveTimelineFinalStatus({
+      requestStatus: 'pending',
+      statusCode: 200,
+      traceFinalStatus: 'success',
+    })).toBe('pending')
+  })
+
   it('uses explicit has_fallback flag for transfer filtering', () => {
     expect(hasUsageFallback(buildUsageRecord({ has_fallback: true }))).toBe(true)
     expect(hasUsageFallback(buildUsageRecord({ has_fallback: false }))).toBe(false)

--- a/frontend/src/features/usage/utils/status.ts
+++ b/frontend/src/features/usage/utils/status.ts
@@ -295,6 +295,9 @@ export function resolveTimelineFinalStatus(params: {
     }
     return requestStatus
   }
+  if (requestStatus === 'pending' || requestStatus === 'streaming') {
+    return requestStatus
+  }
 
   const traceStatus = normalizeTimelineFinalStatus(params.traceFinalStatus)
   if (traceStatus === 'success' || traceStatus === 'failed' || traceStatus === 'cancelled') {
@@ -304,12 +307,12 @@ export function resolveTimelineFinalStatus(params: {
     return traceStatus
   }
 
-  if (hasTerminalSuccessStatusCode !== undefined) {
-    return hasTerminalSuccessStatusCode ? 'success' : 'failed'
-  }
-
   if (params.hasPendingCandidates) {
     return 'pending'
+  }
+
+  if (hasTerminalSuccessStatusCode !== undefined) {
+    return hasTerminalSuccessStatusCode ? 'success' : 'failed'
   }
 
   if (traceStatus) {


### PR DESCRIPTION
问题根因是：点击详情后，时间线组件会根据 status_code 推断终态。记录还在 streaming 时，200 被误判为完成，表格就退回显示“流式”；非 2xx 则会误判为“失败”。

已修改 status.ts：当请求生命周期仍是 pending 或 streaming 时，优先保持活跃状态，不再被详情里的状态码或 trace 终态覆盖。只有后端明确返回 completed / failed / cancelled 后，才切换到终态。