### PR TITLE
feat(models): 支持手动添加全局模型

### DIFF
--- a/frontend/src/features/models/components/GlobalModelFormDialog.vue
+++ b/frontend/src/features/models/components/GlobalModelFormDialog.vue
@@ -16,6 +16,27 @@
         v-if="!isEditMode"
         class="w-[260px] shrink-0 flex flex-col h-full"
       >
+        <!-- 手动添加入口 -->
+        <button
+          type="button"
+          class="mb-3 w-full rounded-lg border px-3 py-2 text-left transition-colors"
+          :class="manualModelMode
+            ? 'border-primary bg-primary/10 text-primary'
+            : 'border-border/60 bg-muted/20 hover:bg-muted/40'"
+          @click="enableManualModelMode"
+        >
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-sm font-medium">手动添加模型</span>
+            <Plus class="h-4 w-4 shrink-0" />
+          </div>
+          <p
+            class="mt-1 text-xs"
+            :class="manualModelMode ? 'text-primary/80' : 'text-muted-foreground'"
+          >
+            无法联网获取目录时，直接填写模型 ID 继续创建。
+          </p>
+        </button>
+
         <!-- 搜索框 -->
         <div class="relative mb-3">
           <Search class="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -88,7 +109,7 @@
               v-if="groupedModels.length === 0"
               class="text-center py-8 text-sm text-muted-foreground"
             >
-              {{ searchQuery ? '未找到模型' : '加载中...' }}
+              {{ emptyModelListText }}
             </div>
           </template>
         </div>
@@ -108,6 +129,12 @@
             <h4 class="font-medium text-sm">
               基本信息
             </h4>
+            <div
+              v-if="manualModelMode && !isEditMode"
+              class="rounded-lg border border-primary/30 bg-primary/5 px-3 py-2 text-xs text-muted-foreground"
+            >
+              当前为手动添加模式。填写模型 ID、名称和价格后即可离线创建统一模型；稍后可在模型详情中关联 Provider。
+            </div>
             <div class="grid grid-cols-2 gap-3">
               <div class="space-y-1.5">
                 <Label
@@ -343,7 +370,7 @@
         {{ isEditMode ? '保存' : '添加' }}
       </Button>
       <Button
-        v-if="selectedModel && !isEditMode"
+        v-if="(selectedModel || manualModelMode) && !isEditMode"
         type="button"
         variant="ghost"
         @click="clearSelection"
@@ -382,6 +409,7 @@ import {
   EMBEDDING_API_FORMATS,
   buildGlobalModelCreatePayload,
   buildGlobalModelUpdatePayload,
+  getModelDirectoryEmptyText,
 } from './global-model-form-helpers'
 
 const props = defineProps<{
@@ -404,6 +432,8 @@ const searchQuery = ref('')
 const allModelsCache = ref<ModelsDevModelItem[]>([]) // 全部模型（缓存）
 const selectedModel = ref<ModelsDevModelItem | null>(null)
 const expandedProvider = ref<string | null>(null)
+const manualModelMode = ref(false)
+const modelListLoadFailed = ref(false)
 
 // 当前显示的模型列表：有搜索词时用全部，否则只用官方
 const allModels = computed(() => {
@@ -466,6 +496,14 @@ const groupedModels = computed(() => {
   return result
 })
 
+const emptyModelListText = computed(() => {
+  return getModelDirectoryEmptyText({
+    searchQuery: searchQuery.value,
+    manualModelMode: manualModelMode.value,
+    modelListLoadFailed: modelListLoadFailed.value,
+  })
+})
+
 // 搜索时如果只有一个提供商，自动展开
 watch(groupedModels, (groups) => {
   if (searchQuery.value && groups.length === 1) {
@@ -476,6 +514,16 @@ watch(groupedModels, (groups) => {
 // 切换提供商展开状态
 function toggleProvider(providerId: string) {
   expandedProvider.value = expandedProvider.value === providerId ? null : providerId
+}
+
+function enableManualModelMode() {
+  manualModelMode.value = true
+  selectedModel.value = null
+  expandedProvider.value = null
+  searchQuery.value = ''
+  if (!form.value.name && !form.value.display_name) {
+    form.value = defaultForm()
+  }
 }
 
 // 阶梯计费配置
@@ -710,11 +758,15 @@ function fillVideoResolutionPricePreset(preset: 'common' | 'sora' | 'veo') {
 async function loadModels() {
   if (allModelsCache.value.length > 0) return
   loading.value = true
+  modelListLoadFailed.value = false
   try {
     // 只加载一次全部模型，过滤在 computed 中完成
     allModelsCache.value = await getModelsDevList(false)
   } catch (err) {
     log.error('Failed to load models:', err)
+    modelListLoadFailed.value = true
+    enableManualModelMode()
+    showError('模型目录加载失败，已切换到手动添加模式，可离线继续创建')
   } finally {
     loading.value = false
   }
@@ -729,6 +781,7 @@ watch(() => props.open, (isOpen) => {
 
 // 选择模型并填充表单
 function selectModel(model: ModelsDevModelItem) {
+  manualModelMode.value = false
   selectedModel.value = model
   expandedProvider.value = model.providerId
   form.value.name = model.modelId
@@ -774,6 +827,7 @@ function selectModel(model: ModelsDevModelItem) {
 
 // 清除选择（手动填写）
 function clearSelection() {
+  manualModelMode.value = false
   selectedModel.value = null
   form.value = defaultForm()
   tieredPricing.value = null
@@ -793,6 +847,8 @@ function resetForm() {
   searchQuery.value = ''
   selectedModel.value = null
   expandedProvider.value = null
+  manualModelMode.value = false
+  modelListLoadFailed.value = false
 }
 
 // 加载模型数据（编辑模式）
@@ -826,6 +882,14 @@ const { isEditMode, handleDialogUpdate, handleCancel } = useFormDialog({
   onClose: () => emit('update:open', false),
   loadData: loadModelData,
   resetForm,
+})
+
+watch(() => form.value.name, (name) => {
+  if (!manualModelMode.value || isEditMode.value) return
+  const modelName = name.trim()
+  if (modelName && !form.value.display_name.trim()) {
+    form.value.display_name = modelName
+  }
 })
 
 async function handleSubmit() {

--- a/frontend/src/features/models/components/__tests__/global-model-form-helpers.spec.ts
+++ b/frontend/src/features/models/components/__tests__/global-model-form-helpers.spec.ts
@@ -4,6 +4,7 @@ import {
   EMBEDDING_API_FORMATS,
   buildGlobalModelCreatePayload,
   buildGlobalModelUpdatePayload,
+  getModelDirectoryEmptyText,
 } from '../global-model-form-helpers'
 
 const embeddingPricing = {
@@ -58,5 +59,27 @@ describe('global model form embedding payload helpers', () => {
       model_type: 'embedding',
       api_formats: ['jina:embedding'],
     })
+  })
+
+  it('surfaces manual-add guidance when the online model directory is unavailable', () => {
+    expect(getModelDirectoryEmptyText({
+      searchQuery: '',
+      manualModelMode: false,
+      modelListLoadFailed: true,
+    })).toBe('模型目录加载失败，请使用手动添加继续创建')
+
+    expect(getModelDirectoryEmptyText({
+      searchQuery: '',
+      manualModelMode: true,
+      modelListLoadFailed: false,
+    })).toBe('已切换到手动添加，可在右侧填写模型信息')
+  })
+
+  it('keeps search empty state ahead of manual/offline guidance', () => {
+    expect(getModelDirectoryEmptyText({
+      searchQuery: 'local-model',
+      manualModelMode: true,
+      modelListLoadFailed: true,
+    })).toBe('未找到模型')
   })
 })

--- a/frontend/src/features/models/components/global-model-form-helpers.ts
+++ b/frontend/src/features/models/components/global-model-form-helpers.ts
@@ -22,6 +22,19 @@ export interface GlobalModelFormPayloadState {
   is_active?: boolean
 }
 
+export interface ModelDirectoryEmptyTextState {
+  searchQuery: string
+  manualModelMode: boolean
+  modelListLoadFailed: boolean
+}
+
+export function getModelDirectoryEmptyText(state: ModelDirectoryEmptyTextState): string {
+  if (state.searchQuery) return '未找到模型'
+  if (state.modelListLoadFailed) return '模型目录加载失败，请使用手动添加继续创建'
+  if (state.manualModelMode) return '已切换到手动添加，可在右侧填写模型信息'
+  return '加载中...'
+}
+
 function cleanGlobalModelConfig(form: GlobalModelFormPayloadState): Record<string, unknown> | undefined {
   return form.config && Object.keys(form.config).length > 0 ? form.config : undefined
 }

--- a/frontend/src/features/providers/components/ProviderModelFormDialog.vue
+++ b/frontend/src/features/providers/components/ProviderModelFormDialog.vue
@@ -11,24 +11,13 @@
       class="space-y-4"
       @submit.prevent="handleSubmit"
     >
-      <!-- 添加模式：选择或手动创建本地全局模型 -->
+      <!-- 添加模式：选择本地全局模型 -->
       <div
         v-if="!isEditing"
         class="space-y-3"
       >
-        <div class="flex items-center justify-between gap-3">
-          <Label for="global-model">选择已有模型或手动添加 *</Label>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            class="h-7 px-2 text-xs"
-            @click="manualGlobalModelMode = !manualGlobalModelMode"
-          >
-            {{ manualGlobalModelMode ? '选择已有模型' : '手动添加' }}
-          </Button>
-        </div>
-        <div v-if="!manualGlobalModelMode" class="space-y-2">
+        <div class="space-y-1.5">
+          <Label for="global-model">选择已有模型 *</Label>
           <Select
             :model-value="form.global_model_id"
             :disabled="loadingGlobalModels"
@@ -48,35 +37,11 @@
             </SelectContent>
           </Select>
         </div>
-        <div v-else class="rounded-lg border border-border/60 bg-muted/20 p-3 space-y-3">
-          <div class="grid grid-cols-2 gap-3">
-            <div class="space-y-1.5">
-              <Label for="manual-global-model-name" class="text-xs">模型ID *</Label>
-              <Input
-                id="manual-global-model-name"
-                v-model="form.manual_global_model_name"
-                placeholder="如 gpt-4o-mini"
-                @update:model-value="syncManualProviderName"
-              />
-            </div>
-            <div class="space-y-1.5">
-              <Label for="manual-global-model-display-name" class="text-xs">显示名称</Label>
-              <Input
-                id="manual-global-model-display-name"
-                v-model="form.manual_global_model_display_name"
-                placeholder="默认使用模型ID"
-              />
-            </div>
-          </div>
-          <p class="text-xs text-muted-foreground">
-            无法联网获取模型目录时，可直接填写模型ID。保存时会先创建本地全局模型，再添加到当前 Provider。
-          </p>
-        </div>
         <p
-          v-if="availableGlobalModels.length === 0 && !loadingGlobalModels && !manualGlobalModelMode"
+          v-if="availableGlobalModels.length === 0 && !loadingGlobalModels"
           class="text-xs text-muted-foreground"
         >
-          没有可选择的本地全局模型。可以切换到“手动添加”继续保存。
+          没有可选择的本地全局模型。请先在模型管理中添加全局模型。
         </p>
         <div class="space-y-1.5">
           <Label for="provider-model-name" class="text-xs">Provider 模型名 *</Label>
@@ -285,7 +250,7 @@ import {
 import { useToast } from '@/composables/useToast'
 import { parseNumberInput, sortResolutionEntries } from '@/utils/form'
 import { createModel, updateModel, getProviderModels } from '@/api/endpoints/models'
-import { createGlobalModel, listGlobalModels, type GlobalModelResponse } from '@/api/global-models'
+import { listGlobalModels, type GlobalModelResponse } from '@/api/global-models'
 import TieredPricingEditor from '@/features/models/components/TieredPricingEditor.vue'
 import type { Model, TieredPricingConfig } from '@/api/endpoints'
 import {
@@ -334,7 +299,6 @@ const showCache1h = true
 const submitting = ref(false)
 const loadingGlobalModels = ref(false)
 const availableGlobalModels = ref<GlobalModelResponse[]>([])
-const manualGlobalModelMode = ref(false)
 
 // 阶梯计费配置
 const tieredPricing = ref<TieredPricingConfig | null>(null)
@@ -369,15 +333,9 @@ const VIDEO_RESOLUTION_PRICE_PRESETS: Record<
   ],
 }
 
-const DEFAULT_MANUAL_GLOBAL_MODEL_PRICING: TieredPricingConfig = {
-  tiers: [{ up_to: null, input_price_per_1m: 0, output_price_per_1m: 0 }],
-}
-
 const form = ref({
   global_model_id: '',
   provider_model_name: '',
-  manual_global_model_name: '',
-  manual_global_model_display_name: '',
   price_per_request: undefined as number | undefined,
   config: {} as Record<string, unknown>,
   // 能力配置
@@ -392,7 +350,6 @@ const form = ref({
 const canSubmitCreate = computed(() => {
   if (isEditing.value) return true
   if (!form.value.provider_model_name.trim()) return false
-  if (manualGlobalModelMode.value) return !!form.value.manual_global_model_name.trim()
   return !!form.value.global_model_id
 })
 
@@ -407,8 +364,6 @@ watch(() => props.open, async (newOpen) => {
       form.value = {
         global_model_id: props.editingModel.global_model_id || '',
         provider_model_name: props.editingModel.provider_model_name || '',
-        manual_global_model_name: '',
-        manual_global_model_display_name: '',
         // 显示有效的按次计费价格（继承自全局模型）
         price_per_request: props.editingModel.effective_price_per_request ?? props.editingModel.price_per_request ?? undefined,
         config: effectiveConfig ? JSON.parse(JSON.stringify(effectiveConfig)) : {},
@@ -470,8 +425,6 @@ function resetForm() {
   form.value = {
     global_model_id: '',
     provider_model_name: '',
-    manual_global_model_name: '',
-    manual_global_model_display_name: '',
     price_per_request: undefined,
     config: {},
     supports_vision: undefined,
@@ -487,23 +440,12 @@ function resetForm() {
   tieredPricingModified.value = false
   originalTieredPricing.value = ''
   availableGlobalModels.value = []
-  manualGlobalModelMode.value = false
 }
 
 function handleGlobalModelSelect(value: string) {
   form.value.global_model_id = value
   const selectedModel = availableGlobalModels.value.find(model => model.id === value)
   form.value.provider_model_name = selectedModel?.name || form.value.provider_model_name
-}
-
-function syncManualProviderName(value: string | number) {
-  const modelName = String(value || '').trim()
-  if (!form.value.provider_model_name.trim()) {
-    form.value.provider_model_name = modelName
-  }
-  if (!form.value.manual_global_model_display_name.trim()) {
-    form.value.manual_global_model_display_name = modelName
-  }
 }
 
 function getNested(obj: Record<string, unknown>, path: string): unknown {
@@ -642,28 +584,6 @@ function _copyVideoPricingFromSelectedGlobal() {
   configTouched.value = true
 }
 
-async function createManualGlobalModel(finalTieredPricing: TieredPricingConfig | null, cleanConfig: Record<string, unknown> | undefined): Promise<GlobalModelResponse> {
-  const modelName = form.value.manual_global_model_name.trim()
-  const displayName = form.value.manual_global_model_display_name.trim() || modelName
-  const supportedCapabilities = [
-    form.value.supports_vision === true ? 'vision' : null,
-    form.value.supports_function_calling === true ? 'function_calling' : null,
-    form.value.supports_streaming === true ? 'streaming' : null,
-    form.value.supports_extended_thinking === true ? 'extended_thinking' : null,
-    form.value.supports_image_generation === true ? 'image_generation' : null,
-  ].filter((capability): capability is string => capability !== null)
-
-  return createGlobalModel({
-    name: modelName,
-    display_name: displayName,
-    default_price_per_request: form.value.price_per_request,
-    default_tiered_pricing: finalTieredPricing || DEFAULT_MANUAL_GLOBAL_MODEL_PRICING,
-    supported_capabilities: supportedCapabilities.length ? supportedCapabilities : undefined,
-    config: cleanConfig,
-    is_active: true,
-  })
-}
-
 // 加载可用的全局模型（排除已添加的）
 async function loadAvailableGlobalModels() {
   loadingGlobalModels.value = true
@@ -701,7 +621,7 @@ function handleClose(value: boolean) {
 async function handleSubmit() {
   if (submitting.value) return
   if (!isEditing.value && !canSubmitCreate.value) {
-    showError(manualGlobalModelMode.value ? '请填写模型ID和 Provider 模型名' : '请选择模型并填写 Provider 模型名', '错误')
+    showError('请选择模型并填写 Provider 模型名', '错误')
     return
   }
 
@@ -734,21 +654,19 @@ async function handleSubmit() {
       showSuccess('模型配置已更新')
     } else {
       // 添加模式：只有用户修改了配置才提交 tiered_pricing，否则保持继承关系
-      const selectedModel = manualGlobalModelMode.value
-        ? await createManualGlobalModel(finalTieredPricing, cleanConfig)
-        : availableGlobalModels.value.find(m => m.id === form.value.global_model_id)
+      const selectedModel = availableGlobalModels.value.find(m => m.id === form.value.global_model_id)
       if (!selectedModel) {
-        showError('请选择模型，或切换到手动添加后填写模型ID', '错误')
+        showError('请选择模型', '错误')
         return
       }
       await createModel(props.providerId, buildProviderModelCreatePayload({
         globalModelId: selectedModel.id,
         providerModelName: form.value.provider_model_name.trim(),
         finalTieredPricing,
-        tieredPricingModified: manualGlobalModelMode.value ? false : tieredPricingModified.value,
-        pricePerRequest: manualGlobalModelMode.value ? undefined : form.value.price_per_request,
+        tieredPricingModified: tieredPricingModified.value,
+        pricePerRequest: form.value.price_per_request,
         cleanConfig,
-        configTouched: manualGlobalModelMode.value ? false : configTouched.value,
+        configTouched: configTouched.value,
         supportsVision: form.value.supports_vision,
         supportsFunctionCalling: form.value.supports_function_calling,
         supportsStreaming: form.value.supports_streaming,

--- a/frontend/src/features/providers/components/__tests__/provider-model-form-helpers.spec.ts
+++ b/frontend/src/features/providers/components/__tests__/provider-model-form-helpers.spec.ts
@@ -49,7 +49,7 @@ describe('provider model form embedding helpers', () => {
     expect('supports_embedding' in payload).toBe(false)
   })
 
-  it('uses manually supplied provider model name in create payload', () => {
+  it('uses supplied provider model name in create payload', () => {
     const payload = buildProviderModelCreatePayload({
       globalModelId: 'gm-local-manual',
       providerModelName: 'intranet-chat-model-v1',


### PR DESCRIPTION
## 摘要
- 在全局模型添加弹窗中增加「手动添加模型」入口，允许模型目录不可用时直接填写模型 ID、名称和价格继续创建。
- 当在线模型目录加载失败时自动切换到手动添加模式，并给出明确的离线创建提示。
- 移除 `ProviderModelFormDialog` 中无可见入口的 Provider 侧“手动创建全局模型”分支，保留现有 provider model 编辑能力。
- 为全局模型目录空状态文案新增 helper 和单测，覆盖加载失败、手动模式和搜索无结果的优先级。

## 为什么还需要这个 PR
之前的 #460 试图解决 #459 中「在线 discovery 不可用时仍要能保存模型配置」的问题，但复查前端入口后发现：`ProviderModelFormDialog` 目前只能通过已有 provider model 的编辑链路看到，例如 `/admin/providers` 的 Provider 详情抽屉模型编辑，以及 `/admin/models` 的 provider model 编辑流程。

也就是说，#460 中 Provider 侧的“添加/手动创建全局模型”分支虽然写在组件里，但当前 UI 没有入口能打开这个添加态；真正能让管理员在目录不可用时继续创建模型的可见入口，是「全局模型」添加弹窗。因此这个 PR 做两件事：

1. 把离线手动创建能力补到真正可见的 Global Model 创建入口。
2. 删除 Provider 表单里无入口的手动创建分支，避免继续保留看似可用但用户实际无法触达的代码。

## ProviderModelFormDialog 现在怎么看得到
- `/admin/providers` → 打开某个 Provider 详情 → 模型列表 → 点击已有模型的编辑按钮 → 打开 `ProviderModelFormDialog` 的编辑态。
- `/admin/models` → 打开某个全局模型详情 → 编辑某个 provider implementation → 打开 `ProviderModelFormDialog` 的编辑态。

这两个路径都不是“添加/手动创建全局模型”入口，所以本 PR 只保留其可见的编辑用途。

## 关联
- Related to #459
- Follows up #460

## 验证
- `lsp_diagnostics`：修改过的 Global Model / Provider Model 文件均无诊断错误
- `npm run test:run -- src/features/providers/components/__tests__/provider-model-form-helpers.spec.ts src/features/models/components/__tests__/global-model-form-helpers.spec.ts`
- `npm run type-check`
- `npm run build`