### PR TITLE
修复：前端 usage API 对齐 Rust 路由

### DIFF
--- a/apps/aether-gateway/src/handlers/admin/observability/usage/summary_routes.rs
+++ b/apps/aether-gateway/src/handlers/admin/observability/usage/summary_routes.rs
@@ -502,7 +502,9 @@ pub(super) async fn maybe_build_local_admin_usage_summary_response(
                 .summarize_usage_audits(&UsageAuditSummaryQuery {
                     created_from_unix_secs,
                     created_until_unix_secs,
-                    ..Default::default()
+                    user_id: query_param_value(query, "user_id"),
+                    provider_name: query_param_value(query, "provider"),
+                    model: query_param_value(query, "model"),
                 })
                 .await?;
             return Ok(Some(build_admin_usage_summary_stats_response_from_summary(

--- a/apps/aether-gateway/src/tests/control/admin/usage.rs
+++ b/apps/aether-gateway/src/tests/control/admin/usage.rs
@@ -388,6 +388,71 @@ async fn gateway_handles_admin_usage_stats_locally_with_trusted_admin_principal(
 }
 
 #[tokio::test]
+async fn gateway_filters_admin_usage_stats_by_query_fields_locally() {
+    let (upstream_url, upstream_hits, upstream_handle) =
+        start_usage_upstream("/api/admin/usage/stats").await;
+
+    let usage_repository = Arc::new(InMemoryUsageReadRepository::seed(vec![
+        sample_usage_row(
+            "usage-1",
+            "req-1",
+            Some("user-1"),
+            Some("key-1"),
+            Some("primary"),
+            "OpenAI",
+            "gpt-5",
+            "completed",
+            120,
+            30,
+            0.3,
+            0.36,
+            DAY_1_UNIX_SECS,
+        ),
+        sample_usage_row(
+            "usage-2",
+            "req-2",
+            Some("user-2"),
+            Some("key-2"),
+            Some("secondary"),
+            "Anthropic",
+            "claude-3-7",
+            "failed",
+            40,
+            10,
+            0.1,
+            0.12,
+            DAY_2_UNIX_SECS,
+        ),
+    ]));
+
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(GatewayDataState::with_usage_reader_for_tests(
+                usage_repository,
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = admin_request(reqwest::Client::new().get(format!(
+        "{gateway_url}/api/admin/usage/stats?start_date=2024-03-21&end_date=2024-03-22&tz_offset_minutes=0&user_id=user-2&provider=Anthropic&model=claude-3-7"
+    )))
+    .send()
+    .await
+    .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["total_requests"], 1);
+    assert_eq!(payload["total_tokens"], 70);
+    assert_eq!(payload["error_count"], 1);
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_defaults_admin_usage_stats_to_bounded_recent_window_when_query_missing() {
     let (upstream_url, upstream_hits, upstream_handle) =
         start_usage_upstream("/api/admin/usage/stats").await;

--- a/frontend/src/api/__tests__/usage-contract.spec.ts
+++ b/frontend/src/api/__tests__/usage-contract.spec.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getMock, cachedRequestMock, dedupedRequestMock, buildCacheKeyMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  cachedRequestMock: vi.fn(async (_key: string, fn: () => Promise<unknown>) => fn()),
+  dedupedRequestMock: vi.fn(async (_key: string, fn: () => Promise<unknown>) => fn()),
+  buildCacheKeyMock: vi.fn(() => 'cache-key'),
+}))
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: getMock,
+  },
+}))
+
+vi.mock('@/utils/cache', () => ({
+  cachedRequest: cachedRequestMock,
+  dedupedRequest: dedupedRequestMock,
+  buildCacheKey: buildCacheKeyMock,
+}))
+
+import { usageApi } from '@/api/usage'
+
+describe('usageApi contract alignment', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    cachedRequestMock.mockClear()
+    dedupedRequestMock.mockClear()
+    buildCacheKeyMock.mockClear()
+  })
+
+  it('loads current-user usage records from the Rust usage endpoint and normalizes pagination', async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        records: [{ id: 'record-1' }],
+        pagination: {
+          total: 42,
+          limit: 10,
+          offset: 10,
+          has_more: true,
+        },
+      },
+    })
+
+    const result = await usageApi.getUsageRecords({
+      page: 2,
+      page_size: 10,
+      start_date: '2026-05-01',
+      end_date: '2026-05-16',
+    })
+
+    expect(getMock).toHaveBeenCalledWith('/api/users/me/usage', {
+      params: {
+        limit: 10,
+        offset: 10,
+        start_date: '2026-05-01',
+        end_date: '2026-05-16',
+      },
+    })
+    expect(result).toEqual({
+      records: [{ id: 'record-1' }],
+      total: 42,
+      page: 2,
+      page_size: 10,
+    })
+  })
+
+  it('loads admin usage for a specific user from admin usage endpoints', async () => {
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          total_requests: 7,
+          total_tokens: 99,
+          total_cost: 12.34,
+          avg_response_time: 456,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          records: [{ id: 'record-2' }],
+          total: 1,
+          limit: 25,
+          offset: 0,
+        },
+      })
+
+    const result = await usageApi.getUserUsage('user-123', {
+      page: 1,
+      page_size: 25,
+      model: 'gpt-5.5',
+    })
+
+    expect(getMock).toHaveBeenNthCalledWith(1, '/api/admin/usage/stats', {
+      params: {
+        user_id: 'user-123',
+        model: 'gpt-5.5',
+      },
+    })
+    expect(getMock).toHaveBeenNthCalledWith(2, '/api/admin/usage/records', {
+      params: {
+        user_id: 'user-123',
+        limit: 25,
+        offset: 0,
+        model: 'gpt-5.5',
+      },
+    })
+    expect(result).toEqual({
+      records: [{ id: 'record-2' }],
+      stats: {
+        total_requests: 7,
+        total_tokens: 99,
+        total_cost: 12.34,
+        avg_response_time: 456,
+      },
+    })
+  })
+})

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -100,6 +100,7 @@ export interface UsageFilters {
   user_id?: string // UUID
   provider_id?: string // UUID
   model?: string
+  search?: string
   start_date?: string
   end_date?: string
   preset?: string
@@ -108,6 +109,172 @@ export interface UsageFilters {
   tz_offset_minutes?: number
   page?: number
   page_size?: number
+}
+
+type UsageListResponse = {
+  records?: unknown
+  pagination?: {
+    total?: unknown
+    limit?: unknown
+    offset?: unknown
+  }
+  total?: unknown
+  limit?: unknown
+  offset?: unknown
+}
+
+function assertPositiveInteger(value: number, field: string): number {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${field} must be a positive integer`)
+  }
+  return value
+}
+
+function assertNonNegativeInteger(value: number, field: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative integer`)
+  }
+  return value
+}
+
+function assertNumber(value: unknown, field: string): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    throw new Error(`Usage response is missing numeric ${field}`)
+  }
+  return value
+}
+
+function assertUsageRecords(value: unknown): UsageRecord[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Usage response is missing records array')
+  }
+  return value as UsageRecord[]
+}
+
+function compactParams(params: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined && value !== null && value !== '')
+  )
+}
+
+function offsetPaginationFromPage(filters?: Pick<UsageFilters, 'page' | 'page_size'>): {
+  page: number
+  pageSize: number | undefined
+  offset: number | undefined
+} {
+  const page = assertPositiveInteger(filters?.page ?? 1, 'page')
+  if (filters?.page_size === undefined) {
+    return { page, pageSize: undefined, offset: undefined }
+  }
+
+  const pageSize = assertPositiveInteger(filters.page_size, 'page_size')
+  return {
+    page,
+    pageSize,
+    offset: assertNonNegativeInteger((page - 1) * pageSize, 'offset'),
+  }
+}
+
+function normalizeUsageRecordPage(
+  payload: UsageListResponse,
+  requested: { page: number; pageSize?: number; offset?: number }
+): {
+  records: UsageRecord[]
+  total: number
+  page: number
+  page_size: number
+} {
+  const records = assertUsageRecords(payload.records)
+  const pagination = payload.pagination
+  const total = assertNumber(pagination?.total ?? payload.total, 'pagination.total')
+  const limit = assertPositiveInteger(
+    assertNumber(pagination?.limit ?? payload.limit, 'pagination.limit'),
+    'pagination.limit'
+  )
+  const offset = assertNonNegativeInteger(
+    assertNumber(pagination?.offset ?? payload.offset, 'pagination.offset'),
+    'pagination.offset'
+  )
+  const resolvedPage = requested.pageSize !== undefined
+    ? requested.page
+    : Math.floor(offset / limit) + 1
+
+  return {
+    records,
+    total,
+    page: resolvedPage,
+    page_size: limit,
+  }
+}
+
+function buildCurrentUserUsageParams(filters?: UsageFilters): {
+  params: Record<string, unknown>
+  pagination: { page: number; pageSize?: number; offset?: number }
+} {
+  if (filters?.user_id || filters?.provider_id || filters?.model || filters?.granularity) {
+    throw new Error('getUsageRecords only supports current-user usage filters; use admin usage APIs for user/model/provider filters')
+  }
+
+  const pagination = offsetPaginationFromPage(filters)
+  return {
+    pagination,
+    params: compactParams({
+      start_date: filters?.start_date,
+      end_date: filters?.end_date,
+      preset: filters?.preset,
+      timezone: filters?.timezone,
+      tz_offset_minutes: filters?.tz_offset_minutes,
+      search: filters?.search,
+      limit: pagination.pageSize,
+      offset: pagination.offset,
+    }),
+  }
+}
+
+function buildAdminUsageRecordParams(userId: string, filters?: UsageFilters): {
+  params: Record<string, unknown>
+} {
+  if (!userId.trim()) {
+    throw new Error('getUserUsage requires a non-empty user id')
+  }
+  if (filters?.provider_id || filters?.granularity) {
+    throw new Error('getUserUsage does not support provider_id or granularity filters')
+  }
+
+  const pagination = offsetPaginationFromPage(filters)
+  return {
+    params: compactParams({
+      user_id: userId,
+      start_date: filters?.start_date,
+      end_date: filters?.end_date,
+      preset: filters?.preset,
+      timezone: filters?.timezone,
+      tz_offset_minutes: filters?.tz_offset_minutes,
+      search: filters?.search,
+      model: filters?.model,
+      limit: pagination.pageSize,
+      offset: pagination.offset,
+    }),
+  }
+}
+
+function buildAdminUsageStatsParams(userId: string, filters?: UsageFilters): Record<string, unknown> {
+  if (!userId.trim()) {
+    throw new Error('getUserUsage requires a non-empty user id')
+  }
+  if (filters?.provider_id || filters?.granularity) {
+    throw new Error('getUserUsage stats does not support provider_id or granularity filters')
+  }
+
+  return compactParams({
+    user_id: userId,
+    start_date: filters?.start_date,
+    end_date: filters?.end_date,
+    preset: filters?.preset,
+    timezone: filters?.timezone,
+    tz_offset_minutes: filters?.tz_offset_minutes,
+    model: filters?.model,
+  })
 }
 
 function normalizeActivityHeatmapResponse(payload: unknown): ActivityHeatmap {
@@ -184,8 +351,9 @@ export const usageApi = {
     page: number
     page_size: number
   }> {
-    const response = await apiClient.get('/api/usage', { params: filters })
-    return response.data
+    const { params, pagination } = buildCurrentUserUsageParams(filters)
+    const response = await apiClient.get<UsageListResponse>('/api/users/me/usage', { params })
+    return normalizeUsageRecordPage(response.data, pagination)
   },
 
   async getUsageStats(filters?: UsageFilters): Promise<UsageStats> {
@@ -244,16 +412,17 @@ export const usageApi = {
     records: UsageRecord[]
     stats: UsageStats
   }> {
-    const response = await apiClient.get(`/api/users/${userId}/usage`, { params: filters })
-    return response.data
-  },
+    const statsParams = buildAdminUsageStatsParams(userId, filters)
+    const { params: recordParams } = buildAdminUsageRecordParams(userId, filters)
+    const [statsResponse, recordsResponse] = await Promise.all([
+      apiClient.get<UsageStats>('/api/admin/usage/stats', { params: statsParams }),
+      apiClient.get<UsageListResponse>('/api/admin/usage/records', { params: recordParams }),
+    ])
 
-  async exportUsage(format: 'csv' | 'json', filters?: UsageFilters): Promise<Blob> {
-    const response = await apiClient.get('/api/usage/export', {
-      params: { ...filters, format },
-      responseType: 'blob'
-    })
-    return response.data
+    return {
+      records: assertUsageRecords(recordsResponse.data.records),
+      stats: statsResponse.data,
+    }
   },
 
   async getAllUsageRecords(params?: {


### PR DESCRIPTION
## 摘要

本 PR 修复前端 usage API 与 Rust 后端 usage 路由不一致的问题，并补齐 `/api/admin/usage/stats` 对查询过滤字段的消费。

核心变化：

- `getUsageRecords()` 从旧 `/api/usage` 改为 Rust 现有 `/api/users/me/usage`。
- 前端分页从 `page/page_size` 转换为 Rust usage 路由使用的 `limit/offset`。
- `getUserUsage(userId)` 从旧 `/api/users/{id}/usage` 改为并行请求：
  - `/api/admin/usage/stats`
  - `/api/admin/usage/records`
- 删除前端未被使用且 Rust 后端没有对应路由的旧 `exportUsage('/api/usage/export')`。
- `/api/admin/usage/stats` 本地汇总现在消费 `user_id`、`provider`、`model` 查询字段。

## 问题复现

在未修改 upstream `main` 上增加红测后可以复现：

### 前端旧路由错接

`usage-contract.spec.ts` 中，当前用户 usage 记录测试失败：

```text
Expected: /api/users/me/usage
Received: /api/usage
```

同时 upstream 仍把分页参数作为 `page/page_size` 传给旧接口，而 Rust usage list 路由使用 `limit/offset`。

### 指定用户 usage 旧路由错接

`getUserUsage('user-123')` 测试失败：

```text
Expected: /api/admin/usage/stats
Received: /api/users/user-123/usage
```

### 后端 stats 查询字段未消费

`gateway_filters_admin_usage_stats_by_query_fields_locally` 在 upstream 上失败：

- 请求带 `user_id=user-2&provider=Anthropic&model=claude-3-7`
- 预期只汇总 1 条
- upstream 实际返回 `total_requests = 2`

这说明 `/api/admin/usage/stats` 本地 Rust 路由没有把这些查询字段传入 `UsageAuditSummaryQuery`。

## 根因

Rust 迁移后 usage 后端路由已经变更，但前端 API 合约仍保留部分 Python-era 路径：

- `/api/usage`
- `/api/users/{id}/usage`
- `/api/usage/export`

同时后端 stats route 虽然本地化到了 Rust repository，但构造 `UsageAuditSummaryQuery` 时只传时间范围，没有传 `user_id/provider/model` 过滤字段，导致前端看起来传了筛选条件，运行时却没有消费。

## 修改内容

- 前端 `usageApi.getUsageRecords()`：
  - 改走 `/api/users/me/usage`
  - 显式构造 `limit/offset`
  - 显式解析 `records + pagination`
  - 响应缺少关键字段时直接报错，避免伪成功

- 前端 `usageApi.getUserUsage(userId)`：
  - 并行请求 admin stats 和 admin records
  - stats 请求携带 `user_id/model/time range`
  - records 请求携带 `user_id/model/search/limit/offset/time range`

- 后端 `/api/admin/usage/stats`：
  - `UsageAuditSummaryQuery` 增加 `user_id`
  - 增加 `provider_name`
  - 增加 `model`

- 测试：
  - 新增前端 API contract test
  - 新增后端 stats query filter 回归测试

## 影响范围

- 修改范围限于 usage API 合约与 usage stats 后端查询字段。
- 不修改前端视觉、landing page、字体、品牌名、logo 或任何定制 UI 元素。
- `exportUsage()` 在当前代码搜索中没有调用点，且 Rust 后端没有对应导出路由，因此移除旧方法以避免继续暴露不可用入口。

## 验证

已在本地隔离 worktree 中验证：

- `npm run test:run -- src/api/__tests__/usage-contract.spec.ts`
- `npm run type-check`
- `cargo test -p aether-gateway gateway_filters_admin_usage_stats_by_query_fields_locally`
- `cargo fmt --check`

## 风险与回滚

风险集中在前端 usage API 的旧调用方。如果外部代码曾直接依赖 `exportUsage()`，需要改为后端正式支持导出路由后再恢复入口。仓库内当前搜索没有发现该方法调用点。本 PR 可独立回滚，不依赖其他 PR。
