### PR TITLE
修复：对齐 provider 模型拉取端点与状态持久化

### DIFF
--- a/crates/aether-data/src/repository/provider_catalog/mysql.rs
+++ b/crates/aether-data/src/repository/provider_catalog/mysql.rs
@@ -669,6 +669,11 @@ WHERE id = ?
                 "provider_api_keys.last_probe_increase_at",
             )?)
             .bind(optional_i64_from_u32(key.last_rpm_peak))
+            .bind(optional_i64_from_u64(
+                key.last_models_fetch_at_unix_secs,
+                "provider_api_keys.last_models_fetch_at",
+            )?)
+            .bind(&key.last_models_fetch_error)
             .bind(updated_at)
             .bind(&key.id)
             .execute(&self.pool)
@@ -1208,6 +1213,8 @@ SET
   utilization_samples = ?,
   last_probe_increase_at = ?,
   last_rpm_peak = ?,
+  last_models_fetch_at = ?,
+  last_models_fetch_error = ?,
   updated_at = ?
 WHERE id = ?
 "#

--- a/crates/aether-data/src/repository/provider_catalog/postgres.rs
+++ b/crates/aether-data/src/repository/provider_catalog/postgres.rs
@@ -1798,7 +1798,12 @@ SET
   updated_at = CASE
     WHEN $38::double precision IS NULL THEN NOW()
     ELSE TO_TIMESTAMP($38::double precision)
-  END
+  END,
+  last_models_fetch_at = CASE
+    WHEN $42::double precision IS NULL THEN NULL
+    ELSE TO_TIMESTAMP($42::double precision)
+  END,
+  last_models_fetch_error = $43
 WHERE id = $1
 "#,
         )
@@ -1846,6 +1851,8 @@ WHERE id = $1
         .bind(key.expires_at_unix_secs.map(|value| value as f64))
         .bind(&key.auth_type_by_format)
         .bind(&key.allow_auth_channel_mismatch_formats)
+        .bind(key.last_models_fetch_at_unix_secs.map(|value| value as f64))
+        .bind(&key.last_models_fetch_error)
         .execute(&self.pool)
         .await
         .map_postgres_err()?

--- a/crates/aether-data/src/repository/provider_catalog/sqlite.rs
+++ b/crates/aether-data/src/repository/provider_catalog/sqlite.rs
@@ -671,6 +671,11 @@ WHERE id = ?
                 "provider_api_keys.last_probe_increase_at",
             )?)
             .bind(optional_i64_from_u32(key.last_rpm_peak))
+            .bind(optional_i64_from_u64(
+                key.last_models_fetch_at_unix_secs,
+                "provider_api_keys.last_models_fetch_at",
+            )?)
+            .bind(&key.last_models_fetch_error)
             .bind(updated_at)
             .bind(&key.id)
             .execute(&self.pool)
@@ -1210,6 +1215,8 @@ SET
   utilization_samples = ?,
   last_probe_increase_at = ?,
   last_rpm_peak = ?,
+  last_models_fetch_at = ?,
+  last_models_fetch_error = ?,
   updated_at = ?
 WHERE id = ?
 "#
@@ -1702,7 +1709,7 @@ mod tests {
         assert_eq!(updated_endpoint.health_score, 0.5);
         assert!(!updated_endpoint.is_active);
 
-        let key = StoredProviderCatalogKey::new(
+        let mut key = StoredProviderCatalogKey::new(
             "key-write-1".to_string(),
             "provider-write-1".to_string(),
             "Default Key".to_string(),
@@ -1740,23 +1747,36 @@ mod tests {
             Some(json!({"openai:chat":{"score":1}})),
             Some(json!({"openai:chat":{"open":false}})),
         );
+        key.last_models_fetch_at_unix_secs = Some(1_730_000_100);
+        key.last_models_fetch_error = Some("stale models fetch error".to_string());
         let created_key = repository
             .create_key(&key)
             .await
             .expect("key should create");
         assert_eq!(created_key.concurrent_limit, Some(3));
         assert_eq!(created_key.total_tokens, 1234);
+        assert_eq!(
+            created_key.last_models_fetch_error.as_deref(),
+            Some("stale models fetch error")
+        );
 
         let mut updated_key = created_key.clone();
         updated_key.name = "Updated Key".to_string();
         updated_key.is_active = false;
         updated_key.upstream_metadata = Some(json!({"models":["gpt-4.1"]}));
+        updated_key.last_models_fetch_at_unix_secs = Some(1_730_000_200);
+        updated_key.last_models_fetch_error = None;
         let updated_key = repository
             .update_key(&updated_key)
             .await
             .expect("key should update");
         assert_eq!(updated_key.name, "Updated Key");
         assert!(!updated_key.is_active);
+        assert_eq!(
+            updated_key.last_models_fetch_at_unix_secs,
+            Some(1_730_000_200)
+        );
+        assert_eq!(updated_key.last_models_fetch_error, None);
 
         assert!(repository
             .update_key_upstream_metadata(

--- a/crates/aether-model-fetch/src/strategy.rs
+++ b/crates/aether-model-fetch/src/strategy.rs
@@ -28,6 +28,7 @@ const ANTIGRAVITY_DAILY_BASE_URL: &str = "https://daily-cloudcode-pa.googleapis.
 const ANTIGRAVITY_PROD_BASE_URL: &str = "https://cloudcode-pa.googleapis.com";
 const ANTIGRAVITY_BLOCKED_MODELS: &[&str] = &["chat_23310", "chat_20706"];
 const VERTEX_API_BASE_URL: &str = "https://aiplatform.googleapis.com";
+const VERTEX_MODEL_GARDEN_LIST_API_VERSION: &str = "v1beta1";
 const VERTEX_PAGE_SIZE: &str = "100";
 const VERTEX_MAX_PAGES: usize = 20;
 const GOOGLE_OAUTH_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
@@ -929,14 +930,7 @@ fn iter_vertex_base_urls(transports: &[GatewayProviderTransportSnapshot]) -> Vec
 }
 
 fn build_vertex_google_list_url(base_url: &str, api_key: &str, page_token: Option<&str>) -> String {
-    let path = if base_url.trim_end_matches('/').ends_with("/v1")
-        || base_url.trim_end_matches('/').ends_with("/v1beta")
-    {
-        "/publishers/google/models"
-    } else {
-        "/v1/publishers/google/models"
-    };
-    let url = build_simple_path_url(base_url, path);
+    let url = build_vertex_model_garden_list_url(base_url, "google");
     let mut url = append_query_param(url, "key", api_key);
     url = append_query_param(url, "pageSize", VERTEX_PAGE_SIZE);
     if let Some(page_token) = page_token {
@@ -947,19 +941,27 @@ fn build_vertex_google_list_url(base_url: &str, api_key: &str, page_token: Optio
 
 fn build_vertex_service_account_list_url(
     base_url: &str,
-    project_id: &str,
-    region: &str,
+    _project_id: &str,
+    _region: &str,
     publisher: &str,
     page_token: Option<&str>,
 ) -> String {
-    let path =
-        format!("/v1/projects/{project_id}/locations/{region}/publishers/{publisher}/models");
-    let mut url = build_simple_path_url(base_url, &path);
+    let mut url = build_vertex_model_garden_list_url(base_url, publisher);
     url = append_query_param(url, "pageSize", VERTEX_PAGE_SIZE);
     if let Some(page_token) = page_token {
         url = append_query_param(url, "pageToken", page_token);
     }
     url
+}
+
+fn build_vertex_model_garden_list_url(base_url: &str, publisher: &str) -> String {
+    let trimmed_base = base_url.trim().trim_end_matches('/');
+    let unversioned_base = trimmed_base
+        .strip_suffix("/v1beta1")
+        .or_else(|| trimmed_base.strip_suffix("/v1"))
+        .unwrap_or(trimmed_base);
+    let path = format!("/{VERTEX_MODEL_GARDEN_LIST_API_VERSION}/publishers/{publisher}/models");
+    build_simple_path_url(unversioned_base, &path)
 }
 
 fn build_simple_path_url(base_url: &str, path: &str) -> String {
@@ -1304,7 +1306,10 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::{json, Value};
 
-    use super::{select_model_fetch_strategy, ModelFetchStrategy, ModelFetchStrategyKind};
+    use super::{
+        build_vertex_google_list_url, build_vertex_service_account_list_url,
+        select_model_fetch_strategy, ModelFetchStrategy, ModelFetchStrategyKind,
+    };
     use crate::fetch_models_from_transports;
     use crate::transport::ModelFetchTransportRuntime;
 
@@ -1498,13 +1503,35 @@ mod tests {
         let urls = executed_urls.lock().expect("executed_urls lock");
         assert_eq!(
             urls.as_slice(),
-            &["https://aiplatform.googleapis.com/v1/publishers/google/models?key=vertex-secret&pageSize=100"]
+            &["https://aiplatform.googleapis.com/v1beta1/publishers/google/models?key=vertex-secret&pageSize=100"]
         );
         assert_eq!(outcome.fetched_model_ids, vec!["gemini-3.1-pro-preview"]);
         assert_eq!(outcome.cached_models.len(), 1);
         assert_eq!(
             outcome.cached_models[0]["api_formats"][0].as_str(),
             Some("gemini:generate_content")
+        );
+    }
+
+    #[test]
+    fn vertex_model_fetch_uses_model_garden_list_endpoint() {
+        assert_eq!(
+            build_vertex_google_list_url(
+                "https://aiplatform.googleapis.com/v1",
+                "vertex-secret",
+                None,
+            ),
+            "https://aiplatform.googleapis.com/v1beta1/publishers/google/models?key=vertex-secret&pageSize=100"
+        );
+        assert_eq!(
+            build_vertex_service_account_list_url(
+                "https://aiplatform.googleapis.com",
+                "project-1",
+                "global",
+                "google",
+                Some("page-2"),
+            ),
+            "https://aiplatform.googleapis.com/v1beta1/publishers/google/models?pageSize=100&pageToken=page-2"
         );
     }
 


### PR DESCRIPTION
## 背景与改动原因

这次修复两个都属于 provider 模型拉取链路的真实 upstream 问题：

1. Vertex AI 的模型列表拉取仍在生成旧的 `v1/.../publishers/.../models` 或 project/location 形态 URL。Model Garden 的 publisher model list 端点应走 `v1beta1/publishers/{publisher}/models`，否则模型列表刷新容易请求到错误或不稳定的列表端点。
2. `provider_api_keys` 的模型拉取状态字段在 `create_key` 时会写入，但 `update_key` 没有回写 `last_models_fetch_at` / `last_models_fetch_error`。这会让 UI 或调度链路看到过期的模型拉取时间/错误，形成“更新看起来成功，但状态仍是旧值”的伪成功。

## upstream 原始问题复现

我先在 upstream 当前代码上只加入回归测试，不改生产代码，确认这两个问题不是本地补丁引入的：

- `cargo test -p aether-model-fetch vertex_model_fetch_uses_model_garden_list_endpoint --lib`
  - 失败断言：实际 URL 是 `https://aiplatform.googleapis.com/v1/publishers/google/models?key=vertex-secret&pageSize=100`
  - 期望 URL 是 `https://aiplatform.googleapis.com/v1beta1/publishers/google/models?key=vertex-secret&pageSize=100`
- `cargo test -p aether-data sqlite_repository_writes_provider_catalog_contract_views --lib`
  - 失败断言：更新后的 `last_models_fetch_at_unix_secs` 仍是旧值 `Some(1730000100)`
  - 期望值是更新提交的新值 `Some(1730000200)`

这说明 upstream 原始实现里确实存在旧端点和更新字段未消费的问题。

## 代码根因

- `crates/aether-model-fetch/src/strategy.rs`
  - API key 模式的 Vertex 列表 URL 仍按 base URL 是否带 `/v1` 拼出旧路径。
  - service account 模式仍拼 `projects/{project}/locations/{region}/publishers/{publisher}/models`。
  - 两条认证路径没有统一到 Model Garden publisher list 端点。
- `crates/aether-data/src/repository/provider_catalog/{sqlite,mysql,postgres}.rs`
  - `create_key` 已经绑定并写入 `last_models_fetch_at` / `last_models_fetch_error`。
  - `update_key` 的 SQL 和 bind 参数遗漏这两个字段，导致运行时模型拉取状态更新后无法落盘。

## 修改措施

- 将 Vertex 模型拉取列表 URL 统一到 `/{v1beta1}/publishers/{publisher}/models`。
- 对传入 base URL 做轻量归一化：如果 base URL 已经以 `/v1` 或 `/v1beta1` 结尾，先去掉版本后再拼 `v1beta1`，避免生成重复版本路径。
- API key 和 service account 两条 Vertex 模型列表路径共用同一个 URL builder，继续保留 `pageSize` / `pageToken`。
- SQLite / MySQL / Postgres 的 `update_key` 全部补齐：
  - `last_models_fetch_at`
  - `last_models_fetch_error`
- 为 SQLite 写入回归断言，验证 `update_key` 能真实回写模型拉取状态字段。
- 为 Vertex URL builder 增加回归测试，验证 API key 和 service account 模式都走 Model Garden publisher list URL。

## 影响范围

- 只影响后端 Rust：
  - `aether-model-fetch` 的 Vertex 模型列表拉取 URL 构造。
  - `aether-data` provider catalog key 更新时的模型拉取状态持久化。
- 不修改数据库 schema。
- 不修改前端页面、视觉元素、字体、品牌名、landing page、Logo 或 GitHub 链接等定制内容。
- 不引入静默 fallback，也不把错误端点伪装成成功端点；模型列表请求仍通过原有执行与错误处理链路返回结果或错误。

## 验证

已在 Docker 内使用 `rust:1.95.0-bookworm` 验证：

- 红测试确认 upstream 原始问题存在：
  - `cargo test -p aether-model-fetch vertex_model_fetch_uses_model_garden_list_endpoint --lib`：修复前失败，实际仍为旧 `v1` URL。
  - `cargo test -p aether-data sqlite_repository_writes_provider_catalog_contract_views --lib`：修复前失败，`last_models_fetch_at_unix_secs` 未更新。
- 修复后验证通过：
  - `cargo test -p aether-model-fetch --lib`
  - `cargo test -p aether-data sqlite --lib`
  - `git diff --check`

## 参考

- Vertex AI Model Garden publisher models list API： https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/publishers.models/list
