### PR TITLE
修复：本地 Docker 构建显式注入 Aether 版本

### DIFF
--- a/Dockerfile.app.local
+++ b/Dockerfile.app.local
@@ -1,11 +1,14 @@
 # syntax=docker/dockerfile:1
 # Aether 运行镜像：Rust gateway 直接服务 API + 前端静态文件（国内镜像源版本）
-# 构建命令: docker build -f Dockerfile.app.local -t aether-app:latest .
+# 构建命令: docker build --build-arg AETHER_BUILD_VERSION=v0.7.2 -f Dockerfile.app.local -t aether-app:latest .
 
 ARG RUST_VERSION=1.95.0
 
 # ==================== 前端构建 ====================
 FROM node:22-slim AS frontend-builder
+ARG AETHER_BUILD_VERSION
+ENV AETHER_BUILD_VERSION=${AETHER_BUILD_VERSION} \
+    AETHER_VERSION=${AETHER_BUILD_VERSION}
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN --mount=type=cache,id=aether-npm-cache,target=/root/.npm,sharing=locked \
@@ -44,6 +47,9 @@ COPY crates/ ./crates/
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM gateway-base AS gateway-builder
+ARG AETHER_BUILD_VERSION
+ENV AETHER_BUILD_VERSION=${AETHER_BUILD_VERSION} \
+    AETHER_VERSION=${AETHER_BUILD_VERSION}
 COPY --from=gateway-planner /build/recipe.json ./recipe.json
 RUN --mount=type=cache,id=aether-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=aether-cargo-git,target=/usr/local/cargo/git,sharing=locked \

--- a/apps/aether-gateway/build.rs
+++ b/apps/aether-gateway/build.rs
@@ -2,14 +2,20 @@ use std::env;
 use std::process::Command;
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=AETHER_BUILD_VERSION");
     println!("cargo:rerun-if-env-changed=AETHER_VERSION");
     println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
     println!("cargo:rerun-if-changed=../../.git/HEAD");
 
     let package_version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".to_string());
-    let version = env::var("AETHER_VERSION")
+    let version = env::var("AETHER_BUILD_VERSION")
         .ok()
         .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            env::var("AETHER_VERSION")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
         .or_else(|| {
             env::var("GITHUB_REF_NAME")
                 .ok()

--- a/apps/aether-gateway/src/tests/architecture/admin_system.rs
+++ b/apps/aether-gateway/src/tests/architecture/admin_system.rs
@@ -1,6 +1,32 @@
 use super::*;
 
 #[test]
+fn admin_system_build_version_contract_uses_explicit_local_build_arg() {
+    let build_rs = read_workspace_file("apps/aether-gateway/build.rs");
+    for pattern in [
+        "cargo:rerun-if-env-changed=AETHER_BUILD_VERSION",
+        "env::var(\"AETHER_BUILD_VERSION\")",
+    ] {
+        assert!(
+            build_rs.contains(pattern),
+            "apps/aether-gateway/build.rs should consume explicit build version pattern {pattern}"
+        );
+    }
+
+    let dockerfile = read_workspace_file("Dockerfile.app.local");
+    for pattern in [
+        "ARG AETHER_BUILD_VERSION",
+        "ENV AETHER_BUILD_VERSION=${AETHER_BUILD_VERSION}",
+        "AETHER_VERSION=${AETHER_BUILD_VERSION}",
+    ] {
+        assert!(
+            dockerfile.contains(pattern),
+            "Dockerfile.app.local should pass explicit build version pattern {pattern}"
+        );
+    }
+}
+
+#[test]
 fn admin_system_and_endpoint_roots_stay_thin() {
     let system_mod = read_workspace_file("apps/aether-gateway/src/handlers/admin/system/mod.rs");
     for pattern in [


### PR DESCRIPTION
## 背景与改动原因

本地 Docker 构建出来的 gateway 在没有 `.git` 元数据、也没有显式传入 `AETHER_VERSION` 时，会回退到 `apps/aether-gateway/Cargo.toml` 的包版本 `0.1.0`。管理后台的更新检查随后会把最新 release（例如 `v0.7.2`）判断为“发现新版本”，即使实际部署镜像已经来自该 release。

这会造成一个典型的“真值源错位”问题：前端显示的更新提示不是由实际部署版本决定，而是由构建环境缺失版本注入后的 fallback 决定。

## upstream 原始问题复现

我先在 upstream 当前代码上只加入架构回归测试，不改生产代码：

- `cargo test -p aether-gateway admin_system_build_version_contract_uses_explicit_local_build_arg --lib`
- 修复前失败在：
  - `apps/aether-gateway/build.rs should consume explicit build version pattern cargo:rerun-if-env-changed=AETHER_BUILD_VERSION`

同时源码可直接看到：

- `apps/aether-gateway/build.rs` 只监听和读取 `AETHER_VERSION`，不读取 `AETHER_BUILD_VERSION`。
- `Dockerfile.app.local` 没有声明 `ARG AETHER_BUILD_VERSION`，也没有把显式版本注入给前端或 Rust gateway 构建阶段。

这说明问题是 upstream 原始构建链路缺失显式版本传递，并不是本地补丁造成的。

## 代码根因

- `current_aether_version()` 已经读取编译期的 `AETHER_BUILD_VERSION`。
- 但 `build.rs` 并不读取外部传入的 `AETHER_BUILD_VERSION`，只读取 `AETHER_VERSION`、`GITHUB_REF_NAME` 或 `git describe`。
- `Dockerfile.app.local` 构建时只复制源码，不复制 `.git`；在没有显式版本环境变量时，`git describe` 不可用，最终回落到 `CARGO_PKG_VERSION`。
- `aether-gateway` 的 crate version 是 `0.1.0`，这会污染管理后台 `/api/admin/system/version` 和 `/api/admin/system/check-update` 的当前版本判断。

## 修改措施

- `apps/aether-gateway/build.rs`
  - 增加 `cargo:rerun-if-env-changed=AETHER_BUILD_VERSION`。
  - 版本解析优先级调整为：
    1. `AETHER_BUILD_VERSION`
    2. `AETHER_VERSION`
    3. `GITHUB_REF_NAME`
    4. `git describe`
    5. `CARGO_PKG_VERSION`
  - 仍保留 `AETHER_VERSION`，避免破坏现有 release workflow。
- `Dockerfile.app.local`
  - 增加 `ARG AETHER_BUILD_VERSION`。
  - 在 `frontend-builder` 和 `gateway-builder` 阶段注入：
    - `AETHER_BUILD_VERSION=${AETHER_BUILD_VERSION}`
    - `AETHER_VERSION=${AETHER_BUILD_VERSION}`
  - 更新注释里的本地构建命令，明确示例：`--build-arg AETHER_BUILD_VERSION=v0.7.2`。
- 增加 architecture 回归测试，锁住本地 Docker 构建版本传递合同，防止后续再次退回到 crate fallback 版本。

## 影响范围

- 只影响本地 Docker 构建版本注入和 gateway build script。
- 不修改版本比较算法本身。
- 不修改数据库 schema。
- 不修改前端页面、视觉元素、字体、品牌名、landing page、Logo 或 GitHub 链接等定制内容。
- 不引入静默 fallback；相反，这次改动把版本真值源显式化，避免 fallback 版本 `0.1.0` 冒充当前运行版本。

## 验证

已在 Docker 内使用 `rust:1.95.0-bookworm` 验证：

- 红测试确认 upstream 原始问题存在：
  - `cargo test -p aether-gateway admin_system_build_version_contract_uses_explicit_local_build_arg --lib`：修复前失败，`build.rs` 未消费 `AETHER_BUILD_VERSION`。
- 修复后验证通过：
  - `cargo test -p aether-gateway admin_system_build_version_contract_uses_explicit_local_build_arg --lib`
  - `cargo test -p aether-admin build_admin_system_check_update_payload --lib`
  - `git diff --check`
