### PR TITLE
fix: use Vertex Model Garden models endpoint

### DIFF
--- a/crates/aether-model-fetch/src/strategy.rs
+++ b/crates/aether-model-fetch/src/strategy.rs
@@ -28,6 +28,7 @@ const ANTIGRAVITY_DAILY_BASE_URL: &str = "https://daily-cloudcode-pa.googleapis.
 const ANTIGRAVITY_PROD_BASE_URL: &str = "https://cloudcode-pa.googleapis.com";
 const ANTIGRAVITY_BLOCKED_MODELS: &[&str] = &["chat_23310", "chat_20706"];
 const VERTEX_API_BASE_URL: &str = "https://aiplatform.googleapis.com";
+const VERTEX_MODEL_GARDEN_API_VERSION: &str = "v1beta1";
 const VERTEX_PAGE_SIZE: &str = "100";
 const VERTEX_MAX_PAGES: usize = 20;
 const GOOGLE_OAUTH_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
@@ -929,14 +930,8 @@ fn iter_vertex_base_urls(transports: &[GatewayProviderTransportSnapshot]) -> Vec
 }
 
 fn build_vertex_google_list_url(base_url: &str, api_key: &str, page_token: Option<&str>) -> String {
-    let path = if base_url.trim_end_matches('/').ends_with("/v1")
-        || base_url.trim_end_matches('/').ends_with("/v1beta")
-    {
-        "/publishers/google/models"
-    } else {
-        "/v1/publishers/google/models"
-    };
-    let url = build_simple_path_url(base_url, path);
+    let path = format!("/{VERTEX_MODEL_GARDEN_API_VERSION}/publishers/google/models");
+    let url = build_vertex_model_garden_path_url(base_url, &path);
     let mut url = append_query_param(url, "key", api_key);
     url = append_query_param(url, "pageSize", VERTEX_PAGE_SIZE);
     if let Some(page_token) = page_token {
@@ -947,14 +942,13 @@ fn build_vertex_google_list_url(base_url: &str, api_key: &str, page_token: Optio
 
 fn build_vertex_service_account_list_url(
     base_url: &str,
-    project_id: &str,
-    region: &str,
+    _project_id: &str,
+    _region: &str,
     publisher: &str,
     page_token: Option<&str>,
 ) -> String {
-    let path =
-        format!("/v1/projects/{project_id}/locations/{region}/publishers/{publisher}/models");
-    let mut url = build_simple_path_url(base_url, &path);
+    let path = format!("/{VERTEX_MODEL_GARDEN_API_VERSION}/publishers/{publisher}/models");
+    let mut url = build_vertex_model_garden_path_url(base_url, &path);
     url = append_query_param(url, "pageSize", VERTEX_PAGE_SIZE);
     if let Some(page_token) = page_token {
         url = append_query_param(url, "pageToken", page_token);
@@ -962,8 +956,14 @@ fn build_vertex_service_account_list_url(
     url
 }
 
-fn build_simple_path_url(base_url: &str, path: &str) -> String {
-    format!("{}{}", base_url.trim().trim_end_matches('/'), path.trim())
+fn build_vertex_model_garden_path_url(base_url: &str, path: &str) -> String {
+    let base = base_url
+        .trim()
+        .trim_end_matches('/')
+        .trim_end_matches("/v1beta1")
+        .trim_end_matches("/v1beta")
+        .trim_end_matches("/v1");
+    format!("{}{}", base, path.trim())
 }
 
 fn parse_vertex_models_payload(
@@ -1311,6 +1311,7 @@ mod tests {
     struct TestRuntime {
         executed_urls: Arc<Mutex<Vec<String>>>,
         response_body: Value,
+        status_code: u16,
     }
 
     #[async_trait]
@@ -1341,7 +1342,7 @@ mod tests {
             Ok(ExecutionResult {
                 request_id: plan.request_id.clone(),
                 candidate_id: plan.candidate_id.clone(),
-                status_code: 200,
+                status_code: self.status_code,
                 headers: BTreeMap::new(),
                 body: Some(ResponseBody {
                     json_body: Some(self.response_body.clone()),
@@ -1489,6 +1490,7 @@ mod tests {
                     "name": "publishers/google/models/gemini-3.1-pro-preview"
                 }]
             }),
+            status_code: 200,
         };
         let outcome =
             fetch_models_from_transports(&runtime, &[sample_custom_aiplatform_transport()])
@@ -1498,13 +1500,45 @@ mod tests {
         let urls = executed_urls.lock().expect("executed_urls lock");
         assert_eq!(
             urls.as_slice(),
-            &["https://aiplatform.googleapis.com/v1/publishers/google/models?key=vertex-secret&pageSize=100"]
+            &["https://aiplatform.googleapis.com/v1beta1/publishers/google/models?key=vertex-secret&pageSize=100"]
         );
         assert_eq!(outcome.fetched_model_ids, vec!["gemini-3.1-pro-preview"]);
         assert_eq!(outcome.cached_models.len(), 1);
         assert_eq!(
             outcome.cached_models[0]["api_formats"][0].as_str(),
             Some("gemini:generate_content")
+        );
+    }
+
+    #[tokio::test]
+    async fn vertex_service_account_fetches_model_garden_publishers_without_project_prefix() {
+        assert_eq!(
+            super::build_vertex_service_account_list_url(
+                "https://us-central1-aiplatform.googleapis.com",
+                "demo-project",
+                "us-central1",
+                "google",
+                None
+            ),
+            "https://us-central1-aiplatform.googleapis.com/v1beta1/publishers/google/models?pageSize=100"
+        );
+        assert_eq!(
+            super::build_vertex_service_account_list_url(
+                "https://aiplatform.googleapis.com/v1",
+                "demo-project",
+                "global",
+                "anthropic",
+                Some("next")
+            ),
+            "https://aiplatform.googleapis.com/v1beta1/publishers/anthropic/models?pageSize=100&pageToken=next"
+        );
+        assert_eq!(
+            super::build_vertex_google_list_url(
+                "https://aiplatform.googleapis.com/v1beta1",
+                "vertex-secret",
+                Some("next")
+            ),
+            "https://aiplatform.googleapis.com/v1beta1/publishers/google/models?key=vertex-secret&pageSize=100&pageToken=next"
         );
     }
 
@@ -1518,6 +1552,7 @@ mod tests {
                     "id": "gpt-5.4-upstream"
                 }]
             }),
+            status_code: 200,
         };
         let outcome = fetch_models_from_transports(&runtime, &[sample_codex_transport()])
             .await
@@ -1558,6 +1593,7 @@ mod tests {
                     }
                 ]
             }),
+            status_code: 200,
         };
         let outcome = fetch_models_from_transports(&runtime, &[sample_kiro_transport()])
             .await


### PR DESCRIPTION
Change the URL for the Vertex Model Garden model list from the project/region path to:

/v1beta1/publishers/{publisher}/models

This is consistent with the Google REST documentation: the parent format is publishers/{publisher}, and the response field is publisherModels/nextPageToken. Reference: https://docs.cloud.google.com/vertex-ai/docs/reference/ rest/v1beta1/publishers.models/list