### PR TITLE
fix(gateway): 关闭被取消的同步候选 pending 状态

### DIFF
--- a/apps/aether-gateway/src/execution_runtime/sync/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/sync/execution.rs
@@ -11,7 +11,7 @@ use aether_scheduler_core::{
 };
 use aether_usage_runtime::{
     build_lifecycle_usage_seed, build_sync_terminal_usage_payload_seed,
-    build_terminal_usage_context_seed,
+    build_terminal_usage_context_seed, build_usage_event_data_seed, UsageEvent, UsageEventType,
 };
 use async_stream::stream;
 use axum::body::{to_bytes, Body, Bytes};
@@ -96,6 +96,158 @@ struct SyncExecutionFailure {
     latency_ms: Option<u64>,
 }
 
+struct SyncAttemptTerminalGuard {
+    state: AppState,
+    plan: ExecutionPlan,
+    report_context: Option<Value>,
+    candidate_started_unix_ms: u64,
+    armed: bool,
+}
+
+impl SyncAttemptTerminalGuard {
+    fn new(
+        state: &AppState,
+        plan: &ExecutionPlan,
+        report_context: Option<Value>,
+        candidate_started_unix_ms: u64,
+    ) -> Self {
+        Self {
+            state: state.clone(),
+            plan: plan.clone(),
+            report_context,
+            candidate_started_unix_ms,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    async fn fail_and_disarm(&mut self, error: &GatewayError) {
+        if !self.armed {
+            return;
+        }
+        self.armed = false;
+        record_sync_attempt_forced_terminal_state(
+            self.state.clone(),
+            self.plan.clone(),
+            self.report_context.clone(),
+            self.candidate_started_unix_ms,
+            UsageEventType::Failed,
+            RequestCandidateStatus::Failed,
+            StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+            "local_sync_attempt_aborted",
+            format!("Local sync attempt failed before terminal finalization: {error:?}"),
+        )
+        .await;
+    }
+}
+
+impl Drop for SyncAttemptTerminalGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        self.armed = false;
+        let state = self.state.clone();
+        let plan = self.plan.clone();
+        let report_context = self.report_context.clone();
+        let candidate_started_unix_ms = self.candidate_started_unix_ms;
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                record_sync_attempt_forced_terminal_state(
+                    state,
+                    plan,
+                    report_context,
+                    candidate_started_unix_ms,
+                    UsageEventType::Cancelled,
+                    RequestCandidateStatus::Cancelled,
+                    499,
+                    "local_sync_attempt_cancelled",
+                    "Local sync attempt was dropped before terminal finalization, usually because the client disconnected or the request task was cancelled.",
+                )
+                .await;
+            });
+        } else {
+            warn!(
+                event_name = "local_sync_attempt_terminal_guard_no_runtime",
+                log_type = "ops",
+                request_id = %short_request_id(self.plan.request_id.as_str()),
+                candidate_id = ?self.plan.candidate_id,
+                "gateway could not finalize dropped local sync attempt because no Tokio runtime is available"
+            );
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn record_sync_attempt_forced_terminal_state(
+    state: AppState,
+    plan: ExecutionPlan,
+    report_context: Option<Value>,
+    candidate_started_unix_ms: u64,
+    usage_event_type: UsageEventType,
+    candidate_status: RequestCandidateStatus,
+    status_code: u16,
+    error_type: &'static str,
+    error_message: impl Into<String>,
+) {
+    let error_message = error_message.into();
+    let terminal_unix_ms = current_request_candidate_unix_ms();
+    let latency_ms = terminal_unix_ms.saturating_sub(candidate_started_unix_ms);
+    record_local_request_candidate_status(
+        &state,
+        &plan,
+        report_context.as_ref(),
+        SchedulerRequestCandidateStatusUpdate {
+            status: candidate_status,
+            status_code: Some(status_code),
+            error_type: Some(error_type.to_string()),
+            error_message: Some(error_message.clone()),
+            latency_ms: Some(latency_ms),
+            started_at_unix_ms: Some(candidate_started_unix_ms),
+            finished_at_unix_ms: Some(terminal_unix_ms),
+        },
+    )
+    .await;
+
+    if !state.usage_runtime.is_enabled() {
+        return;
+    }
+
+    let mut usage_data = build_usage_event_data_seed(&plan, report_context.as_ref());
+    usage_data.status_code = Some(status_code);
+    usage_data.error_message = Some(error_message.clone());
+    usage_data.error_category = Some(
+        match usage_event_type {
+            UsageEventType::Cancelled => "cancelled",
+            _ => "server_error",
+        }
+        .to_string(),
+    );
+    usage_data.response_time_ms = Some(latency_ms);
+    let error_body = json!({
+        "error": {
+            "type": error_type,
+            "message": error_message,
+            "code": status_code
+        }
+    });
+    usage_data.response_headers = Some(json!({"content-type": "application/json"}));
+    usage_data.response_body = Some(error_body.clone());
+    usage_data.client_response_headers = Some(json!({"content-type": "application/json"}));
+    usage_data.client_response_body = Some(error_body);
+
+    state
+        .usage_runtime
+        .record_terminal_event_direct(
+            state.data.as_ref(),
+            UsageEvent::new(usage_event_type, plan.request_id.clone(), usage_data),
+        )
+        .await;
+}
+
 impl SyncExecutionFailure {
     fn from_transport(err: ExecutionRuntimeTransportError) -> Self {
         Self {
@@ -134,6 +286,17 @@ fn record_sync_terminal_usage(
     state
         .usage_runtime
         .record_sync_terminal(state.data.as_ref(), context_seed, payload_seed);
+}
+
+fn record_sync_terminal_usage_and_disarm_guard(
+    state: &AppState,
+    plan: &ExecutionPlan,
+    report_context: Option<&serde_json::Value>,
+    payload: &GatewaySyncReportRequest,
+    terminal_guard: &mut SyncAttemptTerminalGuard,
+) {
+    record_sync_terminal_usage(state, plan, report_context, payload);
+    terminal_guard.disarm();
 }
 
 fn with_sync_error_trace_context(
@@ -1067,6 +1230,13 @@ async fn execute_execution_runtime_sync_impl(
         },
     )
     .await;
+    let mut terminal_guard = SyncAttemptTerminalGuard::new(
+        state,
+        &plan,
+        report_context.clone(),
+        candidate_started_unix_secs,
+    );
+    let result = (async {
     let _provider_pool_in_flight_guard = acquire_provider_pool_in_flight_guard(
         state.runtime_state.clone(),
         &plan.provider_id,
@@ -1658,11 +1828,12 @@ async fn execute_execution_runtime_sync_impl(
             usage_payload,
         )
         .await;
-        record_sync_terminal_usage(
+        record_sync_terminal_usage_and_disarm_guard(
             state,
             &plan,
             implicit_finalize.payload.report_context.as_ref(),
             usage_payload,
+            &mut terminal_guard,
         );
         if let Some(report_payload) = implicit_finalize.outcome.background_report {
             spawn_sync_report(state.clone(), report_payload);
@@ -1710,11 +1881,12 @@ async fn execute_execution_runtime_sync_impl(
                 )
                 .await;
             }
-            record_sync_terminal_usage(
+            record_sync_terminal_usage_and_disarm_guard(
                 state,
                 &plan,
                 payload.report_context.as_ref(),
                 usage_payload,
+                &mut terminal_guard,
             );
             if let Some(report_payload) = outcome.background_report {
                 spawn_sync_report(state.clone(), report_payload);
@@ -1755,11 +1927,12 @@ async fn execute_execution_runtime_sync_impl(
                     &report_payload,
                 )
                 .await;
-                record_sync_terminal_usage(
+                record_sync_terminal_usage_and_disarm_guard(
                     state,
                     &plan,
                     original_report_context.as_ref(),
                     &report_payload,
+                    &mut terminal_guard,
                 );
                 if let Some(snapshot) = local_task_snapshot {
                     let _ = state.upsert_video_task_snapshot(&snapshot).await?;
@@ -1788,7 +1961,13 @@ async fn execute_execution_runtime_sync_impl(
                 resolve_local_sync_success_background_report_kind(payload.report_kind.as_str());
             apply_sync_success_effects(state, &plan, payload.report_context.as_ref(), &payload)
                 .await;
-            record_sync_terminal_usage(state, &plan, payload.report_context.as_ref(), &payload);
+            record_sync_terminal_usage_and_disarm_guard(
+                state,
+                &plan,
+                payload.report_context.as_ref(),
+                &payload,
+                &mut terminal_guard,
+            );
             state
                 .video_tasks
                 .apply_finalize_mutation(request_path, payload.report_kind.as_str());
@@ -1828,7 +2007,13 @@ async fn execute_execution_runtime_sync_impl(
             if let Some(error_report_kind) = background_error_report_kind {
                 payload.report_kind = error_report_kind.to_string();
             }
-            record_sync_terminal_usage(state, &plan, payload.report_context.as_ref(), &payload);
+            record_sync_terminal_usage_and_disarm_guard(
+                state,
+                &plan,
+                payload.report_context.as_ref(),
+                &payload,
+                &mut terminal_guard,
+            );
             if background_error_report_kind.is_some() {
                 spawn_sync_report(state.clone(), payload);
             } else {
@@ -1848,7 +2033,13 @@ async fn execute_execution_runtime_sync_impl(
                 candidate_id,
             )?));
         }
-        record_sync_terminal_usage(state, &plan, payload.report_context.as_ref(), &payload);
+        record_sync_terminal_usage_and_disarm_guard(
+            state,
+            &plan,
+            payload.report_context.as_ref(),
+            &payload,
+            &mut terminal_guard,
+        );
         let response =
             submit_local_core_error_or_sync_finalize(state, trace_id, decision, payload).await?;
         return Ok(Some(attach_control_metadata_headers(
@@ -1877,11 +2068,12 @@ async fn execute_execution_runtime_sync_impl(
         )
         .await;
     }
-    record_sync_terminal_usage(
+    record_sync_terminal_usage_and_disarm_guard(
         state,
         &plan,
         usage_payload.report_context.as_ref(),
         &usage_payload,
+        &mut terminal_guard,
     );
     let response = attach_control_metadata_headers(
         build_client_response_from_parts(
@@ -1899,6 +2091,14 @@ async fn execute_execution_runtime_sync_impl(
     }
 
     Ok(Some(response))
+    })
+    .await;
+    if let Err(error) = result.as_ref() {
+        terminal_guard.fail_and_disarm(error).await;
+    } else {
+        terminal_guard.disarm();
+    }
+    result
 }
 
 #[allow(clippy::too_many_arguments)] // mirrors sync execution context
@@ -2030,9 +2230,15 @@ async fn execute_sync_via_remote_execution_runtime(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aether_data::repository::candidates::InMemoryRequestCandidateRepository;
+    use aether_data::repository::usage::InMemoryUsageReadRepository;
+    use aether_data_contracts::repository::candidates::RequestCandidateReadRepository;
+    use aether_data_contracts::repository::usage::UsageReadRepository;
+    use aether_usage_runtime::UsageRuntimeConfig;
     use futures_util::{pin_mut, StreamExt as _};
     use serde_json::json;
     use std::collections::BTreeMap;
+    use std::sync::Arc;
 
     fn test_openai_image_plan(stream: bool) -> ExecutionPlan {
         ExecutionPlan {
@@ -2056,6 +2262,101 @@ mod tests {
             transport_profile: None,
             timeouts: None,
         }
+    }
+
+    #[tokio::test]
+    async fn sync_attempt_terminal_guard_marks_dropped_pending_attempt_cancelled() {
+        let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
+        let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
+        let state = AppState::new()
+            .expect("gateway state should build")
+            .with_data_state_for_tests(
+                crate::data::GatewayDataState::with_request_candidate_and_usage_repository_for_tests(
+                    Arc::clone(&request_candidate_repository),
+                    Arc::clone(&usage_repository),
+                ),
+            )
+            .with_usage_runtime_for_tests(UsageRuntimeConfig {
+                enabled: true,
+                ..UsageRuntimeConfig::default()
+            });
+        let mut plan = test_openai_image_plan(false);
+        plan.request_id = "sync-cancel-guard-request".to_string();
+        plan.candidate_id = None;
+        let mut report_context = Some(json!({
+            "candidate_index": 0,
+            "retry_index": 0,
+            "user_id": "user-cancel",
+            "api_key_id": "api-key-cancel",
+            "client_api_format": "openai:image",
+            "provider_api_format": "openai:image",
+            "request_path": "/v1/images/generations",
+            "request_path_and_query": "/v1/images/generations",
+            "upstream_url": "https://example.test/v1/images/generations",
+            "mapped_model": "gpt-image-2",
+        }));
+
+        ensure_execution_request_candidate_slot(&state, &mut plan, &mut report_context).await;
+        let started_at = current_request_candidate_unix_ms();
+        state.usage_runtime.record_pending(
+            state.data.as_ref(),
+            build_lifecycle_usage_seed(&plan, report_context.as_ref()),
+        );
+        record_local_request_candidate_status(
+            &state,
+            &plan,
+            report_context.as_ref(),
+            SchedulerRequestCandidateStatusUpdate {
+                status: RequestCandidateStatus::Pending,
+                status_code: None,
+                error_type: None,
+                error_message: None,
+                latency_ms: None,
+                started_at_unix_ms: Some(started_at),
+                finished_at_unix_ms: None,
+            },
+        )
+        .await;
+
+        {
+            let _guard =
+                SyncAttemptTerminalGuard::new(&state, &plan, report_context.clone(), started_at);
+        }
+
+        let mut stored_usage = None;
+        for _ in 0..50 {
+            if let Some(usage) = usage_repository
+                .find_by_request_id("sync-cancel-guard-request")
+                .await
+                .expect("usage should read")
+            {
+                if usage.status == "cancelled" {
+                    stored_usage = Some(usage);
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let stored_usage = stored_usage.expect("cancelled usage should be recorded");
+        assert_eq!(stored_usage.status, "cancelled");
+        assert_eq!(stored_usage.billing_status, "void");
+        assert_eq!(stored_usage.status_code, Some(499));
+        assert_eq!(stored_usage.error_category.as_deref(), Some("cancelled"));
+
+        let stored_candidates = request_candidate_repository
+            .list_by_request_id("sync-cancel-guard-request")
+            .await
+            .expect("request candidates should read");
+        assert_eq!(stored_candidates.len(), 1);
+        assert_eq!(
+            stored_candidates[0].status,
+            RequestCandidateStatus::Cancelled
+        );
+        assert_eq!(stored_candidates[0].status_code, Some(499));
+        assert_eq!(
+            stored_candidates[0].error_type.as_deref(),
+            Some("local_sync_attempt_cancelled")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 背景

同步执行路径会先写入 usage/request candidate 的 `pending` 状态，然后继续等待本地执行运行时、上游响应解析、候选重试或本地 finalize。Rust async future 在客户端断开、请求任务被取消、handler future 被 drop 时，不会继续执行后续 `.await` 之后的终态写入逻辑。

这会导致已经写入的 `pending` usage / request candidate 悬空，只能依赖后续的 `pending_cleanup` 定时任务在超时后补救。补救本身会延迟观测，也会让请求追踪在一段时间内呈现“仍在 pending”的伪状态。

## upstream 问题确认

本分支直接基于当前 upstream `origin/main`：`d51b44d64243026a0c4c171707a3765ab152f7d0`。

在 upstream `apps/aether-gateway/src/execution_runtime/sync/execution.rs` 中可以看到：

- `record_pending(...)` 和 `RequestCandidateStatus::Pending` 会在同步候选执行前写入。
- 后续正常路径会写入 failed/success/cancelled 等终态，但这些写入都依赖 future 继续运行。
- upstream 没有 `Drop`/guard/finally 型终态闭合逻辑，也没有 `local_sync_attempt_cancelled` 这类即时取消终态。
- upstream 仅有 `pending_cleanup` 定时清理，属于超时后的延迟修复，不是同步请求取消时的实时终态闭合。

因此该问题不是本地定制前端、Gemini endpoint 主线补丁或其它本地修改造成的“自挖坑”问题，而是 upstream 同步执行路径本身缺少取消安全终态保护。

## 代码根因

同步候选的关键顺序是：

1. 写入 usage pending。
2. 写入 request candidate pending。
3. 执行本地/远端同步运行时和响应处理。
4. 在正常路径中写入 request candidate 终态与 usage 终态。

如果第 2 步之后、第 4 步之前 future 被 drop，普通控制流不会继续执行，已有 pending 状态不会被即时关闭。

## 修改内容

- 增加 `SyncAttemptTerminalGuard`，在同步候选写入 pending 后 armed。
- 正常返回时 disarm，不改变既有成功、失败、重试、finalize 行为。
- 如果内部错误在终态写入前返回，显式记录 failed/500，避免继续悬空 pending。
- 如果 future 被 drop，异步记录 cancelled/499，并同步关闭 request candidate 与 usage 终态。
- 在 `record_sync_terminal_usage(...)` 已经把终态 usage 交给后台写入后立即 disarm，防止 guard 抢主链、把已经完成的请求覆盖成失败。
- 增加回归测试，覆盖 pending 写入后 guard 被 drop 时 usage 与 request candidate 都落到 cancelled/499。

## 影响范围

- 仅修改同步执行路径：`apps/aether-gateway/src/execution_runtime/sync/execution.rs`。
- 不改变调度选择、provider 路由、模型映射、前端 UI、品牌/视觉元素。
- 不引入 fallback，不切换 provider，不绕过原主链。
- 对正常完成、正常失败、正常候选重试路径保持原有语义；新增逻辑只负责关闭“future 已经无法继续执行”的悬空 pending 窗口。

## 验证

已在隔离 worktree 中执行：

```bash
cargo fmt --all -- --check
cargo test -p aether-gateway sync_attempt_terminal_guard_marks_dropped_pending_attempt_cancelled -- --nocapture
```

测试结果：

- 格式检查通过。
- 定向回归测试通过：`1 passed; 0 failed`。