### PR TITLE
支持 Provider Key 余额查询与自动刷新

### DIFF
--- a/apps/aether-gateway/src/control/route/admin/endpoints_families.rs
+++ b/apps/aether-gateway/src/control/route/admin/endpoints_families.rs
@@ -179,6 +179,17 @@ pub(super) fn classify_admin_endpoints_family_route(
         ))
     } else if method == http::Method::POST
         && normalized_path.starts_with("/api/admin/endpoints/providers/")
+        && normalized_path.ends_with("/key-balance")
+    {
+        Some(classified(
+            "admin_proxy",
+            "endpoints_manage",
+            "query_key_balance",
+            "admin:endpoints_manage",
+            false,
+        ))
+    } else if method == http::Method::POST
+        && normalized_path.starts_with("/api/admin/endpoints/providers/")
         && normalized_path.ends_with("/keys")
     {
         Some(classified(

--- a/apps/aether-gateway/src/control/tests/admin_endpoints.rs
+++ b/apps/aether-gateway/src/control/tests/admin_endpoints.rs
@@ -381,6 +381,20 @@ fn classifies_admin_refresh_provider_quota_as_admin_proxy_route() {
 }
 
 #[test]
+fn classifies_admin_query_provider_key_balance_as_admin_proxy_route() {
+    let headers = http::HeaderMap::new();
+    let uri: Uri = "/api/admin/endpoints/providers/provider-newapi/key-balance"
+        .parse()
+        .expect("uri should parse");
+    let decision = classify_control_route(&http::Method::POST, &uri, &headers)
+        .expect("decision should resolve");
+    assert_eq!(decision.route_class.as_deref(), Some("admin_proxy"));
+    assert_eq!(decision.route_family.as_deref(), Some("endpoints_manage"));
+    assert_eq!(decision.route_kind.as_deref(), Some("query_key_balance"));
+    assert!(!decision.is_execution_runtime_candidate());
+}
+
+#[test]
 fn admin_refresh_provider_quota_buffers_request_body_for_key_selection() {
     let headers = headers(&[]);
     let uri: Uri = "/api/admin/endpoints/providers/provider-codex/refresh-quota"
@@ -390,6 +404,25 @@ fn admin_refresh_provider_quota_buffers_request_body_for_key_selection() {
         .expect("decision should resolve");
     let context = GatewayPublicRequestContext::from_request_parts(
         "trace-refresh-quota",
+        &http::Method::POST,
+        &uri,
+        &headers,
+        Some(decision),
+    );
+
+    assert!(local_proxy_route_requires_buffered_body(&context));
+}
+
+#[test]
+fn admin_query_provider_key_balance_buffers_request_body_for_key_secret() {
+    let headers = headers(&[]);
+    let uri: Uri = "/api/admin/endpoints/providers/provider-newapi/key-balance"
+        .parse()
+        .expect("uri should parse");
+    let decision = classify_control_route(&http::Method::POST, &uri, &headers)
+        .expect("decision should resolve");
+    let context = GatewayPublicRequestContext::from_request_parts(
+        "trace-key-balance",
         &http::Method::POST,
         &uri,
         &headers,

--- a/apps/aether-gateway/src/handlers/admin/provider/endpoint_keys.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/endpoint_keys.rs
@@ -1,3 +1,4 @@
+mod balance;
 mod mutations;
 mod quota;
 mod reads;
@@ -15,6 +16,10 @@ pub(crate) async fn maybe_build_local_admin_endpoints_keys_response(
     request_body: Option<&Bytes>,
 ) -> Result<Option<Response<Body>>, GatewayError> {
     if let Some(response) = reads::maybe_handle(state, request_context, request_body).await? {
+        return Ok(Some(response));
+    }
+
+    if let Some(response) = balance::maybe_handle(state, request_context, request_body).await? {
         return Ok(Some(response));
     }
 

--- a/apps/aether-gateway/src/handlers/admin/provider/endpoint_keys/balance.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/endpoint_keys/balance.rs
@@ -1,0 +1,1018 @@
+use crate::handlers::admin::provider::ops::providers::actions::{
+    admin_provider_ops_query_balance_response_for_credentials,
+    admin_provider_ops_saved_connector_credentials,
+};
+use crate::handlers::admin::provider::shared::paths::admin_provider_id_for_key_balance;
+use crate::handlers::admin::request::{AdminAppState, AdminRequestContext};
+use crate::GatewayError;
+use aether_admin::provider::ops::{
+    admin_provider_ops_config_object, normalize_architecture_id,
+    resolve_admin_provider_ops_base_url,
+};
+use aether_data_contracts::repository::provider_catalog::{
+    StoredProviderCatalogEndpoint, StoredProviderCatalogKey, StoredProviderCatalogProvider,
+};
+use axum::{
+    body::{Body, Bytes},
+    http,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+use std::collections::BTreeSet;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const BALANCE_QUERY_SECRET_CIPHERTEXT_KEY: &str = "secret_ciphertext";
+const BALANCE_QUERY_SECRET_SAVED_AT_KEY: &str = "secret_saved_at";
+
+#[derive(Debug, Deserialize)]
+struct AdminProviderKeyBalanceRequest {
+    #[serde(default)]
+    key_id: Option<String>,
+    #[serde(default)]
+    api_key: Option<String>,
+    #[serde(default)]
+    auth_type: Option<String>,
+    #[serde(default)]
+    api_formats: Option<Vec<String>>,
+    #[serde(default)]
+    architecture_id: Option<String>,
+    #[serde(default)]
+    custom_base_url: Option<String>,
+    #[serde(default)]
+    new_api_user_id: Option<String>,
+    #[serde(default)]
+    sub2api_credential_kind: Option<String>,
+    #[serde(default)]
+    custom_endpoint: Option<String>,
+    #[serde(default)]
+    custom_method: Option<String>,
+    #[serde(default)]
+    custom_currency: Option<String>,
+    #[serde(default)]
+    custom_quota_divisor: Option<f64>,
+    #[serde(default)]
+    custom_balance_path: Option<String>,
+    #[serde(default)]
+    custom_used_path: Option<String>,
+    #[serde(default)]
+    custom_granted_path: Option<String>,
+    #[serde(default)]
+    auto_refresh_interval_minutes: Option<u32>,
+    #[serde(default)]
+    save_balance_secret: bool,
+    #[serde(default)]
+    save_result: bool,
+}
+
+pub(super) async fn maybe_handle(
+    state: &AdminAppState<'_>,
+    request_context: &AdminRequestContext<'_>,
+    request_body: Option<&Bytes>,
+) -> Result<Option<Response<Body>>, GatewayError> {
+    let Some(decision) = request_context.decision() else {
+        return Ok(None);
+    };
+    if decision.route_family.as_deref() != Some("endpoints_manage")
+        || decision.route_kind.as_deref() != Some("query_key_balance")
+        || request_context.method() != http::Method::POST
+        || !request_context
+            .path()
+            .starts_with("/api/admin/endpoints/providers/")
+        || !request_context.path().ends_with("/key-balance")
+    {
+        return Ok(None);
+    }
+
+    let Some(provider_id) = admin_provider_id_for_key_balance(request_context.path()) else {
+        return Ok(Some(not_found_response("Provider 不存在")));
+    };
+    let Some(request_body) = request_body.filter(|body| !body.is_empty()) else {
+        return Ok(Some(bad_request_response("请求体不能为空")));
+    };
+    let payload = match serde_json::from_slice::<AdminProviderKeyBalanceRequest>(request_body) {
+        Ok(payload) => payload,
+        Err(_) => return Ok(Some(bad_request_response("请求体必须是合法的 JSON 对象"))),
+    };
+
+    let Some(provider) = state
+        .read_provider_catalog_providers_by_ids(std::slice::from_ref(&provider_id))
+        .await?
+        .into_iter()
+        .next()
+    else {
+        return Ok(Some(not_found_response(format!(
+            "Provider {provider_id} 不存在"
+        ))));
+    };
+    let endpoints = state
+        .list_provider_catalog_endpoints_by_provider_ids(std::slice::from_ref(&provider_id))
+        .await?;
+
+    let stored_key =
+        match load_optional_stored_key(state, &provider_id, payload.key_id.as_ref()).await? {
+            Ok(key) => key,
+            Err(response) => return Ok(Some(response)),
+        };
+    let auth_type = resolved_balance_auth_type(payload.auth_type.as_deref(), stored_key.as_ref());
+    if !matches!(auth_type.as_str(), "api_key" | "bearer") {
+        return Ok(Some(bad_request_response(
+            "余额查询仅支持 API Key 或 Bearer Token",
+        )));
+    }
+
+    let selected_endpoint = select_balance_endpoint(&endpoints, payload.api_formats.as_deref());
+    let provider_ops_config = admin_provider_ops_config_object(&provider).cloned();
+    let empty_provider_ops_config = Map::new();
+    let provider_ops_config_ref = provider_ops_config
+        .as_ref()
+        .unwrap_or(&empty_provider_ops_config);
+    let request_base_url = trimmed_request_string(payload.custom_base_url.as_ref())
+        .map(|value| value.trim_end_matches('/').to_string());
+    let base_url = request_base_url
+        .or_else(|| {
+            resolve_admin_provider_ops_base_url(&provider, &endpoints, provider_ops_config.as_ref())
+        })
+        .or_else(|| selected_endpoint.map(|endpoint| endpoint.base_url.clone()))
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty());
+    let Some(base_url) = base_url else {
+        return Ok(Some(bad_request_response("Provider 未配置 base_url")));
+    };
+
+    let architecture_id = payload
+        .architecture_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(normalize_architecture_id)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| {
+            resolve_key_balance_architecture_id(&provider, provider_ops_config_ref, &base_url)
+        });
+    let action_config_override = build_balance_action_config_override(&payload, &architecture_id);
+    let action_config_override_ref = if action_config_override.is_empty() {
+        None
+    } else {
+        Some(&action_config_override)
+    };
+    let secret =
+        match resolve_balance_secret(state, &payload, stored_key.as_ref(), &architecture_id) {
+            Ok(secret) => secret,
+            Err(detail) => return Ok(Some(bad_request_response(detail))),
+        };
+    let connector_config = provider_ops_connector_config(provider_ops_config_ref);
+    let saved_credentials = admin_provider_ops_saved_connector_credentials(state, &provider);
+    let credentials = match resolve_balance_credentials(
+        &architecture_id,
+        &auth_type,
+        &secret,
+        saved_credentials,
+        &payload,
+    ) {
+        Ok(credentials) => credentials,
+        Err(detail) => {
+            return Ok(Some(
+                Json(action_not_configured_payload(detail)).into_response(),
+            ))
+        }
+    };
+    let mut response_payload = admin_provider_ops_query_balance_response_for_credentials(
+        state,
+        &provider_id,
+        &provider,
+        &architecture_id,
+        &base_url,
+        provider_ops_config_ref,
+        &connector_config,
+        &credentials,
+        action_config_override_ref,
+    )
+    .await;
+
+    if payload.save_result {
+        let save_outcome = match stored_key.as_ref() {
+            Some(stored_key) => {
+                persist_balance_result_metadata(
+                    state,
+                    stored_key,
+                    &architecture_id,
+                    &payload,
+                    &response_payload,
+                )
+                .await
+            }
+            None => Ok(false),
+        };
+        attach_balance_result_save_status(
+            &mut response_payload,
+            save_outcome,
+            stored_key.as_ref().map(|key| key.id.as_str()),
+        );
+    }
+
+    Ok(Some(Json(response_payload).into_response()))
+}
+
+fn provider_ops_connector_config(provider_ops_config: &Map<String, Value>) -> Map<String, Value> {
+    provider_ops_config
+        .get("connector")
+        .and_then(Value::as_object)
+        .and_then(|connector| connector.get("config"))
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default()
+}
+
+async fn persist_balance_result_metadata(
+    state: &AdminAppState<'_>,
+    stored_key: &StoredProviderCatalogKey,
+    architecture_id: &str,
+    payload: &AdminProviderKeyBalanceRequest,
+    response_payload: &Value,
+) -> Result<bool, String> {
+    if response_payload
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        != "success"
+    {
+        return Ok(false);
+    }
+    let Some(data) = response_payload.get("data").and_then(Value::as_object) else {
+        return Ok(false);
+    };
+
+    let now = current_unix_secs();
+    let extra = data
+        .get("extra")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let plan_name = extra
+        .get("plan_name")
+        .or_else(|| extra.get("planName"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+
+    let saved_secret = if balance_query_secret_matches_request(stored_key, architecture_id, payload)
+    {
+        balance_query_secret_ciphertext(stored_key)
+    } else {
+        None
+    };
+    let new_saved_secret = encrypted_balance_query_secret(state, payload)?;
+    let secret_ciphertext = new_saved_secret
+        .clone()
+        .or_else(|| saved_secret.map(ToOwned::to_owned));
+    let has_saved_secret = secret_ciphertext.is_some();
+    let secret_saved_at = if new_saved_secret.is_some() {
+        Some(now)
+    } else if saved_secret.is_some() {
+        balance_query_secret_saved_at(stored_key)
+    } else {
+        None
+    };
+    let mut balance_query = Map::new();
+    balance_query.insert("updated_at".to_string(), json!(now));
+    balance_query.insert(
+        "architecture_id".to_string(),
+        json!(normalize_architecture_id(architecture_id)),
+    );
+    balance_query.insert(
+        "status".to_string(),
+        response_payload
+            .get("status")
+            .cloned()
+            .unwrap_or(Value::Null),
+    );
+    balance_query.insert(
+        "executed_at".to_string(),
+        response_payload
+            .get("executed_at")
+            .cloned()
+            .unwrap_or(Value::Null),
+    );
+    balance_query.insert(
+        "response_time_ms".to_string(),
+        response_payload
+            .get("response_time_ms")
+            .cloned()
+            .unwrap_or(Value::Null),
+    );
+    balance_query.insert(
+        "total_available".to_string(),
+        data.get("total_available").cloned().unwrap_or(Value::Null),
+    );
+    balance_query.insert(
+        "total_used".to_string(),
+        data.get("total_used").cloned().unwrap_or(Value::Null),
+    );
+    balance_query.insert(
+        "total_granted".to_string(),
+        data.get("total_granted").cloned().unwrap_or(Value::Null),
+    );
+    balance_query.insert(
+        "currency".to_string(),
+        data.get("currency")
+            .cloned()
+            .unwrap_or_else(|| json!("USD")),
+    );
+    balance_query.insert("plan_name".to_string(), json!(plan_name));
+    balance_query.insert(
+        "query_config".to_string(),
+        balance_query_config_metadata(payload, architecture_id, has_saved_secret),
+    );
+    balance_query.insert("extra".to_string(), Value::Object(extra));
+    if let Some(ciphertext) = secret_ciphertext {
+        balance_query.insert(
+            BALANCE_QUERY_SECRET_CIPHERTEXT_KEY.to_string(),
+            Value::String(ciphertext),
+        );
+    }
+    if let Some(saved_at) = secret_saved_at {
+        balance_query.insert(
+            BALANCE_QUERY_SECRET_SAVED_AT_KEY.to_string(),
+            json!(saved_at),
+        );
+    }
+
+    let metadata_update = json!({
+        "balance_query": Value::Object(balance_query),
+    });
+    let merged = merge_upstream_metadata(stored_key.upstream_metadata.as_ref(), &metadata_update);
+    state
+        .update_provider_catalog_key_upstream_metadata(&stored_key.id, Some(&merged), Some(now))
+        .await
+        .map_err(|err| format!("{err:?}"))
+}
+
+fn balance_query_config_metadata(
+    payload: &AdminProviderKeyBalanceRequest,
+    architecture_id: &str,
+    has_saved_secret: bool,
+) -> Value {
+    let normalized_architecture_id = normalize_architecture_id(architecture_id);
+    let mut config = Map::new();
+
+    config.insert("has_saved_secret".to_string(), json!(has_saved_secret));
+
+    if let Some(base_url) = trimmed_request_string(payload.custom_base_url.as_ref()) {
+        config.insert("custom_base_url".to_string(), Value::String(base_url));
+    }
+    if let Some(interval_minutes) = payload
+        .auto_refresh_interval_minutes
+        .filter(|value| *value > 0)
+        .map(|value| value.min(10_080))
+    {
+        config.insert(
+            "auto_refresh_interval_minutes".to_string(),
+            json!(interval_minutes),
+        );
+    }
+
+    match normalized_architecture_id {
+        "new_api" => {
+            if let Some(user_id) = trimmed_request_string(payload.new_api_user_id.as_ref()) {
+                config.insert("new_api_user_id".to_string(), Value::String(user_id));
+            }
+        }
+        "sub2api" => {
+            if let Some(kind) =
+                normalized_sub2api_credential_kind(payload.sub2api_credential_kind.as_deref())
+            {
+                config.insert("sub2api_credential_kind".to_string(), Value::String(kind));
+            }
+        }
+        "generic_api" => {
+            if let Some(endpoint) = trimmed_request_string(payload.custom_endpoint.as_ref()) {
+                config.insert("custom_endpoint".to_string(), Value::String(endpoint));
+            }
+            if let Some(method) = normalized_request_method(payload.custom_method.as_deref()) {
+                config.insert("custom_method".to_string(), Value::String(method));
+            }
+            if let Some(currency) = trimmed_request_string(payload.custom_currency.as_ref()) {
+                config.insert("custom_currency".to_string(), Value::String(currency));
+            }
+            if let Some(divisor) = payload
+                .custom_quota_divisor
+                .filter(|value| value.is_finite() && *value > 0.0)
+            {
+                config.insert("custom_quota_divisor".to_string(), json!(divisor));
+            }
+            if let Some(path) = trimmed_request_string(payload.custom_balance_path.as_ref()) {
+                config.insert("custom_balance_path".to_string(), Value::String(path));
+            }
+            if let Some(path) = trimmed_request_string(payload.custom_used_path.as_ref()) {
+                config.insert("custom_used_path".to_string(), Value::String(path));
+            }
+            if let Some(path) = trimmed_request_string(payload.custom_granted_path.as_ref()) {
+                config.insert("custom_granted_path".to_string(), Value::String(path));
+            }
+        }
+        _ => {}
+    }
+
+    Value::Object(config)
+}
+
+fn encrypted_balance_query_secret(
+    state: &AdminAppState<'_>,
+    payload: &AdminProviderKeyBalanceRequest,
+) -> Result<Option<String>, String> {
+    if !payload.save_balance_secret {
+        return Ok(None);
+    }
+    let Some(secret) = payload
+        .api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(None);
+    };
+    state
+        .encrypt_catalog_secret_with_fallbacks(secret)
+        .map(Some)
+        .ok_or_else(|| "gateway 未配置余额查询凭据加密密钥".to_string())
+}
+
+fn attach_balance_result_save_status(
+    response_payload: &mut Value,
+    outcome: Result<bool, String>,
+    key_id: Option<&str>,
+) {
+    let Some(object) = response_payload.as_object_mut() else {
+        return;
+    };
+    match outcome {
+        Ok(true) => {
+            object.insert("saved_to_key".to_string(), Value::Bool(true));
+            object.insert(
+                "saved_key_id".to_string(),
+                key_id
+                    .map(|value| Value::String(value.to_string()))
+                    .unwrap_or(Value::Null),
+            );
+            object.insert("save_message".to_string(), Value::Null);
+        }
+        Ok(false) => {
+            object.insert("saved_to_key".to_string(), Value::Bool(false));
+            object.insert(
+                "saved_key_id".to_string(),
+                key_id
+                    .map(|value| Value::String(value.to_string()))
+                    .unwrap_or(Value::Null),
+            );
+            object.insert(
+                "save_message".to_string(),
+                Value::String("查询未成功或当前没有可保存的结果，未写入 Key".to_string()),
+            );
+        }
+        Err(message) => {
+            object.insert("saved_to_key".to_string(), Value::Bool(false));
+            object.insert(
+                "saved_key_id".to_string(),
+                key_id
+                    .map(|value| Value::String(value.to_string()))
+                    .unwrap_or(Value::Null),
+            );
+            object.insert(
+                "save_message".to_string(),
+                Value::String(format!("保存余额结果失败: {message}")),
+            );
+        }
+    }
+}
+
+fn merge_upstream_metadata(current: Option<&Value>, updates: &Value) -> Value {
+    let mut merged = current
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(update_object) = updates.as_object() {
+        for (key, value) in update_object {
+            merged.insert(key.clone(), value.clone());
+        }
+    }
+    Value::Object(merged)
+}
+
+fn current_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn build_balance_action_config_override(
+    payload: &AdminProviderKeyBalanceRequest,
+    architecture_id: &str,
+) -> Map<String, Value> {
+    let mut config = Map::new();
+    if normalize_architecture_id(architecture_id) != "generic_api" {
+        return config;
+    }
+
+    if let Some(endpoint) = trimmed_request_string(payload.custom_endpoint.as_ref()) {
+        config.insert("endpoint".to_string(), Value::String(endpoint));
+    }
+    if let Some(method) = normalized_request_method(payload.custom_method.as_deref()) {
+        config.insert("method".to_string(), Value::String(method));
+    }
+    if let Some(currency) = trimmed_request_string(payload.custom_currency.as_ref()) {
+        config.insert("currency".to_string(), Value::String(currency));
+    }
+    if let Some(divisor) = payload
+        .custom_quota_divisor
+        .filter(|value| value.is_finite() && *value > 0.0)
+    {
+        config.insert("quota_divisor".to_string(), json!(divisor));
+    }
+    if let Some(path) = trimmed_request_string(payload.custom_balance_path.as_ref()) {
+        config.insert("balance_path".to_string(), Value::String(path));
+    }
+    if let Some(path) = trimmed_request_string(payload.custom_used_path.as_ref()) {
+        config.insert("used_path".to_string(), Value::String(path));
+    }
+    if let Some(path) = trimmed_request_string(payload.custom_granted_path.as_ref()) {
+        config.insert("granted_path".to_string(), Value::String(path));
+    }
+
+    config
+}
+
+fn trimmed_request_string(value: Option<&String>) -> Option<String> {
+    value
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn normalized_request_method(value: Option<&str>) -> Option<String> {
+    match value.map(str::trim).map(str::to_ascii_uppercase).as_deref() {
+        Some("GET") => Some("GET".to_string()),
+        Some("POST") => Some("POST".to_string()),
+        _ => None,
+    }
+}
+
+async fn load_optional_stored_key(
+    state: &AdminAppState<'_>,
+    provider_id: &str,
+    key_id: Option<&String>,
+) -> Result<Result<Option<StoredProviderCatalogKey>, Response<Body>>, GatewayError> {
+    let Some(key_id) = key_id
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    else {
+        return Ok(Ok(None));
+    };
+    let Some(key) = state
+        .read_provider_catalog_keys_by_ids(&[key_id.to_string()])
+        .await?
+        .into_iter()
+        .next()
+    else {
+        return Ok(Err(not_found_response(format!("Key {key_id} 不存在"))));
+    };
+    if key.provider_id != provider_id {
+        return Ok(Err(not_found_response("Key 不属于当前 Provider")));
+    }
+    Ok(Ok(Some(key)))
+}
+
+fn resolved_balance_auth_type(
+    request_auth_type: Option<&str>,
+    stored_key: Option<&StoredProviderCatalogKey>,
+) -> String {
+    request_auth_type
+        .or_else(|| stored_key.map(|key| key.auth_type.as_str()))
+        .unwrap_or("api_key")
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn resolve_balance_secret(
+    state: &AdminAppState<'_>,
+    payload: &AdminProviderKeyBalanceRequest,
+    stored_key: Option<&StoredProviderCatalogKey>,
+    architecture_id: &str,
+) -> Result<String, String> {
+    if let Some(secret) = payload
+        .api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(secret.to_string());
+    }
+
+    let Some(stored_key) = stored_key else {
+        return Err("请输入 API 密钥后再查询余额".to_string());
+    };
+    if let Some(secret) =
+        resolve_saved_balance_query_secret(state, stored_key, architecture_id, payload)?
+    {
+        return Ok(secret);
+    }
+    if balance_query_requires_saved_secret(architecture_id, payload) {
+        return Err(balance_query_missing_saved_secret_message(
+            architecture_id,
+            payload,
+        ));
+    }
+    let ciphertext = stored_key
+        .encrypted_api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "该 Key 没有可用的密钥内容".to_string())?;
+    let secret = state
+        .decrypt_catalog_secret_with_fallbacks(ciphertext)
+        .ok_or_else(|| "无法解密 API Key，可能是加密密钥已更改".to_string())?;
+    let secret = secret.trim();
+    if secret.is_empty() || secret == "__placeholder__" {
+        return Err("该 Key 没有可用的密钥内容".to_string());
+    }
+    Ok(secret.to_string())
+}
+
+fn balance_query_requires_saved_secret(
+    architecture_id: &str,
+    payload: &AdminProviderKeyBalanceRequest,
+) -> bool {
+    match normalize_architecture_id(architecture_id) {
+        "new_api" => true,
+        "sub2api" => matches!(
+            normalized_sub2api_credential_kind(payload.sub2api_credential_kind.as_deref())
+                .as_deref(),
+            Some("access_token" | "refresh_token")
+        ),
+        _ => false,
+    }
+}
+
+fn balance_query_missing_saved_secret_message(
+    architecture_id: &str,
+    payload: &AdminProviderKeyBalanceRequest,
+) -> String {
+    match normalize_architecture_id(architecture_id) {
+        "new_api" => {
+            "NewAPI 余额刷新需要个人安全设置里的访问令牌。请先打开“查询余额”，填写访问令牌并开启“保存余额查询凭据”。"
+                .to_string()
+        }
+        "sub2api"
+            if matches!(
+                normalized_sub2api_credential_kind(payload.sub2api_credential_kind.as_deref())
+                    .as_deref(),
+                Some("access_token" | "refresh_token")
+            ) =>
+        {
+            "Sub2API 使用 Access/Refresh Token 查询余额时，需要先手动查询并保存余额查询凭据。"
+                .to_string()
+        }
+        _ => "请先保存余额查询凭据后再刷新".to_string(),
+    }
+}
+
+fn resolve_saved_balance_query_secret(
+    state: &AdminAppState<'_>,
+    stored_key: &StoredProviderCatalogKey,
+    architecture_id: &str,
+    payload: &AdminProviderKeyBalanceRequest,
+) -> Result<Option<String>, String> {
+    let Some(ciphertext) = balance_query_secret_ciphertext(stored_key) else {
+        return Ok(None);
+    };
+    if !balance_query_secret_matches_request(stored_key, architecture_id, payload) {
+        return Ok(None);
+    }
+    let plaintext = state
+        .decrypt_catalog_secret_with_fallbacks(ciphertext)
+        .ok_or_else(|| "无法解密已保存的余额查询凭据，可能是加密密钥已更改".to_string())?;
+    let secret = plaintext.trim();
+    if secret.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(secret.to_string()))
+}
+
+fn balance_query_secret_ciphertext(stored_key: &StoredProviderCatalogKey) -> Option<&str> {
+    stored_key
+        .upstream_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("balance_query"))
+        .and_then(Value::as_object)
+        .and_then(|balance| balance.get(BALANCE_QUERY_SECRET_CIPHERTEXT_KEY))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn balance_query_secret_saved_at(stored_key: &StoredProviderCatalogKey) -> Option<u64> {
+    stored_key
+        .upstream_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("balance_query"))
+        .and_then(Value::as_object)
+        .and_then(|balance| balance.get(BALANCE_QUERY_SECRET_SAVED_AT_KEY))
+        .and_then(|value| match value {
+            Value::Number(number) => number.as_u64(),
+            Value::String(raw) => raw.trim().parse::<u64>().ok(),
+            _ => None,
+        })
+}
+
+fn balance_query_secret_matches_request(
+    stored_key: &StoredProviderCatalogKey,
+    architecture_id: &str,
+    payload: &AdminProviderKeyBalanceRequest,
+) -> bool {
+    let Some(balance_query) = stored_key
+        .upstream_metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("balance_query"))
+        .and_then(Value::as_object)
+    else {
+        return true;
+    };
+    let Some(stored_architecture_id) = balance_query
+        .get("architecture_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return true;
+    };
+    let normalized_architecture_id = normalize_architecture_id(architecture_id);
+    if normalize_architecture_id(stored_architecture_id) != normalized_architecture_id {
+        return false;
+    }
+    if normalized_architecture_id != "sub2api" {
+        return true;
+    }
+
+    let stored_kind = balance_query
+        .get("query_config")
+        .and_then(Value::as_object)
+        .and_then(|config| config.get("sub2api_credential_kind"))
+        .and_then(Value::as_str)
+        .and_then(|value| normalized_sub2api_credential_kind(Some(value)));
+    let requested_kind =
+        normalized_sub2api_credential_kind(payload.sub2api_credential_kind.as_deref());
+    match (stored_kind, requested_kind) {
+        (Some(stored_kind), Some(requested_kind)) => stored_kind == requested_kind,
+        _ => true,
+    }
+}
+
+fn select_balance_endpoint<'a>(
+    endpoints: &'a [StoredProviderCatalogEndpoint],
+    api_formats: Option<&[String]>,
+) -> Option<&'a StoredProviderCatalogEndpoint> {
+    let requested_formats = api_formats
+        .into_iter()
+        .flatten()
+        .map(|format| crate::ai_serving::normalize_api_format_alias(format))
+        .collect::<BTreeSet<_>>();
+
+    endpoints
+        .iter()
+        .find(|endpoint| {
+            endpoint.is_active
+                && !requested_formats.is_empty()
+                && requested_formats.contains(&crate::ai_serving::normalize_api_format_alias(
+                    &endpoint.api_format,
+                ))
+        })
+        .or_else(|| endpoints.iter().find(|endpoint| endpoint.is_active))
+        .or_else(|| endpoints.first())
+}
+
+fn resolve_key_balance_architecture_id(
+    provider: &StoredProviderCatalogProvider,
+    provider_ops_config: &Map<String, Value>,
+    base_url: &str,
+) -> String {
+    if let Some(architecture_id) = provider_ops_config
+        .get("architecture_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return architecture_id.to_string();
+    }
+
+    let fingerprint =
+        format!("{} {} {}", provider.provider_type, provider.name, base_url).to_ascii_lowercase();
+    if fingerprint.contains("sub2api") {
+        "sub2api".to_string()
+    } else {
+        "new_api".to_string()
+    }
+}
+
+fn resolve_balance_credentials(
+    architecture_id: &str,
+    auth_type: &str,
+    secret: &str,
+    saved_credentials: Map<String, Value>,
+    payload: &AdminProviderKeyBalanceRequest,
+) -> Result<Map<String, Value>, String> {
+    match normalize_architecture_id(architecture_id) {
+        "new_api" => resolve_new_api_balance_credentials(
+            auth_type,
+            secret,
+            saved_credentials,
+            payload.new_api_user_id.as_ref(),
+        ),
+        "sub2api" => resolve_sub2api_balance_credentials(
+            auth_type,
+            secret,
+            saved_credentials,
+            payload.sub2api_credential_kind.as_deref(),
+        ),
+        normalized => Ok(balance_credentials_for_architecture(
+            normalized, auth_type, secret,
+        )),
+    }
+}
+
+fn resolve_new_api_balance_credentials(
+    auth_type: &str,
+    secret: &str,
+    saved_credentials: Map<String, Value>,
+    request_user_id: Option<&String>,
+) -> Result<Map<String, Value>, String> {
+    let mut credentials = balance_credentials_for_architecture("new_api", auth_type, secret);
+    if let Some(user_id) = request_user_id
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .or_else(|| non_empty_string(&saved_credentials, "user_id"))
+    {
+        credentials.insert("user_id".to_string(), Value::String(user_id.to_string()));
+    }
+
+    Ok(credentials)
+}
+
+fn resolve_sub2api_balance_credentials(
+    auth_type: &str,
+    secret: &str,
+    saved_credentials: Map<String, Value>,
+    credential_kind: Option<&str>,
+) -> Result<Map<String, Value>, String> {
+    match normalized_sub2api_credential_kind(credential_kind).as_deref() {
+        Some("api_key") => {
+            let mut credentials = Map::new();
+            credentials.insert("api_key".to_string(), Value::String(secret.to_string()));
+            return Ok(credentials);
+        }
+        Some("access_token") => {
+            let mut credentials = Map::new();
+            credentials.insert(
+                "_cached_access_token".to_string(),
+                Value::String(secret.to_string()),
+            );
+            credentials.insert(
+                "_cached_token_expires_at".to_string(),
+                Value::from(balance_token_fallback_expires_at()),
+            );
+            return Ok(credentials);
+        }
+        Some("refresh_token") => {
+            let mut credentials = Map::new();
+            credentials.insert("refresh_token".to_string(), json!(secret));
+            return Ok(credentials);
+        }
+        _ => {}
+    }
+
+    if auth_type == "bearer" || looks_like_jwt(secret) {
+        let mut credentials = Map::new();
+        credentials.insert(
+            "_cached_access_token".to_string(),
+            Value::String(secret.to_string()),
+        );
+        credentials.insert(
+            "_cached_token_expires_at".to_string(),
+            Value::from(balance_token_fallback_expires_at()),
+        );
+        return Ok(credentials);
+    }
+    if looks_like_model_api_key(secret) || auth_type == "api_key" {
+        let mut credentials = Map::new();
+        credentials.insert("api_key".to_string(), Value::String(secret.to_string()));
+        return Ok(credentials);
+    }
+    if let Some(api_key) = non_empty_string(&saved_credentials, "api_key") {
+        let mut credentials = saved_credentials.clone();
+        credentials.insert("api_key".to_string(), Value::String(api_key.to_string()));
+        return Ok(credentials);
+    }
+    if has_non_empty_string(&saved_credentials, "_cached_access_token")
+        || has_non_empty_string(&saved_credentials, "refresh_token")
+        || (has_non_empty_string(&saved_credentials, "email")
+            && has_non_empty_string(&saved_credentials, "password"))
+    {
+        return Ok(saved_credentials);
+    }
+
+    let mut credentials = Map::new();
+    credentials.insert("refresh_token".to_string(), json!(secret));
+    Ok(credentials)
+}
+
+fn normalized_sub2api_credential_kind(value: Option<&str>) -> Option<String> {
+    match value.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        Some("api_key" | "apikey" | "api-key") => Some("api_key".to_string()),
+        Some("access_token" | "access-token" | "access" | "bearer") => {
+            Some("access_token".to_string())
+        }
+        Some("refresh_token" | "refresh-token" | "refresh") => Some("refresh_token".to_string()),
+        _ => None,
+    }
+}
+
+fn balance_credentials_for_architecture(
+    architecture_id: &str,
+    _auth_type: &str,
+    secret: &str,
+) -> Map<String, Value> {
+    let mut credentials = Map::new();
+    if normalize_architecture_id(architecture_id) == "sub2api" {
+        credentials.insert("refresh_token".to_string(), json!(secret));
+    } else {
+        credentials.insert("api_key".to_string(), json!(secret));
+    }
+    credentials
+}
+
+fn non_empty_string<'a>(credentials: &'a Map<String, Value>, key: &str) -> Option<&'a str> {
+    credentials
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn has_non_empty_string(credentials: &Map<String, Value>, key: &str) -> bool {
+    non_empty_string(credentials, key).is_some()
+}
+
+fn looks_like_jwt(secret: &str) -> bool {
+    let trimmed = secret.trim();
+    let mut parts = trimmed.split('.');
+    matches!(
+        (parts.next(), parts.next(), parts.next(), parts.next()),
+        (Some(header), Some(payload), Some(signature), None)
+            if !header.is_empty() && !payload.is_empty() && !signature.is_empty()
+    )
+}
+
+fn looks_like_model_api_key(secret: &str) -> bool {
+    let normalized = secret.trim().to_ascii_lowercase();
+    normalized.starts_with("sk-") || normalized.starts_with("sk_")
+}
+
+fn balance_token_fallback_expires_at() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs_f64() + 600.0)
+        .unwrap_or(600.0)
+}
+
+fn action_not_configured_payload(detail: impl Into<String>) -> Value {
+    json!({
+        "status": "not_configured",
+        "action_type": "query_balance",
+        "data": Value::Null,
+        "message": detail.into(),
+        "executed_at": chrono::Utc::now()
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "response_time_ms": Value::Null,
+        "cache_ttl_seconds": 0,
+    })
+}
+
+fn bad_request_response(detail: impl Into<String>) -> Response<Body> {
+    (
+        http::StatusCode::BAD_REQUEST,
+        Json(json!({ "detail": detail.into() })),
+    )
+        .into_response()
+}
+
+fn not_found_response(detail: impl Into<String>) -> Response<Body> {
+    (
+        http::StatusCode::NOT_FOUND,
+        Json(json!({ "detail": detail.into() })),
+    )
+        .into_response()
+}

--- a/apps/aether-gateway/src/handlers/admin/provider/ops/providers/actions/mod.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/ops/providers/actions/mod.rs
@@ -32,6 +32,68 @@ pub(super) fn admin_provider_ops_is_valid_action_type(action_type: &str) -> bool
     )
 }
 
+pub(crate) fn admin_provider_ops_saved_connector_credentials(
+    state: &AdminAppState<'_>,
+    provider: &StoredProviderCatalogProvider,
+) -> serde_json::Map<String, serde_json::Value> {
+    admin_provider_ops_decrypted_credentials(
+        state,
+        admin_provider_ops_config_object(provider)
+            .and_then(admin_provider_ops_connector_object)
+            .and_then(|connector| connector.get("credentials")),
+    )
+}
+
+pub(crate) async fn admin_provider_ops_query_balance_response_for_credentials(
+    state: &AdminAppState<'_>,
+    provider_id: &str,
+    provider: &StoredProviderCatalogProvider,
+    architecture_id: &str,
+    base_url: &str,
+    provider_ops_config: &serde_json::Map<String, serde_json::Value>,
+    connector_config: &serde_json::Map<String, serde_json::Value>,
+    credentials: &serde_json::Map<String, serde_json::Value>,
+    request_config: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> serde_json::Value {
+    let architecture_id = normalize_architecture_id(architecture_id);
+    let Some(architecture) = get_architecture(architecture_id) else {
+        return responses::admin_provider_ops_action_not_supported(
+            "query_balance",
+            ADMIN_PROVIDER_OPS_ACTION_RUST_ONLY_MESSAGE,
+        );
+    };
+    let headers = match build_headers(architecture.architecture_id, connector_config, credentials) {
+        Ok(headers) => headers,
+        Err(message) => {
+            return responses::admin_provider_ops_action_not_configured("query_balance", message);
+        }
+    };
+    let Some(action_config) = resolve_action_config(
+        architecture_id,
+        provider_ops_config,
+        "query_balance",
+        request_config,
+    ) else {
+        return responses::admin_provider_ops_action_not_supported(
+            "query_balance",
+            ADMIN_PROVIDER_OPS_ACTION_RUST_ONLY_MESSAGE,
+        );
+    };
+
+    query_balance::admin_provider_ops_run_query_balance_action(
+        state,
+        provider_id,
+        provider,
+        &architecture,
+        base_url,
+        &action_config,
+        &headers,
+        credentials,
+        None,
+    )
+    .await
+}
+
 pub(crate) async fn admin_provider_ops_local_action_response(
     state: &AdminAppState<'_>,
     provider_id: &str,

--- a/apps/aether-gateway/src/handlers/admin/provider/ops/providers/actions/query_balance/mod.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/ops/providers/actions/query_balance/mod.rs
@@ -111,11 +111,14 @@ pub(super) async fn admin_provider_ops_run_query_balance_action(
 
     if status != http::StatusCode::OK {
         let cookie_auth = architecture.query_balance_cookie_auth_errors;
+        let new_api_token_auth = architecture.architecture_id == "new_api";
         return match status {
             http::StatusCode::UNAUTHORIZED => admin_provider_ops_action_error(
                 "auth_failed",
                 "query_balance",
-                if cookie_auth {
+                if new_api_token_auth {
+                    "访问令牌无效，请使用 New API 个人安全设置里的访问令牌"
+                } else if cookie_auth {
                     "Cookie 已失效，请重新配置"
                 } else {
                     "认证失败"
@@ -125,7 +128,9 @@ pub(super) async fn admin_provider_ops_run_query_balance_action(
             http::StatusCode::FORBIDDEN => admin_provider_ops_action_error(
                 "auth_failed",
                 "query_balance",
-                if cookie_auth {
+                if new_api_token_auth {
+                    "访问令牌无效或无权限，请使用 New API 个人安全设置里的访问令牌"
+                } else if cookie_auth {
                     "Cookie 已失效或无权限"
                 } else {
                     "无权限访问"

--- a/apps/aether-gateway/src/handlers/admin/provider/ops/providers/actions/query_balance/sub2api.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/ops/providers/actions/query_balance/sub2api.rs
@@ -8,7 +8,9 @@ use super::super::responses::{
 };
 use super::super::support::admin_provider_ops_json_object_map;
 use crate::handlers::admin::request::AdminAppState;
-use aether_admin::provider::ops::parse_sub2api_balance_payload;
+use aether_admin::provider::ops::{
+    parse_sub2api_api_key_usage_payload, parse_sub2api_balance_payload,
+};
 use aether_contracts::ProxySnapshot;
 use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogProvider;
 use serde_json::{json, Value};
@@ -24,6 +26,23 @@ pub(super) async fn admin_provider_ops_sub2api_balance_payload(
     proxy_snapshot: Option<&ProxySnapshot>,
 ) -> serde_json::Value {
     let start = std::time::Instant::now();
+    if let Some(api_key) = credentials
+        .get("api_key")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return admin_provider_ops_sub2api_api_key_balance_payload(
+            state,
+            provider_id,
+            base_url,
+            action_config,
+            api_key,
+            proxy_snapshot,
+            start,
+        )
+        .await;
+    }
     let (access_token, updated_credentials, _frontend_updated_credentials) =
         match admin_provider_ops_sub2api_exchange_token(
             state,
@@ -180,6 +199,117 @@ pub(super) async fn admin_provider_ops_sub2api_balance_payload(
                 );
             }
         };
+
+    admin_provider_ops_action_response(
+        "success",
+        "query_balance",
+        data,
+        None,
+        response_time_ms,
+        86400,
+    )
+}
+
+async fn admin_provider_ops_sub2api_api_key_balance_payload(
+    state: &AdminAppState<'_>,
+    provider_id: &str,
+    base_url: &str,
+    action_config: &serde_json::Map<String, serde_json::Value>,
+    api_key: &str,
+    proxy_snapshot: Option<&ProxySnapshot>,
+    start: std::time::Instant,
+) -> serde_json::Value {
+    let usage_endpoint = action_config
+        .get("api_key_usage_endpoint")
+        .or_else(|| action_config.get("usage_endpoint"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("/v1/usage");
+    let usage_url = admin_provider_ops_sub2api_request_url(base_url, usage_endpoint);
+    let auth_value = match reqwest::header::HeaderValue::from_str(&format!("Bearer {api_key}")) {
+        Ok(value) => value,
+        Err(_) => {
+            return admin_provider_ops_action_error(
+                "parse_error",
+                "query_balance",
+                "API Key 格式无效",
+                Some(start.elapsed().as_millis() as u64),
+            );
+        }
+    };
+    let auth_headers = reqwest::header::HeaderMap::from_iter([
+        (reqwest::header::AUTHORIZATION, auth_value),
+        (
+            reqwest::header::ACCEPT,
+            reqwest::header::HeaderValue::from_static("application/json"),
+        ),
+    ]);
+    let request_id = format!("provider-ops-action:sub2api:usage:{provider_id}");
+    let result = admin_provider_ops_execute_json_request(
+        state,
+        &request_id,
+        reqwest::Method::GET,
+        &usage_url,
+        &auth_headers,
+        None,
+        proxy_snapshot,
+    )
+    .await;
+    let response_time_ms = Some(start.elapsed().as_millis() as u64);
+    let (status, response_json) = match result {
+        Ok(result) => result,
+        Err(AdminProviderOpsExecuteJsonError::InvalidJson(message))
+        | Err(AdminProviderOpsExecuteJsonError::Transport(message)) => {
+            return admin_provider_ops_action_error(
+                "network_error",
+                "query_balance",
+                network_error_message(&message),
+                response_time_ms,
+            );
+        }
+    };
+    if matches!(
+        status,
+        http::StatusCode::UNAUTHORIZED | http::StatusCode::FORBIDDEN
+    ) {
+        return admin_provider_ops_action_error(
+            "auth_failed",
+            "query_balance",
+            "认证失败，请检查 API Key",
+            response_time_ms,
+        );
+    }
+    if status != http::StatusCode::OK {
+        return admin_provider_ops_action_error(
+            "unknown_error",
+            "query_balance",
+            format!(
+                "HTTP {}: {}",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("Unknown")
+            ),
+            response_time_ms,
+        );
+    }
+
+    let data = match parse_sub2api_api_key_usage_payload(action_config, &response_json) {
+        Ok(payload) => payload,
+        Err(message) => {
+            return admin_provider_ops_action_error(
+                if message.contains("无效") {
+                    "auth_failed"
+                } else if message == "响应格式无效" {
+                    "parse_error"
+                } else {
+                    "unknown_error"
+                },
+                "query_balance",
+                message,
+                response_time_ms,
+            );
+        }
+    };
 
     admin_provider_ops_action_response(
         "success",

--- a/apps/aether-gateway/src/handlers/admin/provider/ops/providers/config.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/ops/providers/config.rs
@@ -250,6 +250,9 @@ pub(super) fn build_admin_provider_ops_saved_config_value(
     provider: &StoredProviderCatalogProvider,
     payload: AdminProviderOpsSaveConfigRequest,
 ) -> Result<serde_json::Value, String> {
+    let architecture_id =
+        admin_provider_ops_pure::normalize_architecture_id(payload.architecture_id.as_str())
+            .to_string();
     let auth_type = payload.connector.auth_type.trim().to_string();
     if auth_type.is_empty() || !admin_provider_ops_is_supported_auth_type(auth_type.as_str()) {
         return Err("connector.auth_type 必须是合法的认证类型".to_string());
@@ -257,7 +260,7 @@ pub(super) fn build_admin_provider_ops_saved_config_value(
 
     let merged_credentials = admin_provider_ops_merge_credentials(
         state,
-        payload.architecture_id.as_str(),
+        architecture_id.as_str(),
         provider,
         payload.connector.credentials,
     );
@@ -278,7 +281,7 @@ pub(super) fn build_admin_provider_ops_saved_config_value(
         .collect::<serde_json::Map<String, serde_json::Value>>();
 
     Ok(json!({
-        "architecture_id": payload.architecture_id,
+        "architecture_id": architecture_id,
         "base_url": payload.base_url,
         "connector": {
             "auth_type": auth_type,
@@ -328,14 +331,16 @@ pub(super) fn build_admin_provider_ops_config_payload(
         });
     };
     let connector = admin_provider_ops_connector_object(provider_ops_config);
+    let architecture_id = provider_ops_config
+        .get("architecture_id")
+        .and_then(serde_json::Value::as_str)
+        .map(admin_provider_ops_pure::normalize_architecture_id)
+        .unwrap_or("generic_api");
 
     json!({
         "provider_id": provider_id,
         "is_configured": true,
-        "architecture_id": provider_ops_config
-            .get("architecture_id")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("generic_api"),
+        "architecture_id": architecture_id,
         "base_url": resolve_admin_provider_ops_base_url(
             provider,
             endpoints,

--- a/apps/aether-gateway/src/handlers/admin/provider/ops/providers/verify/sub2api.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/ops/providers/verify/sub2api.rs
@@ -6,7 +6,8 @@ use crate::handlers::admin::provider::ops::providers::config::persist_admin_prov
 use crate::handlers::admin::request::AdminAppState;
 use aether_admin::provider::ops::{
     admin_provider_ops_frontend_updated_credentials, admin_provider_ops_verify_failure,
-    parse_verify_payload, ADMIN_PROVIDER_OPS_USER_AGENT,
+    admin_provider_ops_verify_success, admin_provider_ops_verify_user_payload,
+    parse_sub2api_api_key_usage_payload, parse_verify_payload, ADMIN_PROVIDER_OPS_USER_AGENT,
 };
 use aether_contracts::ProxySnapshot;
 use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogProvider;
@@ -21,6 +22,21 @@ pub(super) async fn admin_provider_ops_local_sub2api_verify_response(
     credentials: &Map<String, Value>,
     proxy_snapshot: Option<&ProxySnapshot>,
 ) -> Value {
+    if let Some(api_key) = credentials
+        .get("api_key")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return admin_provider_ops_local_sub2api_api_key_verify_response(
+            state,
+            base_url,
+            api_key,
+            proxy_snapshot,
+        )
+        .await;
+    }
+
     let (access_token, updated_credentials, frontend_updated_credentials) =
         match admin_provider_ops_sub2api_exchange_token(
             state,
@@ -90,6 +106,78 @@ pub(super) async fn admin_provider_ops_local_sub2api_verify_response(
         status,
         &response_json,
         frontend_updated_credentials,
+    )
+}
+
+async fn admin_provider_ops_local_sub2api_api_key_verify_response(
+    state: &AdminAppState<'_>,
+    base_url: &str,
+    api_key: &str,
+    proxy_snapshot: Option<&ProxySnapshot>,
+) -> Value {
+    let usage_url = admin_provider_ops_sub2api_request_url(base_url, "/v1/usage");
+    let auth_value = match reqwest::header::HeaderValue::from_str(&format!("Bearer {api_key}")) {
+        Ok(value) => value,
+        Err(_) => return admin_provider_ops_verify_failure("API Key 格式无效"),
+    };
+    let auth_headers = reqwest::header::HeaderMap::from_iter([
+        (reqwest::header::AUTHORIZATION, auth_value),
+        (
+            reqwest::header::ACCEPT,
+            reqwest::header::HeaderValue::from_static("application/json"),
+        ),
+    ]);
+    let auth_headers =
+        admin_provider_ops_headers_with_transport_controls(&auth_headers, None, true);
+    let (status, response_json) = match admin_provider_ops_execute_json_request(
+        state,
+        "provider-ops-verify:sub2api:api-key",
+        reqwest::Method::GET,
+        &usage_url,
+        &auth_headers,
+        None,
+        proxy_snapshot,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(AdminProviderOpsExecuteJsonError::InvalidJson(message))
+        | Err(AdminProviderOpsExecuteJsonError::Transport(message)) => {
+            return admin_provider_ops_verify_failure(
+                admin_provider_ops_verify_execution_error_message(&message),
+            );
+        }
+    };
+    if matches!(
+        status,
+        http::StatusCode::UNAUTHORIZED | http::StatusCode::FORBIDDEN
+    ) {
+        return admin_provider_ops_verify_failure("认证失败：API Key 无效或已过期");
+    }
+    if status != http::StatusCode::OK {
+        return admin_provider_ops_verify_failure(format!("验证失败：HTTP {}", status.as_u16()));
+    }
+
+    let payload = match parse_sub2api_api_key_usage_payload(&Map::new(), &response_json) {
+        Ok(payload) => payload,
+        Err(message) => return admin_provider_ops_verify_failure(message),
+    };
+    let quota = payload.get("total_available").and_then(Value::as_f64);
+    let extra = payload
+        .get("extra")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+
+    admin_provider_ops_verify_success(
+        admin_provider_ops_verify_user_payload(
+            Some("Sub2API API Key".to_string()),
+            Some("Sub2API API Key".to_string()),
+            None,
+            quota,
+            Some(extra),
+        ),
+        None,
     )
 }
 

--- a/apps/aether-gateway/src/handlers/admin/provider/shared/paths/endpoint_keys.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/shared/paths/endpoint_keys.rs
@@ -12,6 +12,13 @@ pub(crate) fn admin_provider_id_for_refresh_quota(request_path: &str) -> Option<
         .map(ToOwned::to_owned)
 }
 
+pub(crate) fn admin_provider_id_for_key_balance(request_path: &str) -> Option<String> {
+    request_path
+        .strip_prefix("/api/admin/endpoints/providers/")?
+        .strip_suffix("/key-balance")
+        .map(ToOwned::to_owned)
+}
+
 pub(crate) fn admin_reveal_key_id(request_path: &str) -> Option<String> {
     request_path
         .strip_prefix("/api/admin/endpoints/keys/")?

--- a/apps/aether-gateway/src/handlers/admin/provider/shared/paths/mod.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/shared/paths/mod.rs
@@ -15,9 +15,9 @@ pub(crate) use self::crud::{
     is_admin_providers_root,
 };
 pub(crate) use self::endpoint_keys::{
-    admin_clear_oauth_invalid_key_id, admin_export_key_id, admin_provider_id_for_keys,
-    admin_provider_id_for_refresh_quota, admin_reset_cycle_stats_key_id, admin_reveal_key_id,
-    admin_update_key_id,
+    admin_clear_oauth_invalid_key_id, admin_export_key_id, admin_provider_id_for_key_balance,
+    admin_provider_id_for_keys, admin_provider_id_for_refresh_quota,
+    admin_reset_cycle_stats_key_id, admin_reveal_key_id, admin_update_key_id,
 };
 pub(crate) use self::oauth::{
     admin_provider_oauth_batch_import_provider_id, admin_provider_oauth_batch_import_task_path,

--- a/apps/aether-gateway/src/handlers/admin/provider/summary/aggregates.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/summary/aggregates.rs
@@ -31,7 +31,7 @@ pub(crate) async fn build_admin_provider_summary_payload(
         active_global_model_ids_result,
     ) = tokio::join!(
         state.list_provider_catalog_endpoints_by_provider_ids(&provider_ids),
-        state.list_provider_catalog_key_summaries_by_provider_ids(&provider_ids),
+        state.list_provider_catalog_keys_by_provider_ids(&provider_ids),
         state.read_provider_quota_snapshot(provider_id),
         state.list_provider_model_stats(&provider_ids),
         state.list_active_global_model_ids_by_provider_ids(&provider_ids),
@@ -197,7 +197,7 @@ pub(crate) async fn build_admin_providers_summary_payload(
     } else {
         let (endpoints_result, keys_result, model_stats_result, active_global_model_refs_result) = tokio::join!(
             state.list_provider_catalog_endpoints_by_provider_ids(&provider_ids),
-            state.list_provider_catalog_key_summaries_by_provider_ids(&provider_ids),
+            state.list_provider_catalog_keys_by_provider_ids(&provider_ids),
             state.list_provider_model_stats(&provider_ids),
             state.list_active_global_model_ids_by_provider_ids(&provider_ids),
         );

--- a/apps/aether-gateway/src/handlers/admin/provider/summary/value.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/summary/value.rs
@@ -7,7 +7,7 @@ use aether_data_contracts::repository::candidates::{
 use aether_data_contracts::repository::provider_catalog::{
     StoredProviderCatalogEndpoint, StoredProviderCatalogKey, StoredProviderCatalogProvider,
 };
-use serde_json::json;
+use serde_json::{json, Map, Value};
 use std::collections::BTreeMap;
 
 fn json_truthy(value: &serde_json::Value) -> bool {
@@ -25,6 +25,80 @@ fn endpoint_timestamp_or_now(value: Option<u64>, now_unix_secs: u64) -> serde_js
     unix_secs_to_rfc3339(value.unwrap_or(now_unix_secs))
         .map(serde_json::Value::String)
         .unwrap_or(serde_json::Value::Null)
+}
+
+fn finite_json_number(value: Option<&Value>) -> Option<f64> {
+    match value {
+        Some(Value::Number(number)) => number.as_f64().filter(|value| value.is_finite()),
+        Some(Value::String(value)) => value
+            .trim()
+            .parse::<f64>()
+            .ok()
+            .filter(|value| value.is_finite()),
+        _ => None,
+    }
+}
+
+fn finite_json_u64(value: Option<&Value>) -> Option<u64> {
+    finite_json_number(value).and_then(|value| {
+        if value >= 0.0 {
+            Some(value as u64)
+        } else {
+            None
+        }
+    })
+}
+
+fn latest_key_balance_summary(keys: &[StoredProviderCatalogKey]) -> Value {
+    let mut selected: Option<(u64, &StoredProviderCatalogKey, &Map<String, Value>)> = None;
+
+    for key in keys {
+        let Some(balance) = key
+            .upstream_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("balance_query"))
+            .and_then(Value::as_object)
+        else {
+            continue;
+        };
+        let Some(updated_at) = finite_json_u64(balance.get("updated_at")) else {
+            continue;
+        };
+        let has_balance_value = ["total_available", "total_used", "total_granted"]
+            .into_iter()
+            .any(|field| finite_json_number(balance.get(field)).is_some());
+        if !has_balance_value {
+            continue;
+        }
+
+        if selected
+            .as_ref()
+            .is_none_or(|(selected_updated_at, _, _)| updated_at > *selected_updated_at)
+        {
+            selected = Some((updated_at, key, balance));
+        }
+    }
+
+    let Some((updated_at, key, balance)) = selected else {
+        return Value::Null;
+    };
+
+    json!({
+        "key_id": key.id.clone(),
+        "key_name": key.name.clone(),
+        "updated_at": updated_at,
+        "architecture_id": balance.get("architecture_id").cloned().unwrap_or(Value::Null),
+        "status": balance.get("status").cloned().unwrap_or_else(|| json!("success")),
+        "executed_at": balance.get("executed_at").cloned().unwrap_or(Value::Null),
+        "response_time_ms": balance.get("response_time_ms").cloned().unwrap_or(Value::Null),
+        "total_available": balance.get("total_available").cloned().unwrap_or(Value::Null),
+        "total_used": balance.get("total_used").cloned().unwrap_or(Value::Null),
+        "total_granted": balance.get("total_granted").cloned().unwrap_or(Value::Null),
+        "currency": balance.get("currency").cloned().unwrap_or_else(|| json!("USD")),
+        "plan_name": balance.get("plan_name").cloned().unwrap_or(Value::Null),
+        "query_config": balance.get("query_config").cloned().unwrap_or(Value::Null),
+        "extra": balance.get("extra").cloned().unwrap_or(Value::Null),
+    })
 }
 
 pub(crate) fn build_admin_provider_summary_value(
@@ -158,6 +232,7 @@ pub(crate) fn build_admin_provider_summary_value(
         .and_then(|quota| quota.quota_expires_at_unix_secs)
         .or(provider.quota_expires_at_unix_secs)
         .and_then(unix_secs_to_rfc3339);
+    let key_balance_summary = latest_key_balance_summary(keys);
 
     json!({
         "id": provider.id.clone(),
@@ -196,6 +271,7 @@ pub(crate) fn build_admin_provider_summary_value(
         "endpoint_health_details": endpoint_health_details,
         "ops_configured": ops_configured,
         "ops_architecture_id": ops_architecture_id,
+        "key_balance_summary": key_balance_summary,
         "kiro_simulated_cache_enabled": kiro_simulated_cache_enabled,
         "created_at": endpoint_timestamp_or_now(provider.created_at_unix_ms, now_unix_secs),
         "updated_at": endpoint_timestamp_or_now(provider.updated_at_unix_secs, now_unix_secs),

--- a/apps/aether-gateway/src/handlers/admin/request/provider/catalog.rs
+++ b/apps/aether-gateway/src/handlers/admin/request/provider/catalog.rs
@@ -177,6 +177,21 @@ impl<'a> AdminAppState<'a> {
         self.app.update_provider_catalog_key(key).await
     }
 
+    pub(crate) async fn update_provider_catalog_key_upstream_metadata(
+        &self,
+        key_id: &str,
+        upstream_metadata: Option<&serde_json::Value>,
+        updated_at_unix_secs: Option<u64>,
+    ) -> Result<bool, GatewayError> {
+        self.app
+            .update_provider_catalog_key_upstream_metadata(
+                key_id,
+                upstream_metadata,
+                updated_at_unix_secs,
+            )
+            .await
+    }
+
     pub(crate) async fn create_provider_catalog_key(
         &self,
         key: &aether_data_contracts::repository::provider_catalog::StoredProviderCatalogKey,

--- a/apps/aether-gateway/src/handlers/shared/catalog.rs
+++ b/apps/aether-gateway/src/handlers/shared/catalog.rs
@@ -21,6 +21,7 @@ const OAUTH_ACCOUNT_BLOCK_PREFIX: &str = "[ACCOUNT_BLOCK] ";
 const OAUTH_EXPIRED_PREFIX: &str = "[OAUTH_EXPIRED] ";
 const OAUTH_REFRESH_FAILED_PREFIX: &str = "[REFRESH_FAILED] ";
 const OAUTH_REQUEST_FAILED_PREFIX: &str = "[REQUEST_FAILED] ";
+const BALANCE_QUERY_SECRET_CIPHERTEXT_KEY: &str = "secret_ciphertext";
 
 pub(crate) fn provider_catalog_key_supports_format(
     key: &StoredProviderCatalogKey,
@@ -171,6 +172,31 @@ pub(crate) fn parse_catalog_auth_config_json(
         .ok()?
         .as_object()
         .cloned()
+}
+
+fn sanitized_admin_upstream_metadata(upstream_metadata: Option<&Value>) -> Value {
+    let Some(mut metadata) = upstream_metadata.cloned() else {
+        return Value::Null;
+    };
+    let Some(balance_query) = metadata
+        .as_object_mut()
+        .and_then(|metadata| metadata.get_mut("balance_query"))
+        .and_then(Value::as_object_mut)
+    else {
+        return metadata;
+    };
+    let has_saved_secret = balance_query
+        .remove(BALANCE_QUERY_SECRET_CIPHERTEXT_KEY)
+        .is_some();
+    if has_saved_secret {
+        let query_config = balance_query
+            .entry("query_config".to_string())
+            .or_insert_with(|| Value::Object(Map::new()));
+        if let Some(query_config) = query_config.as_object_mut() {
+            query_config.insert("has_saved_secret".to_string(), Value::Bool(true));
+        }
+    }
+    metadata
 }
 
 pub(crate) fn default_provider_key_status_snapshot() -> serde_json::Value {
@@ -1937,7 +1963,7 @@ pub(crate) fn build_admin_provider_key_response(
     );
     payload.insert(
         "upstream_metadata".to_string(),
-        json!(key.upstream_metadata),
+        sanitized_admin_upstream_metadata(key.upstream_metadata.as_ref()),
     );
     payload.insert("proxy".to_string(), json!(key.proxy));
     payload.insert("fingerprint".to_string(), json!(key.fingerprint));

--- a/apps/aether-gateway/src/handlers/shared/request_utils.rs
+++ b/apps/aether-gateway/src/handlers/shared/request_utils.rs
@@ -221,6 +221,7 @@ pub(crate) fn admin_proxy_local_requires_buffered_body(
                 | (Some("endpoints_manage"), http::Method::POST, Some("create_endpoint"))
                 | (Some("endpoints_manage"), http::Method::POST, Some("batch_delete_keys"))
                 | (Some("endpoints_manage"), http::Method::POST, Some("refresh_quota"))
+                | (Some("endpoints_manage"), http::Method::POST, Some("query_key_balance"))
                 | (Some("endpoints_manage"), http::Method::PUT, Some("update_key"))
                 | (Some("endpoints_manage"), http::Method::PUT, Some("update_endpoint"))
                 | (Some("modules_manage"), http::Method::PUT, Some("set_enabled"))

--- a/apps/aether-gateway/src/tests/control/admin/provider_ops.rs
+++ b/apps/aether-gateway/src/tests/control/admin/provider_ops.rs
@@ -1490,7 +1490,24 @@ async fn gateway_verifies_admin_provider_ops_locally_for_new_api_with_trusted_ad
                     .and_then(|value| value.to_str().ok()),
                 Some("session=foo")
             );
-            assert!(headers.contains_key("sec-ch-ua"));
+            assert_eq!(
+                headers
+                    .get(axum::http::header::USER_AGENT)
+                    .and_then(|value| value.to_str().ok()),
+                Some("cc-switch/1.0")
+            );
+            assert_eq!(
+                headers
+                    .get(axum::http::header::CONTENT_TYPE)
+                    .and_then(|value| value.to_str().ok()),
+                Some("application/json")
+            );
+            assert_eq!(
+                headers
+                    .get(axum::http::header::ACCEPT)
+                    .and_then(|value| value.to_str().ok()),
+                Some("application/json")
+            );
             let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
             encoder
                 .write_all(

--- a/crates/aether-admin/src/provider/ops/actions.rs
+++ b/crates/aether-admin/src/provider/ops/actions.rs
@@ -1,3 +1,4 @@
+use super::architectures::normalize_architecture_id;
 use super::verify::admin_provider_ops_value_as_f64;
 use serde_json::{json, Map, Value};
 
@@ -13,7 +14,7 @@ pub fn parse_query_balance_payload(
     action_config: &Map<String, Value>,
     response_json: &Value,
 ) -> Result<Value, String> {
-    match architecture_id {
+    match normalize_architecture_id(architecture_id) {
         "generic_api" | "new_api" | "anyrouter" | "done_hub" => {
             parse_new_api_balance_payload(action_config, response_json)
         }
@@ -113,6 +114,73 @@ pub fn parse_sub2api_balance_payload(
     ))
 }
 
+pub fn parse_sub2api_api_key_usage_payload(
+    action_config: &Map<String, Value>,
+    response_json: &Value,
+) -> Result<Value, String> {
+    let usage_data = sub2api_usage_response_object(response_json)?;
+    let is_valid = bool_value_from_candidates(
+        response_json,
+        usage_data,
+        &["is_active", "data.is_active", "isValid", "data.isValid"],
+    )
+    .unwrap_or(true);
+    if !is_valid {
+        return Err(response_json
+            .get("invalidMessage")
+            .or_else(|| response_json.get("message"))
+            .or_else(|| usage_data.get("invalidMessage"))
+            .or_else(|| usage_data.get("message"))
+            .and_then(Value::as_str)
+            .unwrap_or("API Key 已禁用或无效")
+            .to_string());
+    }
+
+    let remaining = balance_value_from_candidates(
+        response_json,
+        usage_data,
+        action_config,
+        &["remaining_path", "available_path", "balance_path"],
+        &[
+            "remaining",
+            "data.remaining",
+            "quota.remaining",
+            "data.quota.remaining",
+            "balance",
+            "data.balance",
+        ],
+    )
+    .ok_or_else(|| "响应格式无效".to_string())?;
+    let currency = string_value_from_candidates(
+        response_json,
+        usage_data,
+        &["unit", "data.unit", "quota.unit", "data.quota.unit"],
+    )
+    .or_else(|| {
+        action_config
+            .get("currency")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    })
+    .unwrap_or_else(|| "USD".to_string());
+
+    let mut extra = Map::new();
+    extra.insert("is_active".to_string(), json!(is_valid));
+    if let Some(quota) = usage_data.get("quota").filter(|value| value.is_object()) {
+        extra.insert("quota".to_string(), quota.clone());
+    }
+
+    Ok(build_balance_data(
+        None,
+        None,
+        Some(remaining),
+        &currency,
+        extra,
+    ))
+}
+
 pub fn attach_balance_checkin_outcome(
     action_payload: &mut Value,
     outcome: &ProviderOpsCheckinOutcome,
@@ -171,37 +239,314 @@ fn parse_new_api_balance_payload(
     action_config: &Map<String, Value>,
     response_json: &Value,
 ) -> Result<Value, String> {
-    let user_data = if response_json.get("success").and_then(Value::as_bool) == Some(true)
-        && response_json.get("data").is_some_and(Value::is_object)
-    {
-        response_json.get("data")
-    } else if response_json.get("success").and_then(Value::as_bool) == Some(false) {
-        return Err(response_json
-            .get("message")
-            .and_then(Value::as_str)
-            .unwrap_or("业务状态码表示失败")
-            .to_string());
-    } else {
-        Some(response_json)
-    };
-    let Some(user_data) = user_data.and_then(Value::as_object) else {
-        return Err("响应格式无效".to_string());
-    };
-    let quota_divisor = quota_divisor(action_config);
-    let total_available =
-        admin_provider_ops_value_as_f64(user_data.get("quota")).map(|value| value / quota_divisor);
-    let total_used = admin_provider_ops_value_as_f64(user_data.get("used_quota"))
-        .map(|value| value / quota_divisor);
+    let user_data = balance_response_object(response_json)?;
+    let quota_divisor = balance_divisor(action_config);
+    let total_available_raw = balance_value_from_candidates(
+        response_json,
+        user_data,
+        action_config,
+        &[
+            "balance_path",
+            "available_path",
+            "total_available_path",
+            "quota_path",
+        ],
+        &[
+            "total_available",
+            "data.total_available",
+            "balance",
+            "data.balance",
+            "available",
+            "data.available",
+            "remaining",
+            "data.remaining",
+            "quota",
+            "data.quota",
+            "balance_infos.0.total_balance",
+            "balance_infos[0].total_balance",
+            "data.balance_infos.0.total_balance",
+            "data.balance_infos[0].total_balance",
+            "balance_total",
+            "data.balance_total",
+            "total_balance",
+            "data.total_balance",
+        ],
+    );
+    let total_used_raw = balance_value_from_candidates(
+        response_json,
+        user_data,
+        action_config,
+        &[
+            "used_path",
+            "used_quota_path",
+            "spent_path",
+            "usage_path",
+            "total_used_path",
+        ],
+        &[
+            "used_quota",
+            "data.used_quota",
+            "used",
+            "data.used",
+            "total_used",
+            "data.total_used",
+            "spent",
+            "data.spent",
+            "usage",
+            "data.usage",
+        ],
+    );
+    let total_granted_raw = balance_value_from_candidates(
+        response_json,
+        user_data,
+        action_config,
+        &[
+            "granted_path",
+            "total_granted_path",
+            "limit_path",
+            "total_quota_path",
+        ],
+        &[
+            "total_granted",
+            "data.total_granted",
+            "total_quota",
+            "data.total_quota",
+            "granted",
+            "data.granted",
+            "limit",
+            "data.limit",
+            "balance_total",
+            "data.balance_total",
+            "total_balance",
+            "data.total_balance",
+        ],
+    );
+    let total_available_raw = total_available_raw.or(match (total_granted_raw, total_used_raw) {
+        (Some(granted), Some(used)) => Some((granted - used).max(0.0)),
+        _ => None,
+    });
+    let total_used_raw = total_used_raw.or(match (total_granted_raw, total_available_raw) {
+        (Some(granted), Some(available)) => Some((granted - available).max(0.0)),
+        _ => None,
+    });
+    let total_granted_raw = total_granted_raw.or(match (total_available_raw, total_used_raw) {
+        (Some(available), Some(used)) => Some(available + used),
+        _ => None,
+    });
+    let mut extra = Map::new();
+    if let Some(plan_name) = new_api_plan_name(user_data) {
+        extra.insert("plan_name".to_string(), json!(plan_name));
+    }
     Ok(build_balance_data(
-        None,
-        total_used,
-        total_available,
+        total_granted_raw.map(|value| value / quota_divisor),
+        total_used_raw.map(|value| value / quota_divisor),
+        total_available_raw.map(|value| value / quota_divisor),
         action_config
             .get("currency")
             .and_then(Value::as_str)
             .unwrap_or("USD"),
-        Map::new(),
+        extra,
     ))
+}
+
+fn new_api_plan_name(user_data: &Value) -> Option<String> {
+    for key in ["group", "plan_name", "planName", "plan", "package"] {
+        let value = user_data.get(key).and_then(Value::as_str)?.trim();
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn balance_response_object(response_json: &Value) -> Result<&Value, String> {
+    if let Some(success) = response_json.get("success").and_then(Value::as_bool) {
+        if !success {
+            return Err(response_json
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("业务状态码表示失败")
+                .to_string());
+        }
+        if let Some(data) = response_json.get("data").filter(|value| value.is_object()) {
+            return Ok(data);
+        }
+    }
+
+    if let Some(code) = response_json.get("code").and_then(Value::as_i64) {
+        if code != 0 {
+            return Err(response_json
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("查询余额失败")
+                .to_string());
+        }
+        if let Some(data) = response_json.get("data").filter(|value| value.is_object()) {
+            return Ok(data);
+        }
+    }
+
+    response_json
+        .as_object()
+        .map(|_| response_json)
+        .ok_or_else(|| "响应格式无效".to_string())
+}
+
+fn balance_value_from_candidates(
+    full_response: &Value,
+    response_data: &Value,
+    action_config: &Map<String, Value>,
+    config_keys: &[&str],
+    candidate_paths: &[&str],
+) -> Option<f64> {
+    for key in config_keys {
+        if let Some(path) = action_config.get(*key).and_then(Value::as_str) {
+            let path = path.trim();
+            if path.is_empty() {
+                continue;
+            }
+            if let Some(value) = balance_value_at_path(full_response, path)
+                .or_else(|| balance_value_at_path(response_data, path))
+            {
+                return Some(value);
+            }
+        }
+    }
+
+    for path in candidate_paths {
+        if let Some(value) = balance_value_at_path(full_response, path)
+            .or_else(|| balance_value_at_path(response_data, path))
+        {
+            return Some(value);
+        }
+    }
+
+    None
+}
+
+fn balance_value_at_path(value: &Value, path: &str) -> Option<f64> {
+    let mut current = value;
+    for segment in path
+        .split('.')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+    {
+        current = value_at_path_segment(current, segment)?;
+    }
+    admin_provider_ops_value_as_f64(Some(current))
+}
+
+fn value_at_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut current = value;
+    for segment in path
+        .split('.')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+    {
+        current = value_at_path_segment(current, segment)?;
+    }
+    Some(current)
+}
+
+fn value_at_path_segment<'a>(mut current: &'a Value, segment: &str) -> Option<&'a Value> {
+    if !segment.contains('[') {
+        return if current.is_array() {
+            segment
+                .parse::<usize>()
+                .ok()
+                .and_then(|index| current.get(index))
+        } else {
+            current.get(segment)
+        };
+    }
+
+    let mut rest = segment;
+    if let Some(open) = rest.find('[') {
+        let head = rest[..open].trim();
+        if !head.is_empty() {
+            current = current.get(head)?;
+        }
+        rest = &rest[open..];
+    }
+
+    while let Some(stripped) = rest.strip_prefix('[') {
+        let close = stripped.find(']')?;
+        let index = stripped[..close].trim().parse::<usize>().ok()?;
+        current = current.get(index)?;
+        rest = stripped[close + 1..].trim();
+        if rest.is_empty() {
+            return Some(current);
+        }
+    }
+
+    current.get(rest)
+}
+
+fn bool_value_from_candidates(
+    full_response: &Value,
+    response_data: &Value,
+    candidate_paths: &[&str],
+) -> Option<bool> {
+    for path in candidate_paths {
+        if let Some(value) = value_at_path(full_response, path)
+            .or_else(|| value_at_path(response_data, path))
+            .and_then(Value::as_bool)
+        {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn string_value_from_candidates(
+    full_response: &Value,
+    response_data: &Value,
+    candidate_paths: &[&str],
+) -> Option<String> {
+    for path in candidate_paths {
+        if let Some(value) = value_at_path(full_response, path)
+            .or_else(|| value_at_path(response_data, path))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+fn sub2api_usage_response_object(response_json: &Value) -> Result<&Value, String> {
+    if let Some(success) = response_json.get("success").and_then(Value::as_bool) {
+        if !success {
+            return Err(response_json
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("查询失败")
+                .to_string());
+        }
+        if let Some(data) = response_json.get("data").filter(|value| value.is_object()) {
+            return Ok(data);
+        }
+    }
+
+    if let Some(code) = response_json.get("code").and_then(Value::as_i64) {
+        if code != 0 {
+            return Err(response_json
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("查询失败")
+                .to_string());
+        }
+        if let Some(data) = response_json.get("data").filter(|value| value.is_object()) {
+            return Ok(data);
+        }
+    }
+
+    response_json
+        .as_object()
+        .map(|_| response_json)
+        .ok_or_else(|| "响应格式无效".to_string())
 }
 
 fn parse_cubence_balance_payload(
@@ -414,6 +759,12 @@ fn quota_divisor(action_config: &Map<String, Value>) -> f64 {
         .unwrap_or(500000.0)
 }
 
+fn balance_divisor(action_config: &Map<String, Value>) -> f64 {
+    admin_provider_ops_value_as_f64(action_config.get("balance_divisor"))
+        .filter(|value| *value > 0.0)
+        .unwrap_or_else(|| quota_divisor(action_config))
+}
+
 fn parse_rfc3339_unix_secs(value: Option<&Value>) -> Option<i64> {
     let raw = value?.as_str()?.trim();
     if raw.is_empty() {
@@ -466,7 +817,8 @@ fn parse_subscription(value: &Value) -> Option<Value> {
 #[cfg(test)]
 mod tests {
     use super::{
-        attach_balance_checkin_outcome, parse_query_balance_payload, parse_sub2api_balance_payload,
+        attach_balance_checkin_outcome, parse_query_balance_payload,
+        parse_sub2api_api_key_usage_payload, parse_sub2api_balance_payload,
         ProviderOpsCheckinOutcome,
     };
     use serde_json::json;
@@ -488,6 +840,109 @@ mod tests {
 
         assert_eq!(payload["total_available"], json!(5.0));
         assert_eq!(payload["total_used"], json!(1.0));
+    }
+
+    #[test]
+    fn new_api_alias_parser_supports_balance_field_fallbacks() {
+        let payload = parse_query_balance_payload(
+            "oneapi",
+            &json!({ "quota_divisor": 1, "currency": "CNY" })
+                .as_object()
+                .cloned()
+                .expect("config"),
+            &json!({
+                "success": true,
+                "data": {
+                    "balance": 12.5,
+                    "used": 2.25
+                }
+            }),
+        )
+        .expect("payload should parse");
+
+        assert_eq!(payload["currency"], json!("CNY"));
+        assert_eq!(payload["total_available"], json!(12.5));
+        assert_eq!(payload["total_used"], json!(2.25));
+    }
+
+    #[test]
+    fn new_api_parser_supports_total_available_and_total_used_fields() {
+        let payload = parse_query_balance_payload(
+            "new_api",
+            &json!({ "quota_divisor": 1 })
+                .as_object()
+                .cloned()
+                .expect("config"),
+            &json!({
+                "data": {
+                    "total_available": 9.75,
+                    "total_used": 1.25
+                }
+            }),
+        )
+        .expect("payload should parse");
+
+        assert_eq!(payload["total_available"], json!(9.75));
+        assert_eq!(payload["total_used"], json!(1.25));
+        assert_eq!(payload["total_granted"], json!(11.0));
+    }
+
+    #[test]
+    fn new_api_parser_matches_cc_switch_usage_script_shape() {
+        let payload = parse_query_balance_payload(
+            "new_api",
+            &json!({ "quota_divisor": 500000, "currency": "USD" })
+                .as_object()
+                .cloned()
+                .expect("config"),
+            &json!({
+                "success": true,
+                "data": {
+                    "group": "默认套餐",
+                    "quota": 2_500_000,
+                    "used_quota": 500_000
+                }
+            }),
+        )
+        .expect("payload should parse");
+
+        assert_eq!(payload["total_available"], json!(5.0));
+        assert_eq!(payload["total_used"], json!(1.0));
+        assert_eq!(payload["total_granted"], json!(6.0));
+        assert_eq!(payload["currency"], json!("USD"));
+        assert_eq!(payload["extra"]["plan_name"], json!("默认套餐"));
+    }
+
+    #[test]
+    fn generic_api_parser_supports_deepseek_balance_shape() {
+        let payload = parse_query_balance_payload(
+            "generic_api",
+            &json!({
+                "quota_divisor": 1,
+                "currency": "CNY",
+                "balance_path": "balance_infos[0].total_balance"
+            })
+            .as_object()
+            .cloned()
+            .expect("config"),
+            &json!({
+                "is_available": true,
+                "balance_infos": [
+                    {
+                        "currency": "CNY",
+                        "total_balance": "128.50",
+                        "granted_balance": "8.50",
+                        "topped_up_balance": "120.00"
+                    }
+                ]
+            }),
+        )
+        .expect("payload should parse");
+
+        assert_eq!(payload["currency"], json!("CNY"));
+        assert_eq!(payload["total_available"], json!(128.5));
+        assert_eq!(payload["total_used"], json!(null));
+        assert_eq!(payload["total_granted"], json!(null));
     }
 
     #[test]
@@ -538,6 +993,28 @@ mod tests {
 
         assert_eq!(payload["total_available"], json!(10.0));
         assert_eq!(payload["extra"]["active_subscriptions"], json!(2));
+    }
+
+    #[test]
+    fn sub2api_api_key_usage_parser_matches_cc_switch_shape() {
+        let payload = parse_sub2api_api_key_usage_payload(
+            &json!({ "currency": "USD" })
+                .as_object()
+                .cloned()
+                .expect("config"),
+            &json!({
+                "is_active": true,
+                "quota": {
+                    "remaining": "12.5",
+                    "unit": "USD"
+                }
+            }),
+        )
+        .expect("payload should parse");
+
+        assert_eq!(payload["total_available"], json!(12.5));
+        assert_eq!(payload["currency"], json!("USD"));
+        assert_eq!(payload["extra"]["is_active"], json!(true));
     }
 
     #[test]

--- a/crates/aether-admin/src/provider/ops/architectures/mod.rs
+++ b/crates/aether-admin/src/provider/ops/architectures/mod.rs
@@ -119,12 +119,19 @@ pub fn get_architecture(architecture_id: &str) -> Option<ProviderOpsArchitecture
 }
 
 pub fn normalize_architecture_id(architecture_id: &str) -> &'static str {
-    match architecture_id.trim() {
+    let compact = architecture_id
+        .trim()
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase();
+
+    match compact.as_str() {
         "" => "generic_api",
-        "generic_api" => "generic_api",
-        "new_api" => "new_api",
+        "genericapi" => "generic_api",
+        "newapi" | "oneapi" => "new_api",
         "cubence" => "cubence",
-        "done_hub" => "done_hub",
+        "donehub" => "done_hub",
         "yescode" => "yescode",
         "nekocode" => "nekocode",
         "anyrouter" => "anyrouter",
@@ -136,7 +143,7 @@ pub fn normalize_architecture_id(architecture_id: &str) -> &'static str {
 pub fn admin_provider_ops_is_supported_auth_type(auth_type: &str) -> bool {
     matches!(
         auth_type,
-        "api_key" | "session_login" | "oauth" | "cookie" | "none"
+        "api_key" | "refresh_token" | "session_login" | "oauth" | "cookie" | "none"
     )
 }
 
@@ -220,6 +227,8 @@ mod tests {
         assert_eq!(normalize_architecture_id(""), "generic_api");
         assert_eq!(normalize_architecture_id("done_hub"), "done_hub");
         assert_eq!(normalize_architecture_id("new_api"), "new_api");
+        assert_eq!(normalize_architecture_id("newapi"), "new_api");
+        assert_eq!(normalize_architecture_id("one-api"), "new_api");
         assert_eq!(normalize_architecture_id("unknown"), "generic_api");
     }
 

--- a/crates/aether-admin/src/provider/ops/architectures/new_api.rs
+++ b/crates/aether-admin/src/provider/ops/architectures/new_api.rs
@@ -10,8 +10,8 @@ pub(super) fn spec() -> ProviderOpsArchitectureSpec {
         "properties": {
             "api_key": {
                 "type": "string",
-                "title": "访问令牌 (API Key)",
-                "description": "New API 的访问令牌，与 Cookie 二选一",
+                "title": "访问令牌",
+                "description": "在 New API 个人安全设置中获取的访问令牌，与 Cookie 二选一",
                 "x-sensitive": true,
                 "x-input-type": "password"
             },
@@ -30,7 +30,7 @@ pub(super) fn spec() -> ProviderOpsArchitectureSpec {
             "user_id": {
                 "type": "string",
                 "title": "用户 ID",
-                "description": "使用访问令牌时必填，使用 Cookie 时可选"
+                "description": "可选；使用 Cookie 时可自动解析"
             }
         },
         "required": [],
@@ -64,13 +64,6 @@ pub(super) fn spec() -> ProviderOpsArchitectureSpec {
                 "type": "any_required",
                 "fields": ["api_key", "cookie"],
                 "message": "访问令牌和 Cookie 至少需要填写一个"
-            },
-            {
-                "type": "conditional_required",
-                "if": "api_key",
-                "then": ["user_id"],
-                "unless": "cookie",
-                "message": "使用访问令牌时，用户 ID 不能为空"
             }
         ]
     });

--- a/crates/aether-admin/src/provider/ops/architectures/sub2api.rs
+++ b/crates/aether-admin/src/provider/ops/architectures/sub2api.rs
@@ -5,6 +5,38 @@ use super::{
 use serde_json::{json, Map, Value};
 
 pub(super) fn spec() -> ProviderOpsArchitectureSpec {
+    let api_key_usage_schema = json!({
+        "type": "object",
+        "properties": {
+            "base_url": {
+                "type": "string",
+                "title": "站点地址",
+                "description": "API 基础地址"
+            },
+            "api_key": {
+                "type": "string",
+                "title": "API Key",
+                "description": "用于访问 Sub2API /v1/usage 的模型 API Key",
+                "x-sensitive": true,
+                "x-input-type": "password",
+                "x-help": "请求 GET /v1/usage，并通过 Authorization: Bearer <API Key> 查询余量"
+            }
+        },
+        "required": ["api_key"],
+        "x-auth-method": "bearer",
+        "x-auth-type": "api_key",
+        "x-field-groups": [
+            { "fields": ["base_url"] },
+            { "fields": ["api_key"] }
+        ],
+        "x-validation": [
+            {
+                "type": "required",
+                "fields": ["api_key"],
+                "message": "请填写 API Key"
+            }
+        ]
+    });
     let session_login_schema = json!({
         "type": "object",
         "properties": {
@@ -61,7 +93,7 @@ pub(super) fn spec() -> ProviderOpsArchitectureSpec {
         },
         "required": ["refresh_token"],
         "x-auth-method": "bearer",
-        "x-auth-type": "api_key",
+        "x-auth-type": "refresh_token",
         "x-field-groups": [
             { "fields": ["base_url"] },
             { "fields": ["refresh_token"] }
@@ -80,7 +112,7 @@ pub(super) fn spec() -> ProviderOpsArchitectureSpec {
         display_name: "Sub2API",
         description: "Sub2API 风格中转站的预设配置",
         hidden: false,
-        credentials_schema: session_login_schema.clone(),
+        credentials_schema: api_key_usage_schema.clone(),
         verify_endpoint: "/api/v1/auth/me?timezone=Asia/Shanghai",
         verify_mode: ProviderOpsVerifyMode::Sub2ApiExchange,
         balance_mode: ProviderOpsBalanceMode::Sub2ApiDualRequest,
@@ -88,12 +120,17 @@ pub(super) fn spec() -> ProviderOpsArchitectureSpec {
         query_balance_cookie_auth_errors: false,
         supported_auth_types: vec![
             ProviderOpsAuthSpec {
+                auth_type: "api_key",
+                display_name: "API Key 用量接口",
+                credentials_schema: api_key_usage_schema,
+            },
+            ProviderOpsAuthSpec {
                 auth_type: "session_login",
                 display_name: "账号密码",
                 credentials_schema: session_login_schema,
             },
             ProviderOpsAuthSpec {
-                auth_type: "api_key",
+                auth_type: "refresh_token",
                 display_name: "Refresh Token",
                 credentials_schema: refresh_token_schema,
             },
@@ -101,7 +138,7 @@ pub(super) fn spec() -> ProviderOpsArchitectureSpec {
         supported_actions: vec![ProviderOpsActionSpec {
             action_type: "query_balance",
             display_name: "查询余额",
-            description: "查询 Sub2API 账户余额和订阅信息",
+            description: "查询 Sub2API API Key 用量或账户余额和订阅信息",
             config_schema: json!({
                 "type": "object",
                 "properties": {
@@ -114,7 +151,7 @@ pub(super) fn spec() -> ProviderOpsArchitectureSpec {
                 "required": []
             }),
         }],
-        default_connector: Some("session_login"),
+        default_connector: Some("api_key"),
     }
 }
 
@@ -123,6 +160,7 @@ pub(super) fn default_action_config(action_type: &str) -> Option<Map<String, Val
         "query_balance" => Some(json_object(json!({
             "endpoint": "/api/v1/auth/me?timezone=Asia/Shanghai",
             "subscription_endpoint": "/api/v1/subscriptions/summary",
+            "api_key_usage_endpoint": "/v1/usage",
             "method": "GET",
             "currency": "USD"
         }))),

--- a/crates/aether-admin/src/provider/ops/mod.rs
+++ b/crates/aether-admin/src/provider/ops/mod.rs
@@ -4,7 +4,8 @@ pub mod config;
 pub mod verify;
 
 pub use self::actions::{
-    attach_balance_checkin_outcome, parse_query_balance_payload, parse_sub2api_balance_payload,
+    attach_balance_checkin_outcome, parse_query_balance_payload,
+    parse_sub2api_api_key_usage_payload, parse_sub2api_balance_payload,
     parse_yescode_combined_balance_payload, ProviderOpsCheckinOutcome,
 };
 pub use self::architectures::{

--- a/crates/aether-admin/src/provider/ops/verify.rs
+++ b/crates/aether-admin/src/provider/ops/verify.rs
@@ -379,18 +379,9 @@ pub fn admin_provider_ops_verify_headers(
         }
         "new_api" => {
             for (name, value) in [
-                (
-                    "User-Agent",
-                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.7339.249 Electron/38.7.0 Safari/537.36",
-                ),
+                ("User-Agent", "cc-switch/1.0"),
+                ("Content-Type", "application/json"),
                 ("Accept", "application/json"),
-                ("Accept-Language", "zh-CN"),
-                ("sec-ch-ua", "\"Not=A?Brand\";v=\"24\", \"Chromium\";v=\"140\""),
-                ("sec-ch-ua-mobile", "?0"),
-                ("sec-ch-ua-platform", "\"macOS\""),
-                ("Sec-Fetch-Site", "cross-site"),
-                ("Sec-Fetch-Mode", "cors"),
-                ("Sec-Fetch-Dest", "empty"),
             ] {
                 insert_header(&mut headers, name, value)?;
             }

--- a/frontend/src/api/endpoints/keys.ts
+++ b/frontend/src/api/endpoints/keys.ts
@@ -286,6 +286,74 @@ export async function refreshProviderQuota(
   return response.data
 }
 
+export type ProviderKeyBalanceStatus =
+  | 'success'
+  | 'pending'
+  | 'auth_failed'
+  | 'auth_expired'
+  | 'rate_limited'
+  | 'network_error'
+  | 'parse_error'
+  | 'not_configured'
+  | 'not_supported'
+  | 'already_done'
+  | 'unknown_error'
+
+export interface ProviderKeyBalanceInfo {
+  total_granted: number | null
+  total_used: number | null
+  total_available: number | null
+  expires_at: string | null
+  currency: string
+  extra: Record<string, unknown>
+}
+
+export interface ProviderKeyBalanceResult {
+  status: ProviderKeyBalanceStatus
+  action_type: 'query_balance'
+  data: ProviderKeyBalanceInfo | null
+  message: string | null
+  executed_at: string
+  response_time_ms: number | null
+  cache_ttl_seconds: number
+  saved_to_key?: boolean
+  saved_key_id?: string | null
+  save_message?: string | null
+}
+
+export interface ProviderKeyBalanceQuery {
+  key_id?: string
+  api_key?: string
+  auth_type?: 'api_key' | 'bearer' | 'service_account' | 'oauth'
+  api_formats?: string[]
+  architecture_id?: 'new_api' | 'sub2api' | 'generic_api'
+  custom_base_url?: string
+  new_api_user_id?: string
+  sub2api_credential_kind?: 'api_key' | 'access_token' | 'refresh_token'
+  custom_endpoint?: string
+  custom_method?: 'GET' | 'POST'
+  custom_currency?: string
+  custom_quota_divisor?: number
+  custom_balance_path?: string
+  custom_used_path?: string
+  custom_granted_path?: string
+  auto_refresh_interval_minutes?: number
+  save_balance_secret?: boolean
+  save_result?: boolean
+}
+
+export async function queryProviderKeyBalance(
+  providerId: string,
+  data: ProviderKeyBalanceQuery,
+): Promise<ProviderKeyBalanceResult> {
+  const response = await client.post<ProviderKeyBalanceResult>(
+    `/api/admin/endpoints/providers/${providerId}/key-balance`,
+    data,
+    { timeout: 60 * 1000 },
+  )
+  return response.data
+}
+
 /**
  * 批量导入 OAuth 凭据（通用）
  * 支持的 Provider 类型：Codex、Antigravity、GeminiCli、ClaudeCode、Kiro

--- a/frontend/src/api/endpoints/types/provider.ts
+++ b/frontend/src/api/endpoints/types/provider.ts
@@ -402,12 +402,46 @@ export interface GrokUpstreamMetadata {
   account_user_id?: string | null
 }
 
+export interface BalanceQueryUpstreamMetadata {
+  updated_at?: number
+  architecture_id?: string | null
+  status?: string | null
+  executed_at?: string | null
+  response_time_ms?: number | null
+  total_available?: number | null
+  total_used?: number | null
+  total_granted?: number | null
+  currency?: string | null
+  plan_name?: string | null
+  query_config?: {
+    custom_base_url?: string | null
+    new_api_user_id?: string | null
+    sub2api_credential_kind?: 'api_key' | 'access_token' | 'refresh_token' | string | null
+    custom_endpoint?: string | null
+    custom_method?: 'GET' | 'POST' | string | null
+    custom_currency?: string | null
+    custom_quota_divisor?: number | null
+    custom_balance_path?: string | null
+    custom_used_path?: string | null
+    custom_granted_path?: string | null
+    auto_refresh_interval_minutes?: number | null
+    has_saved_secret?: boolean | null
+  } | null
+  extra?: Record<string, unknown> | null
+}
+
+export interface ProviderKeyBalanceSummary extends BalanceQueryUpstreamMetadata {
+  key_id?: string | null
+  key_name?: string | null
+}
+
 export interface UpstreamMetadata {
   codex?: CodexUpstreamMetadata
   antigravity?: AntigravityUpstreamMetadata
   kiro?: KiroUpstreamMetadata
   chatgpt_web?: ChatGPTWebUpstreamMetadata
   grok?: GrokUpstreamMetadata
+  balance_query?: BalanceQueryUpstreamMetadata
 }
 
 // 按格式的健康度数据
@@ -684,6 +718,7 @@ export interface ProviderWithEndpointsSummary {
   failover_rules?: FailoverRulesConfig | null
   ops_configured: boolean  // 是否配置了扩展操作（余额监控等）
   ops_architecture_id?: string  // 扩展操作使用的架构 ID（如 cubence, anyrouter）
+  key_balance_summary?: ProviderKeyBalanceSummary | null
   kiro_simulated_cache_enabled?: boolean
   created_at: string
   updated_at: string

--- a/frontend/src/api/providerOps.ts
+++ b/frontend/src/api/providerOps.ts
@@ -12,7 +12,13 @@ import client from './client'
 // ==================== Types ====================
 
 /** 认证类型 */
-export type ConnectorAuthType = 'api_key' | 'session_login' | 'oauth' | 'cookie' | 'none'
+export type ConnectorAuthType =
+  | 'api_key'
+  | 'refresh_token'
+  | 'session_login'
+  | 'oauth'
+  | 'cookie'
+  | 'none'
 
 /** 操作类型 */
 export type ProviderActionType =

--- a/frontend/src/features/providers/components/KeyFormDialog.vue
+++ b/frontend/src/features/providers/components/KeyFormDialog.vue
@@ -70,14 +70,36 @@
             />
           </template>
           <template v-else>
-            <Input
-              :id="apiKeyInputId"
-              v-model="form.api_key"
-              :name="apiKeyFieldName"
-              masked
-              :required="false"
-              :placeholder="editingKey ? editingKey.api_key_masked : authSecretPlaceholder"
-            />
+            <div class="flex gap-2">
+              <div class="min-w-0 flex-1">
+                <Input
+                  :id="apiKeyInputId"
+                  v-model="form.api_key"
+                  :name="apiKeyFieldName"
+                  masked
+                  :required="false"
+                  :placeholder="editingKey ? editingKey.api_key_masked : authSecretPlaceholder"
+                />
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                class="h-11 shrink-0 gap-1.5 px-3"
+                :disabled="!canQueryBalance"
+                title="查询当前密钥的上游余额"
+                @click="handleQueryBalance"
+              >
+                <Loader2
+                  v-if="balanceLoading"
+                  class="h-3.5 w-3.5 animate-spin"
+                />
+                <WalletCards
+                  v-else
+                  class="h-3.5 w-3.5"
+                />
+                <span>查询余额</span>
+              </Button>
+            </div>
           </template>
           <p
             v-if="editingKey && isRawSecretAuthType(form.auth_type)"
@@ -354,6 +376,487 @@
       </Button>
     </template>
   </Dialog>
+
+  <Dialog
+    :model-value="balanceQueryDialogOpen"
+    title="查询余额"
+    description="选择上游余额接口模板"
+    :icon="WalletCards"
+    size="lg"
+    :z-index="90"
+    @update:model-value="balanceQueryDialogOpen = $event"
+  >
+    <div class="space-y-4">
+      <div class="grid grid-cols-3 gap-1 rounded-md border border-border bg-muted/30 p-1">
+        <button
+          v-for="option in balanceQueryTemplateOptions"
+          :key="option.value"
+          type="button"
+          class="min-w-0 rounded-sm px-2.5 py-2 text-sm font-medium transition-colors"
+          :class="balanceQueryTemplate === option.value
+            ? 'bg-background text-foreground shadow-sm'
+            : 'text-muted-foreground hover:bg-background/70 hover:text-foreground'"
+          @click="balanceQueryTemplate = option.value"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+
+      <div class="rounded-md border border-border bg-background px-3 py-3">
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0">
+            <div class="text-sm font-medium text-foreground">
+              {{ selectedBalanceQueryTemplate.title }}
+            </div>
+            <div class="mt-1 text-xs leading-5 text-muted-foreground">
+              {{ selectedBalanceQueryTemplate.description }}
+            </div>
+          </div>
+          <span class="shrink-0 rounded-sm bg-primary/10 px-2 py-1 text-xs text-primary">
+            {{ selectedBalanceQueryTemplate.badge }}
+          </span>
+        </div>
+
+        <div
+          v-if="balanceQueryTemplate === 'new_api'"
+          class="mt-3 space-y-3"
+        >
+          <div class="grid grid-cols-2 gap-2">
+            <div>
+              <Label
+                for="balance-newapi-base-url"
+                class="text-xs"
+              >站点地址</Label>
+              <Input
+                id="balance-newapi-base-url"
+                v-model="newApiBalanceQuery.base_url"
+                placeholder="留空使用当前 Provider 的 base_url"
+                class="h-8 text-sm"
+              />
+            </div>
+            <div>
+              <Label
+                for="balance-newapi-user-id"
+                class="text-xs"
+              >用户 ID</Label>
+              <Input
+                id="balance-newapi-user-id"
+                v-model="newApiBalanceQuery.user_id"
+                placeholder="可选，对应 New-Api-User"
+                class="h-8 text-sm"
+              />
+            </div>
+          </div>
+          <div>
+            <Label
+              for="balance-newapi-token"
+              class="text-xs"
+            >余额查询访问令牌</Label>
+            <Input
+              id="balance-newapi-token"
+              v-model="newApiBalanceQuery.access_token"
+              masked
+              :placeholder="hasSavedBalanceSecret ? '留空使用已保存的余额查询凭据' : '来自 NewAPI 个人安全设置的访问令牌'"
+              class="h-8 text-sm"
+            />
+            <p class="mt-1 text-xs leading-5 text-muted-foreground">
+              单独用于余额查询；开启下方保存后会加密保存，不会替换当前模型 Key。
+            </p>
+          </div>
+          <div class="grid grid-cols-2 gap-2 text-xs">
+            <div class="rounded-sm border border-border/70 px-2.5 py-2">
+              <div class="text-muted-foreground">
+                接口
+              </div>
+              <div class="mt-1 font-mono text-foreground">
+                GET /api/user/self
+              </div>
+            </div>
+            <div class="rounded-sm border border-border/70 px-2.5 py-2">
+              <div class="text-muted-foreground">
+                额度换算
+              </div>
+              <div class="mt-1 font-mono text-foreground">
+                quota / 500000
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          v-else-if="balanceQueryTemplate === 'sub2api'"
+          class="mt-3 space-y-3"
+        >
+          <div>
+            <Label
+              for="balance-sub2api-base-url"
+              class="text-xs"
+            >站点地址</Label>
+            <Input
+              id="balance-sub2api-base-url"
+              v-model="sub2ApiBalanceQuery.base_url"
+              placeholder="留空使用当前 Provider 的 base_url"
+              class="h-8 text-sm"
+            />
+          </div>
+          <div>
+            <Label
+              for="balance-sub2api-token"
+              class="text-xs"
+            >查询凭据</Label>
+            <Input
+              id="balance-sub2api-token"
+              v-model="sub2ApiBalanceQuery.token"
+              masked
+              placeholder="留空使用外层 API 密钥"
+              class="h-8 text-sm"
+            />
+            <p class="mt-1 text-xs leading-5 text-muted-foreground">
+              使用 Sub2API 的 API Key 请求 /v1/usage；通常留空即可使用当前 Key 查询。
+            </p>
+          </div>
+          <div class="text-xs">
+            <div class="rounded-sm border border-border/70 px-2.5 py-2">
+              <div class="text-muted-foreground">
+                接口
+              </div>
+              <div class="mt-1 font-mono text-foreground">
+                GET /v1/usage
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          v-else
+          class="mt-3 space-y-3"
+        >
+          <div>
+            <Label
+              for="balance-custom-base-url"
+              class="text-xs"
+            >站点地址</Label>
+            <Input
+              id="balance-custom-base-url"
+              v-model="customBalanceQuery.base_url"
+              placeholder="留空使用当前 Provider 的 base_url"
+              class="h-8 text-sm"
+            />
+          </div>
+          <div>
+            <Label
+              for="balance-custom-api-key"
+              class="text-xs"
+            >认证凭据</Label>
+            <Input
+              id="balance-custom-api-key"
+              v-model="customBalanceQuery.api_key"
+              masked
+              placeholder="留空使用外层 API 密钥或已保存密钥"
+              class="h-8 text-sm"
+            />
+          </div>
+          <div class="grid grid-cols-[1fr_auto] gap-2">
+            <div>
+              <Label
+                for="balance-custom-endpoint"
+                class="text-xs"
+              >查询路径</Label>
+              <Input
+                id="balance-custom-endpoint"
+                v-model="customBalanceQuery.endpoint"
+                placeholder="/api/user/self"
+                class="h-8 font-mono text-sm"
+              />
+            </div>
+            <div>
+              <Label class="text-xs">方法</Label>
+              <div class="grid h-8 grid-cols-2 gap-1 rounded-md border border-border bg-muted/30 p-0.5">
+                <button
+                  v-for="method in balanceQueryMethods"
+                  :key="method"
+                  type="button"
+                  class="rounded-sm px-2 text-xs font-medium transition-colors"
+                  :class="customBalanceQuery.method === method
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'"
+                  @click="customBalanceQuery.method = method"
+                >
+                  {{ method }}
+                </button>
+              </div>
+            </div>
+          </div>
+          <div class="grid grid-cols-2 gap-2">
+            <div>
+              <Label
+                for="balance-custom-currency"
+                class="text-xs"
+              >货币单位</Label>
+              <Input
+                id="balance-custom-currency"
+                v-model="customBalanceQuery.currency"
+                placeholder="USD"
+                class="h-8 text-sm"
+              />
+            </div>
+            <div>
+              <Label
+                for="balance-custom-divisor"
+                class="text-xs"
+              >额度除数</Label>
+              <Input
+                id="balance-custom-divisor"
+                v-model.number="customBalanceQuery.quota_divisor"
+                type="number"
+                min="1"
+                class="h-8 text-sm"
+              />
+            </div>
+          </div>
+          <div class="grid grid-cols-3 gap-2">
+            <div>
+              <Label
+                for="balance-custom-balance-path"
+                class="text-xs"
+              >余额字段</Label>
+              <Input
+                id="balance-custom-balance-path"
+                v-model="customBalanceQuery.balance_path"
+                placeholder="data.quota"
+                class="h-8 font-mono text-sm"
+              />
+            </div>
+            <div>
+              <Label
+                for="balance-custom-used-path"
+                class="text-xs"
+              >已用字段</Label>
+              <Input
+                id="balance-custom-used-path"
+                v-model="customBalanceQuery.used_path"
+                placeholder="data.used_quota"
+                class="h-8 font-mono text-sm"
+              />
+            </div>
+            <div>
+              <Label
+                for="balance-custom-granted-path"
+                class="text-xs"
+              >总额字段</Label>
+              <Input
+                id="balance-custom-granted-path"
+                v-model="customBalanceQuery.granted_path"
+                placeholder="可留空自动计算"
+                class="h-8 font-mono text-sm"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex items-center justify-between rounded-md border border-border bg-muted/20 px-3 py-2">
+        <div>
+          <div class="text-sm font-medium text-foreground">
+            查询成功后保存到当前 Key
+          </div>
+          <div class="mt-0.5 text-xs text-muted-foreground">
+            {{ balanceSaveDescription }}
+          </div>
+        </div>
+        <Switch
+          :model-value="saveBalanceResult"
+          :disabled="!canSaveBalanceResultToKey"
+          @update:model-value="setSaveBalanceResult"
+        />
+      </div>
+      <div
+        v-if="canConfigureBalanceSecretSave"
+        class="flex items-center justify-between rounded-md border border-border bg-muted/20 px-3 py-2"
+        :class="!saveBalanceResult ? 'opacity-60' : ''"
+      >
+        <div>
+          <div class="text-sm font-medium text-foreground">
+            保存余额查询凭据
+          </div>
+          <div class="mt-0.5 text-xs text-muted-foreground">
+            {{ balanceSecretSaveDescription }}
+            <span v-if="hasSavedBalanceSecretForSelectedQuery">已保存过，可留空继续沿用。</span>
+          </div>
+        </div>
+        <Switch
+          :model-value="saveBalanceSecret"
+          :disabled="!saveBalanceResult"
+          @update:model-value="saveBalanceSecret = $event"
+        />
+      </div>
+      <div class="grid grid-cols-[1fr_auto] items-end gap-3 rounded-md border border-border bg-background px-3 py-2">
+        <div>
+          <Label
+            for="balance-auto-refresh-interval"
+            class="text-xs"
+          >自动查询间隔</Label>
+          <p class="mt-1 text-xs leading-5 text-muted-foreground">
+            保存到当前 Key 后生效，后台页面打开时会自动静默刷新；填 0 表示关闭。
+          </p>
+        </div>
+        <div class="w-32">
+          <Input
+            id="balance-auto-refresh-interval"
+            :model-value="balanceAutoRefreshIntervalMinutes"
+            type="number"
+            min="0"
+            max="10080"
+            class="h-8 text-sm"
+            :disabled="!saveBalanceResult"
+            @update:model-value="setBalanceAutoRefreshInterval"
+          />
+          <div class="mt-1 text-[10px] text-muted-foreground">
+            分钟
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="flex w-full items-center justify-end gap-2">
+        <Button
+          variant="outline"
+          @click="balanceQueryDialogOpen = false"
+        >
+          取消
+        </Button>
+        <Button
+          :disabled="!canConfirmBalanceQuery"
+          @click="confirmBalanceQuery"
+        >
+          {{ balanceLoading ? '查询中...' : '开始查询' }}
+        </Button>
+      </div>
+    </template>
+  </Dialog>
+
+  <Dialog
+    :model-value="balanceDialogOpen"
+    title="余额查询结果"
+    description="当前密钥的上游账户余额"
+    :icon="WalletCards"
+    size="sm"
+    :z-index="90"
+    @update:model-value="balanceDialogOpen = $event"
+  >
+    <div class="space-y-3">
+      <div
+        v-if="balanceLoading"
+        class="flex items-center justify-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-6 text-sm text-muted-foreground"
+      >
+        <Loader2 class="h-4 w-4 animate-spin" />
+        查询中...
+      </div>
+
+      <div
+        v-else-if="balanceError"
+        class="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+      >
+        {{ balanceError }}
+      </div>
+
+      <template v-else-if="balanceResult">
+        <div
+          v-if="balanceResult.saved_to_key"
+          class="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2.5 text-sm text-emerald-700 dark:text-emerald-300"
+        >
+          查询结果已保存到当前 Key，列表会显示最新余额摘要。
+        </div>
+
+        <div
+          v-else-if="balanceResultPendingSave"
+          class="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2.5 text-sm text-emerald-700 dark:text-emerald-300"
+        >
+          查询成功。保存 Key 后会自动写入余额摘要、查询模板和自动查询间隔。
+        </div>
+
+        <div
+          v-else-if="balanceResult.save_message"
+          class="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-foreground"
+        >
+          {{ balanceResult.save_message }}
+        </div>
+
+        <div
+          v-if="balanceResult.status !== 'success'"
+          class="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-sm text-foreground"
+        >
+          {{ balanceResult.message || balanceStatusText(balanceResult.status) }}
+        </div>
+
+        <template v-else-if="balanceData">
+          <div class="rounded-md border border-border bg-muted/30 px-3 py-3">
+            <div class="text-xs text-muted-foreground">
+              可用余额
+            </div>
+            <div class="mt-1 text-2xl font-semibold text-foreground">
+              {{ formatBalanceAmount(balanceData.total_available, balanceData.currency) }}
+            </div>
+          </div>
+
+          <div class="grid grid-cols-2 gap-2">
+            <div class="rounded-md border border-border/70 px-3 py-2">
+              <div class="text-xs text-muted-foreground">
+                已用额度
+              </div>
+              <div class="mt-1 text-sm font-medium text-foreground">
+                {{ formatBalanceAmount(balanceData.total_used, balanceData.currency) }}
+              </div>
+            </div>
+            <div class="rounded-md border border-border/70 px-3 py-2">
+              <div class="text-xs text-muted-foreground">
+                授予额度
+              </div>
+              <div class="mt-1 text-sm font-medium text-foreground">
+                {{ formatBalanceAmount(balanceData.total_granted, balanceData.currency) }}
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-if="balanceExtraRows.length > 0"
+            class="rounded-md border border-border/70 px-3 py-2"
+          >
+            <div class="text-xs text-muted-foreground">
+              明细
+            </div>
+            <div class="mt-2 space-y-1.5 text-sm">
+              <div
+                v-for="row in balanceExtraRows"
+                :key="row.label"
+                class="flex items-center justify-between gap-3"
+              >
+                <span class="text-muted-foreground">{{ row.label }}</span>
+                <span class="font-medium text-foreground">{{ row.value }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-if="balanceResult.response_time_ms !== null"
+            class="text-xs text-muted-foreground"
+          >
+            响应耗时 {{ balanceResult.response_time_ms }}ms
+          </div>
+        </template>
+      </template>
+    </div>
+
+    <template #footer>
+      <Button
+        variant="outline"
+        @click="balanceDialogOpen = false"
+      >
+        关闭
+      </Button>
+    </template>
+  </Dialog>
 </template>
 
 <script setup lang="ts">
@@ -370,7 +873,7 @@ import {
   SelectContent,
   SelectItem,
 } from '@/components/ui'
-import { Key, SquarePen, CircleHelp } from 'lucide-vue-next'
+import { Key, SquarePen, CircleHelp, WalletCards, Loader2 } from 'lucide-vue-next'
 import { useToast } from '@/composables/useToast'
 import { useFormDialog } from '@/composables/useFormDialog'
 import { parseApiError } from '@/utils/errorParser'
@@ -379,9 +882,13 @@ import JsonImportInput from '@/components/common/JsonImportInput.vue'
 import {
   addProviderKey,
   updateProviderKey,
+  queryProviderKeyBalance,
   sortApiFormats,
   type EndpointAPIKey,
   type EndpointAPIKeyUpdate,
+  type ProviderKeyBalanceInfo,
+  type ProviderKeyBalanceQuery,
+  type ProviderKeyBalanceResult,
   type ProviderEndpoint,
   type ProviderType
 } from '@/api/endpoints'
@@ -393,6 +900,17 @@ type ProviderKeyFormAuthType = RawSecretAuthType | 'service_account'
 interface AuthTypeOption {
   value: ProviderKeyFormAuthType
   label: string
+}
+
+type BalanceQueryTemplate = 'new_api' | 'sub2api' | 'generic_api'
+type BalanceQueryMethod = 'GET' | 'POST'
+
+interface BalanceQueryTemplateOption {
+  value: BalanceQueryTemplate
+  label: string
+  title: string
+  description: string
+  badge: string
 }
 
 const props = defineProps<{
@@ -712,6 +1230,250 @@ const form = ref({
   model_exclude_patterns_text: ''   // 排除规则文本（逗号分隔）
 })
 
+const balanceDialogOpen = ref(false)
+const balanceQueryDialogOpen = ref(false)
+const saveBalanceResult = ref(false)
+const saveBalanceSecret = ref(false)
+const balanceAutoRefreshIntervalMinutes = ref<number>(0)
+const balanceQueryTemplate = ref<BalanceQueryTemplate>('new_api')
+const balanceQueryMethods: BalanceQueryMethod[] = ['GET', 'POST']
+const balanceQueryTemplateOptions: BalanceQueryTemplateOption[] = [
+  {
+    value: 'new_api',
+    label: 'NewAPI',
+    title: 'NewAPI 余额接口',
+    description: '使用个人安全设置中的访问令牌请求 /api/user/self，并按 quota / 500000 换算余额。',
+    badge: '/api/user/self'
+  },
+  {
+    value: 'sub2api',
+    label: 'Sub2API',
+    title: 'Sub2API 余量接口',
+    description: '使用当前 Key 或单独填写的 API Key 请求 /v1/usage 查询余量。',
+    badge: '/v1/usage'
+  },
+  {
+    value: 'generic_api',
+    label: '自定义',
+    title: '自定义余额接口',
+    description: '自行指定请求路径、额度换算和响应字段，适合 DeepSeek 或其他提供商的官方余额接口。',
+    badge: 'Custom'
+  }
+]
+const newApiBalanceQuery = ref({
+  base_url: '',
+  access_token: '',
+  user_id: ''
+})
+const sub2ApiBalanceQuery = ref({
+  base_url: '',
+  token: ''
+})
+const customBalanceQuery = ref({
+  base_url: '',
+  api_key: '',
+  endpoint: '/api/user/self',
+  method: 'GET' as BalanceQueryMethod,
+  currency: 'USD',
+  quota_divisor: 500000 as number | string,
+  balance_path: 'data.quota',
+  used_path: 'data.used_quota',
+  granted_path: ''
+})
+const balanceLoading = ref(false)
+const balanceResult = ref<ProviderKeyBalanceResult | null>(null)
+const balanceError = ref('')
+const pendingBalanceSaveQuery = ref<ProviderKeyBalanceQuery | null>(null)
+const canSaveBalanceResultToKey = computed(() => (
+  !!props.providerId && isRawSecretAuthType(form.value.auth_type)
+))
+const hasSavedBalanceSecret = computed(() => (
+  props.editingKey?.upstream_metadata?.balance_query?.query_config?.has_saved_secret === true
+))
+const savedBalanceQueryTemplate = computed(() => getSavedBalanceQueryTemplate())
+const savedBalanceQueryConfig = computed(() => (
+  props.editingKey?.upstream_metadata?.balance_query?.query_config || null
+))
+const hasSavedBalanceSecretForSelectedQuery = computed(() => {
+  if (!hasSavedBalanceSecret.value || savedBalanceQueryTemplate.value !== balanceQueryTemplate.value) {
+    return false
+  }
+  if (balanceQueryTemplate.value !== 'sub2api') {
+    return true
+  }
+  const savedKind = String(savedBalanceQueryConfig.value?.sub2api_credential_kind || '').trim()
+  return savedKind === 'api_key'
+})
+const balanceCredentialRequiresDedicatedSecret = computed(() => {
+  if (balanceQueryTemplate.value === 'new_api') return true
+  return false
+})
+const canConfigureBalanceSecretSave = computed(() => (
+  balanceCredentialRequiresDedicatedSecret.value || hasSavedBalanceSecretForSelectedQuery.value
+))
+const balanceSaveDescription = computed(() => (
+  props.editingKey?.id
+    ? '保存余额摘要、更新时间和查询配置'
+    : '新增 Key 会在保存后自动写入余额摘要、查询模板和自动查询间隔'
+))
+const balanceSecretSaveDescription = computed(() => (
+  saveBalanceResult.value
+    ? '加密保存本次填写的余额查询令牌，用于刷新和自动查询；不替换当前 Key。'
+    : '需要先开启“查询成功后保存到当前 Key”。'
+))
+const effectiveBalanceSecret = computed(() => {
+  if (balanceQueryTemplate.value === 'new_api') {
+    return newApiBalanceQuery.value.access_token.trim()
+  }
+  if (balanceQueryTemplate.value === 'sub2api') {
+    return sub2ApiBalanceQuery.value.token.trim() || form.value.api_key.trim()
+  }
+  return customBalanceQuery.value.api_key.trim() || form.value.api_key.trim()
+})
+const hasBalanceQuerySecret = computed(() => {
+  if (effectiveBalanceSecret.value || hasSavedBalanceSecretForSelectedQuery.value) {
+    return true
+  }
+  return !!props.editingKey?.id && !balanceCredentialRequiresDedicatedSecret.value
+})
+const selectedBalanceQueryTemplate = computed(() => (
+  balanceQueryTemplateOptions.find(option => option.value === balanceQueryTemplate.value)
+  || balanceQueryTemplateOptions[0]
+))
+const canConfirmBalanceQuery = computed(() => {
+  if (balanceLoading.value || !hasBalanceQuerySecret.value) return false
+  if (balanceQueryTemplate.value === 'generic_api') {
+    return !!customBalanceQuery.value.endpoint.trim()
+  }
+  return true
+})
+
+const canQueryBalance = computed(() => (
+  !!props.providerId &&
+  isRawSecretAuthType(form.value.auth_type) &&
+  !saving.value &&
+  !balanceLoading.value
+))
+
+const balanceData = computed<ProviderKeyBalanceInfo | null>(() => (
+  balanceResult.value?.data ?? null
+))
+const balanceResultPendingSave = computed(() => (
+  !props.editingKey?.id
+  && !!pendingBalanceSaveQuery.value
+  && balanceResult.value?.status === 'success'
+))
+
+const balanceExtraRows = computed(() => {
+  const data = balanceData.value
+  const extra = data?.extra
+  if (!extra) return []
+  const rows: Array<{ label: string; value: string }> = []
+  const currency = data.currency || 'USD'
+  const planName = typeof extra.plan_name === 'string'
+    ? extra.plan_name
+    : typeof extra.planName === 'string'
+      ? extra.planName
+      : null
+  const balance = toFiniteNumber(extra.balance)
+  const points = toFiniteNumber(extra.points)
+  const activeSubscriptions = toFiniteNumber(extra.active_subscriptions)
+  const totalUsedUsd = toFiniteNumber(extra.total_used_usd)
+  if (planName) {
+    rows.push({ label: '套餐', value: planName })
+  }
+  if (balance !== null) {
+    rows.push({ label: '余额', value: formatBalanceAmount(balance, currency) })
+  }
+  if (points !== null) {
+    rows.push({ label: '积分', value: formatBalanceAmount(points, currency) })
+  }
+  if (activeSubscriptions !== null) {
+    rows.push({ label: '有效订阅', value: `${activeSubscriptions}` })
+  }
+  if (totalUsedUsd !== null) {
+    rows.push({ label: '订阅已用', value: formatBalanceAmount(totalUsedUsd, 'USD') })
+  }
+  return rows
+})
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function normalizeAutoRefreshInterval(value: unknown): number {
+  const parsed = toFiniteNumber(value)
+  if (parsed === null || parsed <= 0) return 0
+  return Math.min(Math.floor(parsed), 10080)
+}
+
+function setBalanceAutoRefreshInterval(value: unknown) {
+  balanceAutoRefreshIntervalMinutes.value = normalizeAutoRefreshInterval(value)
+}
+
+function formatBalanceAmount(value: unknown, currency = 'USD'): string {
+  const numberValue = toFiniteNumber(value)
+  if (numberValue === null) return '未知'
+  const normalizedCurrency = (currency || 'USD').toUpperCase()
+  const prefix = normalizedCurrency === 'USD'
+    ? '$'
+    : normalizedCurrency === 'CNY'
+      ? '¥'
+      : `${normalizedCurrency} `
+  const decimals = Math.abs(numberValue) >= 100 ? 2 : 4
+  return `${prefix}${numberValue.toFixed(decimals)}`
+}
+
+function balanceStatusText(status: ProviderKeyBalanceResult['status']): string {
+  const labels: Record<ProviderKeyBalanceResult['status'], string> = {
+    success: '查询成功',
+    pending: '查询处理中',
+    auth_failed: '认证失败',
+    auth_expired: '认证已过期',
+    rate_limited: '请求频率受限',
+    network_error: '网络错误',
+    parse_error: '响应解析失败',
+    not_configured: '未配置余额查询',
+    not_supported: '当前上游不支持余额查询',
+    already_done: '已完成',
+    unknown_error: '查询失败'
+  }
+  return labels[status] || '查询失败'
+}
+
+function normalizeBalanceQueryTemplate(value: unknown): BalanceQueryTemplate | null {
+  const normalized = String(value || '').trim().toLowerCase().replace(/-/g, '_')
+  if (normalized === 'newapi' || normalized === 'new_api') return 'new_api'
+  if (normalized === 'sub2api') return 'sub2api'
+  if (normalized === 'generic' || normalized === 'custom' || normalized === 'generic_api') return 'generic_api'
+  return null
+}
+
+function getSavedBalanceQueryTemplate(): BalanceQueryTemplate | null {
+  return normalizeBalanceQueryTemplate(props.editingKey?.upstream_metadata?.balance_query?.architecture_id)
+}
+
+function getSavedBalanceAutoRefreshInterval(): number {
+  return normalizeAutoRefreshInterval(
+    props.editingKey?.upstream_metadata?.balance_query?.query_config?.auto_refresh_interval_minutes
+  )
+}
+
+function setSaveBalanceResult(value: boolean) {
+  saveBalanceResult.value = value && canSaveBalanceResultToKey.value
+  if (!saveBalanceResult.value) {
+    saveBalanceSecret.value = false
+    pendingBalanceSaveQuery.value = null
+  } else if (props.editingKey || balanceCredentialRequiresDedicatedSecret.value) {
+    saveBalanceSecret.value = true
+  }
+}
+
 watch(
   [() => form.value.auth_type, () => props.providerType, () => props.availableApiFormats],
   () => {
@@ -719,6 +1481,9 @@ watch(
     if (!allowedAuthTypes.has(form.value.auth_type)) {
       form.value.auth_type = getDefaultAuthType()
       return
+    }
+    if (!isRawSecretAuthType(form.value.auth_type)) {
+      setSaveBalanceResult(false)
     }
 
     const filtered = sanitizeApiFormats(form.value.api_formats)
@@ -783,6 +1548,10 @@ function toggleApiFormat(format: string) {
 // 重置表单
 function resetForm() {
   formNonce.value = createFieldNonce()
+  pendingBalanceSaveQuery.value = null
+  saveBalanceResult.value = false
+  saveBalanceSecret.value = false
+  balanceAutoRefreshIntervalMinutes.value = 0
   const defaultApiFormats = getDefaultApiFormats()
   form.value = {
     name: '',
@@ -810,6 +1579,10 @@ function resetForm() {
 // 添加成功后清除部分字段以便继续添加
 function clearForNextAdd() {
   formNonce.value = createFieldNonce()
+  pendingBalanceSaveQuery.value = null
+  saveBalanceResult.value = false
+  saveBalanceSecret.value = false
+  balanceAutoRefreshIntervalMinutes.value = 0
   form.value.name = ''
   form.value.api_key = ''
   form.value.auth_config_text = ''
@@ -823,6 +1596,7 @@ function clearForNextAdd() {
 function loadKeyData() {
   if (!props.editingKey) return
   formNonce.value = createFieldNonce()
+  pendingBalanceSaveQuery.value = null
   form.value = {
     name: props.editingKey.name,
     api_key: '',
@@ -897,6 +1671,167 @@ function parseAuthConfig(): Record<string, unknown> | null {
 
 function handleServiceAccountImportError(payload: { message: string, title?: string }) {
   showError(payload.message, payload.title || '错误')
+}
+
+async function handleQueryBalance() {
+  if (!props.providerId) {
+    showError('无法查询：缺少提供商信息', '错误')
+    return
+  }
+  if (!isRawSecretAuthType(form.value.auth_type)) {
+    showError('余额查询仅支持 API Key 或 Bearer Token', '错误')
+    return
+  }
+  balanceQueryTemplate.value = getSavedBalanceQueryTemplate() || inferBalanceQueryTemplate()
+  setSaveBalanceResult(!!props.editingKey)
+  balanceAutoRefreshIntervalMinutes.value = getSavedBalanceAutoRefreshInterval()
+  balanceQueryDialogOpen.value = true
+}
+
+async function confirmBalanceQuery() {
+  if (!props.providerId) {
+    showError('无法查询：缺少提供商信息', '错误')
+    return
+  }
+  if (!isRawSecretAuthType(form.value.auth_type)) {
+    showError('余额查询仅支持 API Key 或 Bearer Token', '错误')
+    return
+  }
+
+  const apiKey = effectiveBalanceSecret.value
+  if (!apiKey && !props.editingKey?.id) {
+    showError('请填写本次查询凭据，或先在外层填写/保存 API 密钥', '验证失败')
+    return
+  }
+  if (balanceCredentialRequiresDedicatedSecret.value && !apiKey && !hasSavedBalanceSecretForSelectedQuery.value) {
+    showError('请填写本次查询凭据，或先保存过同类型的余额查询凭据', '验证失败')
+    return
+  }
+  if (balanceQueryTemplate.value === 'generic_api' && !customBalanceQuery.value.endpoint.trim()) {
+    showError('请填写自定义查询路径', '验证失败')
+    return
+  }
+
+  balanceQueryDialogOpen.value = false
+  balanceDialogOpen.value = true
+  balanceLoading.value = true
+  balanceResult.value = null
+  balanceError.value = ''
+
+  try {
+    const saveToExistingKey = saveBalanceResult.value && !!props.editingKey?.id
+    const autoRefreshInterval = saveBalanceResult.value
+      ? normalizeAutoRefreshInterval(balanceAutoRefreshIntervalMinutes.value)
+      : 0
+    const query = buildBalanceQueryPayload(apiKey, {
+      keyId: props.editingKey?.id,
+      saveResult: saveToExistingKey,
+      saveBalanceSecret: saveToExistingKey && saveBalanceSecret.value,
+      autoRefreshIntervalMinutes: autoRefreshInterval,
+    })
+    balanceResult.value = await queryProviderKeyBalance(props.providerId, query)
+    if (balanceResult.value.saved_to_key) {
+      emit('saved')
+    }
+    if (!props.editingKey?.id) {
+      pendingBalanceSaveQuery.value = saveBalanceResult.value && balanceResult.value.status === 'success'
+        ? buildBalanceQueryPayload(apiKey, {
+          saveResult: true,
+          saveBalanceSecret: saveBalanceSecret.value,
+          autoRefreshIntervalMinutes: autoRefreshInterval,
+        })
+        : null
+    }
+  } catch (err: unknown) {
+    balanceError.value = parseApiError(err, '查询余额失败')
+  } finally {
+    balanceLoading.value = false
+  }
+}
+
+function buildBalanceQueryPayload(
+  apiKey: string,
+  options: {
+    keyId?: string
+    saveResult: boolean
+    saveBalanceSecret: boolean
+    autoRefreshIntervalMinutes: number
+  },
+): ProviderKeyBalanceQuery {
+  const query: ProviderKeyBalanceQuery = {
+    key_id: options.keyId,
+    api_key: apiKey || undefined,
+    auth_type: balanceQueryAuthType(),
+    api_formats: [...form.value.api_formats],
+    architecture_id: balanceQueryTemplate.value,
+    save_result: options.saveResult,
+    save_balance_secret: options.saveBalanceSecret,
+    auto_refresh_interval_minutes: options.autoRefreshIntervalMinutes,
+  }
+  if (balanceQueryTemplate.value === 'new_api') {
+    query.custom_base_url = trimmedOrUndefined(newApiBalanceQuery.value.base_url)
+    query.new_api_user_id = trimmedOrUndefined(newApiBalanceQuery.value.user_id)
+  } else if (balanceQueryTemplate.value === 'sub2api') {
+    query.custom_base_url = trimmedOrUndefined(sub2ApiBalanceQuery.value.base_url)
+    query.sub2api_credential_kind = 'api_key'
+  } else if (balanceQueryTemplate.value === 'generic_api') {
+    const quotaDivisor = toFiniteNumber(customBalanceQuery.value.quota_divisor)
+    query.custom_base_url = trimmedOrUndefined(customBalanceQuery.value.base_url)
+    query.custom_endpoint = customBalanceQuery.value.endpoint.trim()
+    query.custom_method = customBalanceQuery.value.method
+    query.custom_currency = trimmedOrUndefined(customBalanceQuery.value.currency)
+    query.custom_quota_divisor = quotaDivisor && quotaDivisor > 0 ? quotaDivisor : undefined
+    query.custom_balance_path = trimmedOrUndefined(customBalanceQuery.value.balance_path)
+    query.custom_used_path = trimmedOrUndefined(customBalanceQuery.value.used_path)
+    query.custom_granted_path = trimmedOrUndefined(customBalanceQuery.value.granted_path)
+  }
+  return query
+}
+
+function balanceQueryAuthType(): ProviderKeyBalanceQuery['auth_type'] {
+  if (balanceQueryTemplate.value === 'sub2api') {
+    return 'api_key'
+  }
+  if (balanceQueryTemplate.value === 'new_api') {
+    return 'api_key'
+  }
+  return form.value.auth_type
+}
+
+function inferBalanceQueryTemplate(): BalanceQueryTemplate {
+  const fingerprint = [
+    props.providerType || '',
+    props.endpoint?.provider_name || '',
+    props.endpoint?.base_url || ''
+  ].join(' ').toLowerCase()
+  return fingerprint.includes('sub2api') ? 'sub2api' : 'new_api'
+}
+
+function trimmedOrUndefined(value: string | null | undefined): string | undefined {
+  const trimmed = (value || '').trim()
+  return trimmed ? trimmed : undefined
+}
+
+async function persistPendingBalanceForCreatedKey(keyId: string): Promise<boolean> {
+  if (!props.providerId || !pendingBalanceSaveQuery.value) {
+    return false
+  }
+  try {
+    const result = await queryProviderKeyBalance(props.providerId, {
+      ...pendingBalanceSaveQuery.value,
+      key_id: keyId,
+      save_result: true,
+    })
+    if (result.status !== 'success' || !result.saved_to_key) {
+      showError(result.save_message || result.message || '余额配置未写入新 Key', '余额保存失败')
+      return false
+    }
+    pendingBalanceSaveQuery.value = null
+    return true
+  } catch (err: unknown) {
+    showError(parseApiError(err, '余额配置未写入新 Key'), '余额保存失败')
+    return false
+  }
 }
 
 async function handleSave() {
@@ -993,7 +1928,7 @@ async function handleSave() {
       success('密钥已更新', '成功')
     } else {
       // 新增模式
-      await addProviderKey(props.providerId, {
+      const created = await addProviderKey(props.providerId, {
         api_formats: form.value.api_formats,
         api_key: form.value.api_key,
         auth_type: form.value.auth_type,
@@ -1012,8 +1947,15 @@ async function handleSave() {
         model_include_patterns: parsePatternText(form.value.model_include_patterns_text),
         model_exclude_patterns: parsePatternText(form.value.model_exclude_patterns_text)
       })
+      const hadPendingBalanceSave = !!pendingBalanceSaveQuery.value
+      const balanceSaved = await persistPendingBalanceForCreatedKey(created.id)
 
-      success('密钥已添加', '成功')
+      success(
+        hadPendingBalanceSave && balanceSaved
+          ? '密钥已添加，余额配置已保存'
+          : '密钥已添加',
+        '成功'
+      )
       // 添加模式：不关闭对话框，只清除名称和密钥以便继续添加
       emit('saved')
       clearForNextAdd()

--- a/frontend/src/features/providers/components/ProviderAuthDialog.vue
+++ b/frontend/src/features/providers/components/ProviderAuthDialog.vue
@@ -1,10 +1,10 @@
 <template>
   <Dialog
     :open="open"
-    title="用户认证"
-    description="配置提供商的用户认证信息，用于余额查询、签到等操作"
+    :title="dialogTitle"
+    description="独立配置上游余额/用量查询凭据，不影响模型调用 Key"
     :icon="KeyRound"
-    size="md"
+    size="4xl"
     @update:open="$emit('update:open', $event)"
   >
     <form
@@ -23,38 +23,30 @@
       </div>
       <div
         v-else
-        class="space-y-4"
+        class="space-y-5"
       >
-        <!-- 认证模板 + 认证方式（并排） -->
-        <div class="flex gap-3">
-          <div
-            class="space-y-2"
-            :style="{ flex: currentAuthTypes.length > 1 ? 1 : 'auto', width: currentAuthTypes.length > 1 ? undefined : '100%' }"
-          >
-            <Label>认证模板</Label>
-            <Select
-              v-model="selectedArchitectureId"
-              @update:model-value="handleArchitectureChange"
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="选择认证模板" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem
-                  v-for="arch in architectures"
-                  :key="arch.architecture_id"
-                  :value="arch.architecture_id"
-                >
-                  {{ arch.display_name }}
-                </SelectItem>
-              </SelectContent>
-            </Select>
+        <div class="space-y-2">
+          <div class="flex items-center justify-between gap-3">
+            <Label>预设模板</Label>
+            <span class="text-xs text-muted-foreground">留空则自动使用供应商配置</span>
           </div>
-
+          <div class="flex flex-wrap items-center gap-2">
+            <button
+              v-for="arch in architectures"
+              :key="arch.architecture_id"
+              type="button"
+              class="h-8 rounded-md border px-3 text-xs font-medium transition-colors"
+              :class="selectedArchitectureId === arch.architecture_id
+                ? 'border-primary bg-primary text-primary-foreground shadow-sm'
+                : 'border-border bg-background text-muted-foreground hover:border-primary/40 hover:text-foreground'"
+              @click="selectArchitecturePreset(arch.architecture_id)"
+            >
+              {{ formatArchitectureLabel(arch) }}
+            </button>
+          </div>
           <div
             v-if="currentAuthTypes.length > 1"
-            class="space-y-2"
-            style="flex: 1"
+            class="grid gap-2 sm:max-w-xs"
           >
             <Label>认证方式</Label>
             <Select
@@ -74,6 +66,15 @@
                 </SelectItem>
               </SelectContent>
             </Select>
+          </div>
+        </div>
+
+        <div class="space-y-1">
+          <div class="text-sm font-semibold text-foreground">
+            凭证配置
+          </div>
+          <div class="text-xs text-muted-foreground">
+            不同模板支持的凭据类型不同，API Key、访问令牌和 Refresh Token 会分别保留。
           </div>
         </div>
 
@@ -262,19 +263,43 @@
             :disabled="isVerifying || !canVerify"
             @click="handleVerify"
           >
-            {{ isVerifying ? '验证中...' : '验证' }}
+            <Loader2
+              v-if="isVerifying"
+              class="h-3.5 w-3.5 animate-spin"
+            />
+            <Play
+              v-else
+              class="h-3.5 w-3.5"
+            />
+            {{ isVerifying ? '测试中...' : '测试脚本' }}
           </Button>
           <Button
-            :disabled="isSaving || !canSave"
-            @click="handleSave"
+            variant="outline"
+            :disabled="isSaving || isVerifying"
+            @click="handleFormat"
           >
-            {{ isSaving ? '保存中...' : '保存' }}
+            <Wand2 class="h-3.5 w-3.5" />
+            格式化
           </Button>
           <Button
             variant="outline"
             @click="$emit('update:open', false)"
           >
             取消
+          </Button>
+          <Button
+            :disabled="isSaving || !canSave"
+            @click="handleSave"
+          >
+            <Loader2
+              v-if="isSaving"
+              class="h-3.5 w-3.5 animate-spin"
+            />
+            <Save
+              v-else
+              class="h-3.5 w-3.5"
+            />
+            {{ isSaving ? '保存中...' : '保存配置' }}
           </Button>
         </div>
       </div>
@@ -284,7 +309,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from 'vue'
-import { KeyRound } from 'lucide-vue-next'
+import { KeyRound, Loader2, Play, Save, Wand2 } from 'lucide-vue-next'
 import {
   Dialog,
   Button,
@@ -325,6 +350,7 @@ import { useProxyNodesStore } from '@/stores/proxy-nodes'
 const props = defineProps<{
   open: boolean
   providerId: string
+  providerName?: string
   providerWebsite?: string
   currentConfig?: Record<string, unknown> | null
 }>()
@@ -375,6 +401,12 @@ const architecturesLoaded = ref(false)
 const selectedArchitectureId = ref('new_api')
 const selectedAuthType = ref('')
 const formData = ref<Record<string, unknown>>({})
+
+const dialogTitle = computed(() => (
+  props.providerName
+    ? `配置用量查询 - ${props.providerName}`
+    : '配置用量查询'
+))
 
 // 当前架构支持的认证方式
 const currentAuthTypes = computed(() => {
@@ -441,6 +473,26 @@ function handleArchitectureChange() {
   formChanged.value = true
 }
 
+function selectArchitecturePreset(architectureId: string) {
+  if (selectedArchitectureId.value === architectureId) return
+  selectedArchitectureId.value = architectureId
+  handleArchitectureChange()
+}
+
+function formatArchitectureLabel(arch: ArchitectureInfo): string {
+  const labels: Record<string, string> = {
+    generic_api: '通用模板',
+    new_api: 'NewAPI',
+    sub2api: 'Sub2API',
+    anyrouter: 'AnyRouter',
+    done_hub: 'Done Hub',
+    yescode: 'YesCode',
+    cubence: 'Cubence',
+    nekocode: 'NekoCode',
+  }
+  return labels[arch.architecture_id] || arch.display_name
+}
+
 function handleAuthTypeChange() {
   resetFormData()
   verifyStatus.value = null
@@ -478,7 +530,9 @@ function resetFormData() {
   // 初始化表单数据
   const data: Record<string, unknown> = {}
   for (const [key, prop] of Object.entries(schema.properties)) {
-    data[key] = (prop as Record<string, unknown>)['x-default-value'] ?? ''
+    data[key] = key === 'base_url'
+      ? (props.providerWebsite || (prop as Record<string, unknown>)['x-default-value'] || '')
+      : ((prop as Record<string, unknown>)['x-default-value'] ?? '')
   }
   // 代理相关默认值
   data.proxy_enabled = false
@@ -493,6 +547,22 @@ function formatQuota(quota: number): string {
     return formatQuotaFromSchema(schema, quota)
   }
   return quota.toLocaleString()
+}
+
+function handleFormat() {
+  const normalized: Record<string, unknown> = { ...formData.value }
+  for (const [key, value] of Object.entries(normalized)) {
+    if (typeof value !== 'string') continue
+    normalized[key] = key === 'base_url'
+      ? value.trim().replace(/\/+$/, '')
+      : value.trim()
+  }
+  if (!normalized.base_url && props.providerWebsite) {
+    normalized.base_url = props.providerWebsite.replace(/\/+$/, '')
+  }
+  formData.value = normalized
+  verifyStatus.value = null
+  formChanged.value = true
 }
 
 async function handleVerify() {
@@ -677,6 +747,10 @@ function loadFromConfig(config: Record<string, unknown>) {
   if (!config?.connector) return
 
   hasExistingConfig.value = true
+  const connector = config.connector as {
+    auth_type?: string
+    credentials?: Record<string, unknown>
+  }
 
   // 根据已保存的 architecture_id 选择对应架构
   const architectureId = config.architecture_id || 'new_api'
@@ -684,7 +758,15 @@ function loadFromConfig(config: Record<string, unknown>) {
   selectedArchitectureId.value = archExists ? architectureId : 'new_api'
 
   // 从已保存的 connector auth_type 恢复认证方式选择
-  const savedAuthType = config.connector?.auth_type
+  let savedAuthType = connector?.auth_type
+  if (
+    selectedArchitectureId.value === 'sub2api' &&
+    savedAuthType === 'api_key' &&
+    connector?.credentials?.refresh_token &&
+    !connector?.credentials?.api_key
+  ) {
+    savedAuthType = 'refresh_token'
+  }
   const authTypes = currentAuthTypes.value
   if (savedAuthType && authTypes.some((t) => t.type === savedAuthType)) {
     selectedAuthType.value = savedAuthType
@@ -772,6 +854,16 @@ watch(
         selectedAuthType.value = ''
         resetFormData()
       }
+    }
+  }
+)
+
+watch(
+  () => props.providerWebsite,
+  (value) => {
+    if (!props.open || hasExistingConfig.value || !value) return
+    if (!formData.value.base_url) {
+      formData.value.base_url = value
     }
   }
 )

--- a/frontend/src/features/providers/components/ProviderBalanceCell.vue
+++ b/frontend/src/features/providers/components/ProviderBalanceCell.vue
@@ -1,15 +1,7 @@
 <template>
-  <!-- 余额正在加载中 -->
-  <div
-    v-if="provider.ops_configured && isBalanceLoading(provider.id)"
-    class="flex items-center gap-1.5 text-xs text-muted-foreground"
-  >
-    <Loader2 class="h-3 w-3 animate-spin" />
-    <span>加载中...</span>
-  </div>
   <!-- 显示从上游 API 查询的余额 -->
   <div
-    v-else-if="provider.ops_configured && getProviderBalance(provider.id)"
+    v-if="provider.ops_configured && getProviderBalance(provider.id)"
     class="flex items-center gap-2 text-xs"
   >
     <!-- 余额文字：balance + points 分开显示，或普通余额 -->
@@ -95,6 +87,35 @@
       </div>
     </div>
   </div>
+  <!-- 显示保存到 Key 的手动余额查询摘要 -->
+  <div
+    v-else-if="getSavedKeyBalance(provider)"
+    class="space-y-0.5 text-xs"
+    :title="getSavedKeyBalanceTitle(provider)"
+  >
+    <div class="flex items-center gap-1.5">
+      <WalletCards class="h-3 w-3 text-primary" />
+      <span class="font-semibold text-foreground/90 tabular-nums">
+        {{ formatKeyBalanceAmount(getSavedKeyBalance(provider)?.total_available, getSavedKeyBalance(provider)?.currency || 'USD') }}
+      </span>
+    </div>
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-muted-foreground/70">
+      <span v-if="toFiniteNumber(getSavedKeyBalance(provider)?.total_used) !== null">
+        已用 {{ formatKeyBalanceAmount(getSavedKeyBalance(provider)?.total_used, getSavedKeyBalance(provider)?.currency || 'USD') }}
+      </span>
+      <span>
+        {{ keyBalanceTemplateLabel(getSavedKeyBalance(provider)?.architecture_id) }} · {{ formatKeyBalanceUpdatedAt(getSavedKeyBalance(provider)?.updated_at) }}
+      </span>
+    </div>
+  </div>
+  <!-- 余额正在加载中 -->
+  <div
+    v-else-if="provider.ops_configured && isBalanceLoading(provider.id)"
+    class="flex items-center gap-1.5 text-xs text-muted-foreground"
+  >
+    <Loader2 class="h-3 w-3 animate-spin" />
+    <span>加载中...</span>
+  </div>
   <!-- 余额查询失败时显示错误 -->
   <div
     v-else-if="provider.ops_configured && getProviderBalanceError(provider.id)"
@@ -128,11 +149,18 @@
 </template>
 
 <script setup lang="ts">
-import { Loader2 } from 'lucide-vue-next'
+import { Loader2, WalletCards } from 'lucide-vue-next'
 import Badge from '@/components/ui/badge.vue'
-import type { ProviderWithEndpointsSummary } from '@/api/endpoints'
+import type { ProviderKeyBalanceSummary, ProviderWithEndpointsSummary } from '@/api/endpoints'
 import { formatBillingType } from '@/utils/format'
 import type { BalanceExtraItem } from '@/features/providers/auth-templates'
+import {
+  formatKeyBalanceAmount,
+  formatKeyBalanceUpdatedAt,
+  hasKeyBalanceSummary,
+  keyBalanceTemplateLabel,
+  toFiniteNumber,
+} from '@/features/providers/utils/keyBalanceSummary'
 
 defineProps<{
   provider: ProviderWithEndpointsSummary
@@ -147,4 +175,19 @@ defineProps<{
   formatResetCountdown: (resetsAt: number) => string
   getQuotaUsedColorClass: (provider: ProviderWithEndpointsSummary) => string
 }>()
+
+function getSavedKeyBalance(provider: ProviderWithEndpointsSummary): ProviderKeyBalanceSummary | null {
+  return hasKeyBalanceSummary(provider.key_balance_summary) ? provider.key_balance_summary : null
+}
+
+function getSavedKeyBalanceTitle(provider: ProviderWithEndpointsSummary): string {
+  const summary = getSavedKeyBalance(provider)
+  if (!summary) return ''
+  const parts = [
+    summary.key_name ? `Key: ${summary.key_name}` : null,
+    keyBalanceTemplateLabel(summary.architecture_id),
+    formatKeyBalanceUpdatedAt(summary.updated_at),
+  ].filter(Boolean)
+  return parts.join(' · ')
+}
 </script>

--- a/frontend/src/features/providers/components/ProviderDetailDrawer.vue
+++ b/frontend/src/features/providers/components/ProviderDetailDrawer.vue
@@ -555,6 +555,64 @@
                         </Button>
                       </div>
                     </div>
+                    <!-- 手动余额查询摘要 -->
+                    <div
+                      v-if="getKeyBalanceSummary(key)"
+                      class="mt-2 flex items-center gap-2 rounded-md border border-border/70 bg-muted/20 px-2.5 py-2 text-[11px]"
+                    >
+                      <div class="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+                        <span class="inline-flex items-center gap-1 font-medium text-foreground">
+                          <WalletCards class="h-3 w-3 text-primary" />
+                          上游余额 {{ formatKeyBalanceAmount(getKeyBalanceSummary(key)?.available, getKeyBalanceSummary(key)?.currency) }}
+                        </span>
+                        <span
+                          v-if="getKeyBalanceSummary(key)?.used !== null"
+                          class="text-muted-foreground"
+                        >
+                          已用 {{ formatKeyBalanceAmount(getKeyBalanceSummary(key)?.used, getKeyBalanceSummary(key)?.currency) }}
+                        </span>
+                        <span
+                          v-if="getKeyBalanceSummary(key)?.granted !== null"
+                          class="text-muted-foreground"
+                        >
+                          总额 {{ formatKeyBalanceAmount(getKeyBalanceSummary(key)?.granted, getKeyBalanceSummary(key)?.currency) }}
+                        </span>
+                        <span
+                          v-if="getKeyBalanceSummary(key)?.planName"
+                          class="text-muted-foreground"
+                        >
+                          套餐 {{ getKeyBalanceSummary(key)?.planName }}
+                        </span>
+                        <span class="text-muted-foreground/70">
+                          {{ getKeyBalanceSummary(key)?.templateLabel }} · {{ formatUpdatedAt(getKeyBalanceSummary(key)?.updatedAt || 0) }}
+                        </span>
+                        <span
+                          v-if="getKeyBalanceAutoRefreshIntervalMinutes(key) > 0"
+                          class="text-muted-foreground/70"
+                        >
+                          每 {{ getKeyBalanceAutoRefreshIntervalMinutes(key) }} 分钟自动
+                        </span>
+                        <span
+                          v-if="keyBalanceRefreshRequiresSavedSecret(key) && !hasSavedBalanceSecret(key)"
+                          class="text-amber-600 dark:text-amber-400"
+                        >
+                          需保存查询凭据
+                        </span>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        class="h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground"
+                        :disabled="refreshingBalanceKeyId === key.id || !canRefreshKeyBalance(key)"
+                        :title="getKeyBalanceRefreshTitle(key)"
+                        @click.stop="handleRefreshKeyBalance(key)"
+                      >
+                        <RefreshCw
+                          class="h-3 w-3"
+                          :class="{ 'animate-spin': refreshingBalanceKeyId === key.id }"
+                        />
+                      </Button>
+                    </div>
                     <!-- Codex 上游额度信息（仅当有元数据时显示） -->
                     <div
                       v-if="hasCodexQuotaDisplayData(key)"
@@ -1217,7 +1275,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed, nextTick } from 'vue'
+import { ref, watch, computed, nextTick, onUnmounted } from 'vue'
 import {
   Plus,
   Key,
@@ -1236,6 +1294,7 @@ import {
   ShieldX,
   Globe,
   GitBranch,
+  WalletCards,
 } from 'lucide-vue-next'
 import { parseApiError } from '@/utils/errorParser'
 import { useEscapeKey } from '@/composables/useEscapeKey'
@@ -1282,10 +1341,12 @@ import {
   exportKey,
   refreshProviderOAuth,
   refreshProviderQuota,
+  queryProviderKeyBalance,
   clearOAuthInvalid,
   type ProviderEndpoint,
   type EndpointAPIKey,
   type Model,
+  type ProviderKeyBalanceQuery,
   API_FORMAT_ORDER,
   sortApiFormats,
 } from '@/api/endpoints'
@@ -1330,6 +1391,17 @@ interface ProviderEndpointWithKeys extends ProviderEndpoint {
   rpm_limit?: number
 }
 
+interface KeyBalanceSummary {
+  available: number | null
+  used: number | null
+  granted: number | null
+  currency: string
+  updatedAt: number
+  templateLabel: string
+  planName: string | null
+  architectureId: string
+}
+
 interface Props {
   providerId: string | null
   open: boolean
@@ -1365,6 +1437,8 @@ let keysLoadRequestId = 0
 let mappingPreviewLoadRequestId = 0
 const DEFAULT_PROVIDER_KEYS_PAGE_SIZE = 3
 const CUSTOM_PROVIDER_KEYS_PAGE_SIZE = 4
+const BALANCE_AUTO_REFRESH_CHECK_MS = 60_000
+let balanceAutoRefreshTimer: ReturnType<typeof setInterval> | null = null
 
 function getProviderKeysPageSize(providerType?: string | null): number {
   return (providerType || '').trim().toLowerCase() === 'custom'
@@ -1388,6 +1462,7 @@ const editingKey = ref<EndpointAPIKey | null>(null)
 const deleteKeyConfirmOpen = ref(false)
 const keyToDelete = ref<EndpointAPIKey | null>(null)
 const togglingKeyId = ref<string | null>(null)
+const refreshingBalanceKeyId = ref<string | null>(null)
 
 // 密钥显示状态：key_id -> 完整密钥
 const revealedKeys = ref<Map<string, string>>(new Map())
@@ -1570,6 +1645,7 @@ watch(
       // 仅在抽屉刚打开时启动倒计时
       if (newOpen && !oldOpen) {
         startCountdownTimer()
+        startKeyBalanceAutoRefreshTimer()
       }
       void endpointsPromise.then(() => autoRefreshQuotaInBackground())
     } else if (!newOpen && oldOpen) {
@@ -1581,6 +1657,7 @@ watch(
 
       // 停止倒计时定时器
       stopCountdownTimer()
+      stopKeyBalanceAutoRefreshTimer()
       // 重置所有状态
       loading.value = false
       provider.value = null
@@ -1740,6 +1817,167 @@ function handleEditKey(endpoint: ProviderEndpoint | undefined, key: EndpointAPIK
     oauthKeyEditDialogOpen.value = true
   } else {
     keyFormDialogOpen.value = true
+  }
+}
+
+function canOpenKeyBalanceQuery(key: EndpointAPIKey): boolean {
+  return key.auth_type === 'api_key' || key.auth_type === 'bearer'
+}
+
+function normalizeBalanceArchitectureId(value: unknown): ProviderKeyBalanceQuery['architecture_id'] | undefined {
+  const normalized = String(value || '').trim().toLowerCase().replace(/-/g, '_')
+  if (normalized === 'newapi' || normalized === 'new_api') return 'new_api'
+  if (normalized === 'sub2api') return 'sub2api'
+  if (normalized === 'generic' || normalized === 'custom' || normalized === 'generic_api') return 'generic_api'
+  return undefined
+}
+
+function canRefreshKeyBalance(key: EndpointAPIKey): boolean {
+  return canOpenKeyBalanceQuery(key)
+    && !!normalizeBalanceArchitectureId(key.upstream_metadata?.balance_query?.architecture_id)
+    && (!keyBalanceRefreshRequiresSavedSecret(key) || hasSavedBalanceSecret(key))
+}
+
+function hasSavedBalanceSecret(key: EndpointAPIKey): boolean {
+  return key.upstream_metadata?.balance_query?.query_config?.has_saved_secret === true
+}
+
+function keyBalanceRefreshRequiresSavedSecret(key: EndpointAPIKey): boolean {
+  const architectureId = normalizeBalanceArchitectureId(key.upstream_metadata?.balance_query?.architecture_id)
+  if (architectureId === 'new_api') return true
+  if (architectureId !== 'sub2api') return false
+  const credentialKind = String(
+    key.upstream_metadata?.balance_query?.query_config?.sub2api_credential_kind || ''
+  ).trim()
+  return credentialKind === 'access_token' || credentialKind === 'refresh_token'
+}
+
+function getKeyBalanceAutoRefreshIntervalMinutes(key: EndpointAPIKey): number {
+  const parsed = toFiniteNumber(
+    key.upstream_metadata?.balance_query?.query_config?.auto_refresh_interval_minutes
+  )
+  if (parsed === null || parsed <= 0) return 0
+  return Math.min(Math.floor(parsed), 10080)
+}
+
+function isKeyBalanceAutoRefreshDue(key: EndpointAPIKey): boolean {
+  const intervalMinutes = getKeyBalanceAutoRefreshIntervalMinutes(key)
+  if (intervalMinutes <= 0 || !canRefreshKeyBalance(key)) return false
+
+  const updatedAt = toFiniteNumber(key.upstream_metadata?.balance_query?.updated_at)
+  if (updatedAt === null || updatedAt <= 0) return true
+
+  const now = Math.floor(Date.now() / 1000)
+  return now - updatedAt >= intervalMinutes * 60
+}
+
+function startKeyBalanceAutoRefreshTimer() {
+  if (balanceAutoRefreshTimer) return
+  balanceAutoRefreshTimer = setInterval(() => {
+    void refreshDueKeyBalances()
+  }, BALANCE_AUTO_REFRESH_CHECK_MS)
+}
+
+function stopKeyBalanceAutoRefreshTimer() {
+  if (!balanceAutoRefreshTimer) return
+  clearInterval(balanceAutoRefreshTimer)
+  balanceAutoRefreshTimer = null
+}
+
+async function refreshDueKeyBalances() {
+  if (!props.open || !props.providerId || refreshingBalanceKeyId.value) return
+  const dueKey = providerKeys.value.find(key => key.is_active && isKeyBalanceAutoRefreshDue(key))
+  if (!dueKey) return
+  await handleRefreshKeyBalance(dueKey, { silent: true })
+}
+
+function getKeyBalanceRefreshTitle(key: EndpointAPIKey): string {
+  if (!canOpenKeyBalanceQuery(key)) {
+    return '余额查询仅支持 API Key 或 Bearer Token'
+  }
+  if (!canRefreshKeyBalance(key)) {
+    if (keyBalanceRefreshRequiresSavedSecret(key) && !hasSavedBalanceSecret(key)) {
+      return '需要先手动查询一次，并开启“保存余额查询凭据”'
+    }
+    return '缺少上次查询模板，请先手动查询一次余额'
+  }
+  const summary = getKeyBalanceSummary(key)
+  return summary?.templateLabel
+    ? `重新查询 ${summary.templateLabel} 余额`
+    : '重新查询余额'
+}
+
+function assignSavedBalanceQueryConfig(query: ProviderKeyBalanceQuery, key: EndpointAPIKey) {
+  const config = key.upstream_metadata?.balance_query?.query_config
+  if (!config || typeof config !== 'object') return
+
+  query.custom_base_url = trimmedStringOrUndefined(config.custom_base_url)
+  query.new_api_user_id = trimmedStringOrUndefined(config.new_api_user_id)
+
+  const sub2apiKind = String(config.sub2api_credential_kind || '').trim()
+  if (sub2apiKind === 'api_key' || sub2apiKind === 'access_token' || sub2apiKind === 'refresh_token') {
+    query.sub2api_credential_kind = sub2apiKind
+  }
+
+  query.custom_endpoint = trimmedStringOrUndefined(config.custom_endpoint)
+  const customMethod = String(config.custom_method || '').trim().toUpperCase()
+  if (customMethod === 'GET' || customMethod === 'POST') {
+    query.custom_method = customMethod
+  }
+  query.custom_currency = trimmedStringOrUndefined(config.custom_currency)
+  const customQuotaDivisor = toFiniteNumber(config.custom_quota_divisor)
+  if (customQuotaDivisor !== null && customQuotaDivisor > 0) {
+    query.custom_quota_divisor = customQuotaDivisor
+  }
+  const intervalMinutes = toFiniteNumber(config.auto_refresh_interval_minutes)
+  if (intervalMinutes !== null && intervalMinutes > 0) {
+    query.auto_refresh_interval_minutes = Math.min(Math.floor(intervalMinutes), 10080)
+  }
+  query.custom_balance_path = trimmedStringOrUndefined(config.custom_balance_path)
+  query.custom_used_path = trimmedStringOrUndefined(config.custom_used_path)
+  query.custom_granted_path = trimmedStringOrUndefined(config.custom_granted_path)
+}
+
+function trimmedStringOrUndefined(value: unknown): string | undefined {
+  const trimmed = typeof value === 'string' ? value.trim() : ''
+  return trimmed || undefined
+}
+
+async function handleRefreshKeyBalance(key: EndpointAPIKey, options: { silent?: boolean } = {}) {
+  if (!props.providerId || refreshingBalanceKeyId.value || !canRefreshKeyBalance(key)) return
+
+  const architectureId = normalizeBalanceArchitectureId(key.upstream_metadata?.balance_query?.architecture_id)
+  if (!architectureId) return
+
+  refreshingBalanceKeyId.value = key.id
+  try {
+    const query: ProviderKeyBalanceQuery = {
+      key_id: key.id,
+      auth_type: key.auth_type === 'bearer' ? 'bearer' : 'api_key',
+      api_formats: key.api_formats || [],
+      architecture_id: architectureId,
+      save_result: true,
+    }
+    assignSavedBalanceQueryConfig(query, key)
+
+    const result = await queryProviderKeyBalance(props.providerId, query)
+    if (result.status !== 'success') {
+      if (!options.silent) {
+        showError(result.message || '余额刷新失败', '错误')
+      }
+      return
+    }
+    if (!options.silent) {
+      showSuccess('余额已刷新')
+    }
+    await loadProviderKeysPage(currentKeyPage.value)
+    emit('refresh')
+  } catch (err: unknown) {
+    if (!options.silent) {
+      showError(parseApiError(err, '余额刷新失败'), '错误')
+    }
+  } finally {
+    refreshingBalanceKeyId.value = null
   }
 }
 
@@ -2698,7 +2936,7 @@ async function openAntigravityQuotaDialog(key: EndpointAPIKey) {
 }
 
 async function handleKeyChanged() {
-  await Promise.all([loadEndpoints(), loadMappingPreview()])
+  await Promise.all([loadEndpoints(), loadProviderKeysPage(currentKeyPage.value), loadMappingPreview()])
   emit('refresh')
   // 添加/修改 key 后自动获取 Antigravity 配额（新 key 的 upstream_metadata 为空）
   void autoRefreshQuotaInBackground({ ignoreCooldown: true })
@@ -3167,6 +3405,58 @@ function hasAntigravityQuotaDisplayData(key: EndpointAPIKey): boolean {
     return true
   }
   return hasAntigravityQuotaData(key.upstream_metadata)
+}
+
+function getKeyBalanceSummary(key: EndpointAPIKey): KeyBalanceSummary | null {
+  const metadata = key.upstream_metadata?.balance_query
+  if (!metadata) return null
+  const updatedAt = toFiniteNumber(metadata.updated_at)
+  const available = toFiniteNumber(metadata.total_available)
+  const used = toFiniteNumber(metadata.total_used)
+  const granted = toFiniteNumber(metadata.total_granted)
+  if (updatedAt === null || (available === null && used === null && granted === null)) {
+    return null
+  }
+  const architectureId = String(metadata.architecture_id || '').trim()
+  const labels: Record<string, string> = {
+    new_api: 'NewAPI',
+    sub2api: 'Sub2API',
+    generic_api: '自定义'
+  }
+  return {
+    available,
+    used,
+    granted,
+    currency: String(metadata.currency || 'USD').trim() || 'USD',
+    updatedAt,
+    templateLabel: labels[architectureId] || architectureId || '余额查询',
+    architectureId,
+    planName: typeof metadata.plan_name === 'string' && metadata.plan_name.trim()
+      ? metadata.plan_name.trim()
+      : null,
+  }
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function formatKeyBalanceAmount(value: unknown, currency = 'USD'): string {
+  const numberValue = toFiniteNumber(value)
+  if (numberValue === null) return '未知'
+  const normalizedCurrency = (currency || 'USD').toUpperCase()
+  const prefix = normalizedCurrency === 'USD'
+    ? '$'
+    : normalizedCurrency === 'CNY'
+      ? '¥'
+      : `${normalizedCurrency} `
+  const decimals = Math.abs(numberValue) >= 100 ? 2 : 4
+  return `${prefix}${numberValue.toFixed(decimals)}`
 }
 
 function formatUpdatedAt(updatedAt: number): string {
@@ -3685,6 +3975,7 @@ async function loadProviderKeysPage(page = currentKeyPage.value) {
     currentKeyPage.value = Math.min(result.page, nextTotalPages)
     keyPageSize.value = result.page_size
     syncCurrentSelections(endpoints.value, result.keys)
+    void refreshDueKeyBalances()
   } catch (err: unknown) {
     if (requestId !== keysLoadRequestId || props.providerId !== providerId) return
     providerKeys.value = []
@@ -3781,6 +4072,10 @@ useEscapeKey(() => {
 }, {
   disableOnInput: true,
   once: false
+})
+
+onUnmounted(() => {
+  stopKeyBalanceAutoRefreshTimer()
 })
 </script>
 

--- a/frontend/src/features/providers/components/ProviderMobileCard.vue
+++ b/frontend/src/features/providers/components/ProviderMobileCard.vue
@@ -93,7 +93,7 @@
           variant="ghost"
           size="icon"
           class="h-7 w-7"
-          title="扩展操作配置"
+          title="配置用量查询"
           @click="$emit('openOpsConfig', provider)"
         >
           <KeyRound class="h-3.5 w-3.5" />
@@ -125,17 +125,9 @@
       >
         {{ formatBillingType(provider.billing_type || 'pay_as_you_go') }}
       </Badge>
-      <!-- 余额加载中 -->
-      <span
-        v-if="provider.ops_configured && isBalanceLoading(provider.id)"
-        class="text-muted-foreground flex items-center gap-1"
-      >
-        <Loader2 class="h-3 w-3 animate-spin" />
-        加载中...
-      </span>
       <!-- 余额（从上游 API 查询） -->
       <span
-        v-else-if="provider.ops_configured && getProviderBalance(provider.id)"
+        v-if="provider.ops_configured && getProviderBalance(provider.id)"
         class="text-muted-foreground"
       >
         余额 <span class="font-semibold text-foreground/90">{{ formatBalanceDisplay(getProviderBalance(provider.id)) }}</span>
@@ -156,6 +148,29 @@
           class="ml-1 text-destructive/70"
           :title="getProviderCheckin(provider.id)?.message"
         >签到失败</span>
+      </span>
+      <!-- 保存到 Key 的手动余额查询摘要 -->
+      <span
+        v-else-if="getSavedKeyBalance(provider)"
+        class="text-muted-foreground inline-flex items-center gap-1"
+        :title="getSavedKeyBalanceTitle(provider)"
+      >
+        <WalletCards class="h-3 w-3 text-primary" />
+        余额
+        <span class="font-semibold text-foreground/90">
+          {{ formatKeyBalanceAmount(getSavedKeyBalance(provider)?.total_available, getSavedKeyBalance(provider)?.currency || 'USD') }}
+        </span>
+        <span class="text-muted-foreground/70">
+          {{ keyBalanceTemplateLabel(getSavedKeyBalance(provider)?.architecture_id) }} · {{ formatKeyBalanceUpdatedAt(getSavedKeyBalance(provider)?.updated_at) }}
+        </span>
+      </span>
+      <!-- 余额加载中 -->
+      <span
+        v-else-if="provider.ops_configured && isBalanceLoading(provider.id)"
+        class="text-muted-foreground flex items-center gap-1"
+      >
+        <Loader2 class="h-3 w-3 animate-spin" />
+        加载中...
       </span>
       <!-- 余额查询失败时显示错误 -->
       <span
@@ -233,13 +248,20 @@ import {
   Check,
   X,
   Loader2,
+  WalletCards,
 } from 'lucide-vue-next'
 import Button from '@/components/ui/button.vue'
 import Badge from '@/components/ui/badge.vue'
-import { type ProviderWithEndpointsSummary, formatApiFormatShort } from '@/api/endpoints'
+import { type ProviderKeyBalanceSummary, type ProviderWithEndpointsSummary, formatApiFormatShort } from '@/api/endpoints'
 import { formatBillingType } from '@/utils/format'
 import { sortEndpoints, isEndpointAvailable, getEndpointDotColor, getEndpointTooltip } from '@/features/providers/composables/useEndpointStatus'
 import { isKeyManagedProviderType } from '../utils/providerTypeUtils'
+import {
+  formatKeyBalanceAmount,
+  formatKeyBalanceUpdatedAt,
+  hasKeyBalanceSummary,
+  keyBalanceTemplateLabel,
+} from '@/features/providers/utils/keyBalanceSummary'
 
 const props = defineProps<{
   provider: ProviderWithEndpointsSummary
@@ -306,5 +328,20 @@ function handleDescriptionKeydown(event: KeyboardEvent) {
 
 function getCredentialLabel(provider: ProviderWithEndpointsSummary): '账号' | '密钥' {
   return isKeyManagedProviderType(provider.provider_type) ? '密钥' : '账号'
+}
+
+function getSavedKeyBalance(provider: ProviderWithEndpointsSummary): ProviderKeyBalanceSummary | null {
+  return hasKeyBalanceSummary(provider.key_balance_summary) ? provider.key_balance_summary : null
+}
+
+function getSavedKeyBalanceTitle(provider: ProviderWithEndpointsSummary): string {
+  const summary = getSavedKeyBalance(provider)
+  if (!summary) return ''
+  const parts = [
+    summary.key_name ? `Key: ${summary.key_name}` : null,
+    keyBalanceTemplateLabel(summary.architecture_id),
+    formatKeyBalanceUpdatedAt(summary.updated_at),
+  ].filter(Boolean)
+  return parts.join(' · ')
 }
 </script>

--- a/frontend/src/features/providers/components/ProviderTableRow.vue
+++ b/frontend/src/features/providers/components/ProviderTableRow.vue
@@ -163,7 +163,7 @@
           variant="ghost"
           size="icon"
           class="h-7 w-7 text-muted-foreground/70 hover:text-foreground"
-          title="扩展操作配置"
+          title="配置用量查询"
           @click="$emit('openOpsConfig', provider)"
         >
           <KeyRound class="h-3.5 w-3.5" />

--- a/frontend/src/features/providers/utils/keyBalanceSummary.ts
+++ b/frontend/src/features/providers/utils/keyBalanceSummary.ts
@@ -1,0 +1,54 @@
+import type { ProviderKeyBalanceSummary } from '@/api/endpoints'
+
+export function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+export function hasKeyBalanceSummary(summary: ProviderKeyBalanceSummary | null | undefined): summary is ProviderKeyBalanceSummary {
+  if (!summary) return false
+  const updatedAt = toFiniteNumber(summary.updated_at)
+  if (updatedAt === null) return false
+  return toFiniteNumber(summary.total_available) !== null
+    || toFiniteNumber(summary.total_used) !== null
+    || toFiniteNumber(summary.total_granted) !== null
+}
+
+export function formatKeyBalanceAmount(value: unknown, currency = 'USD'): string {
+  const numberValue = toFiniteNumber(value)
+  if (numberValue === null) return '未知'
+  const normalizedCurrency = (currency || 'USD').toUpperCase()
+  const prefix = normalizedCurrency === 'USD'
+    ? '$'
+    : normalizedCurrency === 'CNY'
+      ? '¥'
+      : `${normalizedCurrency} `
+  const decimals = Math.abs(numberValue) >= 100 ? 2 : 4
+  return `${prefix}${numberValue.toFixed(decimals)}`
+}
+
+export function keyBalanceTemplateLabel(architectureId: unknown): string {
+  const normalized = String(architectureId || '').trim().toLowerCase().replace(/-/g, '_')
+  if (normalized === 'newapi' || normalized === 'new_api') return 'NewAPI'
+  if (normalized === 'sub2api') return 'Sub2API'
+  if (normalized === 'generic' || normalized === 'custom' || normalized === 'generic_api') return '自定义'
+  return normalized || '余额查询'
+}
+
+export function formatKeyBalanceUpdatedAt(updatedAt: unknown): string {
+  const timestamp = toFiniteNumber(updatedAt)
+  if (timestamp === null || timestamp <= 0) return ''
+  const now = Math.floor(Date.now() / 1000)
+  const diff = now - timestamp
+  if (diff <= 60) return '刚刚更新'
+  const minutes = Math.floor(diff / 60)
+  if (minutes < 60) return `${minutes}分钟前`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}小时前`
+  const days = Math.floor(hours / 24)
+  return `${days}天前`
+}

--- a/frontend/src/views/admin/ProviderManagement.vue
+++ b/frontend/src/views/admin/ProviderManagement.vue
@@ -295,6 +295,7 @@
   <ProviderAuthDialog
     v-model:open="opsConfigDialogOpen"
     :provider-id="opsConfigProviderId"
+    :provider-name="opsConfigProviderName"
     :provider-website="opsConfigProviderWebsite"
     @saved="handleOpsConfigSaved"
   />
@@ -325,6 +326,7 @@ import { useProviderBalance } from '@/features/providers/composables/useProvider
 import {
   getProvidersSummary,
   getProvider,
+  getProviderEndpoints,
   deleteProvider,
   getProviderDeleteTask,
   updateProvider,
@@ -517,6 +519,7 @@ const {
 // 扩展操作配置对话框
 const opsConfigDialogOpen = ref(false)
 const opsConfigProviderId = ref('')
+const opsConfigProviderName = ref('')
 const opsConfigProviderWebsite = ref('')
 
 // 内联编辑备注
@@ -707,10 +710,21 @@ async function openEditProviderDialog(provider: ProviderWithEndpointsSummary) {
 }
 
 // 打开扩展操作配置对话框
-function openOpsConfigDialog(provider: ProviderWithEndpointsSummary) {
+async function openOpsConfigDialog(provider: ProviderWithEndpointsSummary) {
   opsConfigProviderId.value = provider.id
+  opsConfigProviderName.value = provider.name
   opsConfigProviderWebsite.value = provider.website || ''
   opsConfigDialogOpen.value = true
+  if (!opsConfigProviderWebsite.value) {
+    try {
+      const endpoints = await getProviderEndpoints(provider.id)
+      if (opsConfigProviderId.value !== provider.id || opsConfigProviderWebsite.value) return
+      const endpoint = endpoints.find(item => item.is_active) || endpoints[0]
+      opsConfigProviderWebsite.value = endpoint?.base_url || ''
+    } catch {
+      // 保持空地址，弹窗内仍可手动填写。
+    }
+  }
 }
 
 // 扩展操作配置保存回调


### PR DESCRIPTION
## 变更内容
- 新增 Provider Key 余额查询接口，支持 NewAPI、Sub2API API Key 和自定义官方余额接口
- 支持查询结果保存到 Key metadata、列表/抽屉展示余额摘要、刷新按钮和自动查询间隔
- 自定义查询支持 endpoint/method/currency/quota divisor/JSON 字段路径，兼容 DeepSeek 这类数组字段返回
- 余额查询凭据单独加密保存，前端仅暴露是否已保存

## 本地验证
- cargo fmt --all --check
- cargo clippy -p aether-admin --all-targets -- -D warnings
- cargo clippy -p aether-gateway --all-targets -- -D warnings
- cargo clippy --workspace --exclude aether-gateway --exclude aether-data --all-targets -- -D warnings
- cargo test -p aether-admin
- cargo test -p aether-gateway provider_key_balance
- cargo test -p aether-gateway query_balance
- cargo test -p aether-gateway gateway_handles_admin_provider_ops_balance_locally
- cargo test -p aether-gateway gateway_handles_admin_provider_ops_sub2api_balance
- cargo test -p aether-gateway gateway_handles_admin_provider_ops_batch_balance_locally
- cargo test -p aether-gateway classifies_admin_provider_ops
- npm run type-check
- npm run build
- git diff --check

备注：本地未安装 redis-server，Redis 集成测试无法完整运行。