### PR TITLE
Fix provider model test compact request bodies

### DIFF
--- a/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test.rs
@@ -564,6 +564,29 @@ fn provider_query_build_test_request_body_for_api_format(
                     client_api_format.as_str(),
                     payload,
                 );
+            } else if matches!(
+                client_api_format.as_str(),
+                "openai:responses" | "openai:responses:compact"
+            ) && !value_has_non_empty_text(object.get("input"))
+            {
+                if let Some(prompt) = object
+                    .remove("prompt")
+                    .filter(|value| value_has_non_empty_text(Some(value)))
+                {
+                    object.insert("input".to_string(), prompt);
+                }
+            }
+            if matches!(
+                client_api_format.as_str(),
+                "openai:responses" | "openai:responses:compact"
+            ) && value_has_non_empty_text(object.get("input"))
+            {
+                object.remove("prompt");
+            }
+            if client_api_format == "openai:responses:compact"
+                && value_has_non_empty_text(object.get("input"))
+            {
+                object.remove("messages");
             }
         }
         return body;

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/adapter.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/adapter.rs
@@ -30,7 +30,9 @@ pub(super) fn provider_query_standard_test_client_api_format(
     provider_api_format: &str,
 ) -> &'static str {
     let normalized_api_format = crate::ai_serving::normalize_api_format_alias(provider_api_format);
-    if crate::ai_serving::is_embedding_api_format(&normalized_api_format) {
+    if normalized_api_format == "openai:responses:compact" {
+        "openai:responses:compact"
+    } else if crate::ai_serving::is_embedding_api_format(&normalized_api_format) {
         "openai:embedding"
     } else if crate::ai_serving::is_rerank_api_format(&normalized_api_format) {
         "openai:rerank"

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/tests.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/tests.rs
@@ -404,7 +404,9 @@ fn provider_query_compact_provider_body_builds_without_chat_conversion() {
         object.insert("stream".to_string(), serde_json::Value::Bool(false));
     }
 
-    assert!(provider_query_request_body_is_openai_responses_shape(&request_body));
+    assert!(provider_query_request_body_is_openai_responses_shape(
+        &request_body
+    ));
 
     let mut provider_request_body = crate::ai_serving::build_local_openai_responses_request_body(
         &request_body,
@@ -424,7 +426,10 @@ fn provider_query_compact_provider_body_builds_without_chat_conversion() {
     );
 
     assert_eq!(provider_request_body["model"], json!("upstream-gpt"));
-    assert_eq!(provider_request_body["input"], json!("hello compact provider"));
+    assert_eq!(
+        provider_request_body["input"],
+        json!("hello compact provider")
+    );
     assert!(provider_request_body.get("messages").is_none());
     assert!(provider_request_body.get("stream").is_none());
     assert!(provider_request_body.get("store").is_none());

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/tests.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/tests.rs
@@ -325,6 +325,112 @@ fn provider_query_responses_test_request_body_defaults_to_responses_input() {
 }
 
 #[test]
+fn provider_query_compact_test_request_body_defaults_to_responses_input() {
+    let payload = json!({"message": "hello from compact"});
+
+    let client_api_format =
+        provider_query_standard_test_client_api_format("openai:responses:compact");
+    let body = provider_query_build_test_request_body_for_api_format(
+        &payload,
+        "gpt-5.4-mini",
+        "/api/admin/provider-query/test-model",
+        client_api_format,
+    );
+
+    assert_eq!(client_api_format, "openai:responses:compact");
+    assert_eq!(body["model"], json!("gpt-5.4-mini"));
+    assert_eq!(body["input"], json!("hello from compact"));
+    assert!(body.get("messages").is_none());
+}
+
+#[test]
+fn provider_query_compact_test_request_body_promotes_prompt_to_input() {
+    let payload = json!({
+        "request_body": {
+            "model": "custom-model",
+            "prompt": "hello from prompt"
+        }
+    });
+
+    let body = provider_query_build_test_request_body_for_api_format(
+        &payload,
+        "fallback-model",
+        "/api/admin/provider-query/test-model",
+        "openai:responses:compact",
+    );
+
+    assert_eq!(body["model"], json!("custom-model"));
+    assert_eq!(body["input"], json!("hello from prompt"));
+    assert!(body.get("prompt").is_none());
+    assert!(provider_query_request_body_is_openai_responses_shape(&body));
+}
+
+#[test]
+fn provider_query_compact_test_request_body_strips_stale_chat_fields() {
+    let payload = json!({
+        "request_body": {
+            "model": "custom-model",
+            "input": "hello from input",
+            "messages": [{ "role": "user", "content": "stale chat body" }],
+            "prompt": "stale prompt"
+        }
+    });
+
+    let body = provider_query_build_test_request_body_for_api_format(
+        &payload,
+        "fallback-model",
+        "/api/admin/provider-query/test-model",
+        "openai:responses:compact",
+    );
+
+    assert_eq!(body["model"], json!("custom-model"));
+    assert_eq!(body["input"], json!("hello from input"));
+    assert!(body.get("messages").is_none());
+    assert!(body.get("prompt").is_none());
+}
+
+#[test]
+fn provider_query_compact_provider_body_builds_without_chat_conversion() {
+    let payload = json!({"message": "hello compact provider"});
+    let client_api_format =
+        provider_query_standard_test_client_api_format("openai:responses:compact");
+    let mut request_body = provider_query_build_test_request_body_for_api_format(
+        &payload,
+        "gpt-5.4-mini",
+        "/api/admin/provider-query/test-model",
+        client_api_format,
+    );
+    if let Some(object) = request_body.as_object_mut() {
+        object.insert("stream".to_string(), serde_json::Value::Bool(false));
+    }
+
+    assert!(provider_query_request_body_is_openai_responses_shape(&request_body));
+
+    let mut provider_request_body = crate::ai_serving::build_local_openai_responses_request_body(
+        &request_body,
+        "upstream-gpt",
+        false,
+    )
+    .expect("compact model test body should build from responses shape");
+    crate::ai_serving::apply_openai_responses_compact_special_body_edits(
+        &mut provider_request_body,
+        "openai:responses:compact",
+    );
+    crate::ai_serving::enforce_request_body_stream_field(
+        &mut provider_request_body,
+        "openai:responses:compact",
+        false,
+        true,
+    );
+
+    assert_eq!(provider_request_body["model"], json!("upstream-gpt"));
+    assert_eq!(provider_request_body["input"], json!("hello compact provider"));
+    assert!(provider_request_body.get("messages").is_none());
+    assert!(provider_request_body.get("stream").is_none());
+    assert!(provider_request_body.get("store").is_none());
+}
+
+#[test]
 fn provider_query_standard_test_rejects_gemini_success_without_visible_output() {
     let result = aether_contracts::ExecutionResult {
         request_id: "provider-test".to_string(),


### PR DESCRIPTION
## Summary
- build provider model-test requests for `openai:responses:compact` as Responses input bodies
- promote legacy `prompt` test payloads into `input` and strip stale chat fields for compact endpoint tests
- add regression coverage for compact model-test request body construction

## Testing
- `git diff --check`
- Not run: `cargo fmt --check` / Rust tests because `cargo` is not installed in this local environment