### PR TITLE
Fix admin users server-side pagination

### DIFF
--- a/apps/aether-gateway/src/data/state/runtime.rs
+++ b/apps/aether-gateway/src/data/state/runtime.rs
@@ -1512,6 +1512,16 @@ impl GatewayDataState {
         }
     }
 
+    pub(crate) async fn count_export_users(
+        &self,
+        query: &aether_data::repository::users::UserExportListQuery,
+    ) -> Result<u64, DataLayerError> {
+        match &self.user_reader {
+            Some(repository) => repository.count_export_users(query).await,
+            None => Ok(0),
+        }
+    }
+
     pub(crate) async fn summarize_export_users(
         &self,
     ) -> Result<aether_data::repository::users::UserExportSummary, DataLayerError> {

--- a/apps/aether-gateway/src/handlers/admin/request/users.rs
+++ b/apps/aether-gateway/src/handlers/admin/request/users.rs
@@ -42,6 +42,13 @@ impl<'a> AdminAppState<'a> {
         self.app.list_export_users_page(query).await
     }
 
+    pub(crate) async fn count_export_users(
+        &self,
+        query: &aether_data::repository::users::UserExportListQuery,
+    ) -> Result<u64, GatewayError> {
+        self.app.count_export_users(query).await
+    }
+
     pub(crate) async fn find_export_user_by_id(
         &self,
         user_id: &str,

--- a/apps/aether-gateway/src/handlers/admin/users/lifecycle/reads.rs
+++ b/apps/aether-gateway/src/handlers/admin/users/lifecycle/reads.rs
@@ -37,16 +37,20 @@ pub(in super::super) async fn build_admin_list_users_response(
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
 
-    let paged_rows = state
-        .list_export_users_page(&aether_data::repository::users::UserExportListQuery {
-            skip,
-            limit,
-            role: role.clone(),
-            is_active,
-            search,
-            group_id,
-        })
-        .await?;
+    let query = aether_data::repository::users::UserExportListQuery {
+        skip,
+        limit,
+        role: role.clone(),
+        is_active,
+        search,
+        group_id,
+    };
+    let (paged_rows_result, total_result) = tokio::join!(
+        state.list_export_users_page(&query),
+        state.count_export_users(&query),
+    );
+    let paged_rows = paged_rows_result?;
+    let total = total_result?;
     let user_ids = paged_rows
         .iter()
         .map(|row| row.id.clone())
@@ -116,7 +120,15 @@ pub(in super::super) async fn build_admin_list_users_response(
         ));
     }
 
-    Ok(Json(payload).into_response())
+    let has_more = (skip as u64).saturating_add(payload.len() as u64) < total;
+    Ok(Json(json!({
+        "items": payload,
+        "total": total,
+        "skip": skip,
+        "limit": limit,
+        "has_more": has_more,
+    }))
+    .into_response())
 }
 
 pub(in super::super) async fn build_admin_get_user_response(

--- a/apps/aether-gateway/src/state/runtime/api_key_exports.rs
+++ b/apps/aether-gateway/src/state/runtime/api_key_exports.rs
@@ -169,6 +169,16 @@ impl AppState {
             .map_err(|err| GatewayError::Internal(err.to_string()))
     }
 
+    pub(crate) async fn count_export_users(
+        &self,
+        query: &aether_data::repository::users::UserExportListQuery,
+    ) -> Result<u64, GatewayError> {
+        self.data
+            .count_export_users(query)
+            .await
+            .map_err(|err| GatewayError::Internal(err.to_string()))
+    }
+
     pub(crate) async fn find_export_user_by_id(
         &self,
         user_id: &str,

--- a/apps/aether-gateway/src/tests/control/admin/users.rs
+++ b/apps/aether-gateway/src/tests/control/admin/users.rs
@@ -300,7 +300,11 @@ async fn gateway_handles_admin_users_root_locally_with_trusted_admin_principal()
 
     assert_eq!(response.status(), StatusCode::OK);
     let payload: serde_json::Value = response.json().await.expect("json body should parse");
-    let items = payload.as_array().expect("list payload should be array");
+    assert_eq!(payload["total"], 1);
+    assert_eq!(payload["skip"], 0);
+    assert_eq!(payload["limit"], 20);
+    assert_eq!(payload["has_more"], false);
+    let items = payload["items"].as_array().expect("items should be array");
     assert_eq!(items.len(), 1);
     assert_eq!(items[0]["id"], "user-1");
     assert_eq!(items[0]["email"], "alice@example.com");
@@ -332,9 +336,10 @@ async fn gateway_handles_admin_users_root_locally_with_trusted_admin_principal()
         .json()
         .await
         .expect("search json body should parse");
-    let search_items = search_payload
+    assert_eq!(search_payload["total"], 1);
+    let search_items = search_payload["items"]
         .as_array()
-        .expect("search list payload should be array");
+        .expect("search items should be array");
     assert_eq!(search_items.len(), 1);
     assert_eq!(search_items[0]["id"], "user-3");
     assert_eq!(search_items[0]["email"], "carol@example.com");
@@ -355,9 +360,10 @@ async fn gateway_handles_admin_users_root_locally_with_trusted_admin_principal()
         .json()
         .await
         .expect("id search json body should parse");
-    let id_search_items = id_search_payload
+    assert_eq!(id_search_payload["total"], 1);
+    let id_search_items = id_search_payload["items"]
         .as_array()
-        .expect("id search list payload should be array");
+        .expect("id search items should be array");
     assert_eq!(id_search_items.len(), 1);
     assert_eq!(id_search_items[0]["id"], "user-3");
 
@@ -377,9 +383,11 @@ async fn gateway_handles_admin_users_root_locally_with_trusted_admin_principal()
         .json()
         .await
         .expect("limited search json body should parse");
-    let limited_search_items = limited_search_payload
+    assert_eq!(limited_search_payload["total"], 3);
+    assert_eq!(limited_search_payload["has_more"], true);
+    let limited_search_items = limited_search_payload["items"]
         .as_array()
-        .expect("limited search list payload should be array");
+        .expect("limited search items should be array");
     assert_eq!(limited_search_items.len(), 2);
 
     assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
@@ -1057,7 +1065,8 @@ async fn gateway_handles_admin_users_root_locally_with_bearer_admin_session() {
 
     assert_eq!(response.status(), StatusCode::OK);
     let payload: serde_json::Value = response.json().await.expect("json body should parse");
-    let items = payload.as_array().expect("list payload should be array");
+    assert_eq!(payload["total"], 1);
+    let items = payload["items"].as_array().expect("items should be array");
     assert_eq!(items.len(), 1);
     assert_eq!(items[0]["id"], "user-1");
     assert_eq!(items[0]["email"], "alice@example.com");

--- a/crates/aether-data/src/repository/users/memory.rs
+++ b/crates/aether-data/src/repository/users/memory.rs
@@ -386,9 +386,8 @@ fn filter_memory_export_rows(
             .read()
             .expect("user repository lock")
             .keys()
-            .filter_map(|(candidate_group_id, user_id)| {
-                (candidate_group_id == group_id).then(|| user_id.clone())
-            })
+            .filter(|(candidate_group_id, _)| candidate_group_id == group_id)
+            .map(|(_, user_id)| user_id.clone())
             .collect::<std::collections::BTreeSet<_>>();
         rows.retain(|row| member_ids.contains(&row.id));
     }

--- a/crates/aether-data/src/repository/users/memory.rs
+++ b/crates/aether-data/src/repository/users/memory.rs
@@ -360,6 +360,59 @@ fn memory_group_members(
         .collect()
 }
 
+fn filter_memory_export_rows(
+    repository: &InMemoryUserReadRepository,
+    query: &UserExportListQuery,
+) -> Vec<StoredUserExportRow> {
+    let mut rows = repository
+        .export_rows
+        .read()
+        .expect("user repository lock")
+        .clone();
+    if let Some(role) = query.role.as_deref() {
+        rows.retain(|row| row.role.eq_ignore_ascii_case(role));
+    }
+    if let Some(is_active) = query.is_active {
+        rows.retain(|row| row.is_active == is_active);
+    }
+    if let Some(group_id) = query
+        .group_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let member_ids = repository
+            .group_members
+            .read()
+            .expect("user repository lock")
+            .keys()
+            .filter_map(|(candidate_group_id, user_id)| {
+                (candidate_group_id == group_id).then(|| user_id.clone())
+            })
+            .collect::<std::collections::BTreeSet<_>>();
+        rows.retain(|row| member_ids.contains(&row.id));
+    }
+    if let Some(search) = query
+        .search
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let search = search.to_ascii_lowercase();
+        rows.retain(|row| {
+            row.id.to_ascii_lowercase().contains(&search)
+                || row.username.to_ascii_lowercase().contains(&search)
+                || row
+                    .email
+                    .as_deref()
+                    .unwrap_or_default()
+                    .to_ascii_lowercase()
+                    .contains(&search)
+        });
+    }
+    rows
+}
+
 fn memory_export_row_from_auth_user(
     repository: &InMemoryUserReadRepository,
     user: &StoredUserAuthRecord,
@@ -477,57 +530,15 @@ impl UserReadRepository for InMemoryUserReadRepository {
         &self,
         query: &UserExportListQuery,
     ) -> Result<Vec<StoredUserExportRow>, DataLayerError> {
-        let mut rows = self
-            .export_rows
-            .read()
-            .expect("user repository lock")
-            .clone();
-        if let Some(role) = query.role.as_deref() {
-            rows.retain(|row| row.role.eq_ignore_ascii_case(role));
-        }
-        if let Some(is_active) = query.is_active {
-            rows.retain(|row| row.is_active == is_active);
-        }
-        if let Some(group_id) = query
-            .group_id
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            let member_ids = self
-                .group_members
-                .read()
-                .expect("user repository lock")
-                .keys()
-                .filter_map(|(candidate_group_id, user_id)| {
-                    (candidate_group_id == group_id).then(|| user_id.clone())
-                })
-                .collect::<std::collections::BTreeSet<_>>();
-            rows.retain(|row| member_ids.contains(&row.id));
-        }
-        if let Some(search) = query
-            .search
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            let search = search.to_ascii_lowercase();
-            rows.retain(|row| {
-                row.id.to_ascii_lowercase().contains(&search)
-                    || row.username.to_ascii_lowercase().contains(&search)
-                    || row
-                        .email
-                        .as_deref()
-                        .unwrap_or_default()
-                        .to_ascii_lowercase()
-                        .contains(&search)
-            });
-        }
-        Ok(rows
+        Ok(filter_memory_export_rows(self, query)
             .into_iter()
             .skip(query.skip)
             .take(query.limit)
             .collect())
+    }
+
+    async fn count_export_users(&self, query: &UserExportListQuery) -> Result<u64, DataLayerError> {
+        Ok(filter_memory_export_rows(self, query).len() as u64)
     }
 
     async fn summarize_export_users(&self) -> Result<UserExportSummary, DataLayerError> {

--- a/crates/aether-data/src/repository/users/mysql.rs
+++ b/crates/aether-data/src/repository/users/mysql.rs
@@ -325,6 +325,48 @@ impl UserReadRepository for MysqlUserReadRepository {
         self.fetch_export_rows(builder).await
     }
 
+    async fn count_export_users(&self, query: &UserExportListQuery) -> Result<u64, DataLayerError> {
+        let mut builder = QueryBuilder::<MySql>::new("SELECT COUNT(*) AS total FROM users");
+        builder.push(" WHERE is_deleted = 0");
+        if let Some(role) = query.role.as_deref() {
+            builder
+                .push(" AND LOWER(role) = ")
+                .push_bind(role.trim().to_ascii_lowercase());
+        }
+        if let Some(is_active) = query.is_active {
+            builder.push(" AND is_active = ").push_bind(is_active);
+        }
+        if let Some(group_id) = query
+            .group_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            builder.push(" AND id IN (SELECT user_id FROM user_group_members WHERE group_id = ");
+            builder.push_bind(group_id);
+            builder.push(")");
+        }
+        if let Some(search) = query
+            .search
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            let pattern = format!("%{}%", search.to_ascii_lowercase());
+            builder
+                .push(" AND (LOWER(id) LIKE ")
+                .push_bind(pattern.clone())
+                .push(" OR LOWER(username) LIKE ")
+                .push_bind(pattern.clone())
+                .push(" OR LOWER(COALESCE(email, '')) LIKE ")
+                .push_bind(pattern)
+                .push(")");
+        }
+
+        let row = builder.build().fetch_one(&self.pool).await.map_sql_err()?;
+        Ok(row.try_get::<i64, _>("total").map_sql_err()?.max(0) as u64)
+    }
+
     async fn summarize_export_users(&self) -> Result<UserExportSummary, DataLayerError> {
         let row = sqlx::query(
             r#"

--- a/crates/aether-data/src/repository/users/postgres.rs
+++ b/crates/aether-data/src/repository/users/postgres.rs
@@ -1015,6 +1015,57 @@ WHERE user_group_members.user_id IN (
         collect_query_rows(query.fetch(&self.pool), map_user_export_row).await
     }
 
+    pub async fn count_export_users(
+        &self,
+        query: &UserExportListQuery,
+    ) -> Result<u64, DataLayerError> {
+        let mut builder =
+            QueryBuilder::<Postgres>::new("SELECT COUNT(*)::BIGINT AS total FROM users");
+        builder.push(" WHERE is_deleted IS FALSE");
+
+        if let Some(role) = query.role.as_deref() {
+            builder
+                .push(" AND LOWER(role::text) = ")
+                .push_bind(role.trim().to_ascii_lowercase());
+        }
+        if let Some(is_active) = query.is_active {
+            builder.push(" AND is_active = ").push_bind(is_active);
+        }
+        if let Some(group_id) = query
+            .group_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            builder.push(" AND id IN (SELECT user_id FROM user_group_members WHERE group_id = ");
+            builder.push_bind(group_id);
+            builder.push(")");
+        }
+        if let Some(search) = query
+            .search
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            let pattern = format!("%{}%", search.to_ascii_lowercase());
+            builder
+                .push(" AND (LOWER(id) LIKE ")
+                .push_bind(pattern.clone())
+                .push(" OR LOWER(username) LIKE ")
+                .push_bind(pattern.clone())
+                .push(" OR LOWER(COALESCE(email, '')) LIKE ")
+                .push_bind(pattern)
+                .push(")");
+        }
+
+        let row = builder
+            .build()
+            .fetch_one(&self.pool)
+            .await
+            .map_postgres_err()?;
+        Ok(row.try_get::<i64, _>("total").map_postgres_err()?.max(0) as u64)
+    }
+
     pub async fn summarize_export_users(&self) -> Result<UserExportSummary, DataLayerError> {
         let row = sqlx::query(SUMMARIZE_EXPORT_USERS_SQL)
             .fetch_one(&self.pool)
@@ -2304,6 +2355,10 @@ impl UserReadRepository for SqlxUserReadRepository {
         query: &UserExportListQuery,
     ) -> Result<Vec<StoredUserExportRow>, DataLayerError> {
         self.list_export_users_page(query).await
+    }
+
+    async fn count_export_users(&self, query: &UserExportListQuery) -> Result<u64, DataLayerError> {
+        self.count_export_users(query).await
     }
 
     async fn summarize_export_users(&self) -> Result<UserExportSummary, DataLayerError> {

--- a/crates/aether-data/src/repository/users/sqlite.rs
+++ b/crates/aether-data/src/repository/users/sqlite.rs
@@ -325,6 +325,48 @@ impl UserReadRepository for SqliteUserReadRepository {
         self.fetch_export_rows(builder).await
     }
 
+    async fn count_export_users(&self, query: &UserExportListQuery) -> Result<u64, DataLayerError> {
+        let mut builder = QueryBuilder::<Sqlite>::new("SELECT COUNT(*) AS total FROM users");
+        builder.push(" WHERE is_deleted = 0");
+        if let Some(role) = query.role.as_deref() {
+            builder
+                .push(" AND LOWER(role) = ")
+                .push_bind(role.trim().to_ascii_lowercase());
+        }
+        if let Some(is_active) = query.is_active {
+            builder.push(" AND is_active = ").push_bind(is_active);
+        }
+        if let Some(group_id) = query
+            .group_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            builder.push(" AND id IN (SELECT user_id FROM user_group_members WHERE group_id = ");
+            builder.push_bind(group_id);
+            builder.push(")");
+        }
+        if let Some(search) = query
+            .search
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            let pattern = format!("%{}%", search.to_ascii_lowercase());
+            builder
+                .push(" AND (LOWER(id) LIKE ")
+                .push_bind(pattern.clone())
+                .push(" OR LOWER(username) LIKE ")
+                .push_bind(pattern.clone())
+                .push(" OR LOWER(COALESCE(email, '')) LIKE ")
+                .push_bind(pattern)
+                .push(")");
+        }
+
+        let row = builder.build().fetch_one(&self.pool).await.map_sql_err()?;
+        Ok(row.try_get::<i64, _>("total").map_sql_err()?.max(0) as u64)
+    }
+
     async fn summarize_export_users(&self) -> Result<UserExportSummary, DataLayerError> {
         let row = sqlx::query(
             r#"

--- a/crates/aether-data/src/repository/users/types.rs
+++ b/crates/aether-data/src/repository/users/types.rs
@@ -669,6 +669,11 @@ pub trait UserReadRepository: Send + Sync {
         query: &UserExportListQuery,
     ) -> Result<Vec<StoredUserExportRow>, crate::DataLayerError>;
 
+    async fn count_export_users(
+        &self,
+        query: &UserExportListQuery,
+    ) -> Result<u64, crate::DataLayerError>;
+
     async fn summarize_export_users(&self) -> Result<UserExportSummary, crate::DataLayerError>;
 
     async fn find_export_user_by_id(

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -3,7 +3,7 @@ import { cachedRequest } from '@/utils/cache'
 import type { UserSession as SessionRecord } from '@/types/session'
 import type { BillingPlan, UserPlanEntitlement } from './billing'
 
-export type UserRole = 'admin' | 'user'
+export type UserRole = 'admin' | 'audit_admin' | 'user'
 export type ListPolicyMode = 'inherit' | 'unrestricted' | 'specific' | 'deny_all'
 export type RateLimitPolicyMode = 'inherit' | 'system' | 'custom'
 export type FeatureSettings = Record<string, unknown>
@@ -264,8 +264,29 @@ export interface GetAllUsersOptions {
   cacheTtlMs?: number
 }
 
+export interface AdminUsersListResponse {
+  items: User[]
+  total: number
+  skip: number
+  limit: number
+  has_more: boolean
+}
+
+function normalizeAdminUsersListResponse(payload: User[] | AdminUsersListResponse): AdminUsersListResponse {
+  if (Array.isArray(payload)) {
+    return {
+      items: payload,
+      total: payload.length,
+      skip: 0,
+      limit: payload.length,
+      has_more: false,
+    }
+  }
+  return payload
+}
+
 export const usersApi = {
-  async getAllUsers(options: GetAllUsersOptions = {}): Promise<User[]> {
+  async getAllUsersPage(options: GetAllUsersOptions = {}): Promise<AdminUsersListResponse> {
     const cacheTtlMs = options.cacheTtlMs ?? 0
     const params: Record<string, string | number> = {}
     const search = options.search?.trim()
@@ -292,13 +313,18 @@ export const usersApi = {
     return cachedRequest(
       cacheKey,
       async () => {
-        const response = await apiClient.get<User[]>('/api/admin/users', {
+        const response = await apiClient.get<User[] | AdminUsersListResponse>('/api/admin/users', {
           params: Object.keys(params).length > 0 ? params : undefined,
         })
-        return response.data
+        return normalizeAdminUsersListResponse(response.data)
       },
       cacheTtlMs,
     )
+  },
+
+  async getAllUsers(options: GetAllUsersOptions = {}): Promise<User[]> {
+    const response = await this.getAllUsersPage(options)
+    return response.items
   },
 
   async getUser(userId: string): Promise<User> {

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -262,6 +262,7 @@ export interface GetAllUsersOptions {
   skip?: number
   limit?: number
   cacheTtlMs?: number
+  cacheKeySuffix?: string
 }
 
 export interface AdminUsersListResponse {
@@ -308,6 +309,7 @@ export const usersApi = {
           options.group_id ?? '',
           options.skip ?? '',
           options.limit ?? '',
+          options.cacheKeySuffix ?? '',
         ].join(':')
 
     return cachedRequest(

--- a/frontend/src/features/users/components/UserGroupsDialog.vue
+++ b/frontend/src/features/users/components/UserGroupsDialog.vue
@@ -363,15 +363,18 @@ async function loadDialogData(): Promise<void> {
 
 async function ensureDialogUsers(): Promise<void> {
   const now = Date.now()
+  const isSameUserVersion = dialogUsersLoadedVersion === props.usersVersion
   if (
-    dialogUsersLoadedVersion === props.usersVersion
+    isSameUserVersion
     && dialogUsersLoadedAt > 0
     && now - dialogUsersLoadedAt < USER_OPTIONS_CACHE_TTL_MS
   ) {
     return
   }
 
-  dialogUsers.value = await usersStore.listAllUsers({ cacheTtlMs: USER_OPTIONS_CACHE_TTL_MS })
+  dialogUsers.value = await usersStore.listAllUsers({
+    cacheTtlMs: isSameUserVersion ? USER_OPTIONS_CACHE_TTL_MS : 0,
+  })
   dialogUsersLoadedAt = Date.now()
   dialogUsersLoadedVersion = props.usersVersion
 }

--- a/frontend/src/features/users/components/UserGroupsDialog.vue
+++ b/frontend/src/features/users/components/UserGroupsDialog.vue
@@ -374,6 +374,7 @@ async function ensureDialogUsers(): Promise<void> {
 
   dialogUsers.value = await usersStore.listAllUsers({
     cacheTtlMs: isSameUserVersion ? USER_OPTIONS_CACHE_TTL_MS : 0,
+    cacheKeySuffix: isSameUserVersion ? undefined : `users-version-${props.usersVersion}`,
   })
   dialogUsersLoadedAt = Date.now()
   dialogUsersLoadedVersion = props.usersVersion

--- a/frontend/src/features/users/components/UserGroupsDialog.vue
+++ b/frontend/src/features/users/components/UserGroupsDialog.vue
@@ -274,7 +274,6 @@ import type {
 
 const props = defineProps<{
   open: boolean
-  users: User[]
 }>()
 
 const emit = defineEmits<{
@@ -295,8 +294,11 @@ const {
 const loading = ref(false)
 const saving = ref(false)
 const groups = ref<UserGroup[]>([])
+const dialogUsers = ref<User[]>([])
 const editingGroupId = ref<string | null>(null)
 const memberUserIds = ref<string[]>([])
+const USER_OPTIONS_CACHE_TTL_MS = 30 * 1000
+let dialogUsersLoadedAt = 0
 
 const form = ref({
   name: '',
@@ -311,7 +313,7 @@ const form = ref({
 })
 
 const selectedGroup = computed(() => groups.value.find((group) => group.id === editingGroupId.value) ?? null)
-const userOptions = computed(() => props.users.map((user) => ({
+const userOptions = computed(() => dialogUsers.value.map((user) => ({
   label: `${user.username}${user.email ? ` (${user.email})` : ''}`,
   value: user.id,
 })))
@@ -334,8 +336,11 @@ function handleDialogUpdate(value: boolean): void {
 async function loadDialogData(): Promise<void> {
   loading.value = true
   try {
-    const response = await usersStore.listUserGroups()
-    groups.value = response.items
+    const [groupsResponse] = await Promise.all([
+      usersStore.listUserGroups(),
+      ensureDialogUsers(),
+    ])
+    groups.value = groupsResponse.items
     if (editingGroupId.value && !groups.value.some((group) => group.id === editingGroupId.value)) {
       editingGroupId.value = null
     }
@@ -352,6 +357,16 @@ async function loadDialogData(): Promise<void> {
   } finally {
     loading.value = false
   }
+}
+
+async function ensureDialogUsers(): Promise<void> {
+  const now = Date.now()
+  if (dialogUsersLoadedAt > 0 && now - dialogUsersLoadedAt < USER_OPTIONS_CACHE_TTL_MS) {
+    return
+  }
+
+  dialogUsers.value = await usersStore.listAllUsers({ cacheTtlMs: USER_OPTIONS_CACHE_TTL_MS })
+  dialogUsersLoadedAt = Date.now()
 }
 
 async function selectGroup(groupId: string): Promise<void> {

--- a/frontend/src/features/users/components/UserGroupsDialog.vue
+++ b/frontend/src/features/users/components/UserGroupsDialog.vue
@@ -274,6 +274,7 @@ import type {
 
 const props = defineProps<{
   open: boolean
+  usersVersion: number
 }>()
 
 const emit = defineEmits<{
@@ -299,6 +300,7 @@ const editingGroupId = ref<string | null>(null)
 const memberUserIds = ref<string[]>([])
 const USER_OPTIONS_CACHE_TTL_MS = 30 * 1000
 let dialogUsersLoadedAt = 0
+let dialogUsersLoadedVersion = -1
 
 const form = ref({
   name: '',
@@ -361,12 +363,17 @@ async function loadDialogData(): Promise<void> {
 
 async function ensureDialogUsers(): Promise<void> {
   const now = Date.now()
-  if (dialogUsersLoadedAt > 0 && now - dialogUsersLoadedAt < USER_OPTIONS_CACHE_TTL_MS) {
+  if (
+    dialogUsersLoadedVersion === props.usersVersion
+    && dialogUsersLoadedAt > 0
+    && now - dialogUsersLoadedAt < USER_OPTIONS_CACHE_TTL_MS
+  ) {
     return
   }
 
   dialogUsers.value = await usersStore.listAllUsers({ cacheTtlMs: USER_OPTIONS_CACHE_TTL_MS })
   dialogUsersLoadedAt = Date.now()
+  dialogUsersLoadedVersion = props.usersVersion
 }
 
 async function selectGroup(groupId: string): Promise<void> {

--- a/frontend/src/stores/users.ts
+++ b/frontend/src/stores/users.ts
@@ -12,6 +12,7 @@ import {
   type ResolveUserBatchSelectionResponse,
   type UserBatchActionRequest,
   type UserBatchActionResponse,
+  type UserRole,
   type UserGroup,
   type UserGroupMember,
   type UpsertUserGroupRequest,
@@ -24,21 +25,32 @@ import { parseApiError } from '@/utils/errorParser'
 
 export const useUsersStore = defineStore('users', () => {
   const users = ref<User[]>([])
+  const total = ref(0)
+  const skip = ref(0)
+  const limit = ref(0)
+  const hasMore = ref(false)
   const loading = ref(false)
   const error = ref<string | null>(null)
 
   async function fetchUsers(options: {
     cacheTtlMs?: number
     search?: string
-    role?: 'admin' | 'user'
+    role?: UserRole
     is_active?: boolean
     group_id?: string
+    skip?: number
+    limit?: number
   } = {}) {
     loading.value = true
     error.value = null
 
     try {
-      users.value = await usersApi.getAllUsers(options)
+      const response = await usersApi.getAllUsersPage(options)
+      users.value = response.items
+      total.value = response.total
+      skip.value = response.skip
+      limit.value = response.limit
+      hasMore.value = response.has_more
     } catch (err: unknown) {
       error.value = parseApiError(err, '获取用户列表失败')
     } finally {
@@ -296,6 +308,10 @@ export const useUsersStore = defineStore('users', () => {
 
   return {
     users,
+    total,
+    skip,
+    limit,
+    hasMore,
     loading,
     error,
     fetchUsers,

--- a/frontend/src/stores/users.ts
+++ b/frontend/src/stores/users.ts
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import {
   usersApi,
   type User,
+  type GetAllUsersOptions,
   type CreateUserRequest,
   type UpdateUserRequest,
   type ApiKey,
@@ -31,6 +32,7 @@ export const useUsersStore = defineStore('users', () => {
   const hasMore = ref(false)
   const loading = ref(false)
   const error = ref<string | null>(null)
+  let fetchUsersRequestId = 0
 
   async function fetchUsers(options: {
     cacheTtlMs?: number
@@ -41,20 +43,44 @@ export const useUsersStore = defineStore('users', () => {
     skip?: number
     limit?: number
   } = {}) {
+    const requestId = ++fetchUsersRequestId
     loading.value = true
     error.value = null
 
     try {
       const response = await usersApi.getAllUsersPage(options)
+      if (requestId !== fetchUsersRequestId) return
       users.value = response.items
       total.value = response.total
       skip.value = response.skip
       limit.value = response.limit
       hasMore.value = response.has_more
     } catch (err: unknown) {
+      if (requestId !== fetchUsersRequestId) return
       error.value = parseApiError(err, '获取用户列表失败')
     } finally {
-      loading.value = false
+      if (requestId === fetchUsersRequestId) {
+        loading.value = false
+      }
+    }
+  }
+
+  async function listAllUsers(options: Omit<GetAllUsersOptions, 'skip' | 'limit'> = {}): Promise<User[]> {
+    const pageSize = 1000
+    const allUsers: User[] = []
+    let skip = 0
+
+    for (;;) {
+      const response = await usersApi.getAllUsersPage({
+        ...options,
+        skip,
+        limit: pageSize,
+      })
+      allUsers.push(...response.items)
+      if (!response.has_more || response.items.length === 0) {
+        return allUsers
+      }
+      skip += response.items.length
     }
   }
 
@@ -315,6 +341,7 @@ export const useUsersStore = defineStore('users', () => {
     loading,
     error,
     fetchUsers,
+    listAllUsers,
     createUser,
     updateUser,
     deleteUser,

--- a/frontend/src/views/admin/Users.vue
+++ b/frontend/src/views/admin/Users.vue
@@ -243,12 +243,12 @@
             <Checkbox
               :checked="isAllFilteredSelected"
               :indeterminate="isPartiallyFilteredSelected"
-              :disabled="filteredUsers.length === 0 || usersStore.loading"
+              :disabled="filteredUserCount === 0 || usersStore.loading"
               @update:checked="toggleSelectFiltered"
             />
             <span>全选筛选结果</span>
           </label>
-          <span>匹配 {{ filteredUsers.length }} 个，当前页 {{ paginatedUsers.length }} 个，已选 {{ selectedCount }} 个</span>
+          <span>匹配 {{ filteredUserCount }} 个，当前页 {{ paginatedUsers.length }} 个，已选 {{ selectedCount }} 个</span>
         </div>
         <div class="flex flex-wrap items-center gap-1.5">
           <Button
@@ -576,10 +576,10 @@
             </AvatarFallback>
           </Avatar>
           <p class="text-sm font-medium text-foreground">
-            {{ searchQuery || filterRole !== 'all' || filterStatus !== 'all' ? '未找到匹配的用户' : '暂无用户' }}
+            {{ searchQuery || filterRole !== 'all' || filterStatus !== 'all' || filterGroup !== 'all' ? '未找到匹配的用户' : '暂无用户' }}
           </p>
           <p
-            v-if="searchQuery || filterRole !== 'all' || filterStatus !== 'all'"
+            v-if="searchQuery || filterRole !== 'all' || filterStatus !== 'all' || filterGroup !== 'all'"
             class="mt-1 text-xs text-muted-foreground"
           >
             尝试调整筛选条件
@@ -812,11 +812,11 @@
       <!-- 分页控件 -->
       <Pagination
         :current="currentPage"
-        :total="filteredUsers.length"
+        :total="filteredUserCount"
         :page-size="pageSize"
         cache-key="users-page-size"
-        @update:current="currentPage = $event"
-        @update:page-size="pageSize = $event"
+        @update:current="handlePageChange"
+        @update:page-size="handlePageSizeChange"
       />
     </Card>
 
@@ -1575,8 +1575,8 @@ const showUserBatchDialog = ref(false)
 const showUserGroupsDialog = ref(false)
 
 const searchQuery = ref('')
-const filterRole = ref('all')
-const filterStatus = ref('all')
+const filterRole = ref<'all' | User['role']>('all')
+const filterStatus = ref<'all' | 'active' | 'inactive'>('all')
 const filterGroup = ref('all')
 const userGroups = ref<UserGroup[]>([])
 const userRoleFilterOptions = [
@@ -1600,7 +1600,7 @@ let userWalletsRequestId = 0
 const filteredUsers = computed(() => {
   let filtered = [...usersStore.users]
 
-  // 先排序：管理员优先，然后按创建时间倒序
+  // 当前页仍按原有视觉规则排序；筛选和分页由后端处理，避免只搜索首批 100 个用户。
   filtered.sort((a, b) => {
     const roleRank = (role: string) => role === 'admin' ? 0 : role === 'audit_admin' ? 1 : 2
     const roleDiff = roleRank(a.role) - roleRank(b.role)
@@ -1609,38 +1609,12 @@ const filteredUsers = computed(() => {
     return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
   })
 
-  // 搜索（支持空格分隔的多关键词 AND 搜索）
-  if (searchQuery.value) {
-    const keywords = searchQuery.value.toLowerCase().split(/\s+/).filter(k => k.length > 0)
-    filtered = filtered.filter(u => {
-      const searchableText = `${u.username} ${u.email || ''}`.toLowerCase()
-      return keywords.every(keyword => searchableText.includes(keyword))
-    })
-  }
-
-  if (filterRole.value !== 'all') {
-    filtered = filtered.filter(u => u.role === filterRole.value)
-  }
-
-  if (filterStatus.value !== 'all') {
-    filtered = filtered.filter(u =>
-      filterStatus.value === 'active' ? u.is_active : !u.is_active
-    )
-  }
-
-  if (filterGroup.value !== 'all') {
-    filtered = filtered.filter(u => (u.groups || []).some(group => group.id === filterGroup.value))
-  }
-
   return filtered
 })
 
-const paginatedUsers = computed(() => {
-  const start = (currentPage.value - 1) * pageSize.value
-  return filteredUsers.value.slice(start, start + pageSize.value)
-})
+const paginatedUsers = computed(() => filteredUsers.value)
 
-const filteredUserCount = computed(() => filteredUsers.value.length)
+const filteredUserCount = computed(() => usersStore.total)
 const {
   selectedIds,
   selectAllFiltered,
@@ -1681,6 +1655,7 @@ const grantableBillingPlans = computed(() =>
 watch([searchQuery, filterRole, filterStatus, filterGroup], () => {
   currentPage.value = 1
   resetBatchSelection()
+  void refreshUsers()
 })
 
 watch(paginatedUsers, (users) => rememberBatchPageUsers(users), { immediate: true })
@@ -1701,13 +1676,34 @@ onMounted(() => {
 
 async function refreshUsers(options: { preferCache?: boolean } = {}) {
   const cacheTtlMs = options.preferCache ? USERS_PAGE_CACHE_TTL_MS : 0
+  const search = searchQuery.value.trim()
   await Promise.all([
-    usersStore.fetchUsers({ cacheTtlMs }),
+    usersStore.fetchUsers({
+      cacheTtlMs,
+      search: search || undefined,
+      role: filterRole.value === 'all' ? undefined : filterRole.value,
+      is_active: filterStatus.value === 'all' ? undefined : filterStatus.value === 'active',
+      group_id: filterGroup.value === 'all' ? undefined : filterGroup.value,
+      skip: (currentPage.value - 1) * pageSize.value,
+      limit: pageSize.value,
+    }),
     loadUserGroups(),
   ])
   void loadUserWallets({
     cacheTtlMs: options.preferCache ? USER_WALLETS_CACHE_TTL_MS : 0,
   })
+}
+
+function handlePageChange(page: number): void {
+  currentPage.value = page
+  void refreshUsers({ preferCache: true })
+}
+
+function handlePageSizeChange(size: number): void {
+  pageSize.value = size
+  currentPage.value = 1
+  resetBatchSelection()
+  void refreshUsers()
 }
 
 async function loadUserGroups(): Promise<void> {

--- a/frontend/src/views/admin/Users.vue
+++ b/frontend/src/views/admin/Users.vue
@@ -843,6 +843,7 @@
 
     <UserGroupsDialog
       :open="showUserGroupsDialog"
+      :users-version="userOptionsVersion"
       @close="showUserGroupsDialog = false"
       @changed="handleUserGroupsChanged"
     />
@@ -1572,6 +1573,7 @@ const showWalletActionDialogState = ref(false)
 const walletActionTarget = ref<{ user: User; wallet: AdminWallet } | null>(null)
 const showUserBatchDialog = ref(false)
 const showUserGroupsDialog = ref(false)
+const userOptionsVersion = ref(0)
 
 const searchQuery = ref('')
 const filterRole = ref<'all' | User['role']>('all')
@@ -1596,20 +1598,7 @@ const USERS_PAGE_CACHE_TTL_MS = 10 * 1000
 const USER_WALLETS_CACHE_TTL_MS = 10 * 1000
 let userWalletsRequestId = 0
 
-const filteredUsers = computed(() => {
-  let filtered = [...usersStore.users]
-
-  // 当前页仍按原有视觉规则排序；筛选和分页由后端处理，避免只搜索首批 100 个用户。
-  filtered.sort((a, b) => {
-    const roleRank = (role: string) => role === 'admin' ? 0 : role === 'audit_admin' ? 1 : 2
-    const roleDiff = roleRank(a.role) - roleRank(b.role)
-    if (roleDiff !== 0) return roleDiff
-    // 同角色按创建时间倒序（新用户在前）
-    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-  })
-
-  return filtered
-})
+const filteredUsers = computed(() => usersStore.users)
 
 const paginatedUsers = computed(() => filteredUsers.value)
 
@@ -1729,6 +1718,10 @@ function openUserBatchDialog(): void {
 async function handleUserBatchCompleted(_result: UserBatchActionResponse): Promise<void> {
   await refreshUsers()
   resetBatchSelection(true)
+}
+
+function invalidateUserOptions(): void {
+  userOptionsVersion.value += 1
 }
 
 function formatDate(dateString: string) {
@@ -1896,6 +1889,8 @@ async function toggleUserStatus(user: User) {
 
   try {
     await usersStore.updateUser(user.id, { is_active: !user.is_active })
+    invalidateUserOptions()
+    await refreshUsers()
     success(`用户已${action}`)
   } catch (err: unknown) {
     error(parseApiError(err, '未知错误'), `${action}用户失败`)
@@ -1946,6 +1941,7 @@ async function handleUserFormSubmit(data: UserFormData & { password?: string; un
         updateData.password = data.password
       }
       await usersStore.updateUser(data.id, updateData)
+      invalidateUserOptions()
       success('用户信息已更新')
     } else {
       // 创建用户
@@ -1963,6 +1959,7 @@ async function handleUserFormSubmit(data: UserFormData & { password?: string; un
       if (data.is_active === false && newUser) {
         await usersStore.updateUser(newUser.id, { is_active: false })
       }
+      invalidateUserOptions()
       success('用户创建成功')
     }
     closeUserFormDialog()
@@ -2270,6 +2267,7 @@ async function deleteUser(user: User) {
 
   try {
     await usersStore.deleteUser(user.id)
+    invalidateUserOptions()
     if (usersStore.users.length === 0 && currentPage.value > 1) {
       currentPage.value -= 1
     }

--- a/frontend/src/views/admin/Users.vue
+++ b/frontend/src/views/admin/Users.vue
@@ -843,7 +843,6 @@
 
     <UserGroupsDialog
       :open="showUserGroupsDialog"
-      :users="usersStore.users"
       @close="showUserGroupsDialog = false"
       @changed="handleUserGroupsChanged"
     />
@@ -1947,7 +1946,6 @@ async function handleUserFormSubmit(data: UserFormData & { password?: string; un
         updateData.password = data.password
       }
       await usersStore.updateUser(data.id, updateData)
-      await loadUserWallets()
       success('用户信息已更新')
     } else {
       // 创建用户
@@ -1965,10 +1963,10 @@ async function handleUserFormSubmit(data: UserFormData & { password?: string; un
       if (data.is_active === false && newUser) {
         await usersStore.updateUser(newUser.id, { is_active: false })
       }
-      await loadUserWallets()
       success('用户创建成功')
     }
     closeUserFormDialog()
+    await refreshUsers()
   } catch (err: unknown) {
     const title = data.id ? '更新用户失败' : '创建用户失败'
     error(parseApiError(err, '未知错误'), title)
@@ -2272,6 +2270,10 @@ async function deleteUser(user: User) {
 
   try {
     await usersStore.deleteUser(user.id)
+    if (usersStore.users.length === 0 && currentPage.value > 1) {
+      currentPage.value -= 1
+    }
+    await refreshUsers()
     success('用户已删除')
   } catch (err: unknown) {
     error(parseApiError(err, '未知错误'), '删除用户失败')


### PR DESCRIPTION
## Summary
- Adds filtered count support for admin user exports across repository implementations so `/api/admin/users` can return pagination metadata.
- Updates the admin users endpoint to return `items`, `total`, `skip`, `limit`, and `has_more` instead of an unbounded array-only contract.
- Wires the Users admin page to request server-side `skip`/`limit` plus search/role/status/group filters, so users beyond the first 100 can be found and managed.

Closes #520

## Verification
- `npm run type-check`
- `npm run build`
- `cargo fmt --check`
- `cargo check -p aether-data`
- `BINDGEN_EXTRA_CLANG_ARGS=-I/usr/lib/gcc/x86_64-linux-gnu/13/include cargo check -p aether-gateway`
- `BINDGEN_EXTRA_CLANG_ARGS=-I/usr/lib/gcc/x86_64-linux-gnu/13/include cargo test -p aether-gateway gateway_handles_admin_users_root_locally --tests`