### PR TITLE
修复 Codex Responses 工具字段和成功请求回收标记

### DIFF
--- a/crates/aether-ai-formats/src/formats/openai/responses/codex.rs
+++ b/crates/aether-ai-formats/src/formats/openai/responses/codex.rs
@@ -375,6 +375,51 @@ fn ensure_codex_chat_reasoning_defaults(
         .or_insert_with(|| json!(CODEX_DEFAULT_REASONING_SUMMARY));
 }
 
+fn codex_tool_type_rejects_top_level_name(tool_type: &str) -> bool {
+    let normalized = tool_type.trim().to_ascii_lowercase();
+    !normalized.is_empty()
+        && normalized != "function"
+        && normalized != "custom"
+        && normalized != "namespace"
+}
+
+fn strip_codex_hosted_tool_names_for_backend(body_object: &mut serde_json::Map<String, Value>) {
+    let Some(tools) = body_object.get_mut("tools").and_then(Value::as_array_mut) else {
+        return;
+    };
+
+    for tool in tools {
+        let Some(tool_object) = tool.as_object_mut() else {
+            continue;
+        };
+        if tool_object
+            .get("type")
+            .and_then(Value::as_str)
+            .is_some_and(codex_tool_type_rejects_top_level_name)
+        {
+            tool_object.remove("name");
+        }
+    }
+}
+
+fn strip_codex_hosted_tool_choice_name_for_backend(
+    body_object: &mut serde_json::Map<String, Value>,
+) {
+    let Some(tool_choice_object) = body_object
+        .get_mut("tool_choice")
+        .and_then(Value::as_object_mut)
+    else {
+        return;
+    };
+    if tool_choice_object
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(codex_tool_type_rejects_top_level_name)
+    {
+        tool_choice_object.remove("name");
+    }
+}
+
 pub fn apply_codex_openai_responses_special_body_edits(
     provider_request_body: &mut Value,
     provider_type: &str,
@@ -420,6 +465,8 @@ pub fn apply_codex_openai_responses_special_body_edits(
     {
         body_object.insert("instructions".to_string(), json!(""));
     }
+    strip_codex_hosted_tool_names_for_backend(body_object);
+    strip_codex_hosted_tool_choice_name_for_backend(body_object);
     if is_openai_image_request(provider_api_format)
         || codex_openai_responses_tool_choice_references_image_generation(body_object)
     {
@@ -618,6 +665,87 @@ mod tests {
             ])
         );
         assert_eq!(provider_request_body["parallel_tool_calls"], json!(false));
+    }
+
+    #[test]
+    fn codex_responses_body_edits_preserve_function_tools_for_codex_backend() {
+        let mut provider_request_body = json!({
+            "input": [],
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "lookup_account",
+                "description": "Lookup an account by id.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "account_id": {
+                            "type": "string"
+                        }
+                    },
+                    "required": ["account_id"],
+                    "additionalProperties": false
+                },
+                "strict": true
+            }],
+            "tool_choice": {
+                "type": "function",
+                "name": "lookup_account"
+            }
+        });
+
+        apply_codex_openai_responses_special_body_edits(
+            &mut provider_request_body,
+            "codex",
+            "openai:responses",
+            None,
+            None,
+        );
+
+        assert_eq!(
+            provider_request_body["tools"][0]["name"],
+            json!("lookup_account")
+        );
+        assert_eq!(
+            provider_request_body["tools"][0]["parameters"]["properties"]["account_id"]["type"],
+            json!("string")
+        );
+        assert_eq!(
+            provider_request_body["tool_choice"]["name"],
+            json!("lookup_account")
+        );
+        assert!(provider_request_body["tools"][0].get("function").is_none());
+    }
+
+    #[test]
+    fn codex_responses_body_edits_strip_name_from_hosted_web_search_tool() {
+        let mut provider_request_body = json!({
+            "input": [],
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "web_search",
+                "name": "web_search"
+            }],
+            "tool_choice": {
+                "type": "web_search",
+                "name": "web_search"
+            }
+        });
+
+        apply_codex_openai_responses_special_body_edits(
+            &mut provider_request_body,
+            "codex",
+            "openai:responses",
+            None,
+            None,
+        );
+
+        assert!(provider_request_body["tools"][0].get("name").is_none());
+        assert!(provider_request_body["tool_choice"].get("name").is_none());
+        assert_eq!(
+            provider_request_body["tool_choice"]["type"],
+            json!("web_search")
+        );
     }
 
     #[test]

--- a/crates/aether-scheduler-core/src/request_candidate.rs
+++ b/crates/aether-scheduler-core/src/request_candidate.rs
@@ -488,6 +488,7 @@ pub fn build_local_request_candidate_status_record(
         demoted_by: metadata.demoted_by.clone(),
         routing_trace: metadata.routing_trace.clone(),
     });
+    let extra_data = mark_request_candidate_stream_completed_if_success(status, extra_data);
     let created_at_unix_ms = started_at_unix_ms.or(finished_at_unix_ms);
 
     Some(UpsertRequestCandidateRecord {
@@ -568,7 +569,7 @@ pub fn build_report_request_candidate_status_record(
         error_message,
         latency_ms,
         concurrent_requests: None,
-        extra_data: slot.extra_data,
+        extra_data: mark_request_candidate_stream_completed_if_success(status, slot.extra_data),
         required_capabilities: None,
         created_at_unix_ms: Some(created_at_unix_ms),
         started_at_unix_ms,
@@ -827,6 +828,23 @@ fn build_report_candidate_extra_data(input: ReportCandidateExtraDataInput) -> Op
         extra_data.insert("routing_trace".to_string(), routing_trace);
     }
     (!extra_data.is_empty()).then_some(Value::Object(extra_data))
+}
+
+fn mark_request_candidate_stream_completed_if_success(
+    status: RequestCandidateStatus,
+    extra_data: Option<Value>,
+) -> Option<Value> {
+    if status != RequestCandidateStatus::Success {
+        return extra_data;
+    }
+
+    let mut object = match extra_data {
+        Some(Value::Object(object)) => object,
+        Some(other) => return Some(other),
+        None => Map::new(),
+    };
+    object.insert("stream_completed".to_string(), Value::Bool(true));
+    Some(Value::Object(object))
 }
 
 fn merge_request_candidate_extra_data(
@@ -1295,6 +1313,53 @@ mod tests {
         assert_eq!(record.finished_at_unix_ms, Some(123));
         assert_eq!(record.created_at_unix_ms, Some(123));
         assert_eq!(record.status, RequestCandidateStatus::Success);
+        assert_eq!(
+            record
+                .extra_data
+                .as_ref()
+                .and_then(|value| value.get("stream_completed")),
+            Some(&json!(true))
+        );
+    }
+
+    #[test]
+    fn local_success_status_marks_stream_completed_for_pending_cleanup_recovery() {
+        let mut plan = sample_plan();
+        plan.candidate_id = Some("cand-1".to_string());
+        let report_context = json!({
+            "request_id": "req-1",
+            "candidate_id": "cand-1",
+            "candidate_index": 0,
+            "retry_index": 0,
+            "user_id": "user-1",
+            "api_key_id": "api-key-1",
+            "client_api_format": "openai:responses",
+            "provider_api_format": "openai:responses",
+        });
+
+        let record =
+            build_local_request_candidate_status_record(LocalRequestCandidateStatusRecordInput {
+                plan: &plan,
+                report_context: Some(&report_context),
+                status_update: SchedulerRequestCandidateStatusUpdate {
+                    status: RequestCandidateStatus::Success,
+                    status_code: Some(200),
+                    error_type: None,
+                    error_message: None,
+                    latency_ms: Some(25),
+                    started_at_unix_ms: Some(1_000),
+                    finished_at_unix_ms: Some(1_025),
+                },
+            })
+            .expect("success status record should build");
+
+        assert_eq!(
+            record
+                .extra_data
+                .as_ref()
+                .and_then(|value| value.get("stream_completed")),
+            Some(&json!(true))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 问题

最新 `origin/main` 上仍然存在两个相关问题：

1. Codex 的 OpenAI Responses 请求里，hosted tool（例如 `web_search`）会带着顶层 `name` 发给后端。这个字段对 hosted tool 不合法，会让正经的 Codex / GPT Pro 订阅路径也被错误请求拖坏。
2. Responses 成功返回后，请求候选记录没有写入 `extra_data.stream_completed=true`。pending cleanup 依赖这个标记判断成功流是否已经完整结束，所以成功请求会被后续恢复逻辑误判。

这次修的是 response/候选状态本身，不是让坏状态继续存在，也不是靠 pending cleanup 放宽条件来绕过去。

## 修改

- Codex OpenAI Responses body edit 阶段：
  - 对 hosted tool 和 hosted `tool_choice` 删除顶层 `name`。
  - 保留 `function` / `custom` / `namespace` 这类需要 `name` 的工具字段，避免误伤正常 function tool。
- 请求候选状态记录阶段：
  - local success 路径写入 `stream_completed=true`。
  - report success 路径同样写入 `stream_completed=true`。

## upstream 复现确认

本分支基于最新 upstream `origin/main`：`d0981c2f`。

在修复前，我先在这个基线上补了回归测试并确认失败：

- hosted `web_search` tool 的顶层 `name` 仍然存在。
- local success candidate 没有 `stream_completed=true`。
- report success candidate 也没有 `stream_completed=true`。

## 验证

已通过：

```bash
cargo test --locked -p aether-ai-formats codex_responses_body_edits --lib
cargo test --locked -p aether-scheduler-core local_success_status_marks_stream_completed_for_pending_cleanup_recovery --lib
cargo test --locked -p aether-scheduler-core builds_report_request_candidate_status_record_with_terminal_timestamps --lib
cargo fmt --all -- --check
cargo test --locked -p aether-ai-formats --lib
cargo test --locked -p aether-scheduler-core --lib
```

本机没有直接安装 `cargo`，上述命令是在 `rust:1.95.0` Docker 容器里跑的。