### PR TITLE
docs: fix duplicated install cd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ docker compose -f docker-compose.single-node.yml pull && docker compose -f docke
 ### 一键安装（默认 Single Node：Linux systemd / macOS launchd + SQLite）
 
 ```bash
-cd Aether && cd Aether
+git clone https://github.com/fawney19/Aether.git
+cd Aether
 curl -fsSL https://raw.githubusercontent.com/fawney19/Aether/main/install.sh | sudo bash
 ```
 


### PR DESCRIPTION
## Summary
- fix duplicated \cd Aether\ in the one-click install docs
- include the missing clone step for the install command block

## Testing
- not run; documentation-only change