### PR TITLE
fix(gateway,data): non-stream watchdog + cleanup failure fidelity

### DIFF
--- a/apps/aether-gateway/src/execution_runtime/sync/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/sync/execution.rs
@@ -3,6 +3,7 @@ use std::io::Error as IoError;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use aether_ai_serving::UPSTREAM_IS_STREAM_KEY;
 use aether_contracts::{
     ExecutionError, ExecutionErrorKind, ExecutionPhase, ExecutionPlan, ExecutionResult,
     ExecutionTelemetry,
@@ -1005,7 +1006,7 @@ fn resolve_openai_image_sync_total_timeout_ms(plan: &ExecutionPlan) -> u64 {
 
 fn report_context_upstream_is_stream(report_context: Option<&Value>) -> bool {
     report_context
-        .and_then(|value| value.get("upstream_is_stream"))
+        .and_then(|value| value.get(UPSTREAM_IS_STREAM_KEY))
         .and_then(Value::as_bool)
         .unwrap_or(false)
 }

--- a/apps/aether-gateway/src/executor/candidate_loop.rs
+++ b/apps/aether-gateway/src/executor/candidate_loop.rs
@@ -1,5 +1,6 @@
 use aether_ai_serving::{
     run_ai_attempt_loop, AiAttemptLoopOutcome, AiAttemptLoopPort, AiExecutionAttempt,
+    UPSTREAM_IS_STREAM_KEY,
 };
 use aether_data_contracts::repository::candidates::RequestCandidateStatus;
 use aether_scheduler_core::{
@@ -471,11 +472,24 @@ fn should_skip_unused_persistence_from_metadata(
     metadata.candidate_group_id.is_some() && metadata.pool_key_index.is_some()
 }
 
-fn resolve_stream_candidate_watchdog_timeout(plan: &aether_contracts::ExecutionPlan) -> Duration {
+fn resolve_stream_candidate_watchdog_timeout(
+    plan: &aether_contracts::ExecutionPlan,
+    report_context: Option<&serde_json::Value>,
+) -> Duration {
+    let upstream_is_stream = report_context
+        .and_then(|context| context.get(UPSTREAM_IS_STREAM_KEY))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(true);
     let timeout_ms = plan
         .timeouts
         .as_ref()
-        .and_then(|timeouts| timeouts.first_byte_ms.or(timeouts.total_ms))
+        .and_then(|timeouts| {
+            if upstream_is_stream {
+                timeouts.first_byte_ms.or(timeouts.total_ms)
+            } else {
+                timeouts.total_ms.or(timeouts.first_byte_ms)
+            }
+        })
         .unwrap_or(DEFAULT_STREAM_CANDIDATE_WATCHDOG_TIMEOUT_MS)
         .max(1);
     Duration::from_millis(timeout_ms)
@@ -493,7 +507,7 @@ where
     Fut:
         std::future::Future<Output = Result<Option<Response<Body>>, GatewayError>> + Send + 'static,
 {
-    let timeout_duration = resolve_stream_candidate_watchdog_timeout(plan);
+    let timeout_duration = resolve_stream_candidate_watchdog_timeout(plan, report_context);
     let candidate_started_unix_ms = current_unix_ms();
     let mut join_handle = tokio::spawn(execute());
     match timeout(timeout_duration, &mut join_handle).await {
@@ -655,24 +669,71 @@ mod tests {
 
     #[test]
     fn stream_candidate_watchdog_prefers_first_byte_timeout() {
-        let timeout =
-            resolve_stream_candidate_watchdog_timeout(&test_plan(Some(ExecutionTimeouts {
+        let report_context = json!({"upstream_is_stream": true});
+        let timeout = resolve_stream_candidate_watchdog_timeout(
+            &test_plan(Some(ExecutionTimeouts {
                 first_byte_ms: Some(12_345),
                 total_ms: Some(90_000),
                 ..ExecutionTimeouts::default()
-            })));
+            })),
+            Some(&report_context),
+        );
 
         assert_eq!(timeout, Duration::from_millis(12_345));
     }
 
     #[test]
     fn stream_candidate_watchdog_uses_default_when_timeouts_missing() {
-        let timeout = resolve_stream_candidate_watchdog_timeout(&test_plan(None));
+        let timeout = resolve_stream_candidate_watchdog_timeout(&test_plan(None), None);
 
         assert_eq!(
             timeout,
             Duration::from_millis(DEFAULT_STREAM_CANDIDATE_WATCHDOG_TIMEOUT_MS)
         );
+    }
+
+    #[test]
+    fn stream_candidate_watchdog_prefers_total_timeout_when_upstream_non_stream() {
+        let report_context = json!({"upstream_is_stream": false});
+        let timeout = resolve_stream_candidate_watchdog_timeout(
+            &test_plan(Some(ExecutionTimeouts {
+                first_byte_ms: Some(300_000),
+                total_ms: Some(599_000),
+                ..ExecutionTimeouts::default()
+            })),
+            Some(&report_context),
+        );
+
+        assert_eq!(timeout, Duration::from_millis(599_000));
+    }
+
+    #[test]
+    fn stream_candidate_watchdog_falls_back_to_first_byte_when_upstream_non_stream_lacks_total() {
+        let report_context = json!({"upstream_is_stream": false});
+        let timeout = resolve_stream_candidate_watchdog_timeout(
+            &test_plan(Some(ExecutionTimeouts {
+                first_byte_ms: Some(300_000),
+                ..ExecutionTimeouts::default()
+            })),
+            Some(&report_context),
+        );
+
+        assert_eq!(timeout, Duration::from_millis(300_000));
+    }
+
+    #[test]
+    fn stream_candidate_watchdog_defaults_to_streaming_when_flag_missing() {
+        let report_context = json!({});
+        let timeout = resolve_stream_candidate_watchdog_timeout(
+            &test_plan(Some(ExecutionTimeouts {
+                first_byte_ms: Some(12_345),
+                total_ms: Some(90_000),
+                ..ExecutionTimeouts::default()
+            })),
+            Some(&report_context),
+        );
+
+        assert_eq!(timeout, Duration::from_millis(12_345));
     }
 
     #[test]

--- a/apps/aether-gateway/src/handlers/public/support/user_me_usage.rs
+++ b/apps/aether-gateway/src/handlers/public/support/user_me_usage.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use aether_ai_serving::UPSTREAM_IS_STREAM_KEY;
 use aether_billing::{
     normalize_input_tokens_for_billing, normalize_total_input_context_for_cache_hit_rate,
 };
@@ -314,7 +315,7 @@ fn users_me_usage_upstream_is_stream(item: &StoredRequestUsageAudit) -> bool {
     item.request_metadata
         .as_ref()
         .and_then(serde_json::Value::as_object)
-        .and_then(|metadata| metadata.get("upstream_is_stream"))
+        .and_then(|metadata| metadata.get(UPSTREAM_IS_STREAM_KEY))
         .and_then(serde_json::Value::as_bool)
         .or_else(|| users_me_usage_headers_stream_flag(item.response_headers.as_ref()))
         .or_else(|| users_me_usage_infer_upstream_stream_from_captured_bodies(item))

--- a/crates/aether-admin/src/observability/usage.rs
+++ b/crates/aether-admin/src/observability/usage.rs
@@ -1,5 +1,6 @@
 use crate::observability::stats::{aggregate_usage_stats, parse_bounded_u32, round_to};
 use aether_ai_formats::api::request_path_implies_stream_request;
+use aether_ai_formats::UPSTREAM_IS_STREAM_KEY;
 use aether_billing::{
     normalize_input_tokens_for_billing, normalize_total_input_context_for_cache_hit_rate,
 };
@@ -1052,7 +1053,7 @@ fn admin_usage_upstream_is_stream(item: &StoredRequestUsageAudit) -> bool {
     item.request_metadata
         .as_ref()
         .and_then(Value::as_object)
-        .and_then(|metadata| metadata.get("upstream_is_stream"))
+        .and_then(|metadata| metadata.get(UPSTREAM_IS_STREAM_KEY))
         .and_then(Value::as_bool)
         .or_else(|| admin_usage_headers_stream_flag(item.response_headers.as_ref()))
         .or_else(|| admin_usage_infer_upstream_stream_from_captured_bodies(item))
@@ -1256,7 +1257,10 @@ pub fn admin_usage_record_json(
         .as_object_mut()
         .expect("admin usage record payload should be an object");
     object.insert("is_stream".to_string(), json!(item.is_stream));
-    object.insert("upstream_is_stream".to_string(), json!(upstream_is_stream));
+    object.insert(
+        UPSTREAM_IS_STREAM_KEY.to_string(),
+        json!(upstream_is_stream),
+    );
     object.insert(
         "client_requested_stream".to_string(),
         json!(client_is_stream),

--- a/crates/aether-ai-formats/src/formats/shared/request.rs
+++ b/crates/aether-ai-formats/src/formats/shared/request.rs
@@ -2,6 +2,14 @@ use base64::Engine as _;
 
 use crate::formats::id::api_format_uses_body_stream_field;
 
+/// JSON key under which `upstream_is_stream` is written into the AI execution
+/// report context and propagated into usage metadata. Shared by the producer
+/// (`aether-ai-serving::report_context`) and every downstream consumer so that
+/// renames cannot silently desync them — a string-literal mismatch here would
+/// degrade to default values (e.g. assuming streaming) without any compile-time
+/// signal.
+pub const UPSTREAM_IS_STREAM_KEY: &str = "upstream_is_stream";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum UpstreamStreamPolicy {
     Auto,

--- a/crates/aether-ai-formats/src/formats/shared/response.rs
+++ b/crates/aether-ai-formats/src/formats/shared/response.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use serde_json::Value;
 
 use crate::contracts::core_success_background_report_kind;
+use crate::formats::shared::request::UPSTREAM_IS_STREAM_KEY;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LocalSyncReportParts {
@@ -66,7 +67,7 @@ fn should_capture_client_sync_success_body(payload: &LocalSyncReportParts) -> bo
         .report_context
         .as_ref()
         .and_then(Value::as_object)
-        .and_then(|context| context.get("upstream_is_stream"))
+        .and_then(|context| context.get(UPSTREAM_IS_STREAM_KEY))
         .and_then(Value::as_bool)
         .unwrap_or(false)
 }

--- a/crates/aether-ai-formats/src/lib.rs
+++ b/crates/aether-ai-formats/src/lib.rs
@@ -29,7 +29,7 @@ pub use formats::shared::model_directives::{
 };
 pub use formats::shared::request::{
     endpoint_config_forces_upstream_stream_policy, enforce_request_body_stream_field,
-    resolve_upstream_is_stream_from_endpoint_config,
+    resolve_upstream_is_stream_from_endpoint_config, UPSTREAM_IS_STREAM_KEY,
 };
 pub use protocol::canonical::{
     canonical_request_unknown_block_count, canonical_response_unknown_block_count,

--- a/crates/aether-ai-serving/src/lib.rs
+++ b/crates/aether-ai-serving/src/lib.rs
@@ -22,6 +22,7 @@ pub mod request_body_diagnostics;
 pub mod runtime_miss;
 pub mod surface_spec;
 
+pub use aether_ai_formats::UPSTREAM_IS_STREAM_KEY;
 pub use aether_pool_core::{
     normalize_enabled_pool_presets, run_pool_scheduler, PoolCandidateFacts, PoolCandidateInput,
     PoolCandidateOrchestration, PoolMemberSignals, PoolRuntimeState, PoolScheduledCandidate,

--- a/crates/aether-ai-serving/src/report_context.rs
+++ b/crates/aether-ai-serving/src/report_context.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use aether_ai_formats::api::ExecutionRuntimeAuthContext;
+use aether_ai_formats::UPSTREAM_IS_STREAM_KEY;
 use aether_scheduler_core::SchedulerRankingOutcome;
 use serde_json::{Map, Value};
 
@@ -140,7 +141,7 @@ pub fn build_ai_execution_report_context(parts: AiExecutionReportContextParts<'_
         Value::Bool(parts.client_requested_stream),
     );
     object.insert(
-        "upstream_is_stream".to_string(),
+        UPSTREAM_IS_STREAM_KEY.to_string(),
         Value::Bool(parts.upstream_is_stream),
     );
     object.insert("has_envelope".to_string(), Value::Bool(parts.has_envelope));

--- a/crates/aether-data/src/repository/usage/memory.rs
+++ b/crates/aether-data/src/repository/usage/memory.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::RwLock;
 
+use aether_ai_formats::UPSTREAM_IS_STREAM_KEY;
 use aether_data_contracts::repository::usage::{
     parse_usage_body_ref, usage_body_ref, StoredUsageAuditAggregation, StoredUsageAuditSummary,
     StoredUsageBreakdownSummaryRow, StoredUsageCacheAffinityHitSummary,
@@ -952,7 +953,7 @@ fn usage_output_tps_uses_generation_time(item: &StoredRequestUsageAudit) -> bool
     item.request_metadata
         .as_ref()
         .and_then(Value::as_object)
-        .and_then(|metadata| metadata.get("upstream_is_stream"))
+        .and_then(|metadata| metadata.get(UPSTREAM_IS_STREAM_KEY))
         .and_then(Value::as_bool)
         .unwrap_or(item.is_stream)
 }

--- a/crates/aether-data/src/repository/usage/mysql.rs
+++ b/crates/aether-data/src/repository/usage/mysql.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 
+use aether_ai_formats::UPSTREAM_IS_STREAM_KEY;
 use async_trait::async_trait;
 use sqlx::{mysql::MySqlRow, Row};
 
@@ -881,7 +882,7 @@ fn usage_upstream_is_stream(usage: &UpsertUsageRecord) -> bool {
         .request_metadata
         .as_ref()
         .and_then(serde_json::Value::as_object)
-        .and_then(|metadata| metadata.get("upstream_is_stream"))
+        .and_then(|metadata| metadata.get(UPSTREAM_IS_STREAM_KEY))
         .and_then(serde_json::Value::as_bool)
         .unwrap_or_else(|| usage.is_stream.unwrap_or(false))
 }
@@ -895,7 +896,7 @@ fn merge_usage_stream_metadata(metadata: &mut Option<serde_json::Value>, upstrea
         return;
     };
     object
-        .entry("upstream_is_stream")
+        .entry(UPSTREAM_IS_STREAM_KEY)
         .or_insert(serde_json::Value::Bool(upstream));
 }
 

--- a/crates/aether-data/src/repository/usage/mysql.rs
+++ b/crates/aether-data/src/repository/usage/mysql.rs
@@ -519,13 +519,20 @@ WHERE request_id = ?
                     continue;
                 }
 
-                let error_message = stale_pending_error_message(&row.status, timeout_minutes);
+                let candidate_info =
+                    latest_failed_candidate_mysql(&mut tx, &row.request_id).await?;
+                let (status_code, error_message) = resolve_stale_pending_failure(
+                    candidate_info.as_ref(),
+                    &row.status,
+                    timeout_minutes,
+                );
+                let status_code_i64 = i64::from(status_code);
                 if row.billing_status == "pending" {
                     sqlx::query(
                         r#"
 UPDATE `usage`
 SET status = 'failed',
-    status_code = 504,
+    status_code = ?,
     error_message = ?,
     billing_status = 'void',
     finalized_at = ?,
@@ -534,6 +541,7 @@ SET status = 'failed',
 WHERE request_id = ?
 "#,
                     )
+                    .bind(status_code_i64)
                     .bind(&error_message)
                     .bind(to_i64(now_unix_secs, "usage finalized_at")?)
                     .bind(&row.request_id)
@@ -551,11 +559,12 @@ WHERE request_id = ?
                         r#"
 UPDATE `usage`
 SET status = 'failed',
-    status_code = 504,
+    status_code = ?,
     error_message = ?
 WHERE request_id = ?
 "#,
                     )
+                    .bind(status_code_i64)
                     .bind(&error_message)
                     .bind(&row.request_id)
                     .execute(&mut *tx)
@@ -686,6 +695,67 @@ ON DUPLICATE KEY UPDATE
 
 fn stale_pending_error_message(status: &str, timeout_minutes: u64) -> String {
     format!("请求超时: 状态 '{status}' 超过 {timeout_minutes} 分钟未完成")
+}
+
+struct FailedCandidateCleanupInfo {
+    status_code: Option<u16>,
+    error_message: Option<String>,
+}
+
+fn resolve_stale_pending_failure(
+    candidate: Option<&FailedCandidateCleanupInfo>,
+    status: &str,
+    timeout_minutes: u64,
+) -> (u16, String) {
+    match candidate {
+        Some(info) => (
+            info.status_code.unwrap_or(502),
+            info.error_message
+                .clone()
+                .unwrap_or_else(|| stale_pending_error_message(status, timeout_minutes)),
+        ),
+        None => (504, stale_pending_error_message(status, timeout_minutes)),
+    }
+}
+
+async fn latest_failed_candidate_mysql(
+    tx: &mut sqlx::Transaction<'_, sqlx::MySql>,
+    request_id: &str,
+) -> Result<Option<FailedCandidateCleanupInfo>, DataLayerError> {
+    let row = sqlx::query(
+        r#"
+SELECT status_code, error_message
+FROM request_candidates
+WHERE request_id = ?
+  AND status IN ('failed', 'cancelled')
+ORDER BY
+  COALESCE(finished_at, started_at, created_at) DESC,
+  retry_index DESC,
+  candidate_index DESC
+LIMIT 1
+"#,
+    )
+    .bind(request_id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_sql_err()?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let status_code = row
+        .try_get::<Option<i64>, _>("status_code")
+        .map_sql_err()?
+        .and_then(|value| u16::try_from(value).ok());
+    let error_message = row
+        .try_get::<Option<String>, _>("error_message")
+        .map_sql_err()?
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    Ok(Some(FailedCandidateCleanupInfo {
+        status_code,
+        error_message,
+    }))
 }
 
 fn bind_upsert<'q>(

--- a/crates/aether-data/src/repository/usage/postgres/mod.rs
+++ b/crates/aether-data/src/repository/usage/postgres/mod.rs
@@ -1690,10 +1690,25 @@ SET status = 'completed',
 WHERE request_id = $1
 "#;
 
+const SELECT_LATEST_FAILED_CANDIDATE_FOR_STALE_REQUESTS_SQL: &str = r#"
+SELECT DISTINCT ON (request_id)
+  request_id,
+  status_code,
+  error_message
+FROM request_candidates
+WHERE request_id = ANY($1)
+  AND status IN ('failed', 'cancelled')
+ORDER BY request_id,
+         COALESCE(finished_at, started_at, created_at) DESC,
+         retry_index DESC,
+         candidate_index DESC,
+         created_at DESC
+"#;
+
 const UPDATE_FAILED_STALE_USAGE_SQL: &str = r#"
 UPDATE usage
 SET status = 'failed',
-    status_code = 504,
+    status_code = $3,
     error_message = $2
 WHERE request_id = $1
 "#;
@@ -1702,7 +1717,7 @@ const UPDATE_FAILED_VOID_STALE_USAGE_SQL: &str = r#"
 WITH updated_usage AS (
     UPDATE usage
     SET status = 'failed',
-        status_code = 504,
+        status_code = $4,
         error_message = $2,
         billing_status = 'void',
         finalized_at = $3,
@@ -8292,17 +8307,44 @@ ORDER BY "usage".user_id ASC
                 .iter()
                 .map(|row| row.request_id.clone())
                 .collect::<Vec<_>>();
-            let completed_request_ids = if request_ids.is_empty() {
-                Vec::new()
+            let (completed_request_ids, failed_candidate_info) = if request_ids.is_empty() {
+                (Vec::new(), std::collections::HashMap::new())
             } else {
-                sqlx::query(SELECT_COMPLETED_PENDING_REQUEST_IDS_SQL)
-                    .bind(request_ids)
+                let completed = sqlx::query(SELECT_COMPLETED_PENDING_REQUEST_IDS_SQL)
+                    .bind(&request_ids)
                     .fetch_all(&mut *tx)
                     .await
                     .map_postgres_err()?
                     .iter()
                     .map(|row| row.try_get("request_id").map_postgres_err())
-                    .collect::<Result<Vec<String>, DataLayerError>>()?
+                    .collect::<Result<Vec<String>, DataLayerError>>()?;
+                let failed_rows =
+                    sqlx::query(SELECT_LATEST_FAILED_CANDIDATE_FOR_STALE_REQUESTS_SQL)
+                        .bind(&request_ids)
+                        .fetch_all(&mut *tx)
+                        .await
+                        .map_postgres_err()?;
+                let mut failed_map = std::collections::HashMap::new();
+                for row in failed_rows {
+                    let request_id: String = row.try_get("request_id").map_postgres_err()?;
+                    let status_code = row
+                        .try_get::<Option<i32>, _>("status_code")
+                        .map_postgres_err()?
+                        .and_then(|value| u16::try_from(value).ok());
+                    let error_message = row
+                        .try_get::<Option<String>, _>("error_message")
+                        .map_postgres_err()?
+                        .map(|value| value.trim().to_string())
+                        .filter(|value| !value.is_empty());
+                    failed_map.insert(
+                        request_id,
+                        FailedCandidateCleanupInfo {
+                            status_code,
+                            error_message,
+                        },
+                    );
+                }
+                (completed, failed_map)
             };
 
             for row in stale_rows {
@@ -8322,12 +8364,16 @@ ORDER BY "usage".user_id ASC
                     continue;
                 }
 
-                let error_message = stale_pending_error_message(&row.status, timeout_minutes);
+                let candidate_info = failed_candidate_info.get(&row.request_id);
+                let (status_code, error_message) =
+                    resolve_stale_pending_failure(candidate_info, &row.status, timeout_minutes);
+                let status_code_i32 = i32::from(status_code);
                 if row.billing_status == "pending" {
                     sqlx::query(UPDATE_FAILED_VOID_STALE_USAGE_SQL)
                         .bind(&row.request_id)
                         .bind(&error_message)
                         .bind(now)
+                        .bind(status_code_i32)
                         .execute(&mut *tx)
                         .await
                         .map_postgres_err()?;
@@ -8335,6 +8381,7 @@ ORDER BY "usage".user_id ASC
                     sqlx::query(UPDATE_FAILED_STALE_USAGE_SQL)
                         .bind(&row.request_id)
                         .bind(&error_message)
+                        .bind(status_code_i32)
                         .execute(&mut *tx)
                         .await
                         .map_postgres_err()?;
@@ -8785,8 +8832,29 @@ struct StalePendingUsageRow {
     billing_status: String,
 }
 
+struct FailedCandidateCleanupInfo {
+    status_code: Option<u16>,
+    error_message: Option<String>,
+}
+
 fn stale_pending_error_message(status: &str, timeout_minutes: u64) -> String {
     format!("请求超时: 状态 '{status}' 超过 {timeout_minutes} 分钟未完成")
+}
+
+fn resolve_stale_pending_failure(
+    candidate: Option<&FailedCandidateCleanupInfo>,
+    status: &str,
+    timeout_minutes: u64,
+) -> (u16, String) {
+    match candidate {
+        Some(info) => (
+            info.status_code.unwrap_or(502),
+            info.error_message
+                .clone()
+                .unwrap_or_else(|| stale_pending_error_message(status, timeout_minutes)),
+        ),
+        None => (504, stale_pending_error_message(status, timeout_minutes)),
+    }
 }
 
 async fn find_usage_by_request_id_in_tx(

--- a/crates/aether-data/src/repository/usage/postgres/tests.rs
+++ b/crates/aether-data/src/repository/usage/postgres/tests.rs
@@ -826,6 +826,14 @@ fn usage_sql_clears_stale_failure_fields_for_non_failed_status_updates() {
 }
 
 #[test]
+fn stale_cleanup_failed_candidate_sql_orders_by_effective_timestamp() {
+    let sql = super::SELECT_LATEST_FAILED_CANDIDATE_FOR_STALE_REQUESTS_SQL;
+    assert!(sql.contains("COALESCE(finished_at, started_at, created_at) DESC"));
+    assert!(!sql.contains("finished_at DESC NULLS LAST"));
+    assert!(!sql.contains("started_at DESC NULLS LAST"));
+}
+
+#[test]
 fn usage_sql_does_not_allow_streaming_to_regress_back_to_pending() {
     assert!(super::UPSERT_SQL.contains(
             "WHEN \"usage\".status = 'streaming' AND EXCLUDED.status = 'pending' THEN \"usage\".status_code"

--- a/crates/aether-data/src/repository/usage/sqlite.rs
+++ b/crates/aether-data/src/repository/usage/sqlite.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 use std::io::Read;
 
+use aether_ai_formats::UPSTREAM_IS_STREAM_KEY;
 use aether_data_contracts::repository::usage::{parse_usage_body_ref, UsageBodyField};
 use async_trait::async_trait;
 use flate2::read::GzDecoder;
@@ -3874,7 +3875,7 @@ fn usage_upstream_is_stream(usage: &UpsertUsageRecord) -> bool {
         .request_metadata
         .as_ref()
         .and_then(serde_json::Value::as_object)
-        .and_then(|metadata| metadata.get("upstream_is_stream"))
+        .and_then(|metadata| metadata.get(UPSTREAM_IS_STREAM_KEY))
         .and_then(serde_json::Value::as_bool)
         .unwrap_or_else(|| usage.is_stream.unwrap_or(false))
 }
@@ -3888,7 +3889,7 @@ fn merge_usage_stream_metadata(metadata: &mut Option<serde_json::Value>, upstrea
         return;
     };
     object
-        .entry("upstream_is_stream")
+        .entry(UPSTREAM_IS_STREAM_KEY)
         .or_insert(serde_json::Value::Bool(upstream));
 }
 

--- a/crates/aether-data/src/repository/usage/sqlite.rs
+++ b/crates/aether-data/src/repository/usage/sqlite.rs
@@ -3525,13 +3525,20 @@ WHERE request_id = ?
                     continue;
                 }
 
-                let error_message = stale_pending_error_message(&row.status, timeout_minutes);
+                let candidate_info =
+                    latest_failed_candidate_sqlite(&mut tx, &row.request_id).await?;
+                let (status_code, error_message) = resolve_stale_pending_failure(
+                    candidate_info.as_ref(),
+                    &row.status,
+                    timeout_minutes,
+                );
+                let status_code_i64 = i64::from(status_code);
                 if row.billing_status == "pending" {
                     sqlx::query(
                         r#"
 UPDATE "usage"
 SET status = 'failed',
-    status_code = 504,
+    status_code = ?,
     error_message = ?,
     billing_status = 'void',
     finalized_at = ?,
@@ -3540,6 +3547,7 @@ SET status = 'failed',
 WHERE request_id = ?
 "#,
                     )
+                    .bind(status_code_i64)
                     .bind(&error_message)
                     .bind(to_i64(now_unix_secs, "usage finalized_at")?)
                     .bind(&row.request_id)
@@ -3557,11 +3565,12 @@ WHERE request_id = ?
                         r#"
 UPDATE "usage"
 SET status = 'failed',
-    status_code = 504,
+    status_code = ?,
     error_message = ?
 WHERE request_id = ?
 "#,
                     )
+                    .bind(status_code_i64)
                     .bind(&error_message)
                     .bind(&row.request_id)
                     .execute(&mut *tx)
@@ -3682,6 +3691,67 @@ DO UPDATE SET
 
 fn stale_pending_error_message(status: &str, timeout_minutes: u64) -> String {
     format!("请求超时: 状态 '{status}' 超过 {timeout_minutes} 分钟未完成")
+}
+
+struct FailedCandidateCleanupInfo {
+    status_code: Option<u16>,
+    error_message: Option<String>,
+}
+
+fn resolve_stale_pending_failure(
+    candidate: Option<&FailedCandidateCleanupInfo>,
+    status: &str,
+    timeout_minutes: u64,
+) -> (u16, String) {
+    match candidate {
+        Some(info) => (
+            info.status_code.unwrap_or(502),
+            info.error_message
+                .clone()
+                .unwrap_or_else(|| stale_pending_error_message(status, timeout_minutes)),
+        ),
+        None => (504, stale_pending_error_message(status, timeout_minutes)),
+    }
+}
+
+async fn latest_failed_candidate_sqlite(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    request_id: &str,
+) -> Result<Option<FailedCandidateCleanupInfo>, DataLayerError> {
+    let row = sqlx::query(
+        r#"
+SELECT status_code, error_message
+FROM request_candidates
+WHERE request_id = ?
+  AND status IN ('failed', 'cancelled')
+ORDER BY
+  COALESCE(finished_at, started_at, created_at) DESC,
+  retry_index DESC,
+  candidate_index DESC
+LIMIT 1
+"#,
+    )
+    .bind(request_id)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_sql_err()?;
+
+    let Some(row) = row else {
+        return Ok(None);
+    };
+    let status_code = row
+        .try_get::<Option<i64>, _>("status_code")
+        .map_sql_err()?
+        .and_then(|value| u16::try_from(value).ok());
+    let error_message = row
+        .try_get::<Option<String>, _>("error_message")
+        .map_sql_err()?
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    Ok(Some(FailedCandidateCleanupInfo {
+        status_code,
+        error_message,
+    }))
 }
 
 fn bind_upsert<'q>(
@@ -4114,6 +4184,91 @@ ORDER BY request_id
         .await
         .expect("void settlement snapshot should load");
         assert_eq!(snapshot, ("void".to_string(), Some(10)));
+    }
+
+    #[tokio::test]
+    async fn sqlite_usage_write_repository_cleanup_uses_failed_candidate_status_when_present() {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("sqlite pool should connect");
+        run_sqlite_migrations(&pool)
+            .await
+            .expect("sqlite migrations should run");
+        seed_stats_targets(&pool).await;
+
+        let repository = SqliteUsageWriteRepository::new(pool.clone());
+        repository
+            .upsert(sample_usage(
+                "request-upstream-reset",
+                "pending",
+                "pending",
+                1,
+            ))
+            .await
+            .expect("pending usage should upsert");
+        repository
+            .upsert(sample_usage("request-stuck", "pending", "pending", 1))
+            .await
+            .expect("pending usage should upsert");
+
+        // request-upstream-reset has a failed candidate carrying a concrete 502 status
+        // and a connection-reset message — cleanup should use them instead of 504.
+        // request-stuck has only a still-pending candidate, so cleanup should fall back to 504.
+        sqlx::query(
+            r#"
+INSERT INTO request_candidates (
+  id,
+  request_id,
+  candidate_index,
+  retry_index,
+  status,
+  status_code,
+  error_message,
+  is_cached,
+  created_at,
+  started_at,
+  finished_at
+) VALUES
+  ('candidate-reset', 'request-upstream-reset', 0, 0, 'failed', 502, 'upstream connection reset by peer', 0, 1, 2, 3),
+  ('candidate-stuck', 'request-stuck', 0, 0, 'pending', NULL, NULL, 0, 1, NULL, NULL)
+"#,
+        )
+        .execute(&pool)
+        .await
+        .expect("request candidates should seed");
+
+        let summary = repository
+            .cleanup_stale_pending_requests(2, 10, 5, 5)
+            .await
+            .expect("cleanup should run");
+        assert_eq!(summary.recovered, 0);
+        assert_eq!(summary.failed, 2);
+
+        let reset = repository
+            .find_by_request_id("request-upstream-reset")
+            .await
+            .expect("upstream-reset usage should load")
+            .expect("upstream-reset usage should exist");
+        assert_eq!(reset.status, "failed");
+        assert_eq!(reset.status_code, Some(502));
+        assert_eq!(
+            reset.error_message.as_deref(),
+            Some("upstream connection reset by peer")
+        );
+
+        let stuck = repository
+            .find_by_request_id("request-stuck")
+            .await
+            .expect("stuck usage should load")
+            .expect("stuck usage should exist");
+        assert_eq!(stuck.status, "failed");
+        assert_eq!(stuck.status_code, Some(504));
+        assert!(stuck
+            .error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("超过 5 分钟未完成")));
     }
 
     #[tokio::test]

--- a/crates/aether-usage-runtime/src/request_metadata.rs
+++ b/crates/aether-usage-runtime/src/request_metadata.rs
@@ -1,6 +1,7 @@
 use aether_ai_formats::api::{
     sanitize_request_path, sanitize_request_path_and_query, sanitize_request_query_string,
 };
+use aether_ai_formats::UPSTREAM_IS_STREAM_KEY;
 use aether_contracts::ExecutionPlan;
 use serde_json::{json, Map, Value};
 
@@ -74,7 +75,7 @@ fn copy_allowed_metadata_fields(source: &Map<String, Value>, target: &mut Map<St
     copy_non_empty_string(source, target, "user_agent");
     copy_non_empty_string(source, target, "client_family");
     copy_bool(source, target, "client_requested_stream");
-    copy_bool(source, target, "upstream_is_stream");
+    copy_bool(source, target, UPSTREAM_IS_STREAM_KEY);
     copy_non_null_value(source, target, "client_session_affinity");
     copy_bool(source, target, "api_key_is_standalone");
     copy_non_empty_string(source, target, "request_path");
@@ -114,7 +115,7 @@ fn move_allowed_metadata_fields(mut source: Map<String, Value>, target: &mut Map
     remove_non_empty_string(&mut source, target, "user_agent");
     remove_non_empty_string(&mut source, target, "client_family");
     remove_bool(&mut source, target, "client_requested_stream");
-    remove_bool(&mut source, target, "upstream_is_stream");
+    remove_bool(&mut source, target, UPSTREAM_IS_STREAM_KEY);
     remove_non_null_value(&mut source, target, "client_session_affinity");
     remove_bool(&mut source, target, "api_key_is_standalone");
     remove_non_empty_string(&mut source, target, "request_path");

--- a/crates/aether-usage-runtime/src/write.rs
+++ b/crates/aether-usage-runtime/src/write.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use aether_ai_formats::UPSTREAM_IS_STREAM_KEY;
 use aether_contracts::{ExecutionPlan, ExecutionTelemetry};
 use aether_data_contracts::repository::usage::{UpsertUsageRecord, UsageBodyCaptureState};
 use aether_data_contracts::DataLayerError;
@@ -718,7 +719,7 @@ pub fn build_sync_terminal_usage_payload_seed(
         .report_context
         .as_ref()
         .and_then(Value::as_object)
-        .and_then(|context| context.get("upstream_is_stream"))
+        .and_then(|context| context.get(UPSTREAM_IS_STREAM_KEY))
         .and_then(Value::as_bool)
         .unwrap_or(false);
     let provider_response_full = if upstream_is_stream && payload.body_base64.is_some() {
@@ -1592,9 +1593,9 @@ fn build_runtime_request_metadata_seed_from_parts(
             Value::Bool(client_requested_stream),
         );
     }
-    if let Some(upstream_is_stream) = context_bool(context, "upstream_is_stream") {
+    if let Some(upstream_is_stream) = context_bool(context, UPSTREAM_IS_STREAM_KEY) {
         metadata.insert(
-            "upstream_is_stream".to_string(),
+            UPSTREAM_IS_STREAM_KEY.to_string(),
             Value::Bool(upstream_is_stream),
         );
     }


### PR DESCRIPTION
## 概要

本 PR 修复两个在真实流量中观察到的生产问题,并附一个为其中第一个修复铺路的小型重构。

- **A 块 — Gateway 看门狗**:stream candidate watchdog 在 endpoint 强制非流式上游时仍按 `timeouts.first_byte_ms` 计时,导致健康的请求在 ~300s 被提前 abort。
- **B 块 — stale-pending 清理**:清理任务用 `status_code=504` 和通用超时文案覆盖了每一条过期请求,把真实的上游失败上下文从仪表盘和客户视图里抹掉了。
- **前置重构**:看门狗需要从 JSON report context 读 `upstream_is_stream`。与其再添一个裸字面量 key 让生产者/消费者跨 crate 静默耦合,不如把它提到 `aether-ai-formats` 的 `pub const UPSTREAM_IS_STREAM_KEY`,通过 `aether-ai-serving`(既有的 gateway 接缝)再导出,并把 `aether-ai-serving`、`aether-usage-runtime`、`aether-admin`、`aether-data`、`aether-gateway` 里的所有字面量站点都迁移过去。行为完全不变。

## 提交清单

1. `refactor(report-context): extract UPSTREAM_IS_STREAM_KEY constant`
   - 改动 12 个文件,无语义变更。
   - 常量定义在 `aether-ai-formats`(所有消费者都已经依赖的最底层 crate),并从 `aether-ai-serving` 再导出,以便 gateway 代码继续走 root-seam 架构(由 `tests::architecture::ai_serving::ai_serving_crate_api_is_confined_to_root_seams` 测试守住)。
   - 故意保留字面量的几处:`json!({"upstream_is_stream": ...})` 宏内的 key(宏语法限制 + 这些是对外 API 响应字段名,不应与内部 key 静默耦合)、SQL 列访问器 `try_get::<...>("upstream_is_stream")`(标识的是数据库 schema 列,不是 JSON key)、测试 fixture / 断言(它们就是要验证 on-wire 契约本身)。

2. `fix(gateway): use total_ms for non-stream upstream watchdog`
   - **现象**:endpoint 配置了 `upstream_stream_policy=force_non_stream` 但客户端仍 stream 时,看门狗按 `first_byte_ms` 计时;非流式上游没有早期首字节,所以健康但耗时长于 `first_byte_ms` 的请求(典型如 image / embedding)在 ~300s 就被打成 504。
   - **修复**:从 `report_context` 读 `upstream_is_stream`。非流式上游优先 `total_ms` → `first_byte_ms` → 默认值;流式上游保持原有优先级。读不到这个 flag 时默认按 stream 处理,兼容历史行为。
   - 测试:4 个新增单元测试,覆盖 `(stream?, total_ms?, first_byte_ms?)` 的全部 4 种组合。

3. `fix(data): cleanup uses failed candidate status instead of 504`
   - **现象**:stale-pending 清理把 `status_code` 硬编码成 504、错误消息硬编码成中文"服务器超时"。已经被观测到失败的请求(上游 connection reset、4xx 认证错误、看门狗 504 等)在清理时被覆盖成误导性的 504/超时,真实原因从仪表盘和客户响应里都看不到了。
   - **修复**:finalize stale usage 行时,先按 `request_id` 取最近一条 `failed`/`cancelled` 候选,复用它的 `status_code`(缺省回落 502)和 `error_message`。若没有任何终态候选(真的卡死在 pending/streaming 的请求),保留原本的 504 + 超时文案 — 那些从清理视角看确实就是超时。
   - 在 MySQL、PostgreSQL、SQLite 上同步实现。三方言都按 `COALESCE(finished_at, started_at, created_at) DESC` 取最新候选,确保在 timing 列存在 NULL 组合时三种 backend 选到的是同一行。Postgres 用 `ANY($1)` 做批量查询;MySQL/SQLite 走逐行查询(stale 批量本身不大,可接受)。
   - 测试:SQLite 集成测试覆盖"有候选→使用候选 status"和"无候选→回落 504"两条分支;Postgres 加 SQL 字符串断言,守住 `ORDER BY` 不被误改。

## 测试

- [x] `cargo check --workspace`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p aether-gateway --lib executor::candidate_loop` — 7/7 通过(4 个新看门狗测试 + 3 个原有测试)
- [x] `cargo test -p aether-gateway --lib tests::architecture::ai_serving::ai_serving_crate_api_is_confined_to_root_seams` — 通过(验证重构后 root-seam 约束仍然成立)
- [x] `cargo test -p aether-data --lib stale_pending` — 4/4 通过
- [x] `cargo test -p aether-data --lib failed_candidate` — 2/2 通过
- [x] Fork 侧 rust-ci:<https://github.com/stabey/Aether-upstream-fork/actions/runs/26216108716> ✅ Format / Clippy / Test / Data DB Smoke (SQLite/MySQL/Postgres) 全绿

## 给 reviewer 的提示

- 重构提交故意排在最前,这样行为变更的两次 fix 在 diff 里就不会和大量机械替换混在一起。
- 三套 SQL repository 是平行实现,建议交叉对照看一遍它们的语义是否一致(SQLite 那份最容易读;MySQL 是镜像;Postgres 在此之上多了批量查询优化)。
- 无需 DB migration,清理逻辑只读写既有列。

---
🤖 由 [Claude Code](https://claude.com/claude-code) 协助生成