### PR TITLE
修复 ChatGPT Web 生图额度扣减与 usage 估算

### DIFF
--- a/apps/aether-gateway/src/ai_serving/planner/standard/openai/responses/decision/request.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/openai/responses/decision/request.rs
@@ -1073,22 +1073,42 @@ fn build_chatgpt_web_image_provider_body_from_openai_responses_body(
         .unwrap_or("gpt-5-5-thinking");
     let image_urls = openai_image_inputs_as_urls(&images);
 
-    let body = json!({
+    let mut body = json!({
         "operation": operation,
         "model": if model.is_empty() { "gpt-image-2" } else { model },
         "web_model": web_model,
         "prompt": prompt,
         "size": size,
         "ratio": chatgpt_web_ratio_for_size(size),
+        "quality": quality,
         "output_format": output_format,
         "images": image_urls,
     });
-    let summary = json!({
+    if let Some(partial_images) = tool
+        .as_ref()
+        .and_then(|tool| tool.get("partial_images"))
+        .or_else(|| object.get("partial_images"))
+        .cloned()
+    {
+        body.as_object_mut()?
+            .insert("partial_images".to_string(), partial_images);
+    }
+    let mut summary = json!({
         "operation": operation,
         "output_format": output_format,
         "size": size,
         "quality": quality,
     });
+    if let Some(partial_images) = tool
+        .as_ref()
+        .and_then(|tool| tool.get("partial_images"))
+        .or_else(|| object.get("partial_images"))
+        .cloned()
+    {
+        summary
+            .as_object_mut()?
+            .insert("partial_images".to_string(), partial_images);
+    }
     Some((body, summary))
 }
 
@@ -1425,5 +1445,37 @@ mod tests {
         assert_eq!(provider_body["stream"], true);
         assert_eq!(summary["operation"], "generate");
         assert_eq!(summary["output_format"], "png");
+    }
+
+    #[test]
+    fn chatgpt_web_responses_image_body_preserves_usage_options() {
+        let body_json = json!({
+            "model": "gpt-image-2",
+            "input": "Draw a glass city",
+            "tools": [
+                {
+                    "type": "image_generation",
+                    "size": "1024x1024",
+                    "quality": "high",
+                    "output_format": "png",
+                    "partial_images": 2
+                }
+            ],
+            "tool_choice": {
+                "type": "image_generation"
+            }
+        });
+
+        let (provider_body, summary) =
+            build_chatgpt_web_image_provider_body_from_openai_responses_body(
+                &body_json,
+                "gpt-image-2",
+            )
+            .expect("responses image body should convert");
+
+        assert_eq!(provider_body["quality"], "high");
+        assert_eq!(provider_body["partial_images"], 2);
+        assert_eq!(summary["quality"], "high");
+        assert_eq!(summary["partial_images"], 2);
     }
 }

--- a/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
+++ b/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
@@ -130,6 +130,17 @@ pub(crate) async fn maybe_execute_chatgpt_web_image_stream(
     }))
 }
 
+pub(crate) async fn maybe_apply_chatgpt_web_image_quota_request_delta_at_candidate_start(
+    state: &AppState,
+    plan: &ExecutionPlan,
+    report_context: Option<&Value>,
+) {
+    if !is_chatgpt_web_image_plan(plan, report_context) {
+        return;
+    }
+    apply_chatgpt_web_image_quota_request_delta_at_start(state, plan).await;
+}
+
 fn is_chatgpt_web_image_plan(plan: &ExecutionPlan, report_context: Option<&Value>) -> bool {
     if !plan
         .provider_api_format
@@ -1062,10 +1073,12 @@ async fn apply_chatgpt_web_image_quota_request_delta(
         .unwrap_or_default();
 
     let now_unix_secs = current_unix_secs();
+    let request_dedup_key = chatgpt_web_image_quota_request_delta_dedup_key(plan);
     if !apply_chatgpt_web_image_quota_request_delta_to_metadata(
         &mut metadata,
         latest_key.status_snapshot.as_ref(),
         now_unix_secs,
+        request_dedup_key.as_deref(),
     ) {
         return Ok(false);
     }
@@ -1097,7 +1110,21 @@ fn apply_chatgpt_web_image_quota_request_delta_to_metadata(
     metadata: &mut Map<String, Value>,
     status_snapshot: Option<&Value>,
     now_unix_secs: u64,
+    request_dedup_key: Option<&str>,
 ) -> bool {
+    let request_dedup_key = request_dedup_key
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if let Some(request_dedup_key) = request_dedup_key {
+        if metadata
+            .get("image_quota_last_local_request_key")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value == request_dedup_key)
+        {
+            return false;
+        }
+    }
+
     let snapshot_window = chatgpt_web_image_quota_snapshot_window(status_snapshot);
     let metadata_limit =
         chatgpt_web_image_quota_f64(metadata.get("image_quota_total")).filter(|value| *value > 0.0);
@@ -1163,6 +1190,12 @@ fn apply_chatgpt_web_image_quota_request_delta_to_metadata(
         "image_quota_last_local_request_at".to_string(),
         json!(now_unix_secs),
     );
+    if let Some(request_dedup_key) = request_dedup_key {
+        metadata.insert(
+            "image_quota_last_local_request_key".to_string(),
+            json!(request_dedup_key),
+        );
+    }
     let local_request_count =
         chatgpt_web_image_quota_u64(metadata.get("image_quota_local_request_count")).unwrap_or(0);
     metadata.insert(
@@ -1170,6 +1203,22 @@ fn apply_chatgpt_web_image_quota_request_delta_to_metadata(
         json!(local_request_count.saturating_add(1)),
     );
     true
+}
+
+fn chatgpt_web_image_quota_request_delta_dedup_key(plan: &ExecutionPlan) -> Option<String> {
+    let request_id = plan.request_id.trim();
+    if request_id.is_empty() {
+        return None;
+    }
+    let candidate_id = plan
+        .candidate_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    Some(match candidate_id {
+        Some(candidate_id) => format!("{request_id}:{candidate_id}"),
+        None => request_id.to_string(),
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -2754,6 +2803,7 @@ mod tests {
             &mut metadata,
             None,
             1_000,
+            None,
         ));
 
         assert_eq!(metadata["image_quota_remaining"], json!(24.0));
@@ -2783,6 +2833,7 @@ mod tests {
             &mut metadata,
             Some(&status_snapshot),
             1_000,
+            None,
         ));
 
         assert_eq!(metadata["image_quota_remaining"], json!(18.0));
@@ -2804,6 +2855,7 @@ mod tests {
             &mut metadata,
             None,
             1_000,
+            None,
         ));
 
         assert_eq!(metadata["image_quota_remaining"], json!(18.0));
@@ -2812,6 +2864,44 @@ mod tests {
         assert_eq!(
             metadata["image_quota_limit_source"],
             json!("first_remaining")
+        );
+    }
+
+    #[test]
+    fn chatgpt_web_image_quota_request_delta_dedupes_same_candidate_start() {
+        let mut metadata = Map::from_iter([
+            ("plan_type".to_string(), json!("free")),
+            ("image_quota_remaining".to_string(), json!(25.0)),
+            ("image_quota_total".to_string(), json!(25.0)),
+            ("image_quota_used".to_string(), json!(0.0)),
+        ]);
+
+        assert!(apply_chatgpt_web_image_quota_request_delta_to_metadata(
+            &mut metadata,
+            None,
+            1_000,
+            Some("request-1:candidate-1"),
+        ));
+        assert!(!apply_chatgpt_web_image_quota_request_delta_to_metadata(
+            &mut metadata,
+            None,
+            1_001,
+            Some("request-1:candidate-1"),
+        ));
+        assert!(apply_chatgpt_web_image_quota_request_delta_to_metadata(
+            &mut metadata,
+            None,
+            1_002,
+            Some("request-1:candidate-2"),
+        ));
+
+        assert_eq!(metadata["image_quota_remaining"], json!(23.0));
+        assert_eq!(metadata["image_quota_total"], json!(25.0));
+        assert_eq!(metadata["image_quota_used"], json!(2.0));
+        assert_eq!(metadata["image_quota_local_request_count"], json!(2u64));
+        assert_eq!(
+            metadata["image_quota_last_local_request_key"],
+            json!("request-1:candidate-2")
         );
     }
 

--- a/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
+++ b/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
@@ -2,12 +2,19 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::io::Error as IoError;
 use std::time::Instant;
 
+use aether_admin::provider::quota::{
+    parse_chatgpt_web_conversation_init_response, quota_refresh_success_invalid_state,
+};
 use aether_contracts::{
     ExecutionPlan, ExecutionResult, ExecutionStreamTerminalSummary, ExecutionTelemetry,
-    RequestBody, ResolvedTransportProfile, ResponseBody, StreamFrame, StreamFramePayload,
-    StreamFrameType, EXECUTION_REQUEST_ACCEPT_INVALID_CERTS_HEADER,
-    EXECUTION_REQUEST_FOLLOW_REDIRECTS_HEADER, TRANSPORT_BACKEND_BROWSER_WREQ,
-    TRANSPORT_HTTP_MODE_AUTO, TRANSPORT_POOL_SCOPE_KEY,
+    ExecutionTimeouts, ProxySnapshot, RequestBody, ResolvedTransportProfile, ResponseBody,
+    StreamFrame, StreamFramePayload, StreamFrameType,
+    EXECUTION_REQUEST_ACCEPT_INVALID_CERTS_HEADER, EXECUTION_REQUEST_FOLLOW_REDIRECTS_HEADER,
+    TRANSPORT_BACKEND_BROWSER_WREQ, TRANSPORT_HTTP_MODE_AUTO, TRANSPORT_POOL_SCOPE_KEY,
+};
+use aether_provider_pool::{
+    build_chatgpt_web_pool_quota_request, normalize_chatgpt_web_image_quota_limit,
+    ProviderPoolQuotaRequestSpec,
 };
 use axum::body::Bytes;
 use base64::Engine as _;
@@ -15,7 +22,7 @@ use chrono::{FixedOffset, Utc};
 use futures_util::stream::{self, BoxStream};
 use futures_util::StreamExt;
 use serde_json::{json, Map, Value};
-use tracing::debug;
+use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::ai_serving::api::StreamingStandardTerminalObserver;
@@ -23,6 +30,9 @@ use crate::clock::current_unix_secs;
 use crate::execution_runtime::ndjson::encode_stream_frame_ndjson;
 use crate::execution_runtime::transport::{
     DirectSyncExecutionRuntime, ExecutionRuntimeTransportError,
+};
+use crate::handlers::shared::{
+    sync_provider_key_oauth_status_snapshot, sync_provider_key_quota_status_snapshot,
 };
 use crate::AppState;
 
@@ -34,6 +44,8 @@ const CHATGPT_WEB_BUILD_NUMBER: &str = "5955942";
 const CHATGPT_WEB_SEC_CH_UA: &str =
     r#""Microsoft Edge";v="143", "Chromium";v="143", "Not A(Brand";v="24""#;
 const CHATGPT_WEB_BROWSER_PROFILE: &str = "chrome143";
+const CHATGPT_WEB_QUOTA_REFRESH_TIMEOUT_MS: u64 = 30_000;
+const CHATGPT_WEB_QUOTA_REFRESH_PROXY_TIMEOUT_MS: u64 = 60_000;
 
 pub(crate) struct ChatGptWebImageStream {
     pub(crate) frame_stream: BoxStream<'static, Result<Bytes, IoError>>,
@@ -257,6 +269,7 @@ async fn execute_chatgpt_web_image(
     let body = if let Some(failure) = summary.failure.as_ref().filter(|_| downloaded.is_empty()) {
         build_failed_sse(&request, failure)
     } else if let Some(image) = downloaded.into_iter().next() {
+        spawn_chatgpt_web_image_quota_refresh_after_success(state, plan, &base_url, token.as_str());
         build_success_sse(&request, &image, report_context)
     } else {
         build_failed_sse(
@@ -930,6 +943,230 @@ async fn execute_subrequest(
     DirectSyncExecutionRuntime::new()
         .execute_sync(&subplan)
         .await
+}
+
+fn spawn_chatgpt_web_image_quota_refresh_after_success(
+    state: &AppState,
+    plan: &ExecutionPlan,
+    base_url: &str,
+    token: &str,
+) {
+    if !state.has_provider_catalog_data_reader() || !state.has_provider_catalog_data_writer() {
+        return;
+    }
+    let token = token.trim();
+    if token.is_empty() || plan.key_id.trim().is_empty() || plan.provider_id.trim().is_empty() {
+        return;
+    }
+
+    let state = state.clone();
+    let plan = plan.clone();
+    let base_url = base_url.to_string();
+    let token = token.to_string();
+    tokio::spawn(async move {
+        if let Err(err) =
+            refresh_chatgpt_web_image_quota_after_success(&state, &plan, &base_url, &token).await
+        {
+            warn!(
+                event_name = "chatgpt_web_image_quota_refresh_after_success_failed",
+                log_type = "ops",
+                request_id = %plan.request_id,
+                candidate_id = ?plan.candidate_id,
+                provider_id = %plan.provider_id,
+                key_id = %plan.key_id,
+                error = %err,
+                "gateway failed to refresh ChatGPT-Web image quota after a successful generation"
+            );
+        }
+    });
+}
+
+async fn refresh_chatgpt_web_image_quota_after_success(
+    state: &AppState,
+    plan: &ExecutionPlan,
+    base_url: &str,
+    token: &str,
+) -> Result<bool, String> {
+    let key_id = plan.key_id.trim();
+    let provider_id = plan.provider_id.trim();
+    let key_ids = [key_id.to_string()];
+    let provider_ids = [provider_id.to_string()];
+    let key_available = state
+        .read_provider_catalog_keys_by_ids(&key_ids)
+        .await
+        .map_err(|err| err.into_message())?
+        .into_iter()
+        .any(|key| key.id == key_id && key.provider_id == provider_id);
+    if !key_available {
+        return Ok(false);
+    }
+    let Some(provider) = state
+        .read_provider_catalog_providers_by_ids(&provider_ids)
+        .await
+        .map_err(|err| err.into_message())?
+        .into_iter()
+        .find(|provider| provider.id == provider_id)
+    else {
+        return Ok(false);
+    };
+    if !provider
+        .provider_type
+        .trim()
+        .eq_ignore_ascii_case("chatgpt_web")
+    {
+        return Ok(false);
+    }
+
+    let authorization = (
+        "authorization".to_string(),
+        format!("Bearer {}", token.trim()),
+    );
+    let spec = build_chatgpt_web_pool_quota_request(key_id, base_url, authorization);
+    let quota_plan = build_chatgpt_web_image_quota_refresh_plan(plan, spec);
+    let result = DirectSyncExecutionRuntime::new()
+        .execute_sync(&quota_plan)
+        .await
+        .map_err(|err| err.to_string())?;
+    if result.status_code != 200 {
+        let body_excerpt = String::from_utf8_lossy(&execution_result_body_bytes_lossy(&result))
+            .chars()
+            .take(320)
+            .collect::<String>();
+        return Err(format!(
+            "conversation/init returned {}: {}",
+            result.status_code, body_excerpt
+        ));
+    }
+
+    let body_json = execution_result_json(&result).map_err(|err| err.to_string())?;
+    let Some(mut metadata) =
+        parse_chatgpt_web_conversation_init_response(&body_json, current_unix_secs())
+    else {
+        return Ok(false);
+    };
+
+    let Some(latest_key) = state
+        .read_provider_catalog_keys_by_ids(&key_ids)
+        .await
+        .map_err(|err| err.into_message())?
+        .into_iter()
+        .find(|key| key.id == key_id && key.provider_id == provider_id)
+    else {
+        return Ok(false);
+    };
+    normalize_chatgpt_web_image_quota_limit(&mut metadata, latest_key.upstream_metadata.as_ref());
+
+    let mut updated_key = latest_key;
+    let updated_upstream_metadata = merge_provider_metadata_object(
+        updated_key.upstream_metadata.as_ref(),
+        "chatgpt_web",
+        metadata,
+    );
+    updated_key.upstream_metadata = updated_upstream_metadata;
+    let (oauth_invalid_at_unix_secs, oauth_invalid_reason) =
+        quota_refresh_success_invalid_state(&updated_key);
+    updated_key.oauth_invalid_at_unix_secs = oauth_invalid_at_unix_secs;
+    updated_key.oauth_invalid_reason = oauth_invalid_reason;
+    updated_key.status_snapshot = sync_provider_key_quota_status_snapshot(
+        updated_key.status_snapshot.as_ref(),
+        "chatgpt_web",
+        updated_key.upstream_metadata.as_ref(),
+        "image_success",
+    );
+    updated_key.status_snapshot =
+        sync_provider_key_oauth_status_snapshot(updated_key.status_snapshot.as_ref(), &updated_key);
+    updated_key.updated_at_unix_secs = Some(current_unix_secs());
+
+    Ok(state
+        .update_provider_catalog_key_runtime_state(&updated_key)
+        .await
+        .map_err(|err| err.into_message())?
+        .is_some())
+}
+
+fn build_chatgpt_web_image_quota_refresh_plan(
+    plan: &ExecutionPlan,
+    spec: ProviderPoolQuotaRequestSpec,
+) -> ExecutionPlan {
+    let ProviderPoolQuotaRequestSpec {
+        request_id,
+        provider_name,
+        quota_kind: _,
+        method,
+        url,
+        mut headers,
+        content_type,
+        json_body,
+        client_api_format,
+        provider_api_format,
+        model_name,
+        accept_invalid_certs,
+    } = spec;
+    if accept_invalid_certs {
+        headers.insert(
+            EXECUTION_REQUEST_ACCEPT_INVALID_CERTS_HEADER.to_string(),
+            "true".to_string(),
+        );
+    }
+    let body = json_body
+        .map(RequestBody::from_json)
+        .unwrap_or(RequestBody {
+            json_body: None,
+            body_bytes_b64: None,
+            body_ref: None,
+        });
+    ExecutionPlan {
+        request_id,
+        candidate_id: plan.candidate_id.clone(),
+        provider_name: Some(provider_name),
+        provider_id: plan.provider_id.clone(),
+        endpoint_id: plan.endpoint_id.clone(),
+        key_id: plan.key_id.clone(),
+        method,
+        url,
+        headers,
+        content_type,
+        content_encoding: None,
+        body,
+        stream: false,
+        client_api_format,
+        provider_api_format,
+        model_name,
+        proxy: plan.proxy.clone(),
+        transport_profile: chatgpt_web_image_transport_profile(plan),
+        timeouts: Some(chatgpt_web_image_quota_refresh_timeouts(
+            plan.proxy.as_ref(),
+        )),
+    }
+}
+
+fn chatgpt_web_image_quota_refresh_timeouts(proxy: Option<&ProxySnapshot>) -> ExecutionTimeouts {
+    let timeout_ms = if proxy.is_some() {
+        CHATGPT_WEB_QUOTA_REFRESH_PROXY_TIMEOUT_MS
+    } else {
+        CHATGPT_WEB_QUOTA_REFRESH_TIMEOUT_MS
+    };
+    ExecutionTimeouts {
+        connect_ms: Some(timeout_ms),
+        read_ms: Some(timeout_ms),
+        write_ms: Some(timeout_ms),
+        pool_ms: Some(timeout_ms),
+        total_ms: Some(timeout_ms),
+        ..ExecutionTimeouts::default()
+    }
+}
+
+fn merge_provider_metadata_object(
+    current: Option<&Value>,
+    section_key: &str,
+    section_value: Value,
+) -> Option<Value> {
+    let mut merged = current
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    merged.insert(section_key.to_string(), section_value);
+    Some(Value::Object(merged))
 }
 
 fn chatgpt_web_image_transport_profile(plan: &ExecutionPlan) -> Option<ResolvedTransportProfile> {
@@ -2092,6 +2329,60 @@ mod tests {
                 .and_then(|value| value.get("source"))
                 .and_then(Value::as_str),
             Some("chatgpt_web_image_default")
+        );
+    }
+
+    #[test]
+    fn chatgpt_web_image_quota_refresh_plan_uses_conversation_init() {
+        let plan = sample_plan(
+            CHATGPT_WEB_DEFAULT_BASE_URL,
+            json!({"prompt": "draw a small test image"}),
+            false,
+        );
+        let spec = build_chatgpt_web_pool_quota_request(
+            &plan.key_id,
+            CHATGPT_WEB_DEFAULT_BASE_URL,
+            (
+                "authorization".to_string(),
+                "Bearer test-access-token".to_string(),
+            ),
+        );
+
+        let quota_plan = build_chatgpt_web_image_quota_refresh_plan(&plan, spec);
+
+        assert_eq!(quota_plan.method, "POST");
+        assert_eq!(
+            quota_plan.url,
+            "https://chatgpt.com/backend-api/conversation/init"
+        );
+        assert_eq!(
+            quota_plan.provider_api_format,
+            "chatgpt_web:conversation_init"
+        );
+        assert_eq!(
+            quota_plan.headers.get("authorization").map(String::as_str),
+            Some("Bearer test-access-token")
+        );
+        assert_eq!(
+            quota_plan
+                .headers
+                .get(EXECUTION_REQUEST_ACCEPT_INVALID_CERTS_HEADER)
+                .map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            quota_plan
+                .transport_profile
+                .as_ref()
+                .map(|profile| profile.backend.as_str()),
+            Some(TRANSPORT_BACKEND_BROWSER_WREQ)
+        );
+        assert_eq!(
+            quota_plan
+                .timeouts
+                .as_ref()
+                .and_then(|timeouts| timeouts.total_ms),
+            Some(CHATGPT_WEB_QUOTA_REFRESH_TIMEOUT_MS)
         );
     }
 

--- a/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
+++ b/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
@@ -2053,12 +2053,13 @@ fn add_unique_values(values: &mut Vec<String>, incoming: impl IntoIterator<Item 
 fn build_success_sse(
     request: &ChatGptWebImageRequest,
     image: &DownloadedImage,
-    _report_context: Option<&Value>,
+    report_context: Option<&Value>,
 ) -> String {
     let response_id = format!("resp_{}", Uuid::new_v4().simple());
     let item_id = format!("ig_{}", Uuid::new_v4().simple());
     let created_at = current_unix_secs() as i64;
     let output_format = output_format_from_mime(&image.mime, request.output_format.as_str());
+    let usage = chatgpt_web_image_usage(request, image, report_context);
     let item = json!({
         "id": item_id,
         "type": "image_generation_call",
@@ -2098,14 +2099,120 @@ fn build_success_sse(
                 "height": image.height,
                 "revised_prompt": Value::Null
             }],
-            "usage": Value::Null,
-            "tool_usage": Value::Null
+            "usage": usage.0,
+            "tool_usage": usage.1
         }
     });
     format!(
         "event: response.created\ndata: {}\n\nevent: response.output_item.done\ndata: {}\n\nevent: response.completed\ndata: {}\n\ndata: [DONE]\n\n",
         created, done, completed
     )
+}
+
+fn chatgpt_web_image_usage(
+    request: &ChatGptWebImageRequest,
+    image: &DownloadedImage,
+    report_context: Option<&Value>,
+) -> (Value, Value) {
+    let input_tokens = chatgpt_web_image_input_tokens(request, report_context);
+    let estimated_output_tokens = chatgpt_web_image_output_tokens(image);
+    let usage = json!({
+        "input_tokens": input_tokens,
+        "output_tokens": estimated_output_tokens,
+        "total_tokens": input_tokens.saturating_add(estimated_output_tokens),
+    });
+    let tool_usage = json!({
+        "image_gen": {
+            "input_tokens": input_tokens,
+            "input_tokens_details": {
+                "image_tokens": 0,
+                "text_tokens": input_tokens
+            },
+            "output_tokens": estimated_output_tokens,
+            "output_tokens_details": {
+                "image_tokens": 0,
+                "text_tokens": estimated_output_tokens
+            },
+            "total_tokens": input_tokens.saturating_add(estimated_output_tokens),
+        }
+    });
+    (usage, tool_usage)
+}
+
+fn chatgpt_web_image_input_tokens(
+    request: &ChatGptWebImageRequest,
+    report_context: Option<&Value>,
+) -> u64 {
+    let prompt = chatgpt_web_image_prompt_text(request, report_context);
+    estimate_text_tokens(prompt.as_str())
+}
+
+fn chatgpt_web_image_output_tokens(image: &DownloadedImage) -> u64 {
+    estimate_text_tokens(image.b64_json.as_str())
+}
+
+fn chatgpt_web_report_context_image_request_text(
+    report_context: Option<&Value>,
+    key: &str,
+) -> Option<String> {
+    report_context
+        .and_then(|value| value.get("image_request"))
+        .and_then(|value| value.get(key))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn chatgpt_web_report_context_original_request_text(
+    report_context: Option<&Value>,
+    key: &str,
+) -> Option<String> {
+    let original = report_context?.get("original_request_body")?;
+    value_text(original.get(key)).or_else(|| {
+        chatgpt_web_original_image_tool_value(original, key)
+            .and_then(|value| value_text(Some(value)))
+    })
+}
+
+fn chatgpt_web_original_image_tool_value<'a>(original: &'a Value, key: &str) -> Option<&'a Value> {
+    original
+        .get("tools")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|tool| {
+            tool.get("type")
+                .and_then(Value::as_str)
+                .is_some_and(|value| value.trim().eq_ignore_ascii_case("image_generation"))
+        })
+        .find_map(|tool| tool.get(key))
+}
+
+fn chatgpt_web_image_prompt_text(
+    request: &ChatGptWebImageRequest,
+    report_context: Option<&Value>,
+) -> String {
+    chatgpt_web_report_context_original_request_text(report_context, "prompt")
+        .or_else(|| chatgpt_web_report_context_image_request_text(report_context, "prompt"))
+        .unwrap_or_else(|| request.prompt.clone())
+}
+
+fn value_text(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn estimate_text_tokens(text: &str) -> u64 {
+    let chars = text.chars().count() as u64;
+    if chars == 0 {
+        0
+    } else {
+        chars.div_ceil(4).max(1)
+    }
 }
 
 fn build_failed_sse(request: &ChatGptWebImageRequest, failure: &Value) -> String {
@@ -2317,11 +2424,22 @@ fn chatgpt_web_image_request_context(plan: &ExecutionPlan) -> Option<Value> {
         "operation".to_string(),
         Value::String("generate".to_string()),
     );
-    for key in ["model", "size", "quality", "output_format"] {
+    for key in [
+        "model",
+        "size",
+        "quality",
+        "ratio",
+        "output_format",
+        "partial_images",
+    ] {
         if let Some(value) = body.get(key).and_then(Value::as_str).map(str::trim) {
             if !value.is_empty() {
                 image_request.insert(key.to_string(), Value::String(value.to_string()));
             }
+            continue;
+        }
+        if let Some(value) = body.get(key).and_then(Value::as_u64) {
+            image_request.insert(key.to_string(), Value::Number(value.into()));
         }
     }
     Some(Value::Object(image_request))
@@ -2757,6 +2875,106 @@ mod tests {
             transport_profile: None,
             timeouts: None,
         }
+    }
+
+    fn completed_response_from_sse(sse: &str) -> Value {
+        sse.lines()
+            .find_map(|line| {
+                let payload = line.strip_prefix("data: ")?;
+                let event = serde_json::from_str::<Value>(payload).ok()?;
+                (event.get("type").and_then(Value::as_str) == Some("response.completed"))
+                    .then_some(event)
+            })
+            .and_then(|event| event.get("response").cloned())
+            .expect("completed response should be present")
+    }
+
+    #[test]
+    fn chatgpt_web_success_sse_includes_estimated_image_usage() {
+        let output_text = "aGVsbG8=".repeat(128);
+        let request = ChatGptWebImageRequest {
+            model: "gpt-image-2".to_string(),
+            web_model: "gpt-5-5-thinking".to_string(),
+            prompt: "draw a test image".to_string(),
+            size: "1024x1024".to_string(),
+            ratio: "1:1".to_string(),
+            output_format: "png".to_string(),
+            images: Vec::new(),
+        };
+        let image = DownloadedImage {
+            b64_json: output_text.clone(),
+            mime: "image/png".to_string(),
+            width: Some(1024),
+            height: Some(1024),
+        };
+        let body = build_success_sse(
+            &request,
+            &image,
+            Some(&json!({
+                "image_request": {
+                    "size": "1024x1024",
+                    "quality": "low"
+                }
+            })),
+        );
+        let completed = completed_response_from_sse(body.as_str());
+        let input_tokens = estimate_text_tokens("draw a test image");
+        let output_tokens = estimate_text_tokens(output_text.as_str());
+
+        assert_eq!(completed["usage"]["input_tokens"], json!(input_tokens));
+        assert_eq!(completed["usage"]["output_tokens"], json!(output_tokens));
+        assert_eq!(
+            completed["tool_usage"]["image_gen"]["output_tokens"],
+            json!(output_tokens)
+        );
+        assert_eq!(
+            completed["tool_usage"]["image_gen"]["input_tokens_details"]["text_tokens"],
+            json!(input_tokens)
+        );
+        assert_eq!(
+            completed["tool_usage"]["image_gen"]["output_tokens_details"]["text_tokens"],
+            json!(output_tokens)
+        );
+        assert_eq!(
+            completed["usage"]["total_tokens"],
+            json!(input_tokens.saturating_add(output_tokens))
+        );
+    }
+
+    #[test]
+    fn chatgpt_web_success_sse_counts_output_text_not_dimensions() {
+        let output_text = "iVBORw0KGgoAAAANSUhEUgAA".repeat(64);
+        let request = ChatGptWebImageRequest {
+            model: "gpt-image-2".to_string(),
+            web_model: "gpt-5-5-thinking".to_string(),
+            prompt: "draw a test image".to_string(),
+            size: "1024x1024".to_string(),
+            ratio: "1:1".to_string(),
+            output_format: "png".to_string(),
+            images: Vec::new(),
+        };
+        let image = DownloadedImage {
+            b64_json: output_text.clone(),
+            mime: "image/png".to_string(),
+            width: Some(1402),
+            height: Some(1122),
+        };
+        let body = build_success_sse(
+            &request,
+            &image,
+            Some(&json!({
+                "image_request": {
+                    "size": "1024x1024",
+                    "quality": "low"
+                }
+            })),
+        );
+        let completed = completed_response_from_sse(body.as_str());
+
+        assert_eq!(
+            completed["usage"]["output_tokens"],
+            json!(estimate_text_tokens(output_text.as_str()))
+        );
     }
 
     #[test]
@@ -3208,8 +3426,19 @@ data: [DONE]
         assert!(body.contains("\"type\":\"image_generation_call\""));
         assert!(body.contains("\"width\":2"));
         assert!(body.contains("\"height\":3"));
-        assert!(body
-            .contains(&base64::engine::general_purpose::STANDARD.encode(png_header_bytes(2, 3))));
+        let expected_output_text =
+            base64::engine::general_purpose::STANDARD.encode(png_header_bytes(2, 3));
+        let expected_output_tokens = estimate_text_tokens(expected_output_text.as_str());
+        assert!(body.contains(&expected_output_text));
+        let completed = completed_response_from_sse(body.as_str());
+        assert_eq!(
+            completed["usage"]["output_tokens"],
+            json!(expected_output_tokens)
+        );
+        assert_eq!(
+            completed["tool_usage"]["image_gen"]["output_tokens"],
+            json!(expected_output_tokens)
+        );
 
         handle.abort();
     }
@@ -3274,11 +3503,25 @@ data: [DONE]
         assert!(decoded_data.contains("\"width\":2"));
         assert!(decoded_data.contains("\"height\":3"));
         assert!(text.contains("\"type\":\"eof\""));
+        let expected_output_tokens = estimate_text_tokens(
+            base64::engine::general_purpose::STANDARD
+                .encode(png_header_bytes(2, 3))
+                .as_str(),
+        );
         let eof_frame = text
             .lines()
             .filter_map(|line| serde_json::from_str::<Value>(line).ok())
             .find(|frame| frame.get("type").and_then(Value::as_str) == Some("eof"))
             .expect("eof frame should exist");
+        assert_eq!(
+            eof_frame
+                .get("payload")
+                .and_then(|payload| payload.get("summary"))
+                .and_then(|summary| summary.get("standardized_usage"))
+                .and_then(|usage| usage.get("output_tokens"))
+                .and_then(Value::as_i64),
+            i64::try_from(expected_output_tokens).ok()
+        );
         assert_eq!(
             eof_frame
                 .get("payload")

--- a/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
+++ b/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Error as IoError;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use aether_admin::provider::quota::{
     parse_chatgpt_web_conversation_init_response, quota_refresh_success_invalid_state,
@@ -964,6 +964,19 @@ fn spawn_chatgpt_web_image_quota_refresh_after_success(
     let base_url = base_url.to_string();
     let token = token.to_string();
     tokio::spawn(async move {
+        if let Err(err) = apply_chatgpt_web_image_quota_success_delta(&state, &plan).await {
+            warn!(
+                event_name = "chatgpt_web_image_quota_success_delta_failed",
+                log_type = "ops",
+                request_id = %plan.request_id,
+                candidate_id = ?plan.candidate_id,
+                provider_id = %plan.provider_id,
+                key_id = %plan.key_id,
+                error = %err,
+                "gateway failed to persist ChatGPT-Web image quota success delta"
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(5)).await;
         if let Err(err) =
             refresh_chatgpt_web_image_quota_after_success(&state, &plan, &base_url, &token).await
         {
@@ -979,6 +992,91 @@ fn spawn_chatgpt_web_image_quota_refresh_after_success(
             );
         }
     });
+}
+
+async fn apply_chatgpt_web_image_quota_success_delta(
+    state: &AppState,
+    plan: &ExecutionPlan,
+) -> Result<bool, String> {
+    let key_id = plan.key_id.trim();
+    let provider_id = plan.provider_id.trim();
+    let Some(mut latest_key) = state
+        .read_provider_catalog_keys_by_ids(&[key_id.to_string()])
+        .await
+        .map_err(|err| err.into_message())?
+        .into_iter()
+        .find(|key| key.id == key_id && key.provider_id == provider_id)
+    else {
+        return Ok(false);
+    };
+
+    let Some(mut metadata) = latest_key
+        .upstream_metadata
+        .as_ref()
+        .and_then(Value::as_object)
+        .and_then(|metadata| metadata.get("chatgpt_web"))
+        .and_then(Value::as_object)
+        .cloned()
+    else {
+        return Ok(false);
+    };
+
+    let now_unix_secs = current_unix_secs();
+    if chatgpt_web_image_quota_u64(metadata.get("image_quota_reset_at"))
+        .is_some_and(|reset_at| reset_at <= now_unix_secs)
+    {
+        return Ok(false);
+    }
+
+    let Some(remaining) = chatgpt_web_image_quota_f64(metadata.get("image_quota_remaining"))
+        .filter(|value| *value > 0.0)
+    else {
+        return Ok(false);
+    };
+    let limit = chatgpt_web_image_quota_f64(metadata.get("image_quota_total"))
+        .filter(|value| *value > 0.0)
+        .unwrap_or(remaining);
+    let new_remaining = (remaining - 1.0).max(0.0);
+
+    metadata.insert("image_quota_remaining".to_string(), json!(new_remaining));
+    metadata.insert("image_quota_total".to_string(), json!(limit));
+    metadata.insert(
+        "image_quota_used".to_string(),
+        json!((limit - new_remaining).max(0.0)),
+    );
+    metadata.insert("updated_at".to_string(), json!(now_unix_secs));
+    metadata.insert(
+        "image_quota_last_local_success_at".to_string(),
+        json!(now_unix_secs),
+    );
+    let local_success_count =
+        chatgpt_web_image_quota_u64(metadata.get("image_quota_local_success_count")).unwrap_or(0);
+    metadata.insert(
+        "image_quota_local_success_count".to_string(),
+        json!(local_success_count.saturating_add(1)),
+    );
+
+    let updated_upstream_metadata = merge_provider_metadata_object(
+        latest_key.upstream_metadata.as_ref(),
+        "chatgpt_web",
+        Value::Object(metadata),
+    );
+    latest_key.upstream_metadata = updated_upstream_metadata;
+    latest_key.status_snapshot = sync_provider_key_quota_status_snapshot(
+        latest_key.status_snapshot.as_ref(),
+        "chatgpt_web",
+        latest_key.upstream_metadata.as_ref(),
+        "image_success_local",
+    );
+    latest_key.status_snapshot =
+        sync_provider_key_oauth_status_snapshot(latest_key.status_snapshot.as_ref(), &latest_key);
+    latest_key.updated_at_unix_secs = Some(now_unix_secs);
+
+    Ok(state
+        .update_provider_catalog_key_runtime_state(&latest_key)
+        .await
+        .map_err(|err| err.into_message())?
+        .is_some())
 }
 
 async fn refresh_chatgpt_web_image_quota_after_success(
@@ -1039,8 +1137,9 @@ async fn refresh_chatgpt_web_image_quota_after_success(
     }
 
     let body_json = execution_result_json(&result).map_err(|err| err.to_string())?;
+    let now_unix_secs = current_unix_secs();
     let Some(mut metadata) =
-        parse_chatgpt_web_conversation_init_response(&body_json, current_unix_secs())
+        parse_chatgpt_web_conversation_init_response(&body_json, now_unix_secs)
     else {
         return Ok(false);
     };
@@ -1055,6 +1154,11 @@ async fn refresh_chatgpt_web_image_quota_after_success(
         return Ok(false);
     };
     normalize_chatgpt_web_image_quota_limit(&mut metadata, latest_key.upstream_metadata.as_ref());
+    preserve_chatgpt_web_local_success_delta(
+        &mut metadata,
+        latest_key.upstream_metadata.as_ref(),
+        now_unix_secs,
+    );
 
     let mut updated_key = latest_key;
     let updated_upstream_metadata = merge_provider_metadata_object(
@@ -1075,13 +1179,90 @@ async fn refresh_chatgpt_web_image_quota_after_success(
     );
     updated_key.status_snapshot =
         sync_provider_key_oauth_status_snapshot(updated_key.status_snapshot.as_ref(), &updated_key);
-    updated_key.updated_at_unix_secs = Some(current_unix_secs());
+    updated_key.updated_at_unix_secs = Some(now_unix_secs);
 
     Ok(state
         .update_provider_catalog_key_runtime_state(&updated_key)
         .await
         .map_err(|err| err.into_message())?
         .is_some())
+}
+
+fn preserve_chatgpt_web_local_success_delta(
+    metadata: &mut Value,
+    existing_upstream_metadata: Option<&Value>,
+    now_unix_secs: u64,
+) {
+    let Some(incoming) = metadata.as_object_mut() else {
+        return;
+    };
+    let Some(existing) = existing_upstream_metadata
+        .and_then(Value::as_object)
+        .and_then(|metadata| metadata.get("chatgpt_web"))
+        .and_then(Value::as_object)
+    else {
+        return;
+    };
+    let Some(local_success_at) =
+        chatgpt_web_image_quota_u64(existing.get("image_quota_last_local_success_at"))
+    else {
+        return;
+    };
+    if now_unix_secs.saturating_sub(local_success_at) > 180 {
+        return;
+    }
+
+    let incoming_reset_at = chatgpt_web_image_quota_u64(incoming.get("image_quota_reset_at"));
+    let existing_reset_at = chatgpt_web_image_quota_u64(existing.get("image_quota_reset_at"));
+    if incoming_reset_at.is_some_and(|reset_at| reset_at <= now_unix_secs) {
+        return;
+    }
+    match (incoming_reset_at, existing_reset_at) {
+        (Some(incoming_reset_at), Some(existing_reset_at))
+            if incoming_reset_at != existing_reset_at =>
+        {
+            return;
+        }
+        (Some(_), Some(_)) | (None, None) => {}
+        _ => return,
+    }
+
+    let Some(existing_remaining) =
+        chatgpt_web_image_quota_f64(existing.get("image_quota_remaining"))
+    else {
+        return;
+    };
+    let Some(incoming_remaining) =
+        chatgpt_web_image_quota_f64(incoming.get("image_quota_remaining"))
+    else {
+        return;
+    };
+    if incoming_remaining <= existing_remaining {
+        return;
+    }
+
+    let limit = chatgpt_web_image_quota_f64(incoming.get("image_quota_total"))
+        .filter(|value| *value > 0.0)
+        .or_else(|| {
+            chatgpt_web_image_quota_f64(existing.get("image_quota_total"))
+                .filter(|value| *value > 0.0)
+        })
+        .unwrap_or_else(|| incoming_remaining.max(existing_remaining));
+    incoming.insert(
+        "image_quota_remaining".to_string(),
+        json!(existing_remaining),
+    );
+    incoming.insert("image_quota_total".to_string(), json!(limit));
+    incoming.insert(
+        "image_quota_used".to_string(),
+        json!((limit - existing_remaining).max(0.0)),
+    );
+    if let Some(value) = existing.get("image_quota_last_local_success_at").cloned() {
+        incoming.insert("image_quota_last_local_success_at".to_string(), value);
+    }
+    if let Some(value) = existing.get("image_quota_local_success_count").cloned() {
+        incoming.insert("image_quota_local_success_count".to_string(), value);
+    }
 }
 
 fn build_chatgpt_web_image_quota_refresh_plan(
@@ -1167,6 +1348,26 @@ fn merge_provider_metadata_object(
         .unwrap_or_default();
     merged.insert(section_key.to_string(), section_value);
     Some(Value::Object(merged))
+}
+
+fn chatgpt_web_image_quota_f64(value: Option<&Value>) -> Option<f64> {
+    match value {
+        Some(Value::Number(number)) => number.as_f64(),
+        Some(Value::String(value)) => value.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+    .filter(|value| value.is_finite())
+}
+
+fn chatgpt_web_image_quota_u64(value: Option<&Value>) -> Option<u64> {
+    let mut parsed = chatgpt_web_image_quota_f64(value)?;
+    if parsed <= 0.0 {
+        return None;
+    }
+    if parsed > 1_000_000_000_000.0 {
+        parsed /= 1000.0;
+    }
+    Some(parsed.floor() as u64)
 }
 
 fn chatgpt_web_image_transport_profile(plan: &ExecutionPlan) -> Option<ResolvedTransportProfile> {
@@ -2384,6 +2585,35 @@ mod tests {
                 .and_then(|timeouts| timeouts.total_ms),
             Some(CHATGPT_WEB_QUOTA_REFRESH_TIMEOUT_MS)
         );
+    }
+
+    #[test]
+    fn chatgpt_web_image_quota_refresh_preserves_recent_local_success_delta() {
+        let mut metadata = json!({
+            "updated_at": 1_000u64,
+            "image_quota_remaining": 25.0,
+            "image_quota_total": 25.0,
+            "image_quota_used": 0.0,
+            "image_quota_reset_at": 2_000u64
+        });
+        let existing = json!({
+            "chatgpt_web": {
+                "updated_at": 995u64,
+                "image_quota_remaining": 24.0,
+                "image_quota_total": 25.0,
+                "image_quota_used": 1.0,
+                "image_quota_reset_at": 2_000u64,
+                "image_quota_last_local_success_at": 998u64,
+                "image_quota_local_success_count": 1u64
+            }
+        });
+
+        preserve_chatgpt_web_local_success_delta(&mut metadata, Some(&existing), 1_000);
+
+        assert_eq!(metadata["image_quota_remaining"], json!(24.0));
+        assert_eq!(metadata["image_quota_total"], json!(25.0));
+        assert_eq!(metadata["image_quota_used"], json!(1.0));
+        assert_eq!(metadata["image_quota_last_local_success_at"], json!(998u64));
     }
 
     async fn start_mock_chatgpt_web() -> (String, tokio::task::JoinHandle<()>) {

--- a/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
+++ b/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
@@ -184,6 +184,8 @@ async fn execute_chatgpt_web_image(
         "gateway executing ChatGPT-Web image request"
     );
 
+    apply_chatgpt_web_image_quota_request_delta_at_start(state, plan).await;
+
     web_bootstrap(plan, &base_url, &fp).await?;
     let requirements = web_requirements(plan, &base_url, &fp, token.as_str()).await?;
     let mut uploads = Vec::new();
@@ -222,7 +224,7 @@ async fn execute_chatgpt_web_image(
         &uploads,
     )
     .await?;
-    spawn_chatgpt_web_image_quota_sync_after_request(state, plan, &base_url, token.as_str());
+    spawn_chatgpt_web_image_quota_refresh_after_request(state, plan, &base_url, token.as_str());
     filter_uploaded_asset_ids(&mut summary, &uploads);
 
     let mut downloaded = resolve_and_download_images(
@@ -945,7 +947,56 @@ async fn execute_subrequest(
         .await
 }
 
-fn spawn_chatgpt_web_image_quota_sync_after_request(
+async fn apply_chatgpt_web_image_quota_request_delta_at_start(
+    state: &AppState,
+    plan: &ExecutionPlan,
+) {
+    if !state.has_provider_catalog_data_reader() || !state.has_provider_catalog_data_writer() {
+        return;
+    }
+    if plan.key_id.trim().is_empty() || plan.provider_id.trim().is_empty() {
+        return;
+    }
+
+    match apply_chatgpt_web_image_quota_request_delta(state, plan).await {
+        Ok(true) => {
+            debug!(
+                event_name = "chatgpt_web_image_quota_request_delta_applied",
+                log_type = "debug",
+                request_id = %plan.request_id,
+                candidate_id = ?plan.candidate_id,
+                provider_id = %plan.provider_id,
+                key_id = %plan.key_id,
+                "gateway persisted ChatGPT-Web image quota request delta"
+            );
+        }
+        Ok(false) => {
+            debug!(
+                event_name = "chatgpt_web_image_quota_request_delta_skipped",
+                log_type = "debug",
+                request_id = %plan.request_id,
+                candidate_id = ?plan.candidate_id,
+                provider_id = %plan.provider_id,
+                key_id = %plan.key_id,
+                "gateway skipped ChatGPT-Web image quota request delta"
+            );
+        }
+        Err(err) => {
+            warn!(
+                event_name = "chatgpt_web_image_quota_request_delta_failed",
+                log_type = "ops",
+                request_id = %plan.request_id,
+                candidate_id = ?plan.candidate_id,
+                provider_id = %plan.provider_id,
+                key_id = %plan.key_id,
+                error = %err,
+                "gateway failed to persist ChatGPT-Web image quota request delta"
+            );
+        }
+    }
+}
+
+fn spawn_chatgpt_web_image_quota_refresh_after_request(
     state: &AppState,
     plan: &ExecutionPlan,
     base_url: &str,
@@ -964,18 +1015,6 @@ fn spawn_chatgpt_web_image_quota_sync_after_request(
     let base_url = base_url.to_string();
     let token = token.to_string();
     tokio::spawn(async move {
-        if let Err(err) = apply_chatgpt_web_image_quota_request_delta(&state, &plan).await {
-            warn!(
-                event_name = "chatgpt_web_image_quota_request_delta_failed",
-                log_type = "ops",
-                request_id = %plan.request_id,
-                candidate_id = ?plan.candidate_id,
-                provider_id = %plan.provider_id,
-                key_id = %plan.key_id,
-                error = %err,
-                "gateway failed to persist ChatGPT-Web image quota request delta"
-            );
-        }
         tokio::time::sleep(Duration::from_secs(5)).await;
         if let Err(err) =
             refresh_chatgpt_web_image_quota_after_success(&state, &plan, &base_url, &token).await
@@ -1000,6 +1039,9 @@ async fn apply_chatgpt_web_image_quota_request_delta(
 ) -> Result<bool, String> {
     let key_id = plan.key_id.trim();
     let provider_id = plan.provider_id.trim();
+    if key_id.is_empty() || provider_id.is_empty() {
+        return Ok(false);
+    }
     let Some(mut latest_key) = state
         .read_provider_catalog_keys_by_ids(&[key_id.to_string()])
         .await
@@ -1038,7 +1080,7 @@ async fn apply_chatgpt_web_image_quota_request_delta(
         latest_key.status_snapshot.as_ref(),
         "chatgpt_web",
         latest_key.upstream_metadata.as_ref(),
-        "image_success_local",
+        "image_request_local",
     );
     latest_key.status_snapshot =
         sync_provider_key_oauth_status_snapshot(latest_key.status_snapshot.as_ref(), &latest_key);
@@ -1057,13 +1099,12 @@ fn apply_chatgpt_web_image_quota_request_delta_to_metadata(
     now_unix_secs: u64,
 ) -> bool {
     let snapshot_window = chatgpt_web_image_quota_snapshot_window(status_snapshot);
-    let limit = chatgpt_web_image_quota_f64(metadata.get("image_quota_total"))
-        .filter(|value| *value > 0.0)
-        .or_else(|| {
-            snapshot_window.and_then(|window| {
-                chatgpt_web_image_quota_f64(window.get("limit_value")).filter(|value| *value > 0.0)
-            })
-        });
+    let metadata_limit =
+        chatgpt_web_image_quota_f64(metadata.get("image_quota_total")).filter(|value| *value > 0.0);
+    let snapshot_limit = snapshot_window.and_then(|window| {
+        chatgpt_web_image_quota_f64(window.get("limit_value")).filter(|value| *value > 0.0)
+    });
+    let candidate_limit = metadata_limit.or(snapshot_limit);
     let used = chatgpt_web_image_quota_f64(metadata.get("image_quota_used")).or_else(|| {
         snapshot_window.and_then(|window| chatgpt_web_image_quota_f64(window.get("used_value")))
     });
@@ -1072,19 +1113,40 @@ fn apply_chatgpt_web_image_quota_request_delta_to_metadata(
             snapshot_window
                 .and_then(|window| chatgpt_web_image_quota_f64(window.get("remaining_value")))
         })
-        .or_else(|| limit.zip(used).map(|(limit, used)| (limit - used).max(0.0)));
+        .or_else(|| {
+            candidate_limit
+                .zip(used)
+                .map(|(limit, used)| (limit - used).max(0.0))
+        });
     let Some(remaining) = remaining else {
         return false;
     };
-    let limit = limit.unwrap_or(remaining.max(0.0));
+    let limit = chatgpt_web_image_quota_request_limit_choice(
+        metadata,
+        status_snapshot,
+        metadata_limit,
+        snapshot_limit,
+        remaining,
+    );
+    let limit_value = limit
+        .as_ref()
+        .map(|limit| limit.value)
+        .unwrap_or(remaining.max(0.0));
     let new_remaining = (remaining - 1.0).max(0.0);
 
     metadata.insert("image_quota_remaining".to_string(), json!(new_remaining));
-    if limit > 0.0 {
-        metadata.insert("image_quota_total".to_string(), json!(limit));
+    if limit_value > 0.0 {
+        metadata.insert("image_quota_total".to_string(), json!(limit_value));
+        if let Some(source) = limit
+            .as_ref()
+            .and_then(|limit| limit.source.as_deref())
+            .filter(|value| !value.is_empty())
+        {
+            metadata.insert("image_quota_limit_source".to_string(), json!(source));
+        }
         metadata.insert(
             "image_quota_used".to_string(),
-            json!((limit - new_remaining).max(0.0)),
+            json!((limit_value - new_remaining).max(0.0)),
         );
     } else if let Some(used) = used {
         metadata.insert("image_quota_used".to_string(), json!(used + 1.0));
@@ -1108,6 +1170,102 @@ fn apply_chatgpt_web_image_quota_request_delta_to_metadata(
         json!(local_request_count.saturating_add(1)),
     );
     true
+}
+
+#[derive(Debug, Clone)]
+struct ChatGptWebImageQuotaRequestLimit {
+    value: f64,
+    source: Option<String>,
+}
+
+fn chatgpt_web_image_quota_request_limit_choice(
+    metadata: &Map<String, Value>,
+    status_snapshot: Option<&Value>,
+    metadata_limit: Option<f64>,
+    snapshot_limit: Option<f64>,
+    remaining: f64,
+) -> Option<ChatGptWebImageQuotaRequestLimit> {
+    let plan_type = chatgpt_web_image_quota_metadata_str(metadata, "plan_type").or_else(|| {
+        chatgpt_web_image_quota_snapshot(status_snapshot)
+            .and_then(|quota| chatgpt_web_image_quota_metadata_str(quota, "plan_type"))
+    });
+    let metadata_limit_source =
+        chatgpt_web_image_quota_metadata_str(metadata, "image_quota_limit_source");
+
+    if let Some(limit) = metadata_limit {
+        if !chatgpt_web_image_quota_limit_is_legacy_free_default(
+            limit,
+            metadata_limit_source,
+            plan_type,
+            remaining,
+        ) {
+            let source = metadata_limit_source.map(ToOwned::to_owned).or_else(|| {
+                let is_first_remaining = plan_type
+                    .is_some_and(|value| value.eq_ignore_ascii_case("free"))
+                    && (limit - remaining).abs() <= f64::EPSILON;
+                Some(
+                    if is_first_remaining {
+                        "first_remaining"
+                    } else {
+                        "stored"
+                    }
+                    .to_string(),
+                )
+            });
+            return Some(ChatGptWebImageQuotaRequestLimit {
+                value: limit,
+                source,
+            });
+        }
+    }
+
+    if let Some(limit) = snapshot_limit {
+        if !chatgpt_web_image_quota_limit_is_legacy_free_default(limit, None, plan_type, remaining)
+        {
+            return Some(ChatGptWebImageQuotaRequestLimit {
+                value: limit,
+                source: Some("status_snapshot".to_string()),
+            });
+        }
+    }
+
+    remaining
+        .is_finite()
+        .then_some(remaining)
+        .filter(|value| *value > 0.0)
+        .map(|value| ChatGptWebImageQuotaRequestLimit {
+            value,
+            source: Some("first_remaining".to_string()),
+        })
+}
+
+fn chatgpt_web_image_quota_metadata_str<'a>(
+    metadata: &'a Map<String, Value>,
+    key: &str,
+) -> Option<&'a str> {
+    metadata
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn chatgpt_web_image_quota_limit_is_legacy_free_default(
+    limit: f64,
+    source: Option<&str>,
+    plan_type: Option<&str>,
+    remaining: f64,
+) -> bool {
+    let plan_type_is_free = plan_type
+        .map(str::trim)
+        .is_some_and(|value| value.eq_ignore_ascii_case("free"));
+    if !plan_type_is_free || source.is_some() {
+        return false;
+    }
+    if (limit - 25.0).abs() > f64::EPSILON {
+        return false;
+    }
+    remaining < limit
 }
 
 async fn refresh_chatgpt_web_image_quota_after_success(
@@ -1302,17 +1460,7 @@ fn merge_provider_metadata_object(
 fn chatgpt_web_image_quota_snapshot_window(
     status_snapshot: Option<&Value>,
 ) -> Option<&Map<String, Value>> {
-    let quota = status_snapshot
-        .and_then(Value::as_object)
-        .and_then(|snapshot| snapshot.get("quota"))
-        .and_then(Value::as_object)?;
-    if quota
-        .get("provider_type")
-        .and_then(Value::as_str)
-        .is_some_and(|value| !value.trim().eq_ignore_ascii_case("chatgpt_web"))
-    {
-        return None;
-    }
+    let quota = chatgpt_web_image_quota_snapshot(status_snapshot)?;
     quota
         .get("windows")
         .and_then(Value::as_array)?
@@ -1337,6 +1485,23 @@ fn chatgpt_web_image_quota_snapshot_window(
                         .is_some_and(|value| value.trim().eq_ignore_ascii_case("account"))
                 })
         })
+}
+
+fn chatgpt_web_image_quota_snapshot(
+    status_snapshot: Option<&Value>,
+) -> Option<&Map<String, Value>> {
+    let quota = status_snapshot
+        .and_then(Value::as_object)
+        .and_then(|snapshot| snapshot.get("quota"))
+        .and_then(Value::as_object)?;
+    if quota
+        .get("provider_type")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().eq_ignore_ascii_case("chatgpt_web"))
+    {
+        return None;
+    }
+    Some(quota)
 }
 
 fn chatgpt_web_image_quota_f64(value: Option<&Value>) -> Option<f64> {
@@ -2624,6 +2789,30 @@ mod tests {
         assert_eq!(metadata["image_quota_total"], json!(25.0));
         assert_eq!(metadata["image_quota_used"], json!(7.0));
         assert_eq!(metadata["image_quota_reset_at"], json!(2_000u64));
+    }
+
+    #[test]
+    fn chatgpt_web_image_quota_request_delta_ignores_legacy_free_25_limit() {
+        let mut metadata = Map::from_iter([
+            ("plan_type".to_string(), json!("free")),
+            ("image_quota_remaining".to_string(), json!(19.0)),
+            ("image_quota_total".to_string(), json!(25.0)),
+            ("image_quota_used".to_string(), json!(6.0)),
+        ]);
+
+        assert!(apply_chatgpt_web_image_quota_request_delta_to_metadata(
+            &mut metadata,
+            None,
+            1_000,
+        ));
+
+        assert_eq!(metadata["image_quota_remaining"], json!(18.0));
+        assert_eq!(metadata["image_quota_total"], json!(19.0));
+        assert_eq!(metadata["image_quota_used"], json!(1.0));
+        assert_eq!(
+            metadata["image_quota_limit_source"],
+            json!("first_remaining")
+        );
     }
 
     async fn start_mock_chatgpt_web() -> (String, tokio::task::JoinHandle<()>) {

--- a/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
+++ b/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
@@ -1145,9 +1145,6 @@ fn apply_chatgpt_web_image_quota_request_delta_to_metadata(
                 .zip(used)
                 .map(|(limit, used)| (limit - used).max(0.0))
         });
-    let Some(remaining) = remaining else {
-        return false;
-    };
     let limit = chatgpt_web_image_quota_request_limit_choice(
         metadata,
         status_snapshot,
@@ -1155,13 +1152,22 @@ fn apply_chatgpt_web_image_quota_request_delta_to_metadata(
         snapshot_limit,
         remaining,
     );
+    if limit.is_none()
+        && chatgpt_web_image_quota_metadata_limit_is_legacy_free_default(
+            metadata,
+            status_snapshot,
+            metadata_limit,
+            remaining,
+        )
+    {
+        metadata.remove("image_quota_total");
+        metadata.remove("image_quota_limit_source");
+    }
     let limit_value = limit
         .as_ref()
         .map(|limit| limit.value)
-        .unwrap_or(remaining.max(0.0));
-    let new_remaining = (remaining - 1.0).max(0.0);
+        .unwrap_or_else(|| remaining.unwrap_or(0.0).max(0.0));
 
-    metadata.insert("image_quota_remaining".to_string(), json!(new_remaining));
     if limit_value > 0.0 {
         metadata.insert("image_quota_total".to_string(), json!(limit_value));
         if let Some(source) = limit
@@ -1171,12 +1177,32 @@ fn apply_chatgpt_web_image_quota_request_delta_to_metadata(
         {
             metadata.insert("image_quota_limit_source".to_string(), json!(source));
         }
-        metadata.insert(
-            "image_quota_used".to_string(),
-            json!((limit_value - new_remaining).max(0.0)),
-        );
-    } else if let Some(used) = used {
-        metadata.insert("image_quota_used".to_string(), json!(used + 1.0));
+    }
+    match remaining {
+        Some(remaining) => {
+            let new_remaining = (remaining - 1.0).max(0.0);
+            metadata.insert("image_quota_remaining".to_string(), json!(new_remaining));
+            if limit_value > 0.0 {
+                metadata.insert(
+                    "image_quota_used".to_string(),
+                    json!((limit_value - new_remaining).max(0.0)),
+                );
+            } else if let Some(used) = used {
+                metadata.insert("image_quota_used".to_string(), json!(used + 1.0));
+            } else {
+                metadata.insert("image_quota_used".to_string(), json!(1.0));
+            }
+        }
+        None => {
+            let new_used = used.unwrap_or(0.0).max(0.0) + 1.0;
+            metadata.insert("image_quota_used".to_string(), json!(new_used));
+            if limit_value > 0.0 {
+                metadata.insert(
+                    "image_quota_remaining".to_string(),
+                    json!((limit_value - new_used).max(0.0)),
+                );
+            }
+        }
     }
     if !metadata.contains_key("image_quota_reset_at") {
         if let Some(reset_at) =
@@ -1227,12 +1253,35 @@ struct ChatGptWebImageQuotaRequestLimit {
     source: Option<String>,
 }
 
+fn chatgpt_web_image_quota_metadata_limit_is_legacy_free_default(
+    metadata: &Map<String, Value>,
+    status_snapshot: Option<&Value>,
+    metadata_limit: Option<f64>,
+    remaining: Option<f64>,
+) -> bool {
+    let Some(limit) = metadata_limit else {
+        return false;
+    };
+    let plan_type = chatgpt_web_image_quota_metadata_str(metadata, "plan_type").or_else(|| {
+        chatgpt_web_image_quota_snapshot(status_snapshot)
+            .and_then(|quota| chatgpt_web_image_quota_metadata_str(quota, "plan_type"))
+    });
+    let metadata_limit_source =
+        chatgpt_web_image_quota_metadata_str(metadata, "image_quota_limit_source");
+    chatgpt_web_image_quota_limit_is_legacy_free_default(
+        limit,
+        metadata_limit_source,
+        plan_type,
+        remaining,
+    )
+}
+
 fn chatgpt_web_image_quota_request_limit_choice(
     metadata: &Map<String, Value>,
     status_snapshot: Option<&Value>,
     metadata_limit: Option<f64>,
     snapshot_limit: Option<f64>,
-    remaining: f64,
+    remaining: Option<f64>,
 ) -> Option<ChatGptWebImageQuotaRequestLimit> {
     let plan_type = chatgpt_web_image_quota_metadata_str(metadata, "plan_type").or_else(|| {
         chatgpt_web_image_quota_snapshot(status_snapshot)
@@ -1251,7 +1300,7 @@ fn chatgpt_web_image_quota_request_limit_choice(
             let source = metadata_limit_source.map(ToOwned::to_owned).or_else(|| {
                 let is_first_remaining = plan_type
                     .is_some_and(|value| value.eq_ignore_ascii_case("free"))
-                    && (limit - remaining).abs() <= f64::EPSILON;
+                    && remaining.is_some_and(|remaining| (limit - remaining).abs() <= f64::EPSILON);
                 Some(
                     if is_first_remaining {
                         "first_remaining"
@@ -1279,11 +1328,9 @@ fn chatgpt_web_image_quota_request_limit_choice(
     }
 
     remaining
-        .is_finite()
-        .then_some(remaining)
-        .filter(|value| *value > 0.0)
-        .map(|value| ChatGptWebImageQuotaRequestLimit {
-            value,
+        .filter(|remaining| remaining.is_finite() && *remaining > 0.0)
+        .map(|remaining| ChatGptWebImageQuotaRequestLimit {
+            value: remaining,
             source: Some("first_remaining".to_string()),
         })
 }
@@ -1303,7 +1350,7 @@ fn chatgpt_web_image_quota_limit_is_legacy_free_default(
     limit: f64,
     source: Option<&str>,
     plan_type: Option<&str>,
-    remaining: f64,
+    remaining: Option<f64>,
 ) -> bool {
     let plan_type_is_free = plan_type
         .map(str::trim)
@@ -1314,7 +1361,7 @@ fn chatgpt_web_image_quota_limit_is_legacy_free_default(
     if (limit - 25.0).abs() > f64::EPSILON {
         return false;
     }
-    remaining < limit
+    remaining.is_none_or(|remaining| remaining.is_finite() && remaining < limit)
 }
 
 async fn refresh_chatgpt_web_image_quota_after_success(
@@ -2843,6 +2890,40 @@ mod tests {
     }
 
     #[test]
+    fn chatgpt_web_image_quota_request_delta_records_unknown_quota_use() {
+        let mut metadata = Map::new();
+
+        assert!(apply_chatgpt_web_image_quota_request_delta_to_metadata(
+            &mut metadata,
+            None,
+            1_000,
+            None,
+        ));
+
+        assert_eq!(metadata.get("image_quota_remaining"), None);
+        assert_eq!(metadata.get("image_quota_total"), None);
+        assert_eq!(metadata["image_quota_used"], json!(1.0));
+        assert_eq!(metadata["image_quota_local_request_count"], json!(1u64));
+        assert_eq!(metadata["updated_at"], json!(1_000u64));
+    }
+
+    #[test]
+    fn chatgpt_web_image_quota_request_delta_derives_remaining_from_limit_only() {
+        let mut metadata = Map::from_iter([("image_quota_total".to_string(), json!(10.0))]);
+
+        assert!(apply_chatgpt_web_image_quota_request_delta_to_metadata(
+            &mut metadata,
+            None,
+            1_000,
+            None,
+        ));
+
+        assert_eq!(metadata["image_quota_remaining"], json!(9.0));
+        assert_eq!(metadata["image_quota_total"], json!(10.0));
+        assert_eq!(metadata["image_quota_used"], json!(1.0));
+    }
+
+    #[test]
     fn chatgpt_web_image_quota_request_delta_ignores_legacy_free_25_limit() {
         let mut metadata = Map::from_iter([
             ("plan_type".to_string(), json!("free")),
@@ -2864,6 +2945,30 @@ mod tests {
         assert_eq!(
             metadata["image_quota_limit_source"],
             json!("first_remaining")
+        );
+    }
+
+    #[test]
+    fn chatgpt_web_image_quota_request_delta_ignores_legacy_free_25_without_remaining() {
+        let mut metadata = Map::from_iter([
+            ("plan_type".to_string(), json!("free")),
+            ("image_quota_total".to_string(), json!(25.0)),
+        ]);
+
+        assert!(apply_chatgpt_web_image_quota_request_delta_to_metadata(
+            &mut metadata,
+            None,
+            1_000,
+            None,
+        ));
+
+        assert_eq!(metadata.get("image_quota_remaining"), None);
+        assert_eq!(metadata.get("image_quota_total"), None);
+        assert_eq!(metadata["image_quota_used"], json!(1.0));
+        assert_eq!(
+            metadata.get("image_quota_limit_source"),
+            None,
+            "legacy free default should not become a first observed limit without remaining"
         );
     }
 

--- a/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
+++ b/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
@@ -222,6 +222,7 @@ async fn execute_chatgpt_web_image(
         &uploads,
     )
     .await?;
+    spawn_chatgpt_web_image_quota_sync_after_request(state, plan, &base_url, token.as_str());
     filter_uploaded_asset_ids(&mut summary, &uploads);
 
     let mut downloaded = resolve_and_download_images(
@@ -269,7 +270,6 @@ async fn execute_chatgpt_web_image(
     let body = if let Some(failure) = summary.failure.as_ref().filter(|_| downloaded.is_empty()) {
         build_failed_sse(&request, failure)
     } else if let Some(image) = downloaded.into_iter().next() {
-        spawn_chatgpt_web_image_quota_refresh_after_success(state, plan, &base_url, token.as_str());
         build_success_sse(&request, &image, report_context)
     } else {
         build_failed_sse(
@@ -945,7 +945,7 @@ async fn execute_subrequest(
         .await
 }
 
-fn spawn_chatgpt_web_image_quota_refresh_after_success(
+fn spawn_chatgpt_web_image_quota_sync_after_request(
     state: &AppState,
     plan: &ExecutionPlan,
     base_url: &str,
@@ -964,16 +964,16 @@ fn spawn_chatgpt_web_image_quota_refresh_after_success(
     let base_url = base_url.to_string();
     let token = token.to_string();
     tokio::spawn(async move {
-        if let Err(err) = apply_chatgpt_web_image_quota_success_delta(&state, &plan).await {
+        if let Err(err) = apply_chatgpt_web_image_quota_request_delta(&state, &plan).await {
             warn!(
-                event_name = "chatgpt_web_image_quota_success_delta_failed",
+                event_name = "chatgpt_web_image_quota_request_delta_failed",
                 log_type = "ops",
                 request_id = %plan.request_id,
                 candidate_id = ?plan.candidate_id,
                 provider_id = %plan.provider_id,
                 key_id = %plan.key_id,
                 error = %err,
-                "gateway failed to persist ChatGPT-Web image quota success delta"
+                "gateway failed to persist ChatGPT-Web image quota request delta"
             );
         }
         tokio::time::sleep(Duration::from_secs(5)).await;
@@ -988,13 +988,13 @@ fn spawn_chatgpt_web_image_quota_refresh_after_success(
                 provider_id = %plan.provider_id,
                 key_id = %plan.key_id,
                 error = %err,
-                "gateway failed to refresh ChatGPT-Web image quota after a successful generation"
+                "gateway failed to refresh ChatGPT-Web image quota after a generation request"
             );
         }
     });
 }
 
-async fn apply_chatgpt_web_image_quota_success_delta(
+async fn apply_chatgpt_web_image_quota_request_delta(
     state: &AppState,
     plan: &ExecutionPlan,
 ) -> Result<bool, String> {
@@ -1010,51 +1010,23 @@ async fn apply_chatgpt_web_image_quota_success_delta(
         return Ok(false);
     };
 
-    let Some(mut metadata) = latest_key
+    let mut metadata = latest_key
         .upstream_metadata
         .as_ref()
         .and_then(Value::as_object)
         .and_then(|metadata| metadata.get("chatgpt_web"))
         .and_then(Value::as_object)
         .cloned()
-    else {
-        return Ok(false);
-    };
+        .unwrap_or_default();
 
     let now_unix_secs = current_unix_secs();
-    if chatgpt_web_image_quota_u64(metadata.get("image_quota_reset_at"))
-        .is_some_and(|reset_at| reset_at <= now_unix_secs)
-    {
+    if !apply_chatgpt_web_image_quota_request_delta_to_metadata(
+        &mut metadata,
+        latest_key.status_snapshot.as_ref(),
+        now_unix_secs,
+    ) {
         return Ok(false);
     }
-
-    let Some(remaining) = chatgpt_web_image_quota_f64(metadata.get("image_quota_remaining"))
-        .filter(|value| *value > 0.0)
-    else {
-        return Ok(false);
-    };
-    let limit = chatgpt_web_image_quota_f64(metadata.get("image_quota_total"))
-        .filter(|value| *value > 0.0)
-        .unwrap_or(remaining);
-    let new_remaining = (remaining - 1.0).max(0.0);
-
-    metadata.insert("image_quota_remaining".to_string(), json!(new_remaining));
-    metadata.insert("image_quota_total".to_string(), json!(limit));
-    metadata.insert(
-        "image_quota_used".to_string(),
-        json!((limit - new_remaining).max(0.0)),
-    );
-    metadata.insert("updated_at".to_string(), json!(now_unix_secs));
-    metadata.insert(
-        "image_quota_last_local_success_at".to_string(),
-        json!(now_unix_secs),
-    );
-    let local_success_count =
-        chatgpt_web_image_quota_u64(metadata.get("image_quota_local_success_count")).unwrap_or(0);
-    metadata.insert(
-        "image_quota_local_success_count".to_string(),
-        json!(local_success_count.saturating_add(1)),
-    );
 
     let updated_upstream_metadata = merge_provider_metadata_object(
         latest_key.upstream_metadata.as_ref(),
@@ -1077,6 +1049,65 @@ async fn apply_chatgpt_web_image_quota_success_delta(
         .await
         .map_err(|err| err.into_message())?
         .is_some())
+}
+
+fn apply_chatgpt_web_image_quota_request_delta_to_metadata(
+    metadata: &mut Map<String, Value>,
+    status_snapshot: Option<&Value>,
+    now_unix_secs: u64,
+) -> bool {
+    let snapshot_window = chatgpt_web_image_quota_snapshot_window(status_snapshot);
+    let limit = chatgpt_web_image_quota_f64(metadata.get("image_quota_total"))
+        .filter(|value| *value > 0.0)
+        .or_else(|| {
+            snapshot_window.and_then(|window| {
+                chatgpt_web_image_quota_f64(window.get("limit_value")).filter(|value| *value > 0.0)
+            })
+        });
+    let used = chatgpt_web_image_quota_f64(metadata.get("image_quota_used")).or_else(|| {
+        snapshot_window.and_then(|window| chatgpt_web_image_quota_f64(window.get("used_value")))
+    });
+    let remaining = chatgpt_web_image_quota_f64(metadata.get("image_quota_remaining"))
+        .or_else(|| {
+            snapshot_window
+                .and_then(|window| chatgpt_web_image_quota_f64(window.get("remaining_value")))
+        })
+        .or_else(|| limit.zip(used).map(|(limit, used)| (limit - used).max(0.0)));
+    let Some(remaining) = remaining else {
+        return false;
+    };
+    let limit = limit.unwrap_or(remaining.max(0.0));
+    let new_remaining = (remaining - 1.0).max(0.0);
+
+    metadata.insert("image_quota_remaining".to_string(), json!(new_remaining));
+    if limit > 0.0 {
+        metadata.insert("image_quota_total".to_string(), json!(limit));
+        metadata.insert(
+            "image_quota_used".to_string(),
+            json!((limit - new_remaining).max(0.0)),
+        );
+    } else if let Some(used) = used {
+        metadata.insert("image_quota_used".to_string(), json!(used + 1.0));
+    }
+    if !metadata.contains_key("image_quota_reset_at") {
+        if let Some(reset_at) =
+            snapshot_window.and_then(|window| chatgpt_web_image_quota_u64(window.get("reset_at")))
+        {
+            metadata.insert("image_quota_reset_at".to_string(), json!(reset_at));
+        }
+    }
+    metadata.insert("updated_at".to_string(), json!(now_unix_secs));
+    metadata.insert(
+        "image_quota_last_local_request_at".to_string(),
+        json!(now_unix_secs),
+    );
+    let local_request_count =
+        chatgpt_web_image_quota_u64(metadata.get("image_quota_local_request_count")).unwrap_or(0);
+    metadata.insert(
+        "image_quota_local_request_count".to_string(),
+        json!(local_request_count.saturating_add(1)),
+    );
+    true
 }
 
 async fn refresh_chatgpt_web_image_quota_after_success(
@@ -1154,11 +1185,6 @@ async fn refresh_chatgpt_web_image_quota_after_success(
         return Ok(false);
     };
     normalize_chatgpt_web_image_quota_limit(&mut metadata, latest_key.upstream_metadata.as_ref());
-    preserve_chatgpt_web_local_success_delta(
-        &mut metadata,
-        latest_key.upstream_metadata.as_ref(),
-        now_unix_secs,
-    );
 
     let mut updated_key = latest_key;
     let updated_upstream_metadata = merge_provider_metadata_object(
@@ -1186,83 +1212,6 @@ async fn refresh_chatgpt_web_image_quota_after_success(
         .await
         .map_err(|err| err.into_message())?
         .is_some())
-}
-
-fn preserve_chatgpt_web_local_success_delta(
-    metadata: &mut Value,
-    existing_upstream_metadata: Option<&Value>,
-    now_unix_secs: u64,
-) {
-    let Some(incoming) = metadata.as_object_mut() else {
-        return;
-    };
-    let Some(existing) = existing_upstream_metadata
-        .and_then(Value::as_object)
-        .and_then(|metadata| metadata.get("chatgpt_web"))
-        .and_then(Value::as_object)
-    else {
-        return;
-    };
-    let Some(local_success_at) =
-        chatgpt_web_image_quota_u64(existing.get("image_quota_last_local_success_at"))
-    else {
-        return;
-    };
-    if now_unix_secs.saturating_sub(local_success_at) > 180 {
-        return;
-    }
-
-    let incoming_reset_at = chatgpt_web_image_quota_u64(incoming.get("image_quota_reset_at"));
-    let existing_reset_at = chatgpt_web_image_quota_u64(existing.get("image_quota_reset_at"));
-    if incoming_reset_at.is_some_and(|reset_at| reset_at <= now_unix_secs) {
-        return;
-    }
-    match (incoming_reset_at, existing_reset_at) {
-        (Some(incoming_reset_at), Some(existing_reset_at))
-            if incoming_reset_at != existing_reset_at =>
-        {
-            return;
-        }
-        (Some(_), Some(_)) | (None, None) => {}
-        _ => return,
-    }
-
-    let Some(existing_remaining) =
-        chatgpt_web_image_quota_f64(existing.get("image_quota_remaining"))
-    else {
-        return;
-    };
-    let Some(incoming_remaining) =
-        chatgpt_web_image_quota_f64(incoming.get("image_quota_remaining"))
-    else {
-        return;
-    };
-    if incoming_remaining <= existing_remaining {
-        return;
-    }
-
-    let limit = chatgpt_web_image_quota_f64(incoming.get("image_quota_total"))
-        .filter(|value| *value > 0.0)
-        .or_else(|| {
-            chatgpt_web_image_quota_f64(existing.get("image_quota_total"))
-                .filter(|value| *value > 0.0)
-        })
-        .unwrap_or_else(|| incoming_remaining.max(existing_remaining));
-    incoming.insert(
-        "image_quota_remaining".to_string(),
-        json!(existing_remaining),
-    );
-    incoming.insert("image_quota_total".to_string(), json!(limit));
-    incoming.insert(
-        "image_quota_used".to_string(),
-        json!((limit - existing_remaining).max(0.0)),
-    );
-    if let Some(value) = existing.get("image_quota_last_local_success_at").cloned() {
-        incoming.insert("image_quota_last_local_success_at".to_string(), value);
-    }
-    if let Some(value) = existing.get("image_quota_local_success_count").cloned() {
-        incoming.insert("image_quota_local_success_count".to_string(), value);
-    }
 }
 
 fn build_chatgpt_web_image_quota_refresh_plan(
@@ -1348,6 +1297,46 @@ fn merge_provider_metadata_object(
         .unwrap_or_default();
     merged.insert(section_key.to_string(), section_value);
     Some(Value::Object(merged))
+}
+
+fn chatgpt_web_image_quota_snapshot_window(
+    status_snapshot: Option<&Value>,
+) -> Option<&Map<String, Value>> {
+    let quota = status_snapshot
+        .and_then(Value::as_object)
+        .and_then(|snapshot| snapshot.get("quota"))
+        .and_then(Value::as_object)?;
+    if quota
+        .get("provider_type")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().eq_ignore_ascii_case("chatgpt_web"))
+    {
+        return None;
+    }
+    quota
+        .get("windows")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(Value::as_object)
+        .find(|window| {
+            window
+                .get("code")
+                .and_then(Value::as_str)
+                .is_some_and(|value| value.trim().eq_ignore_ascii_case("image_gen"))
+        })
+        .or_else(|| {
+            quota
+                .get("windows")
+                .and_then(Value::as_array)?
+                .iter()
+                .filter_map(Value::as_object)
+                .find(|window| {
+                    window
+                        .get("scope")
+                        .and_then(Value::as_str)
+                        .is_some_and(|value| value.trim().eq_ignore_ascii_case("account"))
+                })
+        })
 }
 
 fn chatgpt_web_image_quota_f64(value: Option<&Value>) -> Option<f64> {
@@ -2588,32 +2577,53 @@ mod tests {
     }
 
     #[test]
-    fn chatgpt_web_image_quota_refresh_preserves_recent_local_success_delta() {
-        let mut metadata = json!({
-            "updated_at": 1_000u64,
-            "image_quota_remaining": 25.0,
-            "image_quota_total": 25.0,
-            "image_quota_used": 0.0,
-            "image_quota_reset_at": 2_000u64
-        });
-        let existing = json!({
-            "chatgpt_web": {
-                "updated_at": 995u64,
-                "image_quota_remaining": 24.0,
-                "image_quota_total": 25.0,
-                "image_quota_used": 1.0,
-                "image_quota_reset_at": 2_000u64,
-                "image_quota_last_local_success_at": 998u64,
-                "image_quota_local_success_count": 1u64
-            }
-        });
+    fn chatgpt_web_image_quota_request_delta_decrements_remaining_count() {
+        let mut metadata = Map::from_iter([
+            ("image_quota_remaining".to_string(), json!(25.0)),
+            ("image_quota_total".to_string(), json!(25.0)),
+            ("image_quota_used".to_string(), json!(0.0)),
+            ("image_quota_reset_at".to_string(), json!(2_000u64)),
+        ]);
 
-        preserve_chatgpt_web_local_success_delta(&mut metadata, Some(&existing), 1_000);
+        assert!(apply_chatgpt_web_image_quota_request_delta_to_metadata(
+            &mut metadata,
+            None,
+            1_000,
+        ));
 
         assert_eq!(metadata["image_quota_remaining"], json!(24.0));
         assert_eq!(metadata["image_quota_total"], json!(25.0));
         assert_eq!(metadata["image_quota_used"], json!(1.0));
-        assert_eq!(metadata["image_quota_last_local_success_at"], json!(998u64));
+        assert_eq!(metadata["image_quota_local_request_count"], json!(1u64));
+    }
+
+    #[test]
+    fn chatgpt_web_image_quota_request_delta_can_use_status_snapshot() {
+        let mut metadata = Map::new();
+        let status_snapshot = json!({
+            "quota": {
+                "provider_type": "chatgpt_web",
+                "windows": [{
+                    "code": "image_gen",
+                    "scope": "account",
+                    "remaining_value": 19.0,
+                    "limit_value": 25.0,
+                    "used_value": 6.0,
+                    "reset_at": 2_000u64
+                }]
+            }
+        });
+
+        assert!(apply_chatgpt_web_image_quota_request_delta_to_metadata(
+            &mut metadata,
+            Some(&status_snapshot),
+            1_000,
+        ));
+
+        assert_eq!(metadata["image_quota_remaining"], json!(18.0));
+        assert_eq!(metadata["image_quota_total"], json!(25.0));
+        assert_eq!(metadata["image_quota_used"], json!(7.0));
+        assert_eq!(metadata["image_quota_reset_at"], json!(2_000u64));
     }
 
     async fn start_mock_chatgpt_web() -> (String, tokio::task::JoinHandle<()>) {

--- a/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
+++ b/apps/aether-gateway/src/execution_runtime/chatgpt_web_image.rs
@@ -46,6 +46,11 @@ const CHATGPT_WEB_SEC_CH_UA: &str =
 const CHATGPT_WEB_BROWSER_PROFILE: &str = "chrome143";
 const CHATGPT_WEB_QUOTA_REFRESH_TIMEOUT_MS: u64 = 30_000;
 const CHATGPT_WEB_QUOTA_REFRESH_PROXY_TIMEOUT_MS: u64 = 60_000;
+const GPT_IMAGE2_TOKEN_MIN_PIXELS: u64 = 655_360;
+const GPT_IMAGE2_TOKEN_MAX_PIXELS: u64 = 8_294_400;
+const GPT_IMAGE2_TOKEN_MAX_EDGE: u64 = 3_840;
+const GPT_IMAGE2_TOKEN_MAX_ASPECT_RATIO: u64 = 3;
+const GPT_IMAGE2_PARTIAL_IMAGE_OUTPUT_TOKENS: u64 = 100;
 
 pub(crate) struct ChatGptWebImageStream {
     pub(crate) frame_stream: BoxStream<'static, Result<Bytes, IoError>>,
@@ -320,6 +325,8 @@ struct ChatGptWebImageRequest {
     size: String,
     ratio: String,
     output_format: String,
+    quality: Option<String>,
+    partial_images: u64,
     images: Vec<String>,
 }
 
@@ -349,6 +356,8 @@ impl ChatGptWebImageRequest {
             size: text("size").unwrap_or_else(|| "1024x1024".to_string()),
             ratio: text("ratio").unwrap_or_else(|| "1:1".to_string()),
             output_format: text("output_format").unwrap_or_else(|| "png".to_string()),
+            quality: text("quality"),
+            partial_images: json_u64(body.get("partial_images")).unwrap_or(0),
             images,
         })
     }
@@ -2115,7 +2124,7 @@ fn chatgpt_web_image_usage(
     report_context: Option<&Value>,
 ) -> (Value, Value) {
     let input_tokens = chatgpt_web_image_input_tokens(request, report_context);
-    let estimated_output_tokens = chatgpt_web_image_output_tokens(image);
+    let estimated_output_tokens = chatgpt_web_image_output_tokens(request, image, report_context);
     let usage = json!({
         "input_tokens": input_tokens,
         "output_tokens": estimated_output_tokens,
@@ -2130,8 +2139,8 @@ fn chatgpt_web_image_usage(
             },
             "output_tokens": estimated_output_tokens,
             "output_tokens_details": {
-                "image_tokens": 0,
-                "text_tokens": estimated_output_tokens
+                "image_tokens": estimated_output_tokens,
+                "text_tokens": 0
             },
             "total_tokens": input_tokens.saturating_add(estimated_output_tokens),
         }
@@ -2147,8 +2156,86 @@ fn chatgpt_web_image_input_tokens(
     estimate_text_tokens(prompt.as_str())
 }
 
-fn chatgpt_web_image_output_tokens(image: &DownloadedImage) -> u64 {
-    estimate_text_tokens(image.b64_json.as_str())
+fn chatgpt_web_image_output_tokens(
+    request: &ChatGptWebImageRequest,
+    image: &DownloadedImage,
+    report_context: Option<&Value>,
+) -> u64 {
+    let quality = chatgpt_web_image_quality(request, report_context);
+    let size = chatgpt_web_image_size(request, image, report_context);
+    let partial_images = chatgpt_web_image_partial_images(request, report_context);
+    let base_tokens = size
+        .map(|(width, height)| gpt_image2_output_tokens(width, height, quality.as_str()))
+        .unwrap_or_else(|| gpt_image2_output_tokens(1024, 1024, quality.as_str()));
+    base_tokens
+        .saturating_add(partial_images.saturating_mul(GPT_IMAGE2_PARTIAL_IMAGE_OUTPUT_TOKENS))
+}
+
+fn chatgpt_web_image_quality(
+    request: &ChatGptWebImageRequest,
+    report_context: Option<&Value>,
+) -> String {
+    let candidate = [
+        chatgpt_web_report_context_image_request_text(report_context, "quality"),
+        chatgpt_web_report_context_original_request_text(report_context, "quality"),
+        request.quality.clone(),
+    ]
+    .into_iter()
+    .flatten()
+    .find(|value| !value.is_empty())
+    .unwrap_or_else(|| "medium".to_string());
+    normalize_gpt_image2_quality(candidate.as_str())
+}
+
+fn chatgpt_web_image_size(
+    request: &ChatGptWebImageRequest,
+    image: &DownloadedImage,
+    report_context: Option<&Value>,
+) -> Option<(u64, u64)> {
+    if let Some(candidate) = downloaded_image_dimensions(image)
+        .filter(|(width, height)| gpt_image2_dimensions_are_plausible(*width, *height))
+    {
+        return Some(candidate);
+    }
+
+    let candidates = [
+        chatgpt_web_report_context_image_request_text(report_context, "size")
+            .and_then(|value| parse_gpt_image2_size(value.as_str())),
+        chatgpt_web_report_context_original_request_text(report_context, "size")
+            .and_then(|value| parse_gpt_image2_size(value.as_str())),
+        parse_gpt_image2_size(request.size.as_str()),
+    ];
+    for candidate in candidates.into_iter().flatten() {
+        if gpt_image2_dimensions_are_valid(candidate.0, candidate.1) {
+            return Some(candidate);
+        }
+    }
+
+    let ratio = chatgpt_web_image_ratio(request, report_context);
+    Some(chatgpt_web_fallback_size_for_ratio(ratio.as_str()))
+}
+
+fn chatgpt_web_image_partial_images(
+    request: &ChatGptWebImageRequest,
+    report_context: Option<&Value>,
+) -> u64 {
+    chatgpt_web_report_context_image_request_u64(report_context, "partial_images")
+        .or_else(|| {
+            chatgpt_web_report_context_original_request_u64(report_context, "partial_images")
+        })
+        .unwrap_or(request.partial_images)
+}
+
+fn chatgpt_web_image_ratio(
+    request: &ChatGptWebImageRequest,
+    report_context: Option<&Value>,
+) -> String {
+    chatgpt_web_report_context_image_request_text(report_context, "ratio")
+        .or_else(|| chatgpt_web_report_context_original_request_text(report_context, "ratio"))
+        .or_else(|| {
+            chatgpt_web_report_context_original_request_text(report_context, "aspect_ratio")
+        })
+        .unwrap_or_else(|| request.ratio.clone())
 }
 
 fn chatgpt_web_report_context_image_request_text(
@@ -2164,6 +2251,16 @@ fn chatgpt_web_report_context_image_request_text(
         .map(ToOwned::to_owned)
 }
 
+fn chatgpt_web_report_context_image_request_u64(
+    report_context: Option<&Value>,
+    key: &str,
+) -> Option<u64> {
+    report_context
+        .and_then(|value| value.get("image_request"))
+        .and_then(|value| value.get(key))
+        .and_then(|value| json_u64(Some(value)))
+}
+
 fn chatgpt_web_report_context_original_request_text(
     report_context: Option<&Value>,
     key: &str,
@@ -2172,6 +2269,16 @@ fn chatgpt_web_report_context_original_request_text(
     value_text(original.get(key)).or_else(|| {
         chatgpt_web_original_image_tool_value(original, key)
             .and_then(|value| value_text(Some(value)))
+    })
+}
+
+fn chatgpt_web_report_context_original_request_u64(
+    report_context: Option<&Value>,
+    key: &str,
+) -> Option<u64> {
+    let original = report_context?.get("original_request_body")?;
+    json_u64(original.get(key)).or_else(|| {
+        chatgpt_web_original_image_tool_value(original, key).and_then(|value| json_u64(Some(value)))
     })
 }
 
@@ -2206,6 +2313,107 @@ fn value_text(value: Option<&Value>) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn downloaded_image_dimensions(image: &DownloadedImage) -> Option<(u64, u64)> {
+    match (image.width, image.height) {
+        (Some(width), Some(height)) if width > 0 && height > 0 => {
+            Some((width as u64, height as u64))
+        }
+        _ => None,
+    }
+}
+
+fn gpt_image2_dimensions_are_plausible(width: u64, height: u64) -> bool {
+    let pixels = width.saturating_mul(height);
+    if !(GPT_IMAGE2_TOKEN_MIN_PIXELS..=GPT_IMAGE2_TOKEN_MAX_PIXELS).contains(&pixels) {
+        return false;
+    }
+    let max_edge = width.max(height);
+    let min_edge = width.min(height);
+    if max_edge > GPT_IMAGE2_TOKEN_MAX_EDGE {
+        return false;
+    }
+    if max_edge > min_edge.saturating_mul(GPT_IMAGE2_TOKEN_MAX_ASPECT_RATIO) {
+        return false;
+    }
+    true
+}
+
+fn gpt_image2_dimensions_are_valid(width: u64, height: u64) -> bool {
+    width % 16 == 0 && height % 16 == 0 && gpt_image2_dimensions_are_plausible(width, height)
+}
+
+fn normalize_gpt_image2_quality(value: &str) -> String {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "low" => "low".to_string(),
+        "medium" | "standard" | "auto" => "medium".to_string(),
+        "high" | "hd" => "high".to_string(),
+        _ => "medium".to_string(),
+    }
+}
+
+fn parse_gpt_image2_size(size: &str) -> Option<(u64, u64)> {
+    let normalized = size.trim().to_ascii_lowercase().replace('×', "x");
+    let (width, height) = normalized.split_once('x')?;
+    let width = width
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .filter(|value| *value > 0)?;
+    let height = height
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .filter(|value| *value > 0)?;
+    Some((width, height))
+}
+
+fn chatgpt_web_fallback_size_for_ratio(ratio: &str) -> (u64, u64) {
+    match ratio.trim() {
+        "3:2" => (1216, 832),
+        "2:3" => (832, 1216),
+        "4:3" => (1152, 864),
+        "3:4" => (864, 1152),
+        "5:4" => (1120, 896),
+        "4:5" => (896, 1120),
+        "16:9" => (1344, 768),
+        "9:16" => (768, 1344),
+        "21:9" => (1536, 640),
+        _ => (1024, 1024),
+    }
+}
+
+// Estimate GPT Image 2 image-token output using the same dimensions and quality
+// drivers as OpenAI's public cost calculator. This intentionally ignores the
+// base64 response length, which is only a transport encoding.
+fn gpt_image2_output_tokens(width: u64, height: u64, quality: &str) -> u64 {
+    let quality_scale = match quality.trim().to_ascii_lowercase().as_str() {
+        "low" => 16u64,
+        "high" => 96u64,
+        _ => 48u64,
+    };
+    let long = width.max(height);
+    let short = width.min(height);
+    let short_scale = round_div_u64(quality_scale.saturating_mul(short), long);
+    let (long_scale, short_scale) = if width >= height {
+        (quality_scale, short_scale)
+    } else {
+        (short_scale, quality_scale)
+    };
+    let latent_pixels = u128::from(long_scale).saturating_mul(u128::from(short_scale));
+    let image_pixels = u128::from(width).saturating_mul(u128::from(height));
+    let numerator =
+        latent_pixels.saturating_mul(u128::from(2_000_000u64).saturating_add(image_pixels));
+    let tokens = (numerator.saturating_add(4_000_000u128 - 1)) / 4_000_000u128;
+    u64::try_from(tokens).unwrap_or(u64::MAX)
+}
+
+fn round_div_u64(numerator: u64, denominator: u64) -> u64 {
+    if denominator == 0 {
+        return 0;
+    }
+    numerator.saturating_add(denominator / 2) / denominator
+}
+
 fn estimate_text_tokens(text: &str) -> u64 {
     let chars = text.chars().count() as u64;
     if chars == 0 {
@@ -2213,6 +2421,23 @@ fn estimate_text_tokens(text: &str) -> u64 {
     } else {
         chars.div_ceil(4).max(1)
     }
+}
+
+fn json_u64(value: Option<&Value>) -> Option<u64> {
+    value.and_then(|value| {
+        value
+            .as_u64()
+            .or_else(|| {
+                value
+                    .as_i64()
+                    .and_then(|number| (number >= 0).then_some(number as u64))
+            })
+            .or_else(|| {
+                value
+                    .as_str()
+                    .and_then(|number| number.trim().parse::<u64>().ok())
+            })
+    })
 }
 
 fn build_failed_sse(request: &ChatGptWebImageRequest, failure: &Value) -> String {
@@ -2890,8 +3115,16 @@ mod tests {
     }
 
     #[test]
+    fn gpt_image2_output_token_estimator_matches_pricing_calculator_examples() {
+        assert_eq!(gpt_image2_output_tokens(1024, 1024, "low"), 196);
+        assert_eq!(gpt_image2_output_tokens(1024, 1024, "medium"), 1756);
+        assert_eq!(gpt_image2_output_tokens(1536, 1024, "medium"), 1372);
+        assert_eq!(gpt_image2_output_tokens(1024, 1536, "medium"), 1372);
+        assert_eq!(gpt_image2_output_tokens(1024, 1024, "high"), 7024);
+    }
+
+    #[test]
     fn chatgpt_web_success_sse_includes_estimated_image_usage() {
-        let output_text = "aGVsbG8=".repeat(128);
         let request = ChatGptWebImageRequest {
             model: "gpt-image-2".to_string(),
             web_model: "gpt-5-5-thinking".to_string(),
@@ -2899,10 +3132,12 @@ mod tests {
             size: "1024x1024".to_string(),
             ratio: "1:1".to_string(),
             output_format: "png".to_string(),
+            quality: Some("low".to_string()),
+            partial_images: 0,
             images: Vec::new(),
         };
         let image = DownloadedImage {
-            b64_json: output_text.clone(),
+            b64_json: "aGVsbG8=".repeat(128),
             mime: "image/png".to_string(),
             width: Some(1024),
             height: Some(1024),
@@ -2919,7 +3154,7 @@ mod tests {
         );
         let completed = completed_response_from_sse(body.as_str());
         let input_tokens = estimate_text_tokens("draw a test image");
-        let output_tokens = estimate_text_tokens(output_text.as_str());
+        let output_tokens = 196;
 
         assert_eq!(completed["usage"]["input_tokens"], json!(input_tokens));
         assert_eq!(completed["usage"]["output_tokens"], json!(output_tokens));
@@ -2932,7 +3167,7 @@ mod tests {
             json!(input_tokens)
         );
         assert_eq!(
-            completed["tool_usage"]["image_gen"]["output_tokens_details"]["text_tokens"],
+            completed["tool_usage"]["image_gen"]["output_tokens_details"]["image_tokens"],
             json!(output_tokens)
         );
         assert_eq!(
@@ -2942,8 +3177,7 @@ mod tests {
     }
 
     #[test]
-    fn chatgpt_web_success_sse_counts_output_text_not_dimensions() {
-        let output_text = "iVBORw0KGgoAAAANSUhEUgAA".repeat(64);
+    fn chatgpt_web_success_sse_uses_image_dimensions_not_output_text() {
         let request = ChatGptWebImageRequest {
             model: "gpt-image-2".to_string(),
             web_model: "gpt-5-5-thinking".to_string(),
@@ -2951,10 +3185,12 @@ mod tests {
             size: "1024x1024".to_string(),
             ratio: "1:1".to_string(),
             output_format: "png".to_string(),
+            quality: Some("low".to_string()),
+            partial_images: 0,
             images: Vec::new(),
         };
         let image = DownloadedImage {
-            b64_json: output_text.clone(),
+            b64_json: "iVBORw0KGgoAAAANSUhEUgAA".repeat(64),
             mime: "image/png".to_string(),
             width: Some(1402),
             height: Some(1122),
@@ -2973,7 +3209,7 @@ mod tests {
 
         assert_eq!(
             completed["usage"]["output_tokens"],
-            json!(estimate_text_tokens(output_text.as_str()))
+            json!(gpt_image2_output_tokens(1402, 1122, "low"))
         );
     }
 
@@ -3428,16 +3664,12 @@ data: [DONE]
         assert!(body.contains("\"height\":3"));
         let expected_output_text =
             base64::engine::general_purpose::STANDARD.encode(png_header_bytes(2, 3));
-        let expected_output_tokens = estimate_text_tokens(expected_output_text.as_str());
         assert!(body.contains(&expected_output_text));
         let completed = completed_response_from_sse(body.as_str());
-        assert_eq!(
-            completed["usage"]["output_tokens"],
-            json!(expected_output_tokens)
-        );
+        assert_eq!(completed["usage"]["output_tokens"], json!(1756));
         assert_eq!(
             completed["tool_usage"]["image_gen"]["output_tokens"],
-            json!(expected_output_tokens)
+            json!(1756)
         );
 
         handle.abort();
@@ -3503,11 +3735,6 @@ data: [DONE]
         assert!(decoded_data.contains("\"width\":2"));
         assert!(decoded_data.contains("\"height\":3"));
         assert!(text.contains("\"type\":\"eof\""));
-        let expected_output_tokens = estimate_text_tokens(
-            base64::engine::general_purpose::STANDARD
-                .encode(png_header_bytes(2, 3))
-                .as_str(),
-        );
         let eof_frame = text
             .lines()
             .filter_map(|line| serde_json::from_str::<Value>(line).ok())
@@ -3520,7 +3747,7 @@ data: [DONE]
                 .and_then(|summary| summary.get("standardized_usage"))
                 .and_then(|usage| usage.get("output_tokens"))
                 .and_then(Value::as_i64),
-            i64::try_from(expected_output_tokens).ok()
+            Some(1756)
         );
         assert_eq!(
             eof_frame

--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -61,7 +61,10 @@ use crate::clock::current_unix_ms as current_request_candidate_unix_ms;
 use crate::constants::{CONTROL_CANDIDATE_ID_HEADER, CONTROL_REQUEST_ID_HEADER};
 use crate::control::GatewayControlDecision;
 use crate::execution_runtime::build_direct_execution_frame_stream;
-use crate::execution_runtime::chatgpt_web_image::maybe_execute_chatgpt_web_image_stream;
+use crate::execution_runtime::chatgpt_web_image::{
+    maybe_apply_chatgpt_web_image_quota_request_delta_at_candidate_start,
+    maybe_execute_chatgpt_web_image_stream,
+};
 use crate::execution_runtime::grok::maybe_execute_grok_stream;
 use crate::execution_runtime::kiro_cache::{
     billed_input_tokens as kiro_billed_input_tokens, build_kiro_prompt_cache_profile,
@@ -858,6 +861,12 @@ pub(crate) async fn execute_execution_runtime_stream(
             .await;
         });
     }
+    maybe_apply_chatgpt_web_image_quota_request_delta_at_candidate_start(
+        state,
+        &plan,
+        report_context.as_ref(),
+    )
+    .await;
     let plan_request_id_for_log = short_request_id(plan.request_id.as_str());
     let provider_name = plan
         .provider_name

--- a/apps/aether-gateway/src/execution_runtime/sync/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/sync/execution.rs
@@ -39,7 +39,10 @@ use crate::api::response::{
 };
 use crate::clock::current_unix_ms as current_request_candidate_unix_ms;
 use crate::control::GatewayControlDecision;
-use crate::execution_runtime::chatgpt_web_image::maybe_execute_chatgpt_web_image_sync;
+use crate::execution_runtime::chatgpt_web_image::{
+    maybe_apply_chatgpt_web_image_quota_request_delta_at_candidate_start,
+    maybe_execute_chatgpt_web_image_sync,
+};
 use crate::execution_runtime::grok::maybe_execute_grok_sync;
 use crate::execution_runtime::oauth_retry::refresh_oauth_plan_auth_for_retry;
 #[cfg(test)]
@@ -1333,6 +1336,12 @@ async fn execute_execution_runtime_sync_impl(
             started_at_unix_ms: Some(candidate_started_unix_secs),
             finished_at_unix_ms: None,
         },
+    )
+    .await;
+    maybe_apply_chatgpt_web_image_quota_request_delta_at_candidate_start(
+        state,
+        &plan,
+        report_context.as_ref(),
     )
     .await;
     let mut terminal_guard = SyncAttemptTerminalGuard::new(

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/chatgpt_web.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/chatgpt_web.rs
@@ -5,12 +5,15 @@ use super::shared::{
     quota_key_auto_removed, quota_refresh_success_invalid_state, ProviderQuotaExecutionOutcome,
 };
 use crate::handlers::admin::provider::shared::payloads::{
-    OAUTH_ACCOUNT_BLOCK_PREFIX, OAUTH_EXPIRED_PREFIX,
+    OAUTH_ACCOUNT_BLOCK_PREFIX, OAUTH_EXPIRED_PREFIX, OAUTH_REFRESH_FAILED_PREFIX,
 };
 use crate::handlers::admin::request::{AdminAppState, AdminGatewayProviderTransportSnapshot};
 use crate::GatewayError;
 use aether_admin::provider::quota::parse_chatgpt_web_conversation_init_response;
-use aether_contracts::ProxySnapshot;
+use aether_contracts::{
+    ExecutionResult, ProxySnapshot, ResolvedTransportProfile, TRANSPORT_BACKEND_BROWSER_WREQ,
+    TRANSPORT_HTTP_MODE_AUTO, TRANSPORT_POOL_SCOPE_KEY,
+};
 use aether_data_contracts::repository::provider_catalog::{
     StoredProviderCatalogEndpoint, StoredProviderCatalogKey, StoredProviderCatalogProvider,
 };
@@ -18,10 +21,12 @@ use aether_provider_pool::{
     build_chatgpt_web_pool_quota_request, enrich_chatgpt_web_quota_metadata,
     normalize_chatgpt_web_image_quota_limit,
 };
+use base64::Engine as _;
 use serde_json::json;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const PLACEHOLDER_API_KEY: &str = "__placeholder__";
+const CHATGPT_WEB_BROWSER_PROFILE: &str = "chrome143";
 
 fn chatgpt_web_auth_config(
     transport: &AdminGatewayProviderTransportSnapshot,
@@ -74,19 +79,99 @@ async fn execute_chatgpt_web_quota_plan(
         )));
     let spec =
         build_chatgpt_web_pool_quota_request(&transport.key.id, &endpoint.base_url, authorization);
+    let resolved_transport_profile = state.resolve_transport_profile(transport);
     let plan = super::shared::build_provider_quota_execution_plan(
         transport,
         spec,
         proxy,
-        state.resolve_transport_profile(transport),
+        chatgpt_web_quota_transport_profile(resolved_transport_profile.as_ref()),
         timeouts,
     );
 
     execute_provider_quota_plan(state, transport, plan, "chatgpt_web").await
 }
 
+fn chatgpt_web_quota_transport_profile(
+    transport_profile: Option<&ResolvedTransportProfile>,
+) -> Option<ResolvedTransportProfile> {
+    match transport_profile {
+        Some(profile)
+            if profile
+                .backend
+                .trim()
+                .eq_ignore_ascii_case(TRANSPORT_BACKEND_BROWSER_WREQ) =>
+        {
+            Some(profile.clone())
+        }
+        _ => Some(default_chatgpt_web_quota_transport_profile()),
+    }
+}
+
+fn default_chatgpt_web_quota_transport_profile() -> ResolvedTransportProfile {
+    ResolvedTransportProfile {
+        profile_id: CHATGPT_WEB_BROWSER_PROFILE.to_string(),
+        backend: TRANSPORT_BACKEND_BROWSER_WREQ.to_string(),
+        http_mode: TRANSPORT_HTTP_MODE_AUTO.to_string(),
+        pool_scope: TRANSPORT_POOL_SCOPE_KEY.to_string(),
+        header_fingerprint: None,
+        extra: Some(json!({
+            "browser_profile": CHATGPT_WEB_BROWSER_PROFILE,
+            "source": "chatgpt_web_quota_default",
+        })),
+    }
+}
+
+fn chatgpt_web_quota_error_detail(result: &ExecutionResult) -> Option<String> {
+    extract_execution_error_message(result).or_else(|| {
+        let body = result.body.as_ref()?.body_bytes_b64.as_deref()?;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(body)
+            .ok()?;
+        let text = String::from_utf8_lossy(&decoded).trim().to_string();
+        (!text.is_empty()).then_some(text)
+    })
+}
+
+fn chatgpt_web_is_structured_account_block(message: &str) -> bool {
+    let lowered = message.to_ascii_lowercase();
+    [
+        "account has been disabled",
+        "account disabled",
+        "account has been deactivated",
+        "account_deactivated",
+        "account deactivated",
+        "organization has been disabled",
+        "organization_disabled",
+        "deactivated_workspace",
+        "account suspended",
+        "account banned",
+        "account_block",
+        "account blocked",
+        "访问被禁止",
+        "账户访问被禁止",
+        "账户已封禁",
+        "封禁",
+        "封号",
+        "被封",
+    ]
+    .iter()
+    .any(|keyword| lowered.contains(keyword))
+}
+
+fn chatgpt_web_quota_403_refresh_failed_reason(message: Option<&str>) -> String {
+    let detail = message
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .filter(|value| !value.contains('<'))
+        .unwrap_or("ChatGPT Web 访问验证失败，请检查浏览器指纹、Cloudflare 验证或代理/地区限制");
+    format!("{OAUTH_REFRESH_FAILED_PREFIX}{detail}")
+}
+
 fn chatgpt_web_quota_invalid_reason(status_code: u16, upstream_message: Option<&str>) -> String {
     let message = upstream_message.unwrap_or_default().trim();
+    if status_code == 403 && !chatgpt_web_is_structured_account_block(message) {
+        return chatgpt_web_quota_403_refresh_failed_reason(upstream_message);
+    }
     let detail = if message.is_empty() {
         match status_code {
             401 => "ChatGPT Web Token 无效或已过期",
@@ -101,6 +186,19 @@ fn chatgpt_web_quota_invalid_reason(status_code: u16, upstream_message: Option<&
         403 => format!("{OAUTH_ACCOUNT_BLOCK_PREFIX}{detail}"),
         _ => detail.to_string(),
     }
+}
+
+fn chatgpt_web_quota_result_message(reason: &str) -> String {
+    for prefix in [
+        OAUTH_REFRESH_FAILED_PREFIX,
+        OAUTH_EXPIRED_PREFIX,
+        OAUTH_ACCOUNT_BLOCK_PREFIX,
+    ] {
+        if let Some(message) = reason.strip_prefix(prefix) {
+            return message.trim().to_string();
+        }
+    }
+    reason.trim().to_string()
 }
 
 pub(crate) async fn refresh_chatgpt_web_provider_quota_locally(
@@ -216,8 +314,20 @@ pub(crate) async fn refresh_chatgpt_web_provider_quota_locally(
                 message = Some("响应中未包含 ChatGPT Web 生图限额信息".to_string());
             }
         } else {
-            let err_msg = extract_execution_error_message(&result);
-            message = Some(match err_msg.as_deref() {
+            let err_msg = chatgpt_web_quota_error_detail(&result);
+            let invalid_reason = if matches!(result.status_code, 401 | 403) {
+                Some(chatgpt_web_quota_invalid_reason(
+                    result.status_code,
+                    err_msg.as_deref(),
+                ))
+            } else {
+                None
+            };
+            let display_detail = invalid_reason
+                .as_deref()
+                .map(chatgpt_web_quota_result_message)
+                .or_else(|| err_msg.clone());
+            message = Some(match display_detail.as_deref() {
                 Some(detail) if !detail.is_empty() => {
                     format!(
                         "conversation/init 返回状态码 {}: {}",
@@ -229,12 +339,14 @@ pub(crate) async fn refresh_chatgpt_web_provider_quota_locally(
 
             if matches!(result.status_code, 401 | 403) {
                 oauth_invalid_at_unix_secs = Some(now_unix_secs);
-                oauth_invalid_reason = Some(chatgpt_web_quota_invalid_reason(
-                    result.status_code,
-                    err_msg.as_deref(),
-                ));
+                oauth_invalid_reason = invalid_reason;
                 status = if result.status_code == 401 {
                     "auth_invalid".to_string()
+                } else if oauth_invalid_reason
+                    .as_deref()
+                    .is_some_and(|reason| reason.starts_with(OAUTH_REFRESH_FAILED_PREFIX))
+                {
+                    "refresh_failed".to_string()
                 } else {
                     "forbidden".to_string()
                 };
@@ -302,4 +414,82 @@ pub(crate) async fn refresh_chatgpt_web_provider_quota_locally(
         "message": format!("已处理 {} 个 Key", results.len()),
         "auto_removed": auto_removed_count,
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aether_contracts::{ResponseBody, TRANSPORT_BACKEND_REQWEST_RUSTLS};
+    use base64::Engine as _;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn quota_refresh_defaults_to_browser_wreq_transport() {
+        let profile = chatgpt_web_quota_transport_profile(None).expect("transport profile");
+
+        assert_eq!(profile.backend, TRANSPORT_BACKEND_BROWSER_WREQ);
+        assert_eq!(profile.profile_id, CHATGPT_WEB_BROWSER_PROFILE);
+        assert_eq!(profile.http_mode, TRANSPORT_HTTP_MODE_AUTO);
+        assert_eq!(profile.pool_scope, TRANSPORT_POOL_SCOPE_KEY);
+        assert_eq!(
+            profile
+                .extra
+                .as_ref()
+                .and_then(|value| value.get("browser_profile"))
+                .and_then(serde_json::Value::as_str),
+            Some(CHATGPT_WEB_BROWSER_PROFILE)
+        );
+    }
+
+    #[test]
+    fn quota_refresh_overrides_non_browser_transport() {
+        let reqwest_profile = ResolvedTransportProfile {
+            profile_id: "chrome_136".to_string(),
+            backend: TRANSPORT_BACKEND_REQWEST_RUSTLS.to_string(),
+            http_mode: TRANSPORT_HTTP_MODE_AUTO.to_string(),
+            pool_scope: TRANSPORT_POOL_SCOPE_KEY.to_string(),
+            header_fingerprint: None,
+            extra: None,
+        };
+
+        let profile =
+            chatgpt_web_quota_transport_profile(Some(&reqwest_profile)).expect("transport profile");
+
+        assert_eq!(profile.backend, TRANSPORT_BACKEND_BROWSER_WREQ);
+        assert_eq!(profile.profile_id, CHATGPT_WEB_BROWSER_PROFILE);
+    }
+
+    #[test]
+    fn browser_challenge_403_is_not_account_block() {
+        let body = "<!DOCTYPE html><html><head><title>Just a moment...</title></head><body>Cloudflare</body></html>";
+        let result = ExecutionResult {
+            request_id: "chatgpt-web-quota:test".to_string(),
+            candidate_id: None,
+            status_code: 403,
+            headers: BTreeMap::new(),
+            body: Some(ResponseBody {
+                json_body: None,
+                body_bytes_b64: Some(base64::engine::general_purpose::STANDARD.encode(body)),
+            }),
+            telemetry: None,
+            error: None,
+        };
+
+        let detail = chatgpt_web_quota_error_detail(&result).expect("html body should decode");
+        let reason = chatgpt_web_quota_invalid_reason(result.status_code, Some(&detail));
+
+        assert!(reason.starts_with(OAUTH_REFRESH_FAILED_PREFIX));
+        assert!(!reason.starts_with(OAUTH_ACCOUNT_BLOCK_PREFIX));
+        assert_eq!(
+            chatgpt_web_quota_result_message(&reason),
+            "ChatGPT Web 访问验证失败，请检查浏览器指纹、Cloudflare 验证或代理/地区限制"
+        );
+    }
+
+    #[test]
+    fn explicit_account_block_403_remains_account_block() {
+        let reason = chatgpt_web_quota_invalid_reason(403, Some("account has been deactivated"));
+
+        assert!(reason.starts_with(OAUTH_ACCOUNT_BLOCK_PREFIX));
+    }
 }

--- a/apps/aether-gateway/src/handlers/shared/catalog.rs
+++ b/apps/aether-gateway/src/handlers/shared/catalog.rs
@@ -442,11 +442,47 @@ fn chatgpt_web_image_quota_limit(
         .get("image_quota_total")
         .and_then(admin_provider_quota_pure::coerce_json_f64)
         .filter(|value| *value > 0.0);
+    let plan_type = metadata
+        .get("plan_type")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_ascii_lowercase());
+    let limit_source = metadata
+        .get("image_quota_limit_source")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
     if let Some(limit) = explicit_limit {
-        return Some(limit);
+        if !chatgpt_web_image_quota_limit_is_legacy_free_default(
+            limit,
+            limit_source,
+            plan_type.as_deref(),
+            remaining,
+        ) {
+            return Some(limit);
+        }
     }
 
     remaining.filter(|value| *value > 0.0)
+}
+
+fn chatgpt_web_image_quota_limit_is_legacy_free_default(
+    limit: f64,
+    limit_source: Option<&str>,
+    plan_type: Option<&str>,
+    remaining: Option<f64>,
+) -> bool {
+    let plan_type_is_free = plan_type
+        .map(str::trim)
+        .is_some_and(|value| value.eq_ignore_ascii_case("free"));
+    if !plan_type_is_free || limit_source.is_some() {
+        return false;
+    }
+    if (limit - 25.0).abs() > f64::EPSILON {
+        return false;
+    }
+    remaining.is_some_and(|value| value < limit)
 }
 
 fn model_quota_window_snapshot(
@@ -2531,6 +2567,33 @@ mod tests {
         assert_eq!(window.get("limit_value"), Some(&json!(24.0)));
         assert_eq!(window.get("used_value"), Some(&json!(0.0)));
         assert_eq!(window.get("remaining_ratio"), Some(&json!(1.0)));
+    }
+
+    #[test]
+    fn provider_key_status_snapshot_payload_ignores_chatgpt_web_legacy_free_25_limit() {
+        let mut key = sample_catalog_key();
+        key.upstream_metadata = Some(json!({
+            "chatgpt_web": {
+                "updated_at": 1_778_067_246u64,
+                "plan_type": "free",
+                "image_quota_remaining": 19.0,
+                "image_quota_total": 25.0
+            }
+        }));
+
+        let payload = provider_key_status_snapshot_payload(&key, "chatgpt_web");
+        let window = payload
+            .get("quota")
+            .and_then(Value::as_object)
+            .and_then(|quota| quota.get("windows"))
+            .and_then(Value::as_array)
+            .and_then(|windows| windows.first())
+            .and_then(Value::as_object)
+            .expect("image quota window should exist");
+
+        assert_eq!(window.get("remaining_value"), Some(&json!(19.0)));
+        assert_eq!(window.get("limit_value"), Some(&json!(19.0)));
+        assert_eq!(window.get("used_value"), Some(&json!(0.0)));
     }
 
     #[test]

--- a/apps/aether-gateway/src/handlers/shared/catalog.rs
+++ b/apps/aether-gateway/src/handlers/shared/catalog.rs
@@ -482,7 +482,7 @@ fn chatgpt_web_image_quota_limit_is_legacy_free_default(
     if (limit - 25.0).abs() > f64::EPSILON {
         return false;
     }
-    remaining.is_some_and(|value| value < limit)
+    remaining.is_none_or(|value| value < limit)
 }
 
 fn model_quota_window_snapshot(

--- a/apps/aether-gateway/src/handlers/shared/catalog.rs
+++ b/apps/aether-gateway/src/handlers/shared/catalog.rs
@@ -438,16 +438,6 @@ fn chatgpt_web_image_quota_limit(
     metadata: &Map<String, Value>,
     remaining: Option<f64>,
 ) -> Option<f64> {
-    let plan_type = metadata
-        .get("plan_type")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(|value| value.to_ascii_lowercase());
-    if plan_type.as_deref() == Some("free") {
-        return Some(25.0);
-    }
-
     let explicit_limit = metadata
         .get("image_quota_total")
         .and_then(admin_provider_quota_pure::coerce_json_f64)
@@ -2535,12 +2525,12 @@ mod tests {
         assert_eq!(quota.get("code"), Some(&json!("ok")));
         assert_eq!(quota.get("plan_type"), Some(&json!("free")));
         assert_eq!(quota.get("reset_at"), Some(&json!(1_778_157_172u64)));
-        assert_eq!(quota.get("usage_ratio"), Some(&json!(0.04)));
+        assert_eq!(quota.get("usage_ratio"), Some(&json!(0.0)));
         assert_eq!(window.get("code"), Some(&json!("image_gen")));
         assert_eq!(window.get("remaining_value"), Some(&json!(24.0)));
-        assert_eq!(window.get("limit_value"), Some(&json!(25.0)));
-        assert_eq!(window.get("used_value"), Some(&json!(1.0)));
-        assert_eq!(window.get("remaining_ratio"), Some(&json!(0.96)));
+        assert_eq!(window.get("limit_value"), Some(&json!(24.0)));
+        assert_eq!(window.get("used_value"), Some(&json!(0.0)));
+        assert_eq!(window.get("remaining_ratio"), Some(&json!(1.0)));
     }
 
     #[test]

--- a/crates/aether-ai-formats/src/formats/openai/image/request.rs
+++ b/crates/aether-ai-formats/src/formats/openai/image/request.rs
@@ -206,6 +206,21 @@ pub fn build_chatgpt_web_image_request_body(
     if let Some(user) = request.user.as_ref() {
         body.insert("user".to_string(), Value::String(user.clone()));
     }
+    if let Some(quality) = request
+        .tool
+        .get("quality")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        body.insert("quality".to_string(), Value::String(quality.to_string()));
+    }
+    if let Some(partial_images) = request.tool.get("partial_images").and_then(Value::as_u64) {
+        body.insert(
+            "partial_images".to_string(),
+            Value::Number(Number::from(partial_images)),
+        );
+    }
     if let Some(output_format) = request
         .summary_json
         .get("output_format")
@@ -1591,6 +1606,28 @@ mod tests {
         )
         .expect("1024x1024 should pass");
         assert_eq!(by_size["size"], "1024x1024");
+    }
+
+    #[test]
+    fn chatgpt_web_preserves_quality_and_partial_images() {
+        let parts = request_parts("/v1/images/generations", Some("application/json"));
+        let body = build_chatgpt_web_image_request_body(
+            &parts,
+            &json!({
+                "model": "gpt-image-2",
+                "prompt": "draw",
+                "size": "1024x1024",
+                "quality": "high",
+                "partial_images": 2,
+                "output_format": "png"
+            }),
+            None,
+        )
+        .expect("request should pass");
+
+        assert_eq!(body["quality"], "high");
+        assert_eq!(body["partial_images"], 2);
+        assert_eq!(body["output_format"], "png");
     }
 
     #[test]

--- a/crates/aether-data/src/repository/usage/mod.rs
+++ b/crates/aether-data/src/repository/usage/mod.rs
@@ -640,15 +640,13 @@ pub(crate) fn provider_api_key_usage_is_error(
 pub(crate) fn provider_api_key_usage_contribution(
     usage: &StoredRequestUsageAudit,
 ) -> Option<ProviderApiKeyUsageContribution> {
-    if matches!(usage.status.as_str(), "pending" | "streaming") {
-        return None;
-    }
     let key_id = usage
         .provider_api_key_id
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())?
         .to_string();
+    let is_in_flight = matches!(usage.status.as_str(), "pending" | "streaming");
     let is_success = provider_api_key_usage_is_success(
         usage.status.as_str(),
         usage.status_code,
@@ -665,8 +663,14 @@ pub(crate) fn provider_api_key_usage_contribution(
         request_count: 1,
         success_count: i64::from(is_success),
         error_count: i64::from(is_error),
-        total_tokens: i64::try_from(usage.total_tokens).unwrap_or(i64::MAX),
-        total_cost_usd: if usage.total_cost_usd.is_finite() {
+        total_tokens: if is_in_flight {
+            0
+        } else {
+            i64::try_from(usage.total_tokens).unwrap_or(i64::MAX)
+        },
+        total_cost_usd: if is_in_flight {
+            0.0
+        } else if usage.total_cost_usd.is_finite() {
             usage.total_cost_usd.max(0.0)
         } else {
             0.0
@@ -1029,7 +1033,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_api_key_usage_contribution_tracks_terminal_requests_only() {
+    fn provider_api_key_usage_contribution_counts_in_flight_requests_once() {
         let usage = StoredRequestUsageAudit::new(
             "usage-1".to_string(),
             "request-1".to_string(),
@@ -1074,11 +1078,36 @@ mod tests {
 
         let mut streaming = usage.clone();
         streaming.status = "streaming".to_string();
-        assert!(provider_api_key_usage_contribution(&streaming).is_none());
+        let streaming_contribution =
+            provider_api_key_usage_contribution(&streaming).expect("streaming should count");
+        assert_eq!(streaming_contribution.request_count, 1);
+        assert_eq!(streaming_contribution.success_count, 0);
+        assert_eq!(streaming_contribution.error_count, 0);
+        assert_eq!(streaming_contribution.total_tokens, 0);
+        assert_eq!(streaming_contribution.total_cost_usd, 0.0);
+        assert_eq!(streaming_contribution.total_response_time_ms, 0);
 
-        let mut pending = usage;
+        let mut pending = usage.clone();
         pending.status = "pending".to_string();
-        assert!(provider_api_key_usage_contribution(&pending).is_none());
+        let pending_contribution =
+            provider_api_key_usage_contribution(&pending).expect("pending should count");
+        assert_eq!(pending_contribution.request_count, 1);
+        assert_eq!(pending_contribution.success_count, 0);
+        assert_eq!(pending_contribution.error_count, 0);
+        assert_eq!(pending_contribution.total_tokens, 0);
+        assert_eq!(pending_contribution.total_cost_usd, 0.0);
+        assert_eq!(pending_contribution.total_response_time_ms, 0);
+
+        let terminal_contribution =
+            provider_api_key_usage_contribution(&usage).expect("terminal should count");
+        let delta =
+            ProviderApiKeyUsageDelta::between(&pending_contribution, &terminal_contribution);
+        assert_eq!(delta.request_count, 0);
+        assert_eq!(delta.success_count, 1);
+        assert_eq!(delta.error_count, 0);
+        assert_eq!(delta.total_tokens, 20);
+        assert_eq!(delta.total_cost_usd, 0.25);
+        assert_eq!(delta.total_response_time_ms, 120);
     }
 
     #[test]

--- a/crates/aether-data/src/repository/usage/mysql.rs
+++ b/crates/aether-data/src/repository/usage/mysql.rs
@@ -389,19 +389,28 @@ WHERE provider_api_key_id IS NOT NULL AND provider_api_key_id <> ''
             let error_message: Option<String> = row.try_get("error_message").map_sql_err()?;
             let entry = stats.entry(key_id).or_default();
             entry.request_count += 1;
-            if provider_api_key_usage_is_success(&status, status_code_u16, error_message.as_deref())
-            {
+            let is_success = provider_api_key_usage_is_success(
+                &status,
+                status_code_u16,
+                error_message.as_deref(),
+            );
+            let is_in_flight = matches!(status.as_str(), "pending" | "streaming");
+            if is_success {
                 entry.success_count += 1;
             }
             if provider_api_key_usage_is_error(&status, status_code_u16, error_message.as_deref()) {
                 entry.error_count += 1;
             }
-            entry.total_tokens += row.try_get::<i64, _>("total_tokens").map_sql_err()?;
-            entry.total_cost_usd += row.try_get::<f64, _>("total_cost_usd").map_sql_err()?;
-            entry.total_response_time_ms += row
-                .try_get::<Option<i64>, _>("response_time_ms")
-                .map_sql_err()?
-                .unwrap_or_default();
+            if !is_in_flight {
+                entry.total_tokens += row.try_get::<i64, _>("total_tokens").map_sql_err()?;
+                entry.total_cost_usd += row.try_get::<f64, _>("total_cost_usd").map_sql_err()?;
+            }
+            if is_success {
+                entry.total_response_time_ms += row
+                    .try_get::<Option<i64>, _>("response_time_ms")
+                    .map_sql_err()?
+                    .unwrap_or_default();
+            }
             entry.last_used_at = entry.last_used_at.max(
                 row.try_get::<Option<i64>, _>("updated_at_unix_secs")
                     .map_sql_err()?,

--- a/crates/aether-data/src/repository/usage/postgres/queries/rebuild_provider_api_key_usage_stats_sql.sql
+++ b/crates/aether-data/src/repository/usage/postgres/queries/rebuild_provider_api_key_usage_stats_sql.sql
@@ -24,15 +24,23 @@ WITH aggregated AS (
       END
     ), 0)::BIGINT AS error_count,
     COALESCE(SUM(
-      GREATEST(
-        COALESCE(
-          total_tokens,
-          COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)
-        ),
-        0
-      )::BIGINT
+      CASE
+        WHEN status IN ('pending', 'streaming') THEN 0
+        ELSE GREATEST(
+          COALESCE(
+            total_tokens,
+            COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)
+          ),
+          0
+        )::BIGINT
+      END
     ), 0)::BIGINT AS total_tokens,
-    COALESCE(SUM(COALESCE(total_cost_usd, 0)), 0)::NUMERIC(20,8) AS total_cost_usd,
+    COALESCE(SUM(
+      CASE
+        WHEN status IN ('pending', 'streaming') THEN 0
+        ELSE COALESCE(total_cost_usd, 0)
+      END
+    ), 0)::NUMERIC(20,8) AS total_cost_usd,
     COALESCE(SUM(
       CASE
         WHEN status IN ('completed', 'success', 'ok', 'billed', 'settled')
@@ -47,7 +55,6 @@ WITH aggregated AS (
   FROM usage_billing_facts AS "usage"
   WHERE provider_api_key_id IS NOT NULL
     AND BTRIM(provider_api_key_id) <> ''
-    AND status NOT IN ('pending', 'streaming')
   GROUP BY provider_api_key_id
 )
 UPDATE provider_api_keys

--- a/crates/aether-data/src/repository/usage/sqlite.rs
+++ b/crates/aether-data/src/repository/usage/sqlite.rs
@@ -3409,8 +3409,14 @@ SELECT
   COUNT(*) AS request_count,
   COALESCE(SUM({success_flag_expr}), 0) AS success_count,
   COALESCE(SUM({error_flag_expr}), 0) AS error_count,
-  COALESCE(SUM(MAX(COALESCE(total_tokens, 0), 0)), 0) AS total_tokens,
-  COALESCE(SUM(COALESCE(CAST(total_cost_usd AS REAL), 0)), 0) AS total_cost_usd,
+  COALESCE(SUM(CASE
+    WHEN status IN ('pending', 'streaming') THEN 0
+    ELSE MAX(COALESCE(total_tokens, 0), 0)
+  END), 0) AS total_tokens,
+  COALESCE(SUM(CASE
+    WHEN status IN ('pending', 'streaming') THEN 0
+    ELSE COALESCE(CAST(total_cost_usd AS REAL), 0)
+  END), 0) AS total_cost_usd,
   COALESCE(SUM(CASE
     WHEN {success_flag_expr} = 1 AND response_time_ms IS NOT NULL
     THEN MAX(COALESCE(response_time_ms, 0), 0)

--- a/crates/aether-provider-pool/src/lib.rs
+++ b/crates/aether-provider-pool/src/lib.rs
@@ -277,6 +277,23 @@ mod tests {
     }
 
     #[test]
+    fn chatgpt_web_quota_metadata_ignores_upstream_free_25_default() {
+        let mut metadata = json!({
+            "plan_type": "free",
+            "image_quota_remaining": 19,
+            "image_quota_total": 25,
+        });
+        normalize_chatgpt_web_image_quota_limit(&mut metadata, None);
+
+        assert_eq!(metadata["image_quota_total"], json!(19.0));
+        assert_eq!(metadata["image_quota_used"], json!(0.0));
+        assert_eq!(
+            metadata["image_quota_limit_source"],
+            json!("first_remaining")
+        );
+    }
+
+    #[test]
     fn chatgpt_web_quota_metadata_preserves_marked_free_first_limit() {
         let mut metadata = json!({
             "plan_type": "free",

--- a/crates/aether-provider-pool/src/lib.rs
+++ b/crates/aether-provider-pool/src/lib.rs
@@ -253,6 +253,55 @@ mod tests {
     }
 
     #[test]
+    fn chatgpt_web_quota_metadata_does_not_preserve_legacy_free_25_limit() {
+        let mut metadata = json!({
+            "plan_type": "free",
+            "image_quota_remaining": 19,
+        });
+        normalize_chatgpt_web_image_quota_limit(
+            &mut metadata,
+            Some(&json!({
+                "chatgpt_web": {
+                    "plan_type": "free",
+                    "image_quota_total": 25
+                }
+            })),
+        );
+
+        assert_eq!(metadata["image_quota_total"], json!(19.0));
+        assert_eq!(metadata["image_quota_used"], json!(0.0));
+        assert_eq!(
+            metadata["image_quota_limit_source"],
+            json!("first_remaining")
+        );
+    }
+
+    #[test]
+    fn chatgpt_web_quota_metadata_preserves_marked_free_first_limit() {
+        let mut metadata = json!({
+            "plan_type": "free",
+            "image_quota_remaining": 18,
+        });
+        normalize_chatgpt_web_image_quota_limit(
+            &mut metadata,
+            Some(&json!({
+                "chatgpt_web": {
+                    "plan_type": "free",
+                    "image_quota_total": 19,
+                    "image_quota_limit_source": "first_remaining"
+                }
+            })),
+        );
+
+        assert_eq!(metadata["image_quota_total"], json!(19.0));
+        assert_eq!(metadata["image_quota_used"], json!(1.0));
+        assert_eq!(
+            metadata["image_quota_limit_source"],
+            json!("first_remaining")
+        );
+    }
+
+    #[test]
     fn windsurf_quota_request_uses_user_status_connect_rpc() {
         let spec = build_windsurf_pool_quota_request("key-ws", "session-token-123");
 

--- a/crates/aether-provider-pool/src/lib.rs
+++ b/crates/aether-provider-pool/src/lib.rs
@@ -212,7 +212,7 @@ mod tests {
     }
 
     #[test]
-    fn chatgpt_web_quota_metadata_enriches_auth_and_normalizes_free_limit() {
+    fn chatgpt_web_quota_metadata_enriches_auth_and_uses_first_remaining_as_limit() {
         let mut metadata = json!({
             "image_quota_remaining": 12,
         });
@@ -229,8 +229,8 @@ mod tests {
         assert_eq!(metadata["plan_type"], json!("free"));
         assert_eq!(metadata["email"], json!("user@example.com"));
         assert_eq!(metadata["account_id"], json!("acct-1"));
-        assert_eq!(metadata["image_quota_total"], json!(25.0));
-        assert_eq!(metadata["image_quota_used"], json!(13.0));
+        assert_eq!(metadata["image_quota_total"], json!(12.0));
+        assert_eq!(metadata["image_quota_used"], json!(0.0));
     }
 
     #[test]

--- a/crates/aether-provider-pool/src/providers/chatgpt_web.rs
+++ b/crates/aether-provider-pool/src/providers/chatgpt_web.rs
@@ -181,8 +181,6 @@ pub fn normalize_chatgpt_web_image_quota_limit(
     };
 
     let remaining = provider_pool_json_f64(object.get("image_quota_remaining"));
-    let explicit_limit =
-        provider_pool_json_f64(object.get("image_quota_total")).filter(|value| *value > 0.0);
     let plan_type = chatgpt_web_image_quota_plan_type(object)
         .map(ToOwned::to_owned)
         .or_else(|| {
@@ -190,6 +188,16 @@ pub fn normalize_chatgpt_web_image_quota_limit(
                 .as_ref()
                 .and_then(|existing| existing.plan_type.clone())
         });
+    let raw_explicit_limit =
+        provider_pool_json_f64(object.get("image_quota_total")).filter(|value| *value > 0.0);
+    let explicit_limit_is_free_default = raw_explicit_limit.is_some_and(|limit| {
+        is_legacy_chatgpt_web_free_default_limit_value(limit, None, plan_type.as_deref(), remaining)
+    });
+    if explicit_limit_is_free_default {
+        object.remove("image_quota_total");
+        object.remove("image_quota_limit_source");
+    }
+    let explicit_limit = raw_explicit_limit.filter(|_| !explicit_limit_is_free_default);
     let limit = explicit_limit
         .map(|limit| ChatGptWebImageQuotaLimit {
             value: limit,
@@ -294,16 +302,30 @@ fn is_legacy_chatgpt_web_free_default_limit(
     plan_type: Option<&str>,
     remaining: Option<f64>,
 ) -> bool {
+    is_legacy_chatgpt_web_free_default_limit_value(
+        existing_limit.value,
+        existing_limit.source.as_deref(),
+        plan_type,
+        remaining,
+    )
+}
+
+fn is_legacy_chatgpt_web_free_default_limit_value(
+    value: f64,
+    source: Option<&str>,
+    plan_type: Option<&str>,
+    remaining: Option<f64>,
+) -> bool {
     let plan_type_is_free = plan_type
         .map(str::trim)
         .is_some_and(|value| value.eq_ignore_ascii_case("free"));
-    if !plan_type_is_free || existing_limit.source.is_some() {
+    if !plan_type_is_free || source.is_some() {
         return false;
     }
-    if (existing_limit.value - 25.0).abs() > f64::EPSILON {
+    if (value - 25.0).abs() > f64::EPSILON {
         return false;
     }
-    remaining.is_some_and(|remaining| remaining < existing_limit.value)
+    remaining.is_some_and(|remaining| remaining < value)
 }
 
 pub(crate) fn quota_exhausted_from_bucket(bucket: &Map<String, Value>) -> bool {

--- a/crates/aether-provider-pool/src/providers/chatgpt_web.rs
+++ b/crates/aether-provider-pool/src/providers/chatgpt_web.rs
@@ -325,7 +325,7 @@ fn is_legacy_chatgpt_web_free_default_limit_value(
     if (value - 25.0).abs() > f64::EPSILON {
         return false;
     }
-    remaining.is_some_and(|remaining| remaining < value)
+    remaining.is_none_or(|remaining| remaining < value)
 }
 
 pub(crate) fn quota_exhausted_from_bucket(bucket: &Map<String, Value>) -> bool {

--- a/crates/aether-provider-pool/src/providers/chatgpt_web.rs
+++ b/crates/aether-provider-pool/src/providers/chatgpt_web.rs
@@ -183,20 +183,37 @@ pub fn normalize_chatgpt_web_image_quota_limit(
     let remaining = provider_pool_json_f64(object.get("image_quota_remaining"));
     let explicit_limit =
         provider_pool_json_f64(object.get("image_quota_total")).filter(|value| *value > 0.0);
-    let limit =
-        explicit_limit.or_else(|| infer_chatgpt_web_image_quota_limit(remaining, existing_limit));
+    let plan_type = chatgpt_web_image_quota_plan_type(object)
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            existing_limit
+                .as_ref()
+                .and_then(|existing| existing.plan_type.clone())
+        });
+    let limit = explicit_limit
+        .map(|limit| ChatGptWebImageQuotaLimit {
+            value: limit,
+            source: Some("upstream_total".to_string()),
+            plan_type: plan_type.clone(),
+        })
+        .or_else(|| {
+            infer_chatgpt_web_image_quota_limit(remaining, existing_limit, plan_type.as_deref())
+        });
 
     if let Some(limit) = limit {
-        object.insert("image_quota_total".to_string(), json!(limit));
+        object.insert("image_quota_total".to_string(), json!(limit.value));
+        if let Some(source) = limit.source.as_deref().filter(|value| !value.is_empty()) {
+            object.insert("image_quota_limit_source".to_string(), json!(source));
+        }
 
         if !object.contains_key("image_quota_used") {
             if let Some(remaining) = remaining {
                 object.insert(
                     "image_quota_used".to_string(),
-                    json!((limit - remaining).max(0.0)),
+                    json!((limit.value - remaining).max(0.0)),
                 );
             } else if object.get("image_quota_blocked").and_then(Value::as_bool) == Some(true) {
-                object.insert("image_quota_used".to_string(), json!(limit));
+                object.insert("image_quota_used".to_string(), json!(limit.value));
             }
         }
     }
@@ -214,24 +231,79 @@ fn chatgpt_web_auth_config_string(auth_config: Option<&Value>, fields: &[&str]) 
     })
 }
 
-fn existing_chatgpt_web_image_quota_limit(upstream_metadata: Option<&Value>) -> Option<f64> {
-    upstream_metadata
+#[derive(Debug, Clone)]
+struct ChatGptWebImageQuotaLimit {
+    value: f64,
+    source: Option<String>,
+    plan_type: Option<String>,
+}
+
+fn chatgpt_web_image_quota_plan_type(object: &Map<String, Value>) -> Option<&str> {
+    object
+        .get("plan_type")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+fn existing_chatgpt_web_image_quota_limit(
+    upstream_metadata: Option<&Value>,
+) -> Option<ChatGptWebImageQuotaLimit> {
+    let bucket = upstream_metadata
         .and_then(Value::as_object)
         .and_then(|metadata| metadata.get("chatgpt_web"))
-        .and_then(Value::as_object)
-        .and_then(|bucket| provider_pool_json_f64(bucket.get("image_quota_total")))
-        .filter(|value| *value > 0.0)
+        .and_then(Value::as_object)?;
+    let value =
+        provider_pool_json_f64(bucket.get("image_quota_total")).filter(|value| *value > 0.0)?;
+    let source = bucket
+        .get("image_quota_limit_source")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let plan_type = chatgpt_web_image_quota_plan_type(bucket).map(ToOwned::to_owned);
+    Some(ChatGptWebImageQuotaLimit {
+        value,
+        source,
+        plan_type,
+    })
 }
 
 fn infer_chatgpt_web_image_quota_limit(
     remaining: Option<f64>,
-    existing_limit: Option<f64>,
-) -> Option<f64> {
-    if let Some(existing_limit) = existing_limit.filter(|value| *value > 0.0) {
-        return Some(existing_limit);
+    existing_limit: Option<ChatGptWebImageQuotaLimit>,
+    plan_type: Option<&str>,
+) -> Option<ChatGptWebImageQuotaLimit> {
+    if let Some(existing_limit) = existing_limit {
+        if !is_legacy_chatgpt_web_free_default_limit(&existing_limit, plan_type, remaining) {
+            return Some(existing_limit);
+        }
     }
 
-    remaining.filter(|value| *value > 0.0)
+    remaining
+        .filter(|value| *value > 0.0)
+        .map(|value| ChatGptWebImageQuotaLimit {
+            value,
+            source: Some("first_remaining".to_string()),
+            plan_type: plan_type.map(ToOwned::to_owned),
+        })
+}
+
+fn is_legacy_chatgpt_web_free_default_limit(
+    existing_limit: &ChatGptWebImageQuotaLimit,
+    plan_type: Option<&str>,
+    remaining: Option<f64>,
+) -> bool {
+    let plan_type_is_free = plan_type
+        .map(str::trim)
+        .is_some_and(|value| value.eq_ignore_ascii_case("free"));
+    if !plan_type_is_free || existing_limit.source.is_some() {
+        return false;
+    }
+    if (existing_limit.value - 25.0).abs() > f64::EPSILON {
+        return false;
+    }
+    remaining.is_some_and(|remaining| remaining < existing_limit.value)
 }
 
 pub(crate) fn quota_exhausted_from_bucket(bucket: &Map<String, Value>) -> bool {

--- a/crates/aether-provider-pool/src/providers/chatgpt_web.rs
+++ b/crates/aether-provider-pool/src/providers/chatgpt_web.rs
@@ -24,8 +24,6 @@ const CHATGPT_WEB_CLIENT_VERSION: &str = "prod-be885abbfcfe7b1f511e88b3003d9ee44
 const CHATGPT_WEB_BUILD_NUMBER: &str = "5955942";
 const CHATGPT_WEB_SEC_CH_UA: &str =
     r#""Microsoft Edge";v="143", "Chromium";v="143", "Not A(Brand";v="24""#;
-const CHATGPT_WEB_FREE_IMAGE_QUOTA_LIMIT: f64 = 25.0;
-
 #[derive(Debug, Clone, Default)]
 pub struct ChatGptWebProviderPoolAdapter;
 
@@ -185,14 +183,8 @@ pub fn normalize_chatgpt_web_image_quota_limit(
     let remaining = provider_pool_json_f64(object.get("image_quota_remaining"));
     let explicit_limit =
         provider_pool_json_f64(object.get("image_quota_total")).filter(|value| *value > 0.0);
-    let plan_type = chatgpt_web_json_string(object.get("plan_type"));
-    let is_free_plan = plan_type.is_some_and(|value| value.trim().eq_ignore_ascii_case("free"));
-    let limit = if is_free_plan {
-        Some(CHATGPT_WEB_FREE_IMAGE_QUOTA_LIMIT)
-    } else {
-        explicit_limit
-            .or_else(|| infer_chatgpt_web_image_quota_limit(plan_type, remaining, existing_limit))
-    };
+    let limit =
+        explicit_limit.or_else(|| infer_chatgpt_web_image_quota_limit(remaining, existing_limit));
 
     if let Some(limit) = limit {
         object.insert("image_quota_total".to_string(), json!(limit));
@@ -222,13 +214,6 @@ fn chatgpt_web_auth_config_string(auth_config: Option<&Value>, fields: &[&str]) 
     })
 }
 
-fn chatgpt_web_json_string(value: Option<&Value>) -> Option<&str> {
-    value
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-}
-
 fn existing_chatgpt_web_image_quota_limit(upstream_metadata: Option<&Value>) -> Option<f64> {
     upstream_metadata
         .and_then(Value::as_object)
@@ -239,15 +224,9 @@ fn existing_chatgpt_web_image_quota_limit(upstream_metadata: Option<&Value>) -> 
 }
 
 fn infer_chatgpt_web_image_quota_limit(
-    plan_type: Option<&str>,
     remaining: Option<f64>,
     existing_limit: Option<f64>,
 ) -> Option<f64> {
-    let normalized_plan = plan_type.unwrap_or_default().trim().to_ascii_lowercase();
-    if normalized_plan == "free" {
-        return Some(CHATGPT_WEB_FREE_IMAGE_QUOTA_LIMIT);
-    }
-
     if let Some(existing_limit) = existing_limit.filter(|value| *value > 0.0) {
         return Some(existing_limit);
     }

--- a/frontend/src/features/providers/components/ProviderDetailDrawer.vue
+++ b/frontend/src/features/providers/components/ProviderDetailDrawer.vue
@@ -1056,7 +1056,7 @@
                       </div>
                       <div>
                         <div class="flex items-center justify-between text-[10px] mb-0.5">
-                          <span class="text-muted-foreground">使用额度</span>
+                          <span class="text-muted-foreground">剩余额度</span>
                           <span :class="getQuotaRemainingClass(getChatGPTWebQuotaUsedPercent(key))">
                             {{ getChatGPTWebQuotaRemainingPercent(key).toFixed(1) }}%
                           </span>
@@ -1070,7 +1070,7 @@
                         </div>
                         <div class="flex items-center justify-between text-[9px] text-muted-foreground/70 mt-0.5">
                           <span>
-                            {{ formatChatGPTWebUsage(getChatGPTWebQuotaDisplay(key)?.image_quota_used) }} /
+                            {{ formatChatGPTWebUsage(getChatGPTWebQuotaDisplay(key)?.image_quota_remaining) }} /
                             {{ formatChatGPTWebUsage(getChatGPTWebQuotaDisplay(key)?.image_quota_total) }}
                           </span>
                           <span v-if="getChatGPTWebQuotaDisplay(key)?.image_quota_reset_at">

--- a/frontend/src/utils/__tests__/providerKeyQuota.spec.ts
+++ b/frontend/src/utils/__tests__/providerKeyQuota.spec.ts
@@ -105,6 +105,28 @@ describe('providerKeyQuota', () => {
     }, 'grok')).toBe('Auto剩余 40.0% (60/150) | Heavy剩余 0.0% (0/20)')
   })
 
+  it('formats ChatGPT Web image quota as remaining count', () => {
+    expect(getQuotaDisplayText({
+      status_snapshot: {
+        quota: {
+          provider_type: 'chatgpt_web',
+          code: 'ok',
+          exhausted: false,
+          windows: [
+            {
+              code: 'image_gen',
+              scope: 'account',
+              remaining_ratio: 0.96,
+              used_value: 1,
+              remaining_value: 24,
+              limit_value: 25,
+            },
+          ],
+        },
+      },
+    }, 'chatgpt_web')).toBe('生图剩余 24/25')
+  })
+
   it('surfaces Windsurf hard account states', () => {
     expect(getQuotaDisplayText({
       status_snapshot: {

--- a/frontend/src/utils/providerKeyQuota.ts
+++ b/frontend/src/utils/providerKeyQuota.ts
@@ -343,19 +343,13 @@ function getChatGPTWebQuotaText(quota: QuotaStatusSnapshot): string | null {
   if (!window) return normalizeText(quota.label)
 
   const remainingPercent = getQuotaWindowRemainingPercent(window)
-  if (typeof window.remaining_value === 'number' && typeof window.limit_value === 'number' && window.limit_value > 0 && window.remaining_value <= 0) {
-    return `生图剩余 ${formatQuotaValue(window.remaining_value)}/${formatQuotaValue(window.limit_value)}`
-  }
-  if (remainingPercent != null) {
-    if (typeof window.used_value === 'number' && typeof window.limit_value === 'number' && window.limit_value > 0) {
-      return `生图剩余 ${formatPercent(remainingPercent)} (${formatQuotaValue(window.used_value)}/${formatQuotaValue(window.limit_value)})`
-    }
-    return `生图剩余 ${formatPercent(remainingPercent)}`
-  }
-
   if (typeof window.remaining_value === 'number' && typeof window.limit_value === 'number' && window.limit_value > 0) {
     return `生图剩余 ${formatQuotaValue(window.remaining_value)}/${formatQuotaValue(window.limit_value)}`
   }
+  if (remainingPercent != null) {
+    return `生图剩余 ${formatPercent(remainingPercent)}`
+  }
+
   if (typeof window.remaining_value === 'number') {
     return `生图剩余 ${formatQuotaValue(window.remaining_value)}`
   }

--- a/frontend/src/views/admin/PoolManagement.vue
+++ b/frontend/src/views/admin/PoolManagement.vue
@@ -3700,7 +3700,7 @@ function getQuotaProgressLabel(label: string): string {
 }
 
 function getQuotaProgressCountdown(item: QuotaProgressItem) {
-  if (!['日', '5H', '周', 'Spark5H', 'Spark周', 'Auto', 'Fast', 'Expert', 'Heavy', 'Grok 4.3'].includes(item.label)) return null
+  if (!['日', '5H', '周', 'Spark5H', 'Spark周', 'Auto', 'Fast', 'Expert', 'Heavy', 'Grok 4.3', '生图'].includes(item.label)) return null
   if (item.resetAtSeconds == null && item.resetSeconds == null) return null
   return getCodexResetCountdown(
     item.resetAtSeconds,

--- a/frontend/src/views/admin/PoolManagement.vue
+++ b/frontend/src/views/admin/PoolManagement.vue
@@ -4109,10 +4109,10 @@ function buildQuotaProgressItemsFromSnapshot(key: PoolKeyDetail): QuotaProgressI
     const remainingValue = typeof window?.remaining_value === 'number' ? window.remaining_value : null
     const limitValue = typeof window?.limit_value === 'number' ? window.limit_value : null
     const usedValue = typeof window?.used_value === 'number' ? window.used_value : null
-    const detail = usedValue != null && limitValue != null
-      ? `${formatQuotaValue(usedValue)}/${formatQuotaValue(limitValue)}`
-      : remainingValue != null && limitValue != null
-        ? `${formatQuotaValue(Math.max(limitValue - remainingValue, 0))}/${formatQuotaValue(limitValue)}`
+    const detail = remainingValue != null && limitValue != null
+      ? `${formatQuotaValue(remainingValue)}/${formatQuotaValue(limitValue)}`
+      : usedValue != null && limitValue != null
+        ? `${formatQuotaValue(Math.max(limitValue - usedValue, 0))}/${formatQuotaValue(limitValue)}`
         : remainingValue != null
           ? `剩余 ${formatQuotaValue(remainingValue)}`
           : undefined

--- a/frontend/src/views/admin/__tests__/PoolManagement.codex-cycle-stats.spec.ts
+++ b/frontend/src/views/admin/__tests__/PoolManagement.codex-cycle-stats.spec.ts
@@ -643,6 +643,47 @@ describe('PoolManagement Codex cycle stats mode', () => {
     expect(root.querySelectorAll('button[title="查看评分计算结果"]').length).toBeGreaterThan(0)
   })
 
+  it('shows ChatGPT Web image quota reset countdown above the quota bar', async () => {
+    const chatgptWebKey = createPoolKey('chatgpt_web', {
+      api_formats: ['openai:image'],
+      status_snapshot: {
+        oauth: { code: 'valid' },
+        account: { code: 'ok', blocked: false },
+        quota: {
+          code: 'ok',
+          exhausted: false,
+          provider_type: 'chatgpt_web',
+          updated_at: 1_700_000_000,
+          windows: [
+            {
+              code: 'image_gen',
+              label: '生图',
+              scope: 'account',
+              remaining_ratio: 0.96,
+              remaining_value: 24,
+              limit_value: 25,
+              reset_seconds: 3600,
+            },
+          ],
+        },
+      },
+    })
+    endpointMocks.getPoolOverview.mockResolvedValue({ items: [createOverview('chatgpt_web')] })
+    endpointMocks.listPoolKeys.mockResolvedValue(createKeyPage(chatgptWebKey))
+    endpointMocks.getProvider.mockResolvedValue(createProvider('chatgpt_web', {
+      api_formats: ['openai:image'],
+    }))
+
+    const root = mountPoolManagement()
+    await settle()
+
+    const resetTexts = Array.from(root.querySelectorAll('[data-testid="pool-quota-reset-text"]'))
+      .map((element) => element.textContent?.trim())
+      .filter(Boolean)
+    expect(resetTexts).toContain('1h')
+    expect(root.textContent).toContain('生图')
+  })
+
   it('opens only one score popover across desktop and mobile layouts', async () => {
     const scoredKey = createPoolKey('codex', {
       pool_score: {


### PR DESCRIPTION
## 变更说明

- 修复 ChatGPT Web 额度刷新时 `conversation/init` 返回 403 被误判为刷新失败的问题
- 调整 ChatGPT Web 生图请求的额度扣减时机：账号被选中并发起调用时即记录请求并本地预扣额度，后续刷新额度再进行纠偏
- 修复生图成功后号池配额不缩减、需要手动刷新才更新的问题
- 调整配额展示为剩余额度递减，例如 `25/25 -> 24/25`
- Free 账号不再强制显示 25 限额，改为使用首次获取到的额度作为限额
- 补齐 ChatGPT Web 号池中的重置时间展示，与 Codex 号池额度条展示保持一致
- ChatGPT Web 生图响应补齐 `usage` / `tool_usage`，方便下游读取 token 用量
- 保留 `quality` / `partial_images` 参数传递
- output tokens 改为按图片尺寸与 quality 近似估算，避免按 base64 文本长度导致异常高 token

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p aether-gateway chatgpt_web_image --lib -- --nocapture`
- `cargo test -p aether-gateway chatgpt_web_responses_image_body_preserves_usage_options --lib -- --nocapture`
- `cargo test -p aether-ai-formats chatgpt_web_preserves_quality_and_partial_images --lib -- --nocapture`