### PR TITLE
Fix unsupported OpenAI response fields and enhance model tests

### DIFF
--- a/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test.rs
@@ -1,5 +1,5 @@
 use super::super::payload::{
-    provider_query_extract_api_key_id, provider_query_extract_force_refresh,
+    provider_query_extract_api_key_ids, provider_query_extract_force_refresh,
     provider_query_extract_model, provider_query_extract_provider_id,
     provider_query_extract_request_id,
 };
@@ -860,7 +860,7 @@ async fn provider_query_select_preferred_non_kiro_endpoint(
     provider: &StoredProviderCatalogProvider,
     endpoints: &[StoredProviderCatalogEndpoint],
     keys: &[StoredProviderCatalogKey],
-    selected_key_id: Option<&str>,
+    selected_key_ids: Option<&BTreeSet<String>>,
 ) -> Option<StoredProviderCatalogEndpoint> {
     for priority in 0..=2 {
         for endpoint in endpoints.iter().filter(|endpoint| endpoint.is_active) {
@@ -873,7 +873,7 @@ async fn provider_query_select_preferred_non_kiro_endpoint(
             }
             for key in keys {
                 if !key.is_active
-                    || selected_key_id.is_some_and(|value| value != key.id.as_str())
+                    || !provider_query_selected_key_ids_allow_key(selected_key_ids, &key.id)
                     || !provider_query_key_supports_endpoint(
                         key,
                         &provider.provider_type,
@@ -905,7 +905,7 @@ async fn provider_query_select_preferred_non_kiro_endpoint(
             endpoint.is_active
                 && keys.iter().any(|key| {
                     key.is_active
-                        && selected_key_id.is_none_or(|value| value == key.id.as_str())
+                        && provider_query_selected_key_ids_allow_key(selected_key_ids, &key.id)
                         && provider_query_key_supports_endpoint(
                             key,
                             &provider.provider_type,
@@ -915,6 +915,22 @@ async fn provider_query_select_preferred_non_kiro_endpoint(
         })
         .or_else(|| endpoints.iter().find(|endpoint| endpoint.is_active))
         .cloned()
+}
+
+fn provider_query_selected_key_ids_allow_key(
+    selected_key_ids: Option<&BTreeSet<String>>,
+    key_id: &str,
+) -> bool {
+    selected_key_ids.is_none_or(|ids| ids.contains(key_id))
+}
+
+fn provider_query_selected_key_ids_all_exist(
+    selected_key_ids: &BTreeSet<String>,
+    keys: &[StoredProviderCatalogKey],
+) -> bool {
+    selected_key_ids
+        .iter()
+        .all(|id| keys.iter().any(|key| key.id == *id))
 }
 
 fn provider_query_test_key_sort_key(
@@ -1262,7 +1278,7 @@ async fn provider_query_build_kiro_test_candidates(
                 ADMIN_PROVIDER_QUERY_NO_ACTIVE_API_KEY_DETAIL,
             )
         })?;
-    let selected_key_id = provider_query_extract_api_key_id(payload);
+    let selected_key_ids = provider_query_extract_api_key_ids(payload);
     let requested_endpoint_id = provider_query_extract_endpoint_id(payload);
     let requested_api_format = provider_query_extract_api_format(payload);
     let endpoint = if requested_endpoint_id.is_none()
@@ -1274,7 +1290,7 @@ async fn provider_query_build_kiro_test_candidates(
             provider,
             &endpoints,
             &all_keys,
-            selected_key_id.as_deref(),
+            selected_key_ids.as_ref(),
         )
         .await
         .ok_or_else(|| {
@@ -1307,21 +1323,10 @@ async fn provider_query_build_kiro_test_candidates(
         }
     };
 
-    if let Some(api_key_id) = selected_key_id.as_deref() {
-        let Some(key) = all_keys.iter().find(|key| key.id == api_key_id) else {
+    if let Some(selected_key_ids) = selected_key_ids.as_ref() {
+        if !provider_query_selected_key_ids_all_exist(selected_key_ids, &all_keys) {
             return Err(build_admin_provider_query_not_found_response(
                 ADMIN_PROVIDER_QUERY_API_KEY_NOT_FOUND_DETAIL,
-            ));
-        };
-        if !key.is_active
-            || !provider_query_key_supports_endpoint(
-                key,
-                &provider.provider_type,
-                &endpoint.api_format,
-            )
-        {
-            return Err(build_admin_provider_query_not_found_response(
-                ADMIN_PROVIDER_QUERY_NO_ACTIVE_TEST_CANDIDATE_DETAIL,
             ));
         }
     }
@@ -1380,11 +1385,7 @@ async fn provider_query_build_kiro_test_candidates(
     let mut keys = all_keys
         .into_iter()
         .filter(|key| key.is_active)
-        .filter(|key| {
-            selected_key_id
-                .as_deref()
-                .is_none_or(|value| value == key.id.as_str())
-        })
+        .filter(|key| provider_query_selected_key_ids_allow_key(selected_key_ids.as_ref(), &key.id))
         .filter(|key| {
             provider_query_key_supports_endpoint(key, &provider.provider_type, &endpoint.api_format)
         })

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/tests.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/tests.rs
@@ -232,6 +232,27 @@ fn provider_query_request_body_model_uses_non_empty_string_only() {
 }
 
 #[test]
+fn provider_query_model_test_extracts_multiple_selected_key_ids() {
+    let payload = json!({
+        "api_key_ids": [" key-b ", "", "key-a", "key-b"],
+        "api_key_id": "key-c"
+    });
+
+    let ids = provider_query_extract_api_key_ids(&payload)
+        .expect("non-empty key selection should be extracted")
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    assert_eq!(ids, vec!["key-a", "key-b", "key-c"]);
+}
+
+#[test]
+fn provider_query_model_test_empty_selected_key_ids_keep_default_selection() {
+    assert!(provider_query_extract_api_key_ids(&json!({})).is_none());
+    assert!(provider_query_extract_api_key_ids(&json!({ "api_key_ids": [] })).is_none());
+}
+
+#[test]
 fn provider_query_standard_test_resolves_codex_responses_upstream_streaming() {
     assert!(provider_query_resolve_standard_test_upstream_is_stream(
         None,

--- a/apps/aether-gateway/src/handlers/admin/provider/query/payload.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/payload.rs
@@ -1,6 +1,7 @@
 use axum::body::Bytes;
 use axum::response::{IntoResponse, Response};
 use serde_json::json;
+use std::collections::BTreeSet;
 
 pub(crate) fn parse_admin_provider_query_body(
     request_body: Option<&Bytes>,
@@ -34,6 +35,47 @@ pub(crate) fn provider_query_extract_api_key_id(payload: &serde_json::Value) -> 
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn provider_query_insert_api_key_id(ids: &mut BTreeSet<String>, value: &str) {
+    let value = value.trim();
+    if !value.is_empty() {
+        ids.insert(value.to_string());
+    }
+}
+
+pub(crate) fn provider_query_extract_api_key_ids(
+    payload: &serde_json::Value,
+) -> Option<BTreeSet<String>> {
+    let mut ids = BTreeSet::new();
+
+    if let Some(value) = payload
+        .get("api_key_ids")
+        .or_else(|| payload.get("provider_key_ids"))
+        .or_else(|| payload.get("key_ids"))
+    {
+        match value {
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    if let Some(value) = item.as_str() {
+                        provider_query_insert_api_key_id(&mut ids, value);
+                    }
+                }
+            }
+            serde_json::Value::String(value) => {
+                for item in value.split(',') {
+                    provider_query_insert_api_key_id(&mut ids, item);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(api_key_id) = provider_query_extract_api_key_id(payload) {
+        ids.insert(api_key_id);
+    }
+
+    (!ids.is_empty()).then_some(ids)
 }
 
 pub(crate) fn provider_query_extract_force_refresh(payload: &serde_json::Value) -> bool {

--- a/apps/aether-gateway/src/handlers/admin/users/lifecycle/update.rs
+++ b/apps/aether-gateway/src/handlers/admin/users/lifecycle/update.rs
@@ -152,12 +152,7 @@ pub(in super::super) async fn build_admin_update_user_response(
     };
     let effective_role = role.as_deref().unwrap_or(existing_user.role.as_str());
     let group_ids = if field_presence.contains("group_ids") {
-        let requested_group_ids = normalize_admin_user_group_ids(payload.group_ids);
-        Some(
-            state
-                .include_default_user_group_ids_for_role(&requested_group_ids, effective_role)
-                .await?,
-        )
+        Some(normalize_admin_user_group_ids(payload.group_ids))
     } else if role.is_some() {
         let requested_group_ids = state
             .list_user_groups_for_user(&user_id)

--- a/apps/aether-gateway/src/tests/control/admin/users.rs
+++ b/apps/aether-gateway/src/tests/control/admin/users.rs
@@ -1699,6 +1699,83 @@ async fn gateway_returns_conflict_for_admin_lock_user_api_key_when_writer_unavai
 }
 
 #[tokio::test]
+async fn gateway_allows_admin_update_user_to_clear_explicit_groups() {
+    let upstream_hits = Arc::new(Mutex::new(0usize));
+    let upstream_hits_clone = Arc::clone(&upstream_hits);
+    let upstream = Router::new().fallback(any(move |_request: Request| {
+        let upstream_hits_inner = Arc::clone(&upstream_hits_clone);
+        async move {
+            *upstream_hits_inner.lock().expect("mutex should lock") += 1;
+            (StatusCode::OK, Body::from("unexpected upstream hit"))
+        }
+    }));
+
+    let user_repository = Arc::new(
+        InMemoryUserReadRepository::seed_auth_users(vec![sample_admin_user("user-1")])
+            .with_export_users(vec![sample_admin_export_user("user-1")]),
+    );
+    let default_group = user_repository
+        .create_user_group(UpsertUserGroupRecord {
+            name: "GPT Adapt".to_string(),
+            description: None,
+            priority: 0,
+            allowed_providers: None,
+            allowed_providers_mode: "unrestricted".to_string(),
+            allowed_api_formats: None,
+            allowed_api_formats_mode: "unrestricted".to_string(),
+            allowed_models: None,
+            allowed_models_mode: "unrestricted".to_string(),
+            rate_limit: None,
+            rate_limit_mode: "system".to_string(),
+        })
+        .await
+        .expect("default group should create")
+        .expect("default group should exist");
+    user_repository
+        .add_user_to_group(&default_group.id, "user-1")
+        .await
+        .expect("default membership should create");
+
+    let (upstream_url, upstream_handle) = start_server(upstream).await;
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(
+                GatewayDataState::with_user_reader_for_tests(user_repository.clone())
+                    .with_system_config_values_for_tests(vec![(
+                        crate::constants::DEFAULT_USER_GROUP_CONFIG_KEY.to_string(),
+                        json!(default_group.id),
+                    )]),
+            ),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .put(format!("{gateway_url}/api/admin/users/user-1"))
+        .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({ "group_ids": [] }))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["groups"], json!([]));
+    assert!(user_repository
+        .list_user_groups_for_user("user-1")
+        .await
+        .expect("memberships should load")
+        .is_empty());
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_returns_conflict_for_admin_update_user_when_writer_unavailable() {
     let upstream_hits = Arc::new(Mutex::new(0usize));
     let upstream_hits_clone = Arc::clone(&upstream_hits);

--- a/crates/aether-ai-formats/src/formats/openai/responses/codex.rs
+++ b/crates/aether-ai-formats/src/formats/openai/responses/codex.rs
@@ -12,6 +12,20 @@ const CODEX_DEFAULT_INSTRUCTIONS: &str = "";
 const CODEX_DEFAULT_REASONING_EFFORT: &str = "medium";
 const CODEX_DEFAULT_REASONING_SUMMARY: &str = "auto";
 const CODEX_REASONING_ENCRYPTED_CONTENT_INCLUDE: &str = "reasoning.encrypted_content";
+const CODEX_OPENAI_RESPONSES_UNSUPPORTED_BODY_FIELDS: &[&str] = &[
+    "max_output_tokens",
+    "max_completion_tokens",
+    "temperature",
+    "top_p",
+    "frequency_penalty",
+    "presence_penalty",
+    "user",
+    "metadata",
+    "prompt_cache_retention",
+    "safety_identifier",
+    "stream_options",
+    "previous_response_id",
+];
 const CODEX_DEFAULT_USER_AGENT: &str =
     "codex-tui/0.122.0 (Mac OS 15.2.0; arm64) vscode/2.6.11 (codex-tui; 0.122.0)";
 const CODEX_DEFAULT_ORIGINATOR: &str = "codex-tui";
@@ -729,17 +743,10 @@ pub fn apply_codex_openai_responses_special_body_edits(
         return;
     };
 
-    if !body_rules_handle_path(body_rules, "max_output_tokens") {
-        body_object.remove("max_output_tokens");
-    }
-    if !body_rules_handle_path(body_rules, "temperature") {
-        body_object.remove("temperature");
-    }
-    if !body_rules_handle_path(body_rules, "top_p") {
-        body_object.remove("top_p");
-    }
-    if !body_rules_handle_path(body_rules, "metadata") {
-        body_object.remove("metadata");
+    for field in CODEX_OPENAI_RESPONSES_UNSUPPORTED_BODY_FIELDS {
+        if !body_rules_handle_path(body_rules, field) {
+            body_object.remove(*field);
+        }
     }
     if is_openai_responses_compact_request(provider_api_format) {
         body_object.remove("store");
@@ -881,6 +888,7 @@ mod tests {
         apply_codex_openai_responses_chat_body_edits,
         apply_codex_openai_responses_special_body_edits,
         apply_openai_responses_compact_special_body_edits, CODEX_OPENAI_IMAGE_INTERNAL_MODEL,
+        CODEX_OPENAI_RESPONSES_UNSUPPORTED_BODY_FIELDS,
     };
     use serde_json::json;
 
@@ -1007,6 +1015,42 @@ mod tests {
             json!("lookup_account")
         );
         assert!(provider_request_body["tools"][0].get("function").is_none());
+    }
+
+    #[test]
+    fn codex_responses_body_edits_strip_sub2api_unsupported_fields() {
+        let mut provider_request_body = json!({
+            "input": [{"role": "user", "content": "hello"}],
+            "model": "gpt-5.4",
+            "max_output_tokens": 1024,
+            "max_completion_tokens": 1024,
+            "temperature": 0.2,
+            "top_p": 0.8,
+            "frequency_penalty": 0.1,
+            "presence_penalty": 0.1,
+            "user": "user-123",
+            "metadata": {"client": "cursor"},
+            "prompt_cache_retention": "24h",
+            "safety_identifier": "safe-user-123",
+            "stream_options": {"include_usage": true},
+            "previous_response_id": "resp_123"
+        });
+
+        apply_codex_openai_responses_special_body_edits(
+            &mut provider_request_body,
+            "codex",
+            "openai:responses",
+            None,
+            None,
+        );
+
+        for field in CODEX_OPENAI_RESPONSES_UNSUPPORTED_BODY_FIELDS {
+            assert!(
+                provider_request_body.get(*field).is_none(),
+                "{field} must be stripped"
+            );
+        }
+        assert_eq!(provider_request_body["input"][0]["content"], json!("hello"));
     }
 
     #[test]

--- a/frontend/src/api/endpoints/providers.ts
+++ b/frontend/src/api/endpoints/providers.ts
@@ -196,6 +196,7 @@ export interface TestModelRequest {
   provider_id: string
   model_name: string
   api_key_id?: string
+  api_key_ids?: string[]
   endpoint_id?: string
   message?: string
   api_format?: string
@@ -249,6 +250,7 @@ export interface TestModelFailoverRequest {
   mode: 'global' | 'direct' | 'pool'
   model_name: string
   failover_models?: string[]
+  api_key_ids?: string[]
   api_format?: string
   endpoint_id?: string
   message?: string

--- a/frontend/src/composables/useModelTest.ts
+++ b/frontend/src/composables/useModelTest.ts
@@ -20,6 +20,7 @@ export interface StartTestParams {
   endpointId?: string
   endpointBaseUrl?: string
   message?: string
+  apiKeyIds?: string[]
   applyModelMapping?: boolean
   mappedModelName?: string
   requestHeaders?: Record<string, unknown>
@@ -150,13 +151,17 @@ export function useModelTest(options: UseModelTestOptions) {
     reqId: string,
     signal?: AbortSignal,
   ): Promise<TestModelFailoverResponse> {
+    const message = normalizedMessage(params.message)
+    const apiKeyIds = normalizedApiKeyIds(params.apiKeyIds)
+
     return normalizeDirectTestResult(params, await testModel({
       provider_id: providerId(),
       model_name: params.modelName,
       mode: params.mode,
       api_format: params.apiFormat,
       endpoint_id: params.endpointId,
-      ...(normalizedMessage(params.message) ? { message: normalizedMessage(params.message) } : {}),
+      ...(apiKeyIds ? { api_key_ids: apiKeyIds } : {}),
+      ...(message ? { message } : {}),
       ...(typeof params.applyModelMapping === 'boolean' ? { apply_model_mapping: params.applyModelMapping } : {}),
       ...(params.mappedModelName ? { mapped_model_name: params.mappedModelName } : {}),
       ...(params.requestHeaders ? { request_headers: params.requestHeaders } : {}),
@@ -171,6 +176,13 @@ export function useModelTest(options: UseModelTestOptions) {
     return typeof message === 'string' && message.trim()
       ? message.trim()
       : undefined
+  }
+
+  function normalizedApiKeyIds(apiKeyIds?: string[]): string[] | undefined {
+    const ids = Array.isArray(apiKeyIds)
+      ? apiKeyIds.map(item => item.trim()).filter(Boolean)
+      : []
+    return ids.length > 0 ? [...new Set(ids)] : undefined
   }
 
   async function pollTestTrace(reqId: string, token: number) {
@@ -249,6 +261,7 @@ export function useModelTest(options: UseModelTestOptions) {
 
     try {
       const message = normalizedMessage(params.message)
+      const apiKeyIds = normalizedApiKeyIds(params.apiKeyIds)
 
       let result = params.mode === 'direct'
         ? await runDirectTest(params, reqId, abortController.signal)
@@ -257,6 +270,7 @@ export function useModelTest(options: UseModelTestOptions) {
           mode: params.mode,
           model_name: params.modelName,
           failover_models: [params.modelName],
+          ...(apiKeyIds ? { api_key_ids: apiKeyIds } : {}),
           api_format: params.apiFormat,
           endpoint_id: params.endpointId,
           ...(message ? { message } : {}),

--- a/frontend/src/features/providers/components/provider-tabs/ModelTestDialog.vue
+++ b/frontend/src/features/providers/components/provider-tabs/ModelTestDialog.vue
@@ -99,6 +99,33 @@
         </div>
       </div>
 
+      <div
+        v-if="showKeySelector"
+        class="space-y-2"
+      >
+        <div class="flex items-center justify-between gap-3">
+          <div class="text-sm font-medium text-foreground">
+            测试 Key
+          </div>
+          <div class="text-xs text-muted-foreground">
+            {{ keySelectionStatus }}
+          </div>
+        </div>
+        <MultiSelect
+          :model-value="selectedKeyIds"
+          :options="keyOptions"
+          :placeholder="keySelectorPlaceholder"
+          search-placeholder="搜索 Key"
+          empty-text="暂无可选 Key"
+          no-results-text="未找到匹配 Key"
+          trigger-class="h-9 min-h-9 rounded-md border-border/60 text-xs"
+          dropdown-min-width="24rem"
+          :search-threshold="0"
+          :disabled="keyOptionsLoading && keyOptions.length === 0"
+          @update:model-value="emit('update:selectedKeyIds', $event)"
+        />
+      </div>
+
       <div class="grid gap-4 lg:grid-cols-2 lg:items-start">
         <div class="space-y-2">
           <div class="flex items-center justify-between gap-3">
@@ -772,9 +799,11 @@ import {
 } from '@/components/ui'
 import Button from '@/components/ui/button.vue'
 import Textarea from '@/components/ui/textarea.vue'
+import MultiSelect from '@/components/common/MultiSelect.vue'
 import { formatApiFormat } from '@/api/endpoints/types/api-format'
 import type { TestAttemptDetail, TestCandidateSummary, TestModelFailoverResponse } from '@/api/endpoints/providers'
 import type { CandidateRecord, RequestTrace } from '@/api/requestTrace'
+import type { MultiSelectOption } from '@/components/common/MultiSelect.vue'
 import JsonContent from '@/features/usage/components/RequestDetailDrawer/JsonContent.vue'
 import { useClipboard } from '@/composables/useClipboard'
 import { useDarkMode } from '@/composables/useDarkMode'
@@ -797,6 +826,8 @@ type TestModelMappingOption = {
   priority?: number
 }
 
+type TestKeyOption = MultiSelectOption
+
 const props = defineProps<{
   open: boolean
   result: TestModelFailoverResponse | null
@@ -818,6 +849,9 @@ const props = defineProps<{
   modelMappingAvailable?: boolean
   modelMappingOptions?: TestModelMappingOption[]
   selectedModelMapping?: string | null
+  keyOptions?: TestKeyOption[]
+  selectedKeyIds?: string[]
+  keyOptionsLoading?: boolean
   startDisabled?: boolean
 }>()
 
@@ -827,15 +861,30 @@ const emit = defineEmits<{
   start: []
   selectEndpoint: [endpointId: string]
   selectModelMapping: [modelName: string]
+  'update:selectedKeyIds': [value: string[]]
   'update:requestHeadersDraft': [value: string]
   'update:requestBodyDraft': [value: string]
 }>()
 
 const endpoints = computed(() => props.endpoints ?? [])
 const modelMappingOptions = computed(() => props.modelMappingOptions ?? [])
+const keyOptions = computed(() => props.keyOptions ?? [])
+const selectedKeyIds = computed(() => props.selectedKeyIds ?? [])
+const keyOptionsLoading = computed(() => props.keyOptionsLoading === true)
 const modelMappingAvailable = computed(
   () => props.modelMappingAvailable === true && modelMappingOptions.value.length > 0,
 )
+const showKeySelector = computed(() => (
+  keyOptionsLoading.value || keyOptions.value.length > 0 || selectedKeyIds.value.length > 0
+))
+const keySelectorPlaceholder = computed(() => (
+  keyOptionsLoading.value && keyOptions.value.length === 0 ? '正在加载 Key' : '默认调度（不指定 Key）'
+))
+const keySelectionStatus = computed(() => {
+  if (selectedKeyIds.value.length > 0) return `已选 ${selectedKeyIds.value.length}`
+  if (keyOptionsLoading.value) return '加载中'
+  return '默认'
+})
 const requestedModelName = computed(() => props.requestedModelName?.trim() || '')
 const selectedModelMapping = computed(() => props.selectedModelMapping?.trim() || '')
 const selectedModelMappingValue = computed(() => (

--- a/frontend/src/features/providers/components/provider-tabs/ModelsTab.vue
+++ b/frontend/src/features/providers/components/provider-tabs/ModelsTab.vue
@@ -232,12 +232,16 @@
     :model-mapping-available="testModelMappingAvailable"
     :model-mapping-options="testModelMappingOptions"
     :selected-model-mapping="selectedTestMappedModelName"
+    :key-options="testKeyOptions"
+    :selected-key-ids="selectedTestKeyIds"
+    :key-options-loading="loadingModelTestKeys"
     :start-disabled="!selectedTestEndpoint || !!testRequestHeadersError || !!testRequestBodyError"
     @close="handleTestDialogClose"
     @back="handleTestDialogBack"
     @start="handleStartPendingTest"
     @select-endpoint="handleSelectTestEndpoint"
     @select-model-mapping="handleSelectModelMapping"
+    @update:selected-key-ids="handleSelectTestKeyIds"
     @update:request-headers-draft="testRequestHeadersDraft = $event"
     @update:request-body-draft="testRequestBodyDraft = $event"
   />
@@ -257,7 +261,7 @@ import {
   type Model,
   type ProviderEndpoint,
 } from '@/api/endpoints'
-import { type EndpointAPIKey } from '@/api/endpoints/keys'
+import { getProviderKeys, type EndpointAPIKey } from '@/api/endpoints/keys'
 import { updateModel } from '@/api/endpoints/models'
 import { parseApiError } from '@/utils/errorParser'
 import { formatApiFormat } from '@/api/endpoints/types/api-format'
@@ -269,6 +273,7 @@ import {
   isModelTestableApiFormat,
   isModelTestableEndpoint,
   listModelTestMappedModelOptions,
+  modelTestKeySupportsEndpoint,
   normalizeModelTestMappedModelSelection,
   parseModelTestRequestHeadersDraft,
   parseModelTestRequestBodyDraft,
@@ -307,6 +312,10 @@ const testRequestHeadersResetValue = ref('')
 const testRequestBodyDraft = ref('')
 const testRequestBodyResetValue = ref('')
 const selectedTestMappedModelName = ref<string | null>(null)
+const selectedTestKeyIds = ref<string[]>([])
+const modelTestProviderKeys = ref<EndpointAPIKey[]>([])
+const modelTestKeysLoadedProviderId = ref<string | null>(null)
+const loadingModelTestKeys = ref(false)
 const isPoolManagedProvider = computed(() => Boolean(props.provider.pool_advanced))
 const activeEndpoints = computed(() => (props.endpoints ?? [])
   .filter(endpoint => {
@@ -336,6 +345,32 @@ const mappedTestModelName = computed(() => {
     : null
 })
 const testModelMappingAvailable = computed(() => testModelMappingOptions.value.length > 0)
+const providerKeysForModelTest = computed(() => (
+  modelTestKeysLoadedProviderId.value === props.provider.id
+    ? modelTestProviderKeys.value
+    : props.providerKeys ?? []
+))
+const testKeyOptions = computed(() => {
+  const endpoint = selectedTestEndpoint.value
+  if (!endpoint) return []
+
+  const seen = new Set<string>()
+  return [...providerKeysForModelTest.value]
+    .filter((key) => {
+      if (seen.has(key.id)) return false
+      seen.add(key.id)
+      return modelTestKeySupportsEndpoint(key, endpoint, props.provider.provider_type)
+    })
+    .sort((left, right) => {
+      const priority = left.internal_priority - right.internal_priority
+      if (priority !== 0) return priority
+      return formatTestKeyOptionLabel(left).localeCompare(formatTestKeyOptionLabel(right))
+    })
+    .map(key => ({
+      value: key.id,
+      label: formatTestKeyOptionLabel(key),
+    }))
+})
 const effectiveTestRequestModelName = computed(() => (
   mappedTestModelName.value || pendingRequestedModelName.value
 ))
@@ -506,6 +541,7 @@ function handleTestDialogClose() {
   pendingTestModel.value = null
   selectedTestEndpoint.value = null
   selectedTestMappedModelName.value = null
+  selectedTestKeyIds.value = []
   testRequestHeadersDraft.value = ''
   testRequestHeadersResetValue.value = ''
   testRequestBodyDraft.value = ''
@@ -524,6 +560,7 @@ function handleSelectTestEndpoint(endpointId: string) {
   selectedTestEndpoint.value = endpoint
   syncSelectedTestModelMapping()
   resetTestRequestBodyForSelectedEndpoint()
+  pruneSelectedTestKeyIds()
 }
 
 function handleSelectModelMapping(modelName: string) {
@@ -532,6 +569,10 @@ function handleSelectModelMapping(modelName: string) {
     modelName,
   )
   syncTestRequestBodyModel()
+}
+
+function handleSelectTestKeyIds(ids: string[]) {
+  selectedTestKeyIds.value = normalizeSelectedTestKeyIds(ids)
 }
 
 async function handleStartPendingTest() {
@@ -557,6 +598,7 @@ async function handleStartPendingTest() {
   }
 
   selectedTestEndpoint.value = endpoint
+  pruneSelectedTestKeyIds()
   const model = pendingTestModel.value
   const modelName = model.global_model_name || model.provider_model_name
   const endpointPrefix = `[${formatApiFormat(endpoint.api_format)}] `
@@ -567,6 +609,7 @@ async function handleStartPendingTest() {
     apiFormat: endpoint.api_format,
     endpointId: endpoint.id,
     endpointBaseUrl: endpoint.base_url,
+    apiKeyIds: selectedTestKeyIds.value,
     applyModelMapping: Boolean(mappedTestModelName.value),
     mappedModelName: mappedTestModelName.value ?? undefined,
     requestHeaders,
@@ -591,6 +634,7 @@ async function testModelConnection(model: Model) {
   selectedTestEndpoint.value = selectPreferredModelTestEndpoint(model, activeEndpoints.value)
   const requestedModelName = getModelTestRequestedModelName(model)
   selectedTestMappedModelName.value = null
+  selectedTestKeyIds.value = []
   testRequestHeadersResetValue.value = buildDefaultModelTestRequestHeaders()
   testRequestHeadersDraft.value = testRequestHeadersResetValue.value
   testRequestBodyResetValue.value = buildDefaultModelTestRequestBody(
@@ -601,6 +645,49 @@ async function testModelConnection(model: Model) {
   testRequestBodyDraft.value = testRequestBodyResetValue.value
   modelTest.testResult.value = null
   modelTest.dialogOpen.value = true
+  void ensureModelTestKeysLoaded()
+}
+
+function normalizeSelectedTestKeyIds(ids: string[]): string[] {
+  const allowed = new Set(testKeyOptions.value.map(option => option.value))
+  const selected = ids
+    .map(id => id.trim())
+    .filter(id => id && allowed.has(id))
+  return [...new Set(selected)]
+}
+
+function pruneSelectedTestKeyIds() {
+  if (selectedTestKeyIds.value.length === 0) return
+  selectedTestKeyIds.value = normalizeSelectedTestKeyIds(selectedTestKeyIds.value)
+}
+
+async function ensureModelTestKeysLoaded() {
+  if (modelTestKeysLoadedProviderId.value === props.provider.id || loadingModelTestKeys.value) {
+    return
+  }
+
+  loadingModelTestKeys.value = true
+  try {
+    modelTestProviderKeys.value = await getProviderKeys(props.provider.id)
+    modelTestKeysLoadedProviderId.value = props.provider.id
+    pruneSelectedTestKeyIds()
+  } catch (err: unknown) {
+    showError(parseApiError(err, '加载测试 Key 失败'), '错误')
+  } finally {
+    loadingModelTestKeys.value = false
+  }
+}
+
+function formatTestKeyOptionLabel(key: EndpointAPIKey): string {
+  const name = key.name?.trim()
+  const masked = key.api_key_masked?.trim()
+  const authType = key.auth_type?.trim()
+  const primary = name || masked || key.id
+  const suffix = [
+    masked && masked !== primary ? masked : '',
+    authType || '',
+  ].filter(Boolean)
+  return suffix.length > 0 ? `${primary} · ${suffix.join(' · ')}` : primary
 }
 
 function getModelTestRequestedModelName(model: Model | null): string {
@@ -659,6 +746,17 @@ function resetTestRequestBodyForSelectedEndpoint() {
 watch(
   [effectiveTestRequestModelName, () => selectedTestEndpoint.value?.api_format],
   () => syncTestRequestBodyModel(),
+)
+
+watch(testKeyOptions, () => pruneSelectedTestKeyIds())
+
+watch(
+  () => props.provider.id,
+  () => {
+    modelTestProviderKeys.value = []
+    modelTestKeysLoadedProviderId.value = null
+    selectedTestKeyIds.value = []
+  },
 )
 
 // 暴露给父组件


### PR DESCRIPTION
## Summary

- Add support for selecting one or more provider API keys when running provider model tests.
- Keep the existing default behavior when no key is selected, so model tests still use normal scheduling.
- Add backend request parsing for `api_key_ids` while preserving compatibility with the existing `api_key_id`.
- Filter model test candidates by selected keys and return the existing key-not-found error when selected keys are invalid.
- Add a frontend key selector to the model test dialog with search, multi-select, and select-all support.
- Load full provider key options for model tests and prune selections when provider or endpoint context changes.

## Testing

- `cargo test -p aether-gateway provider_query_model_test`
- `npm run type-check`
- `npm run test:run -- src/features/providers/components/provider-tabs/__tests__/model-test-request.spec.ts`
- `cargo fmt --check`
- `git diff --check`