### PR TITLE
fix(frontend): 修复登录成功后的跳转兜底

### DIFF
--- a/frontend/src/features/auth/components/LoginDialog.vue
+++ b/frontend/src/features/auth/components/LoginDialog.vue
@@ -265,6 +265,7 @@ import { oauthApi, type OAuthProviderInfo } from '@/api/oauth'
 import { getClientDeviceId } from '@/utils/deviceId'
 import { getApiUrl } from '@/utils/url'
 import { getOAuthIcon } from '@/utils/oauth-icons'
+import { navigateAfterLogin } from '@/features/auth/utils/loginRedirect'
 
 const props = defineProps<{
   modelValue: boolean
@@ -361,15 +362,7 @@ async function handleLogin(event?: Event) {
   if (success) {
     const targetPath = consumeStoredRedirectPath() ?? (authStore.canAccessAdmin ? '/admin/dashboard' : '/dashboard')
 
-    try {
-      const navigationFailure = await router.push(targetPath)
-      if (navigationFailure) {
-        throw navigationFailure
-      }
-    } catch {
-      showError('登录成功，但跳转失败，请刷新页面或手动进入控制台')
-      return
-    }
+    await navigateAfterLogin(router, targetPath)
 
     showSuccess('登录成功，正在跳转...')
 

--- a/frontend/src/features/auth/components/__tests__/LoginDialog.spec.ts
+++ b/frontend/src/features/auth/components/__tests__/LoginDialog.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, type App } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
 
 import LoginDialog from '../LoginDialog.vue'
 
@@ -29,12 +30,16 @@ const oauthApiMocks = vi.hoisted(() => ({
   getProviders: vi.fn(),
 }))
 
-vi.mock('vue-router', () => ({
-  useRoute: () => routeMock,
-  useRouter: () => ({
-    push: routerPushMock,
-  }),
-}))
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRoute: () => routeMock,
+    useRouter: () => ({
+      push: routerPushMock,
+    }),
+  }
+})
 
 vi.mock('@/stores/auth', () => ({
   useAuthStore: () => authStoreMock,
@@ -156,6 +161,21 @@ async function settle() {
   }
 }
 
+async function createDuplicatedNavigationFailure(path: string) {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path,
+        component: defineComponent({ setup: () => () => null }),
+      },
+    ],
+  })
+
+  await router.push(path)
+  return router.push(path)
+}
+
 beforeEach(() => {
   authStoreMock.loading = false
   authStoreMock.error = ''
@@ -241,5 +261,27 @@ describe('LoginDialog password manager contract', () => {
     expect(routerPushMock).toHaveBeenCalledWith('/admin/dashboard')
     expect(sessionStorage.getItem('redirectPath')).toBeNull()
     expect(toastMocks.success).toHaveBeenCalledWith('登录成功，正在跳转...')
+  })
+
+  it('treats duplicated router navigation after successful auth as a completed login', async () => {
+    authStoreMock.login.mockResolvedValue(true)
+    routerPushMock.mockResolvedValue(await createDuplicatedNavigationFailure('/dashboard'))
+    const root = mountLoginDialog()
+    await settle()
+
+    const form = root.querySelector('form')
+    const username = root.querySelector<HTMLInputElement>('input[name="username"]')
+    const password = root.querySelector<HTMLInputElement>('input[name="password"]')
+
+    username!.value = 'user@example.com'
+    password!.value = 'secret-from-manager'
+    form!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    await settle()
+
+    expect(authStoreMock.login).toHaveBeenCalledWith('user@example.com', 'secret-from-manager', 'local')
+    expect(routerPushMock).toHaveBeenCalledWith('/dashboard')
+    expect(toastMocks.error).not.toHaveBeenCalled()
+    expect(toastMocks.success).toHaveBeenCalledWith('登录成功，正在跳转...')
+    expect(root.querySelector('[data-testid="dialog"]')).toBeNull()
   })
 })

--- a/frontend/src/features/auth/utils/__tests__/loginRedirect.spec.ts
+++ b/frontend/src/features/auth/utils/__tests__/loginRedirect.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createMemoryHistory, createRouter, type Router } from 'vue-router'
+
+import { navigateAfterLogin } from '../loginRedirect'
+
+function createRouterMock(push: Router['push']): Router {
+  return { push } as Router
+}
+
+async function createDuplicatedNavigationFailure(path: string) {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path,
+        component: {},
+      },
+    ],
+  })
+
+  await router.push(path)
+  return router.push(path)
+}
+
+async function createAbortedNavigationFailure(path: string) {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {
+        path,
+        component: {},
+      },
+    ],
+  })
+  router.beforeEach(() => false)
+
+  return router.push(path)
+}
+
+describe('navigateAfterLogin', () => {
+  it('treats duplicated Vue Router navigation as a completed login navigation', async () => {
+    const push = vi.fn<Router['push']>().mockResolvedValue(await createDuplicatedNavigationFailure('/dashboard'))
+    const documentNavigate = vi.fn()
+
+    const result = await navigateAfterLogin(createRouterMock(push), '/dashboard', documentNavigate)
+
+    expect(push).toHaveBeenCalledWith('/dashboard')
+    expect(documentNavigate).not.toHaveBeenCalled()
+    expect(result).toBe('already-there')
+  })
+
+  it('falls back to document navigation when route chunk loading rejects during SPA navigation', async () => {
+    const push = vi.fn<Router['push']>().mockRejectedValue(new Error('Failed to fetch dynamically imported module'))
+    const documentNavigate = vi.fn()
+
+    const result = await navigateAfterLogin(createRouterMock(push), '/admin/dashboard', documentNavigate)
+
+    expect(push).toHaveBeenCalledWith('/admin/dashboard')
+    expect(documentNavigate).toHaveBeenCalledWith('/admin/dashboard')
+    expect(result).toBe('document')
+  })
+
+  it('falls back to document navigation when the router reports a real navigation failure', async () => {
+    const push = vi.fn<Router['push']>().mockResolvedValue(await createAbortedNavigationFailure('/dashboard'))
+    const documentNavigate = vi.fn()
+
+    const result = await navigateAfterLogin(createRouterMock(push), '/dashboard', documentNavigate)
+
+    expect(push).toHaveBeenCalledWith('/dashboard')
+    expect(documentNavigate).toHaveBeenCalledWith('/dashboard')
+    expect(result).toBe('document')
+  })
+})

--- a/frontend/src/features/auth/utils/loginRedirect.ts
+++ b/frontend/src/features/auth/utils/loginRedirect.ts
@@ -1,0 +1,33 @@
+import { isNavigationFailure, NavigationFailureType, type Router } from 'vue-router'
+
+export type LoginNavigationResult = 'router' | 'already-there' | 'document'
+
+type DocumentNavigate = (targetPath: string) => void
+
+function defaultDocumentNavigate(targetPath: string) {
+  window.location.assign(targetPath)
+}
+
+export async function navigateAfterLogin(
+  router: Router,
+  targetPath: string,
+  documentNavigate: DocumentNavigate = defaultDocumentNavigate,
+): Promise<LoginNavigationResult> {
+  try {
+    const navigationFailure = await router.push(targetPath)
+
+    if (isNavigationFailure(navigationFailure, NavigationFailureType.duplicated)) {
+      return 'already-there'
+    }
+
+    if (navigationFailure) {
+      documentNavigate(targetPath)
+      return 'document'
+    }
+
+    return 'router'
+  } catch {
+    documentNavigate(targetPath)
+    return 'document'
+  }
+}


### PR DESCRIPTION
## 前因后果

用户登录接口已经成功返回后，前端会继续调用 `router.push(targetPath)` 跳到控制台。

旧逻辑把 `router.push()` 的所有非空返回值或异常都当成跳转失败，然后直接显示：

```text
登录成功，但跳转失败，请刷新页面或手动进入控制台
```

这会导致一个实际问题：认证状态已经成功建立，但用户仍然停在登录弹窗或首页，看起来像是“登录成功了但进不去控制台”。

这类情况不一定是认证失败，常见触发点包括：

- 当前页面已经是目标页面，Vue Router 返回 duplicated navigation；
- 前端刚发布后，浏览器仍拿着旧 bundle，跳转时加载新的 route chunk 失败；
- Vue Router 返回真实 navigation failure 或 promise reject。

## 修复内容

- duplicated navigation 视为已经到达目标页，不再弹失败提示；
- 正常情况仍然使用 `router.push()` 做 SPA 跳转；
- 如果 SPA 跳转失败，改用 `window.location.assign(targetPath)` 做整页跳转，保证登录成功后能进入目标路径；
- 新增回归测试，覆盖 duplicated navigation、route chunk 加载失败和真实 navigation failure。

## 验证

已在干净的 upstream `main` 分支 worktree 上验证：

```bash
npm run type-check
npm run test:run
npm run build
```