### PR TITLE
新增 Antigravity CLI Provider，保留 Antigravity

### DIFF
--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/antigravity.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/antigravity.rs
@@ -241,7 +241,7 @@ pub(crate) async fn refresh_antigravity_provider_quota_locally(
             payload.insert("metadata".to_string(), metadata);
         }
         if let Some(quota_snapshot) = build_quota_snapshot_payload(
-            "antigravity",
+            &provider.provider_type,
             key.status_snapshot.as_ref(),
             metadata_update.as_ref(),
         ) {

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/dispatch.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/quota/dispatch.rs
@@ -31,6 +31,10 @@ const PROVIDER_QUOTA_REFRESH_HANDLERS: &[(&str, ProviderQuotaRefreshHandler)] = 
         refresh_antigravity_provider_quota_locally_boxed,
     ),
     (
+        "antigravity_cli",
+        refresh_antigravity_provider_quota_locally_boxed,
+    ),
+    (
         "chatgpt_web",
         refresh_chatgpt_web_provider_quota_locally_boxed,
     ),

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/runtime.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/runtime.rs
@@ -70,12 +70,18 @@ fn select_provider_oauth_runtime_endpoint(
                 .eq_ignore_ascii_case("openai:chat")
         })
         .or_else(|| matching_endpoint(endpoints, include_inactive, |_| true)),
-        "antigravity" => matching_endpoint(endpoints, include_inactive, |endpoint| {
-            endpoint
-                .api_format
-                .trim()
-                .eq_ignore_ascii_case("gemini:generate_content")
-        }),
+        provider_type
+            if crate::provider_transport::antigravity::is_antigravity_runtime_provider_type(
+                provider_type,
+            ) =>
+        {
+            matching_endpoint(endpoints, include_inactive, |endpoint| {
+                endpoint
+                    .api_format
+                    .trim()
+                    .eq_ignore_ascii_case("gemini:generate_content")
+            })
+        }
         "kiro" => matching_endpoint(endpoints, include_inactive, |endpoint| {
             endpoint
                 .api_format

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/state/storage.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/state/storage.rs
@@ -17,7 +17,7 @@ pub(crate) fn build_provider_oauth_start_response(
         "authorization_url": authorization_url,
         "redirect_uri": template.redirect_uri,
         "provider_type": template.provider_type,
-        "instructions": "1) 打开 authorization_url 完成授权\n2) 授权后会跳转到 redirect_uri（localhost）\n3) 复制浏览器地址栏完整 URL，调用 complete 接口粘贴 callback_url",
+        "instructions": "1) 打开 authorization_url 完成授权\n2) 授权后会跳转到 redirect_uri\n3) 复制浏览器地址栏完整 URL，调用 complete 接口粘贴 callback_url",
     })
 }
 

--- a/apps/aether-gateway/src/handlers/admin/provider/pool_admin/payloads.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/pool_admin/payloads.rs
@@ -207,6 +207,13 @@ fn admin_pool_quota_snapshot_matches_provider(
     }
 }
 
+fn admin_pool_provider_type_uses_antigravity_quota(provider_type: &str) -> bool {
+    matches!(
+        provider_type.trim().to_ascii_lowercase().as_str(),
+        "antigravity" | "antigravity_cli"
+    )
+}
+
 fn admin_pool_quota_window<'a>(
     quota_snapshot: &'a serde_json::Map<String, serde_json::Value>,
     code: &str,
@@ -874,7 +881,7 @@ fn admin_pool_build_account_quota(
                 return Some(account_quota);
             }
         }
-        "antigravity" => {
+        provider_type if admin_pool_provider_type_uses_antigravity_quota(provider_type) => {
             if let Some(account_quota) =
                 admin_pool_build_antigravity_account_quota_from_snapshot(quota_snapshot)
             {

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models/mod.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models/mod.rs
@@ -36,9 +36,9 @@ use crate::provider_key_auth::{
 };
 use crate::provider_transport::antigravity::{
     build_antigravity_safe_v1internal_request, build_antigravity_static_identity_headers,
-    classify_local_antigravity_request_support, AntigravityEnvelopeRequestType,
-    AntigravityRequestEnvelopeSupport, AntigravityRequestSideSupport,
-    AntigravityRequestSideUnsupportedReason,
+    classify_local_antigravity_request_support, is_antigravity_runtime_provider_type,
+    AntigravityEnvelopeRequestType, AntigravityRequestEnvelopeSupport,
+    AntigravityRequestSideSupport, AntigravityRequestSideUnsupportedReason,
 };
 use crate::provider_transport::kiro::{
     build_kiro_generate_assistant_response_url, build_kiro_provider_headers,
@@ -621,12 +621,7 @@ pub(crate) async fn build_admin_provider_query_models_response(
     }
     let active_key_count = active_keys.len();
 
-    if provider
-        .provider_type
-        .trim()
-        .eq_ignore_ascii_case("antigravity")
-        && !force_refresh
-    {
+    if is_antigravity_runtime_provider_type(&provider.provider_type) && !force_refresh {
         if let Some(models) = provider_query_read_provider_cached_models(state, &provider.id).await
         {
             let models = provider_query_attach_model_test_capabilities(&provider, models);
@@ -647,11 +642,7 @@ pub(crate) async fn build_admin_provider_query_models_response(
         }
     }
 
-    let ordered_keys = if provider
-        .provider_type
-        .trim()
-        .eq_ignore_ascii_case("antigravity")
-    {
+    let ordered_keys = if is_antigravity_runtime_provider_type(&provider.provider_type) {
         provider_query_sort_antigravity_keys(state, &provider, &endpoints, active_keys).await?
     } else {
         active_keys
@@ -686,23 +677,13 @@ pub(crate) async fn build_admin_provider_query_models_response(
         } else {
             fetch_count += 1;
         }
-        if provider
-            .provider_type
-            .trim()
-            .eq_ignore_ascii_case("antigravity")
-            && result.has_success
-        {
+        if is_antigravity_runtime_provider_type(&provider.provider_type) && result.has_success {
             break;
         }
     }
 
     let models = aggregate_models_for_cache(&all_models);
-    if provider
-        .provider_type
-        .trim()
-        .eq_ignore_ascii_case("antigravity")
-        && !models.is_empty()
-    {
+    if is_antigravity_runtime_provider_type(&provider.provider_type) && !models.is_empty() {
         provider_query_write_provider_cached_models(state, &provider.id, &models).await;
     }
     let success = !models.is_empty();

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/adapter.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/adapter.rs
@@ -1,8 +1,9 @@
 use super::DEFAULT_PROVIDER_QUERY_TEST_MESSAGE;
 use crate::handlers::admin::request::{AdminAppState, AdminGatewayProviderTransportSnapshot};
 use crate::provider_transport::antigravity::{
-    classify_local_antigravity_request_support, AntigravityEnvelopeRequestType,
-    AntigravityRequestSideSupport, AntigravityRequestSideUnsupportedReason,
+    classify_local_antigravity_request_support, is_antigravity_runtime_provider_type,
+    AntigravityEnvelopeRequestType, AntigravityRequestSideSupport,
+    AntigravityRequestSideUnsupportedReason,
 };
 use crate::provider_transport::kiro::supports_local_kiro_request_transport_with_network;
 use serde_json::{json, Value};
@@ -237,7 +238,7 @@ pub(super) fn provider_query_test_adapter_for_provider_api_format(
     if normalized_api_format == "openai:image" {
         return Some(ProviderQueryTestAdapter::OpenAiImage);
     }
-    if provider_type.trim().eq_ignore_ascii_case("antigravity")
+    if is_antigravity_runtime_provider_type(provider_type)
         && normalized_api_format == "gemini:generate_content"
     {
         return Some(ProviderQueryTestAdapter::Antigravity);

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/tests.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test/tests.rs
@@ -627,6 +627,13 @@ fn provider_query_test_adapter_routes_fixed_provider_endpoint_types() {
         Some(ProviderQueryTestAdapter::Antigravity)
     );
     assert_eq!(
+        provider_query_test_adapter_for_provider_api_format(
+            "antigravity_cli",
+            "gemini:generate_content"
+        ),
+        Some(ProviderQueryTestAdapter::Antigravity)
+    );
+    assert_eq!(
         provider_query_test_adapter_for_provider_api_format("grok", "openai:chat"),
         Some(ProviderQueryTestAdapter::Grok)
     );
@@ -692,6 +699,10 @@ fn provider_query_endpoint_priority_prefers_text_before_cli_and_image() {
     );
     assert_eq!(
         provider_query_model_test_endpoint_priority("antigravity", "gemini:generate_content"),
+        Some(1)
+    );
+    assert_eq!(
+        provider_query_model_test_endpoint_priority("antigravity_cli", "gemini:generate_content"),
         Some(1)
     );
 }

--- a/apps/aether-gateway/src/handlers/admin/provider/write/normalize.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/write/normalize.rs
@@ -4,9 +4,11 @@ pub(crate) fn normalize_provider_type_input(value: &str) -> Result<String, Strin
     let normalized = value.trim().to_ascii_lowercase();
     match normalized.as_str() {
         "custom" | "claude_code" | "kiro" | "codex" | "chatgpt_web" | "gemini_cli"
-        | "antigravity" | "vertex_ai" | "grok" | "windsurf" => Ok(normalized),
+        | "antigravity" | "antigravity_cli" | "vertex_ai" | "grok" | "windsurf" => {
+            Ok(normalized)
+        }
         _ => Err(
-            "provider_type 仅支持 custom / claude_code / kiro / codex / chatgpt_web / gemini_cli / antigravity / vertex_ai / grok / windsurf"
+            "provider_type 仅支持 custom / claude_code / kiro / codex / chatgpt_web / gemini_cli / antigravity / antigravity_cli / vertex_ai / grok / windsurf"
                 .to_string(),
         ),
     }

--- a/apps/aether-gateway/src/handlers/shared/catalog.rs
+++ b/apps/aether-gateway/src/handlers/shared/catalog.rs
@@ -1386,6 +1386,7 @@ fn build_windsurf_quota_status_snapshot(
 }
 
 fn build_antigravity_quota_status_snapshot(
+    provider_type: &str,
     upstream_metadata: Option<&Value>,
     source: &str,
 ) -> Option<Value> {
@@ -1448,7 +1449,7 @@ fn build_antigravity_quota_status_snapshot(
 
     Some(json!({
         "version": 2,
-        "provider_type": "antigravity",
+        "provider_type": provider_type,
         "code": code,
         "label": label,
         "reason": reason,
@@ -1633,7 +1634,11 @@ pub(crate) fn sync_provider_key_quota_status_snapshot(
         "kiro" => build_kiro_quota_status_snapshot(upstream_metadata, source),
         "chatgpt_web" => build_chatgpt_web_quota_status_snapshot(upstream_metadata, source),
         "windsurf" => build_windsurf_quota_status_snapshot(upstream_metadata, source),
-        "antigravity" => build_antigravity_quota_status_snapshot(upstream_metadata, source),
+        "antigravity" | "antigravity_cli" => build_antigravity_quota_status_snapshot(
+            &normalized_provider_type,
+            upstream_metadata,
+            source,
+        ),
         "grok" => build_grok_quota_status_snapshot(upstream_metadata, source),
         "gemini_cli" => build_gemini_cli_quota_status_snapshot(upstream_metadata, source),
         _ => None,
@@ -3282,6 +3287,32 @@ mod tests {
         assert_eq!(
             quota.get("windows").and_then(Value::as_array).map(Vec::len),
             Some(2usize)
+        );
+    }
+
+    #[test]
+    fn provider_key_status_snapshot_payload_uses_antigravity_cli_provider_type_with_antigravity_metadata(
+    ) {
+        let mut key = sample_catalog_key();
+        key.upstream_metadata = Some(json!({
+            "antigravity": {
+                "updated_at": 1_775_553_285u64,
+                "quota_by_model": {
+                    "gemini-3.1-flash-lite": { "used_percent": 10.0 }
+                }
+            }
+        }));
+
+        let payload = provider_key_status_snapshot_payload(&key, "antigravity_cli");
+        let quota = payload
+            .get("quota")
+            .and_then(Value::as_object)
+            .expect("quota snapshot should be object");
+
+        assert_eq!(quota.get("provider_type"), Some(&json!("antigravity_cli")));
+        assert_eq!(
+            quota.get("windows").and_then(Value::as_array).map(Vec::len),
+            Some(1usize)
         );
     }
 

--- a/apps/aether-gateway/src/provider_key_auth.rs
+++ b/apps/aether-gateway/src/provider_key_auth.rs
@@ -114,15 +114,12 @@ fn key_has_auth_type_overrides(key: &StoredProviderCatalogKey) -> bool {
 }
 
 fn provider_uses_bearer_oauth_runtime(provider_type: &str) -> bool {
+    if aether_provider_transport::antigravity::is_antigravity_runtime_provider_type(provider_type) {
+        return true;
+    }
     matches!(
         provider_type.trim().to_ascii_lowercase().as_str(),
-        "claude_code"
-            | "codex"
-            | "chatgpt_web"
-            | "gemini_cli"
-            | "antigravity"
-            | "kiro"
-            | "windsurf"
+        "claude_code" | "codex" | "chatgpt_web" | "gemini_cli" | "kiro" | "windsurf"
     )
 }
 

--- a/apps/aether-gateway/src/tests/control/admin/oauth.rs
+++ b/apps/aether-gateway/src/tests/control/admin/oauth.rs
@@ -298,13 +298,14 @@ async fn gateway_handles_admin_provider_oauth_supported_types_locally_with_trust
     assert_eq!(response.status(), StatusCode::OK);
     let payload: serde_json::Value = response.json().await.expect("json body should parse");
     let items = payload.as_array().expect("items should be array");
-    assert_eq!(items.len(), 6);
+    assert_eq!(items.len(), 7);
     assert_eq!(items[0]["provider_type"], "claude_code");
     assert_eq!(items[1]["provider_type"], "codex");
     assert_eq!(items[2]["provider_type"], "chatgpt_web");
     assert_eq!(items[3]["provider_type"], "gemini_cli");
     assert_eq!(items[4]["provider_type"], "antigravity");
-    assert_eq!(items[5]["provider_type"], "windsurf");
+    assert_eq!(items[5]["provider_type"], "antigravity_cli");
+    assert_eq!(items[6]["provider_type"], "windsurf");
     assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
 
     gateway_handle.abort();
@@ -1985,6 +1986,135 @@ async fn gateway_handles_admin_provider_oauth_start_provider_locally_with_truste
 
     gateway_handle.abort();
     upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_starts_antigravity_oauth_with_existing_antigravity_authorization_url() {
+    let mut provider = sample_provider("provider-antigravity", "Antigravity", 10);
+    provider.provider_type = "antigravity".to_string();
+
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![],
+        vec![],
+    ));
+    let state = AppState::new()
+        .expect("gateway should build")
+        .with_data_state_for_tests(GatewayDataState::with_provider_catalog_reader_for_tests(
+            provider_catalog_repository,
+        ));
+
+    let response = local_admin_provider_oauth_response(
+        &state,
+        http::Method::POST,
+        "/api/admin/provider-oauth/providers/provider-antigravity/start",
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body should read");
+    let payload: serde_json::Value = serde_json::from_slice(&body).expect("json body should parse");
+    assert_eq!(payload["provider_type"], "antigravity");
+    assert_eq!(
+        payload["redirect_uri"],
+        "http://localhost:51121/oauth2callback"
+    );
+
+    let authorization_url = payload["authorization_url"]
+        .as_str()
+        .expect("authorization_url should exist");
+    let parsed = url::Url::parse(authorization_url).expect("authorization url should parse");
+    let params = parsed
+        .query_pairs()
+        .into_owned()
+        .collect::<std::collections::BTreeMap<_, _>>();
+
+    assert_eq!(
+        parsed.as_str().split('?').next(),
+        Some("https://accounts.google.com/o/oauth2/v2/auth")
+    );
+    assert_eq!(
+        params.get("redirect_uri").map(String::as_str),
+        Some("http://localhost:51121/oauth2callback")
+    );
+    assert!(!params.contains_key("access_type"));
+    assert!(!params.contains_key("prompt"));
+    assert_eq!(
+        params.get("code_challenge_method").map(String::as_str),
+        Some("S256")
+    );
+    assert!(!params
+        .get("scope")
+        .is_some_and(|scope| scope.split_whitespace().any(|item| item == "openid")));
+}
+
+#[tokio::test]
+async fn gateway_starts_antigravity_cli_oauth_with_precise_cli_authorization_url() {
+    let mut provider = sample_provider("provider-antigravity-cli", "Antigravity CLI", 10);
+    provider.provider_type = "antigravity_cli".to_string();
+
+    let provider_catalog_repository = Arc::new(InMemoryProviderCatalogReadRepository::seed(
+        vec![provider],
+        vec![],
+        vec![],
+    ));
+    let state = AppState::new()
+        .expect("gateway should build")
+        .with_data_state_for_tests(GatewayDataState::with_provider_catalog_reader_for_tests(
+            provider_catalog_repository,
+        ));
+
+    let response = local_admin_provider_oauth_response(
+        &state,
+        http::Method::POST,
+        "/api/admin/provider-oauth/providers/provider-antigravity-cli/start",
+        None,
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body should read");
+    let payload: serde_json::Value = serde_json::from_slice(&body).expect("json body should parse");
+    assert_eq!(payload["provider_type"], "antigravity_cli");
+    assert_eq!(
+        payload["redirect_uri"],
+        "https://antigravity.google/oauth-callback"
+    );
+
+    let authorization_url = payload["authorization_url"]
+        .as_str()
+        .expect("authorization_url should exist");
+    let parsed = url::Url::parse(authorization_url).expect("authorization url should parse");
+    let params = parsed
+        .query_pairs()
+        .into_owned()
+        .collect::<std::collections::BTreeMap<_, _>>();
+
+    assert_eq!(
+        parsed.as_str().split('?').next(),
+        Some("https://accounts.google.com/o/oauth2/auth")
+    );
+    assert_eq!(
+        params.get("redirect_uri").map(String::as_str),
+        Some("https://antigravity.google/oauth-callback")
+    );
+    assert_eq!(
+        params.get("access_type").map(String::as_str),
+        Some("offline")
+    );
+    assert_eq!(params.get("prompt").map(String::as_str), Some("consent"));
+    assert_eq!(
+        params.get("code_challenge_method").map(String::as_str),
+        Some("S256")
+    );
+    assert!(params
+        .get("scope")
+        .is_some_and(|scope| scope.split_whitespace().any(|item| item == "openid")));
 }
 
 #[tokio::test]

--- a/crates/aether-ai-formats/src/provider_compat/surfaces.rs
+++ b/crates/aether-ai-formats/src/provider_compat/surfaces.rs
@@ -1,4 +1,5 @@
 pub const ANTIGRAVITY_PROVIDER_TYPE: &str = "antigravity";
+pub const ANTIGRAVITY_CLI_PROVIDER_TYPE: &str = "antigravity_cli";
 pub const KIRO_PROVIDER_TYPE: &str = "kiro";
 pub const WINDSURF_PROVIDER_TYPE: &str = "windsurf";
 pub const KIRO_ENVELOPE_NAME: &str = "kiro:generateAssistantResponse";
@@ -86,6 +87,20 @@ const PROVIDER_ADAPTATION_SURFACES: &[ProviderAdaptationDescriptor] = &[
     },
 ];
 
+fn provider_type_matches_descriptor(
+    descriptor_provider_type: Option<&str>,
+    provider_type: &str,
+) -> bool {
+    let Some(descriptor_provider_type) = descriptor_provider_type else {
+        return false;
+    };
+    if descriptor_provider_type.eq_ignore_ascii_case(provider_type) {
+        return true;
+    }
+    descriptor_provider_type.eq_ignore_ascii_case(ANTIGRAVITY_PROVIDER_TYPE)
+        && provider_type.eq_ignore_ascii_case(ANTIGRAVITY_CLI_PROVIDER_TYPE)
+}
+
 pub fn provider_adaptation_descriptor_for_envelope(
     envelope_name: &str,
     provider_api_format: &str,
@@ -107,9 +122,7 @@ pub fn provider_adaptation_descriptor_for_provider_type(
     let provider_type = provider_type.trim();
     let provider_api_format = provider_api_format.trim().to_ascii_lowercase();
     PROVIDER_ADAPTATION_SURFACES.iter().find(|descriptor| {
-        descriptor
-            .provider_type
-            .is_some_and(|value| value.eq_ignore_ascii_case(provider_type))
+        provider_type_matches_descriptor(descriptor.provider_type, provider_type)
             && descriptor
                 .anchor_api_format
                 .eq_ignore_ascii_case(provider_api_format.as_str())
@@ -153,6 +166,7 @@ pub fn provider_adaptation_should_unwrap_stream_envelope(
 mod tests {
     use super::{
         provider_adaptation_allows_sync_finalize_envelope, provider_adaptation_anchor_api_format,
+        provider_adaptation_descriptor_for_provider_type,
         provider_adaptation_requires_eventstream_accept,
         provider_adaptation_should_unwrap_stream_envelope, ANTIGRAVITY_V1INTERNAL_ENVELOPE_NAME,
         GEMINI_CLI_V1INTERNAL_ENVELOPE_NAME, KIRO_ENVELOPE_NAME, WINDSURF_ENVELOPE_NAME,
@@ -206,5 +220,26 @@ mod tests {
             WINDSURF_ENVELOPE_NAME,
             "openai:chat"
         ));
+    }
+
+    #[test]
+    fn antigravity_cli_uses_antigravity_runtime_surface_without_renaming_antigravity() {
+        let antigravity = provider_adaptation_descriptor_for_provider_type(
+            "antigravity",
+            "gemini:generate_content",
+        )
+        .expect("antigravity descriptor should resolve");
+        let antigravity_cli = provider_adaptation_descriptor_for_provider_type(
+            "antigravity_cli",
+            "gemini:generate_content",
+        )
+        .expect("antigravity cli descriptor should resolve");
+
+        assert_eq!(antigravity.provider_type, Some("antigravity"));
+        assert_eq!(antigravity_cli.provider_type, Some("antigravity"));
+        assert_eq!(
+            antigravity_cli.envelope_name,
+            ANTIGRAVITY_V1INTERNAL_ENVELOPE_NAME
+        );
     }
 }

--- a/crates/aether-data/src/repository/candidate_selection/memory.rs
+++ b/crates/aether-data/src/repository/candidate_selection/memory.rs
@@ -313,7 +313,7 @@ fn key_auth_channel_matches(row: &StoredMinimalCandidateSelectionRow, api_format
         "kiro" => {
             matches!(auth_type.as_str(), "oauth" | "bearer") && api_format == "claude:messages"
         }
-        "gemini_cli" | "antigravity" => {
+        "gemini_cli" | "antigravity" | "antigravity_cli" => {
             auth_type == "oauth" && api_format == "gemini:generate_content"
         }
         "grok" => {

--- a/crates/aether-data/src/repository/candidate_selection/mysql.rs
+++ b/crates/aether-data/src/repository/candidate_selection/mysql.rs
@@ -442,7 +442,7 @@ fn key_auth_channel_matches(row: &CandidateSelectionRow, api_format: &str) -> bo
                             .as_deref()
                             .is_some_and(|value| !value.trim().is_empty())))
         }
-        "gemini_cli" | "antigravity" => {
+        "gemini_cli" | "antigravity" | "antigravity_cli" => {
             auth_type == "oauth" && api_format == "gemini:generate_content"
         }
         "grok" => {

--- a/crates/aether-data/src/repository/candidate_selection/postgres.rs
+++ b/crates/aether-data/src/repository/candidate_selection/postgres.rs
@@ -101,7 +101,7 @@ INNER JOIN LATERAL (
         AND LOWER($3) IN ('openai:chat', 'openai:responses', 'claude:messages', 'openai:image')
       )
       OR (
-        LOWER(BTRIM(p.provider_type)) IN ('gemini_cli', 'antigravity')
+        LOWER(BTRIM(p.provider_type)) IN ('gemini_cli', 'antigravity', 'antigravity_cli')
         AND LOWER(BTRIM(pak.auth_type)) = 'oauth'
         AND LOWER($3) = 'gemini:generate_content'
       )
@@ -132,6 +132,7 @@ INNER JOIN LATERAL (
           'grok',
           'vertex_ai',
           'antigravity',
+          'antigravity_cli',
           'kiro',
           'windsurf'
         )
@@ -194,7 +195,7 @@ WHERE p.is_active = TRUE
       AND LOWER($3) IN ('openai:chat', 'openai:responses', 'claude:messages', 'openai:image')
     )
     OR (
-      LOWER(BTRIM(p.provider_type)) IN ('gemini_cli', 'antigravity')
+      LOWER(BTRIM(p.provider_type)) IN ('gemini_cli', 'antigravity', 'antigravity_cli')
       AND LOWER(BTRIM(pak.auth_type)) = 'oauth'
       AND LOWER($3) = 'gemini:generate_content'
     )
@@ -225,6 +226,7 @@ WHERE p.is_active = TRUE
         'grok',
         'vertex_ai',
         'antigravity',
+        'antigravity_cli',
         'kiro',
         'windsurf'
       )
@@ -380,7 +382,7 @@ INNER JOIN LATERAL (
         AND LOWER($4) IN ('openai:chat', 'openai:responses', 'claude:messages', 'openai:image')
       )
       OR (
-        LOWER(BTRIM(p.provider_type)) IN ('gemini_cli', 'antigravity')
+        LOWER(BTRIM(p.provider_type)) IN ('gemini_cli', 'antigravity', 'antigravity_cli')
         AND LOWER(BTRIM(pak.auth_type)) = 'oauth'
         AND LOWER($4) = 'gemini:generate_content'
       )
@@ -411,6 +413,7 @@ INNER JOIN LATERAL (
           'grok',
           'vertex_ai',
           'antigravity',
+          'antigravity_cli',
           'kiro',
           'windsurf'
         )
@@ -474,7 +477,7 @@ WHERE p.is_active = TRUE
       AND LOWER($4) IN ('openai:chat', 'openai:responses', 'claude:messages', 'openai:image')
     )
     OR (
-      LOWER(BTRIM(p.provider_type)) IN ('gemini_cli', 'antigravity')
+      LOWER(BTRIM(p.provider_type)) IN ('gemini_cli', 'antigravity', 'antigravity_cli')
       AND LOWER(BTRIM(pak.auth_type)) = 'oauth'
       AND LOWER($4) = 'gemini:generate_content'
     )
@@ -505,6 +508,7 @@ WHERE p.is_active = TRUE
         'grok',
         'vertex_ai',
         'antigravity',
+        'antigravity_cli',
         'kiro',
         'windsurf'
       )
@@ -668,7 +672,7 @@ WHERE p.is_active = TRUE
       AND LOWER($6) IN ('openai:chat', 'openai:responses', 'claude:messages', 'openai:image')
     )
     OR (
-      LOWER(BTRIM(p.provider_type)) IN ('gemini_cli', 'antigravity')
+      LOWER(BTRIM(p.provider_type)) IN ('gemini_cli', 'antigravity', 'antigravity_cli')
       AND LOWER(BTRIM(pak.auth_type)) = 'oauth'
       AND LOWER($6) = 'gemini:generate_content'
     )
@@ -699,6 +703,7 @@ WHERE p.is_active = TRUE
         'grok',
         'vertex_ai',
         'antigravity',
+        'antigravity_cli',
         'kiro',
         'windsurf'
       )

--- a/crates/aether-data/src/repository/candidate_selection/sqlite.rs
+++ b/crates/aether-data/src/repository/candidate_selection/sqlite.rs
@@ -530,7 +530,7 @@ fn push_key_auth_channel_sql_filter(
       )
     )
     OR (
-      LOWER(TRIM(p.provider_type)) IN ('gemini_cli', 'antigravity')
+      LOWER(TRIM(p.provider_type)) IN ('gemini_cli', 'antigravity', 'antigravity_cli')
       AND LOWER(TRIM(pak.auth_type)) = 'oauth'
       AND "#,
     );
@@ -586,6 +586,7 @@ fn push_key_auth_channel_sql_filter(
         'grok',
         'vertex_ai',
         'antigravity',
+        'antigravity_cli',
         'kiro',
         'windsurf'
       )
@@ -841,7 +842,7 @@ fn key_auth_channel_matches(row: &CandidateSelectionRow, api_format: &str) -> bo
                             .as_deref()
                             .is_some_and(|value| !value.trim().is_empty())))
         }
-        "gemini_cli" | "antigravity" => {
+        "gemini_cli" | "antigravity" | "antigravity_cli" => {
             auth_type == "oauth" && api_format == "gemini:generate_content"
         }
         "grok" => {

--- a/crates/aether-model-fetch/src/strategy.rs
+++ b/crates/aether-model-fetch/src/strategy.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use aether_contracts::{ExecutionPlan, ExecutionResult, RequestBody};
+use aether_provider_transport::antigravity::is_antigravity_runtime_provider_type;
 use aether_provider_transport::{
     is_vertex_api_key_transport_context, resolve_transport_execution_timeouts,
     resolve_transport_profile, GatewayProviderTransportSnapshot,
@@ -139,7 +140,9 @@ fn select_model_fetch_strategy(
     }
 
     let kind = match provider_type.as_str() {
-        "antigravity" => ModelFetchStrategyKind::Antigravity,
+        provider_type if is_antigravity_runtime_provider_type(provider_type) => {
+            ModelFetchStrategyKind::Antigravity
+        }
         "vertex_ai" => ModelFetchStrategyKind::Vertex,
         "windsurf" => ModelFetchStrategyKind::Windsurf,
         _ => ModelFetchStrategyKind::StandardTransport,
@@ -1529,6 +1532,23 @@ mod tests {
         transport
     }
 
+    fn sample_antigravity_transport(provider_type: &str) -> GatewayProviderTransportSnapshot {
+        let mut transport = sample_custom_aiplatform_transport();
+        transport.provider.provider_type = provider_type.to_string();
+        transport.provider.name = "Antigravity".to_string();
+        transport.endpoint.api_format = "gemini:generate_content".to_string();
+        transport.endpoint.api_family = Some("gemini".to_string());
+        transport.endpoint.endpoint_kind = Some("generate_content".to_string());
+        transport.endpoint.base_url = "https://cloudcode-pa.googleapis.com".to_string();
+        transport.endpoint.custom_path = None;
+        transport.key.auth_type = "oauth".to_string();
+        transport.key.api_formats = Some(vec!["gemini:generate_content".to_string()]);
+        transport.key.decrypted_api_key = "access-token".to_string();
+        transport.key.decrypted_auth_config =
+            Some(r#"{"project_id":"project-1","refresh_token":"refresh-token"}"#.to_string());
+        transport
+    }
+
     fn sample_openai_transport(
         endpoint_id: &str,
         api_format: &str,
@@ -1587,6 +1607,16 @@ mod tests {
 
         assert_eq!(strategy.provider_id(), "windsurf");
         assert_eq!(strategy.kind(), ModelFetchStrategyKind::Windsurf);
+    }
+
+    #[test]
+    fn strategy_selection_uses_antigravity_fetch_for_antigravity_cli() {
+        let strategy =
+            select_model_fetch_strategy(&[sample_antigravity_transport("antigravity_cli")])
+                .expect("strategy should select");
+
+        assert_eq!(strategy.provider_id(), "antigravity_cli");
+        assert_eq!(strategy.kind(), ModelFetchStrategyKind::Antigravity);
     }
 
     #[tokio::test]

--- a/crates/aether-oauth/src/provider/providers/antigravity.rs
+++ b/crates/aether-oauth/src/provider/providers/antigravity.rs
@@ -3,6 +3,9 @@ use super::generic::{
 };
 use crate::provider::ProviderOAuthAdapter;
 
+pub const ANTIGRAVITY_PROVIDER_TYPE: &str = "antigravity";
+pub const ANTIGRAVITY_CLI_PROVIDER_TYPE: &str = "antigravity_cli";
+
 #[derive(Debug, Clone)]
 pub struct AntigravityProviderOAuthAdapter {
     inner: GenericProviderOAuthAdapter,
@@ -10,9 +13,15 @@ pub struct AntigravityProviderOAuthAdapter {
 
 impl Default for AntigravityProviderOAuthAdapter {
     fn default() -> Self {
+        Self::for_provider_type(ANTIGRAVITY_PROVIDER_TYPE)
+    }
+}
+
+impl AntigravityProviderOAuthAdapter {
+    pub fn for_provider_type(provider_type: &'static str) -> Self {
         Self {
             inner: GenericProviderOAuthAdapter::new(
-                template_for_provider_type("antigravity")
+                template_for_provider_type(provider_type)
                     .expect("antigravity template should exist"),
             ),
         }
@@ -93,7 +102,7 @@ impl ProviderOAuthAdapter for AntigravityProviderOAuthAdapter {
         account: &crate::provider::ProviderOAuthAccount,
     ) -> Result<Option<crate::provider::ProviderOAuthProbeResult>, crate::core::OAuthError> {
         Ok(Some(provider_account_state_from_metadata(
-            "antigravity",
+            self.provider_type(),
             account,
         )))
     }
@@ -109,6 +118,7 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::json;
     use std::collections::BTreeMap;
+    use std::sync::{Arc, Mutex};
 
     struct UnusedExecutor;
 
@@ -122,10 +132,37 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn antigravity_probe_marks_forbidden_metadata_invalid() {
-        let adapter = AntigravityProviderOAuthAdapter::default();
-        let ctx = ProviderOAuthTransportContext {
+    #[derive(Clone, Default)]
+    struct CapturingExecutor {
+        requests: Arc<Mutex<Vec<OAuthHttpRequest>>>,
+    }
+
+    #[async_trait]
+    impl OAuthHttpExecutor for CapturingExecutor {
+        async fn execute(
+            &self,
+            request: OAuthHttpRequest,
+        ) -> Result<OAuthHttpResponse, crate::core::OAuthError> {
+            self.requests
+                .lock()
+                .expect("requests should lock")
+                .push(request);
+            Ok(OAuthHttpResponse {
+                status_code: 200,
+                body_text: json!({
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token",
+                    "token_type": "Bearer",
+                    "expires_in": 3600
+                })
+                .to_string(),
+                json_body: None,
+            })
+        }
+    }
+
+    fn sample_context() -> ProviderOAuthTransportContext {
+        ProviderOAuthTransportContext {
             provider_id: String::new(),
             provider_type: "antigravity".to_string(),
             endpoint_id: None,
@@ -137,7 +174,179 @@ mod tests {
             endpoint_config: None,
             key_config: None,
             network: crate::network::OAuthNetworkContext::provider_operation(None),
-        };
+        }
+    }
+
+    #[test]
+    fn antigravity_authorize_url_preserves_existing_antigravity_contract() {
+        let adapter = AntigravityProviderOAuthAdapter::default();
+        let response = adapter
+            .build_authorize_url(&sample_context(), "state-1", Some("challenge-1"))
+            .expect("authorize url should build");
+
+        let parsed = url::Url::parse(&response.authorize_url).expect("authorize url should parse");
+        let params = parsed
+            .query_pairs()
+            .into_owned()
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(
+            parsed.as_str().split('?').next(),
+            Some("https://accounts.google.com/o/oauth2/v2/auth")
+        );
+        assert_eq!(
+            params.get("client_id").map(String::as_str),
+            Some("1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com")
+        );
+        assert_eq!(
+            params.get("redirect_uri").map(String::as_str),
+            Some("http://localhost:51121/oauth2callback")
+        );
+        assert!(!params.contains_key("access_type"));
+        assert!(!params.contains_key("prompt"));
+        assert_eq!(params.get("state").map(String::as_str), Some("state-1"));
+        assert_eq!(
+            params.get("code_challenge").map(String::as_str),
+            Some("challenge-1")
+        );
+        assert_eq!(
+            params.get("code_challenge_method").map(String::as_str),
+            Some("S256")
+        );
+
+        let scope = params.get("scope").expect("scope should exist");
+        assert!(!scope.split_whitespace().any(|item| item == "openid"));
+        for expected in [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/userinfo.email",
+            "https://www.googleapis.com/auth/userinfo.profile",
+            "https://www.googleapis.com/auth/cclog",
+            "https://www.googleapis.com/auth/experimentsandconfigs",
+        ] {
+            assert!(
+                scope.split_whitespace().any(|item| item == expected),
+                "scope should include {expected}; got {scope}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn antigravity_exchange_preserves_existing_redirect_and_scope_replay() {
+        let adapter = AntigravityProviderOAuthAdapter::default();
+        let executor = CapturingExecutor::default();
+
+        adapter
+            .exchange_code(
+                &executor,
+                &sample_context(),
+                "code-1",
+                "state-1",
+                Some("verifier-1"),
+            )
+            .await
+            .expect("exchange should succeed");
+
+        let requests = executor.requests.lock().expect("requests should lock");
+        assert_eq!(requests.len(), 1);
+        let body = std::str::from_utf8(
+            requests[0]
+                .body_bytes
+                .as_deref()
+                .expect("form body should exist"),
+        )
+        .expect("form body should be utf8");
+        let params = url::form_urlencoded::parse(body.as_bytes())
+            .into_owned()
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(
+            params.get("redirect_uri").map(String::as_str),
+            Some("http://localhost:51121/oauth2callback")
+        );
+        assert_eq!(
+            params.get("code_verifier").map(String::as_str),
+            Some("verifier-1")
+        );
+        assert!(params.contains_key("scope"));
+    }
+
+    #[test]
+    fn antigravity_cli_authorize_url_matches_cli_oauth_contract() {
+        let adapter = AntigravityProviderOAuthAdapter::for_provider_type("antigravity_cli");
+        let mut ctx = sample_context();
+        ctx.provider_type = "antigravity_cli".to_string();
+        let response = adapter
+            .build_authorize_url(&ctx, "state-1", Some("challenge-1"))
+            .expect("authorize url should build");
+
+        let parsed = url::Url::parse(&response.authorize_url).expect("authorize url should parse");
+        let params = parsed
+            .query_pairs()
+            .into_owned()
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(
+            parsed.as_str().split('?').next(),
+            Some("https://accounts.google.com/o/oauth2/auth")
+        );
+        assert_eq!(
+            params.get("redirect_uri").map(String::as_str),
+            Some("https://antigravity.google/oauth-callback")
+        );
+        assert_eq!(
+            params.get("access_type").map(String::as_str),
+            Some("offline")
+        );
+        assert_eq!(params.get("prompt").map(String::as_str), Some("consent"));
+        assert_eq!(
+            params.get("code_challenge_method").map(String::as_str),
+            Some("S256")
+        );
+        assert!(params
+            .get("scope")
+            .is_some_and(|scope| scope.split_whitespace().any(|item| item == "openid")));
+    }
+
+    #[tokio::test]
+    async fn antigravity_cli_exchange_uses_cli_redirect_uri_without_scope_replay() {
+        let adapter = AntigravityProviderOAuthAdapter::for_provider_type("antigravity_cli");
+        let executor = CapturingExecutor::default();
+        let mut ctx = sample_context();
+        ctx.provider_type = "antigravity_cli".to_string();
+
+        adapter
+            .exchange_code(&executor, &ctx, "code-1", "state-1", Some("verifier-1"))
+            .await
+            .expect("exchange should succeed");
+
+        let requests = executor.requests.lock().expect("requests should lock");
+        assert_eq!(requests.len(), 1);
+        let body = std::str::from_utf8(
+            requests[0]
+                .body_bytes
+                .as_deref()
+                .expect("form body should exist"),
+        )
+        .expect("form body should be utf8");
+        let params = url::form_urlencoded::parse(body.as_bytes())
+            .into_owned()
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(
+            params.get("redirect_uri").map(String::as_str),
+            Some("https://antigravity.google/oauth-callback")
+        );
+        assert_eq!(
+            params.get("code_verifier").map(String::as_str),
+            Some("verifier-1")
+        );
+        assert!(!params.contains_key("scope"));
+    }
+
+    #[tokio::test]
+    async fn antigravity_probe_marks_forbidden_metadata_invalid() {
+        let adapter = AntigravityProviderOAuthAdapter::default();
+        let ctx = sample_context();
         let account = ProviderOAuthAccount {
             provider_type: "antigravity".to_string(),
             access_token: "access-token".to_string(),

--- a/crates/aether-oauth/src/provider/providers/generic.rs
+++ b/crates/aether-oauth/src/provider/providers/generic.rs
@@ -24,6 +24,8 @@ pub struct GenericProviderOAuthTemplate {
     pub redirect_uri: &'static str,
     pub use_pkce: bool,
     pub uses_json_payload: bool,
+    pub authorize_params: &'static [(&'static str, &'static str)],
+    pub include_scope_in_token_request: bool,
 }
 
 pub const GENERIC_PROVIDER_OAUTH_TEMPLATES: &[GenericProviderOAuthTemplate] = &[
@@ -38,6 +40,8 @@ pub const GENERIC_PROVIDER_OAUTH_TEMPLATES: &[GenericProviderOAuthTemplate] = &[
         redirect_uri: "http://localhost:54545/callback",
         use_pkce: true,
         uses_json_payload: true,
+        authorize_params: &[],
+        include_scope_in_token_request: true,
     },
     GenericProviderOAuthTemplate {
         provider_type: "codex",
@@ -50,6 +54,8 @@ pub const GENERIC_PROVIDER_OAUTH_TEMPLATES: &[GenericProviderOAuthTemplate] = &[
         redirect_uri: "http://localhost:1455/auth/callback",
         use_pkce: true,
         uses_json_payload: false,
+        authorize_params: &[],
+        include_scope_in_token_request: true,
     },
     GenericProviderOAuthTemplate {
         provider_type: "chatgpt_web",
@@ -62,6 +68,8 @@ pub const GENERIC_PROVIDER_OAUTH_TEMPLATES: &[GenericProviderOAuthTemplate] = &[
         redirect_uri: "http://localhost:1455/auth/callback",
         use_pkce: true,
         uses_json_payload: false,
+        authorize_params: &[],
+        include_scope_in_token_request: true,
     },
     GenericProviderOAuthTemplate {
         provider_type: "gemini_cli",
@@ -78,6 +86,8 @@ pub const GENERIC_PROVIDER_OAUTH_TEMPLATES: &[GenericProviderOAuthTemplate] = &[
         redirect_uri: "http://localhost:8085/oauth2callback",
         use_pkce: false,
         uses_json_payload: false,
+        authorize_params: &[],
+        include_scope_in_token_request: true,
     },
     GenericProviderOAuthTemplate {
         provider_type: "antigravity",
@@ -96,6 +106,29 @@ pub const GENERIC_PROVIDER_OAUTH_TEMPLATES: &[GenericProviderOAuthTemplate] = &[
         redirect_uri: "http://localhost:51121/oauth2callback",
         use_pkce: true,
         uses_json_payload: false,
+        authorize_params: &[],
+        include_scope_in_token_request: true,
+    },
+    GenericProviderOAuthTemplate {
+        provider_type: "antigravity_cli",
+        display_name: "Antigravity CLI",
+        authorize_url: "https://accounts.google.com/o/oauth2/auth",
+        token_url: "https://oauth2.googleapis.com/token",
+        client_id: "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com",
+        client_secret: "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",
+        scopes: &[
+            "openid",
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/userinfo.email",
+            "https://www.googleapis.com/auth/userinfo.profile",
+            "https://www.googleapis.com/auth/cclog",
+            "https://www.googleapis.com/auth/experimentsandconfigs",
+        ],
+        redirect_uri: "https://antigravity.google/oauth-callback",
+        use_pkce: true,
+        uses_json_payload: false,
+        authorize_params: &[("access_type", "offline"), ("prompt", "consent")],
+        include_scope_in_token_request: false,
     },
 ];
 
@@ -141,7 +174,9 @@ impl GenericProviderOAuthAdapter {
         state: Option<&str>,
         pkce_verifier: Option<&str>,
     ) -> Result<ProviderOAuthTokenSet, OAuthError> {
-        let scope = (!self.template.scopes.is_empty()).then(|| self.template.scopes.join(" "));
+        let scope = (self.template.include_scope_in_token_request
+            && !self.template.scopes.is_empty())
+        .then(|| self.template.scopes.join(" "));
         let request_id = match grant_type {
             "authorization_code" => "provider-oauth:exchange-code".to_string(),
             "refresh_token" => "provider-oauth:refresh-token".to_string(),
@@ -303,6 +338,9 @@ impl ProviderOAuthAdapter for GenericProviderOAuthAdapter {
             query.append_pair("state", state);
             if !self.template.scopes.is_empty() {
                 query.append_pair("scope", &self.template.scopes.join(" "));
+            }
+            for (name, value) in self.template.authorize_params {
+                query.append_pair(name, value);
             }
             if let Some(challenge) = code_challenge {
                 query.append_pair("code_challenge", challenge);

--- a/crates/aether-oauth/src/provider/providers/mod.rs
+++ b/crates/aether-oauth/src/provider/providers/mod.rs
@@ -4,7 +4,9 @@ mod generic;
 mod kiro;
 mod windsurf;
 
-pub use antigravity::AntigravityProviderOAuthAdapter;
+pub use antigravity::{
+    AntigravityProviderOAuthAdapter, ANTIGRAVITY_CLI_PROVIDER_TYPE, ANTIGRAVITY_PROVIDER_TYPE,
+};
 pub use codex::CodexProviderOAuthAdapter;
 pub use generic::{
     GenericProviderOAuthAdapter, GenericProviderOAuthTemplate, GENERIC_PROVIDER_OAUTH_TEMPLATES,

--- a/crates/aether-oauth/src/provider/service.rs
+++ b/crates/aether-oauth/src/provider/service.rs
@@ -20,12 +20,16 @@ impl ProviderOAuthService {
         use super::providers::{
             AntigravityProviderOAuthAdapter, CodexProviderOAuthAdapter,
             GenericProviderOAuthAdapter, KiroProviderOAuthAdapter, WindsurfProviderOAuthAdapter,
+            ANTIGRAVITY_CLI_PROVIDER_TYPE,
         };
 
         let mut service = Self::new()
             .with_adapter(Arc::new(KiroProviderOAuthAdapter::default()))
             .with_adapter(Arc::new(CodexProviderOAuthAdapter::default()))
             .with_adapter(Arc::new(AntigravityProviderOAuthAdapter::default()))
+            .with_adapter(Arc::new(
+                AntigravityProviderOAuthAdapter::for_provider_type(ANTIGRAVITY_CLI_PROVIDER_TYPE),
+            ))
             .with_adapter(Arc::new(WindsurfProviderOAuthAdapter));
         for provider_type in ["claude_code", "chatgpt_web", "gemini_cli"] {
             if let Some(adapter) = GenericProviderOAuthAdapter::for_provider_type(provider_type) {
@@ -128,6 +132,7 @@ mod tests {
             "chatgpt_web",
             "gemini_cli",
             "antigravity",
+            "antigravity_cli",
             "kiro",
             "windsurf",
         ] {

--- a/crates/aether-provider-pool/src/lib.rs
+++ b/crates/aether-provider-pool/src/lib.rs
@@ -25,11 +25,11 @@ pub use providers::{
     grok_supported_quota_windows_for_tier, normalize_chatgpt_web_image_quota_limit,
     AntigravityProviderPoolAdapter, ChatGptWebProviderPoolAdapter, CodexProviderPoolAdapter,
     DefaultProviderPoolAdapter, GrokProviderPoolAdapter, KiroPoolQuotaAuthInput,
-    KiroProviderPoolAdapter, UnsupportedQuotaProviderPoolAdapter,
-    ANTIGRAVITY_FETCH_AVAILABLE_MODELS_PATH, CHATGPT_WEB_CONVERSATION_INIT_PATH,
-    CHATGPT_WEB_DEFAULT_BASE_URL, CODEX_WHAM_USAGE_URL, KIRO_USAGE_LIMITS_PATH,
-    KIRO_USAGE_SDK_VERSION, WINDSURF_MODEL_CONFIGS_PATH, WINDSURF_RATE_LIMIT_PATH,
-    WINDSURF_USER_STATUS_PATH,
+    KiroProviderPoolAdapter, UnsupportedQuotaProviderPoolAdapter, ANTIGRAVITY_CLI_PROVIDER_TYPE,
+    ANTIGRAVITY_FETCH_AVAILABLE_MODELS_PATH, ANTIGRAVITY_PROVIDER_TYPE,
+    CHATGPT_WEB_CONVERSATION_INIT_PATH, CHATGPT_WEB_DEFAULT_BASE_URL, CODEX_WHAM_USAGE_URL,
+    KIRO_USAGE_LIMITS_PATH, KIRO_USAGE_SDK_VERSION, WINDSURF_MODEL_CONFIGS_PATH,
+    WINDSURF_RATE_LIMIT_PATH, WINDSURF_USER_STATUS_PATH,
 };
 pub use quota::{
     provider_pool_key_account_quota_exhausted, provider_pool_key_scheduling_label,
@@ -68,6 +68,7 @@ mod tests {
             service.provider_types().collect::<Vec<_>>(),
             [
                 "antigravity",
+                "antigravity_cli",
                 "chatgpt_web",
                 "claude_code",
                 "codex",
@@ -93,6 +94,7 @@ mod tests {
             service.provider_types_for_capability(ProviderPoolCapability::QuotaRefresh),
             [
                 "antigravity",
+                "antigravity_cli",
                 "chatgpt_web",
                 "codex",
                 "grok",
@@ -102,6 +104,7 @@ mod tests {
         );
         assert!(service.supports_quota_refresh("codex"));
         assert!(service.supports_quota_refresh("antigravity"));
+        assert!(service.supports_quota_refresh("antigravity_cli"));
         assert!(service.supports_quota_refresh("grok"));
         assert!(service.supports_quota_refresh("windsurf"));
         assert!(!service.supports_quota_refresh("gemini_cli"));

--- a/crates/aether-provider-pool/src/providers/antigravity.rs
+++ b/crates/aether-provider-pool/src/providers/antigravity.rs
@@ -9,14 +9,30 @@ use crate::provider::{
 };
 use crate::quota_refresh::ProviderPoolQuotaRequestSpec;
 
+pub const ANTIGRAVITY_PROVIDER_TYPE: &str = "antigravity";
+pub const ANTIGRAVITY_CLI_PROVIDER_TYPE: &str = "antigravity_cli";
 pub const ANTIGRAVITY_FETCH_AVAILABLE_MODELS_PATH: &str = "/v1internal:fetchAvailableModels";
 
-#[derive(Debug, Clone, Default)]
-pub struct AntigravityProviderPoolAdapter;
+#[derive(Debug, Clone)]
+pub struct AntigravityProviderPoolAdapter {
+    provider_type: &'static str,
+}
+
+impl Default for AntigravityProviderPoolAdapter {
+    fn default() -> Self {
+        Self::for_provider_type(ANTIGRAVITY_PROVIDER_TYPE)
+    }
+}
+
+impl AntigravityProviderPoolAdapter {
+    pub const fn for_provider_type(provider_type: &'static str) -> Self {
+        Self { provider_type }
+    }
+}
 
 impl ProviderPoolAdapter for AntigravityProviderPoolAdapter {
     fn provider_type(&self) -> &'static str {
-        "antigravity"
+        self.provider_type
     }
 
     fn capabilities(&self) -> ProviderPoolCapabilities {

--- a/crates/aether-provider-pool/src/providers/mod.rs
+++ b/crates/aether-provider-pool/src/providers/mod.rs
@@ -9,7 +9,8 @@ pub mod windsurf;
 
 pub use antigravity::AntigravityProviderPoolAdapter;
 pub use antigravity::{
-    build_antigravity_pool_quota_request, ANTIGRAVITY_FETCH_AVAILABLE_MODELS_PATH,
+    build_antigravity_pool_quota_request, ANTIGRAVITY_CLI_PROVIDER_TYPE,
+    ANTIGRAVITY_FETCH_AVAILABLE_MODELS_PATH, ANTIGRAVITY_PROVIDER_TYPE,
 };
 pub use chatgpt_web::ChatGptWebProviderPoolAdapter;
 pub use chatgpt_web::{

--- a/crates/aether-provider-pool/src/service.rs
+++ b/crates/aether-provider-pool/src/service.rs
@@ -13,7 +13,7 @@ use crate::provider::{ProviderPoolAdapter, ProviderPoolMemberInput};
 use crate::providers::{
     AntigravityProviderPoolAdapter, ChatGptWebProviderPoolAdapter, CodexProviderPoolAdapter,
     DefaultProviderPoolAdapter, GrokProviderPoolAdapter, KiroProviderPoolAdapter,
-    WindsurfProviderPoolAdapter, CLAUDE_CODE_PROVIDER_POOL_ADAPTER,
+    WindsurfProviderPoolAdapter, ANTIGRAVITY_CLI_PROVIDER_TYPE, CLAUDE_CODE_PROVIDER_POOL_ADAPTER,
     GEMINI_CLI_PROVIDER_POOL_ADAPTER, VERTEX_AI_PROVIDER_POOL_ADAPTER,
 };
 
@@ -47,7 +47,10 @@ impl ProviderPoolService {
 
     pub fn with_builtin_adapters() -> Self {
         Self::new()
-            .with_adapter(Arc::new(AntigravityProviderPoolAdapter))
+            .with_adapter(Arc::new(AntigravityProviderPoolAdapter::default()))
+            .with_adapter(Arc::new(AntigravityProviderPoolAdapter::for_provider_type(
+                ANTIGRAVITY_CLI_PROVIDER_TYPE,
+            )))
             .with_adapter(Arc::new(CLAUDE_CODE_PROVIDER_POOL_ADAPTER))
             .with_adapter(Arc::new(CodexProviderPoolAdapter))
             .with_adapter(Arc::new(GEMINI_CLI_PROVIDER_POOL_ADAPTER))

--- a/crates/aether-provider-transport/src/antigravity/auth.rs
+++ b/crates/aether-provider-transport/src/antigravity/auth.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use super::super::snapshot::GatewayProviderTransportSnapshot;
 
 pub const ANTIGRAVITY_PROVIDER_TYPE: &str = "antigravity";
+pub const ANTIGRAVITY_CLI_PROVIDER_TYPE: &str = "antigravity_cli";
 pub const ANTIGRAVITY_REQUEST_USER_AGENT: &str = "antigravity";
 const ANTIGRAVITY_CLIENT_NAME: &str = "antigravity";
 const ANTIGRAVITY_GOOG_API_CLIENT: &str = "gl-node/18.18.2 fire/0.8.6 grpc/1.10.x";
@@ -31,15 +32,15 @@ pub enum AntigravityRequestAuthUnsupportedReason {
     MissingProjectId,
 }
 
+pub fn is_antigravity_runtime_provider_type(provider_type: &str) -> bool {
+    let normalized = provider_type.trim().to_ascii_lowercase();
+    normalized == ANTIGRAVITY_PROVIDER_TYPE || normalized == ANTIGRAVITY_CLI_PROVIDER_TYPE
+}
+
 pub fn resolve_local_antigravity_request_auth(
     transport: &GatewayProviderTransportSnapshot,
 ) -> AntigravityRequestAuthSupport {
-    if !transport
-        .provider
-        .provider_type
-        .trim()
-        .eq_ignore_ascii_case(ANTIGRAVITY_PROVIDER_TYPE)
-    {
+    if !is_antigravity_runtime_provider_type(&transport.provider.provider_type) {
         return AntigravityRequestAuthSupport::Unsupported(
             AntigravityRequestAuthUnsupportedReason::WrongProviderType,
         );

--- a/crates/aether-provider-transport/src/antigravity/mod.rs
+++ b/crates/aether-provider-transport/src/antigravity/mod.rs
@@ -4,8 +4,9 @@ mod request;
 mod url;
 
 pub use auth::{
-    build_antigravity_static_identity_headers, resolve_local_antigravity_request_auth,
-    AntigravityRequestAuth, AntigravityRequestAuthSupport, AntigravityRequestAuthUnsupportedReason,
+    build_antigravity_static_identity_headers, is_antigravity_runtime_provider_type,
+    resolve_local_antigravity_request_auth, AntigravityRequestAuth, AntigravityRequestAuthSupport,
+    AntigravityRequestAuthUnsupportedReason, ANTIGRAVITY_CLI_PROVIDER_TYPE,
     ANTIGRAVITY_PROVIDER_TYPE, ANTIGRAVITY_REQUEST_USER_AGENT,
 };
 pub use policy::{

--- a/crates/aether-provider-transport/src/antigravity/policy.rs
+++ b/crates/aether-provider-transport/src/antigravity/policy.rs
@@ -2,8 +2,8 @@ use serde_json::Value;
 
 use super::super::snapshot::GatewayProviderTransportSnapshot;
 use super::auth::{
-    resolve_local_antigravity_request_auth, AntigravityRequestAuth, AntigravityRequestAuthSupport,
-    AntigravityRequestAuthUnsupportedReason, ANTIGRAVITY_PROVIDER_TYPE,
+    is_antigravity_runtime_provider_type, resolve_local_antigravity_request_auth,
+    AntigravityRequestAuth, AntigravityRequestAuthSupport, AntigravityRequestAuthUnsupportedReason,
 };
 use super::request::{
     classify_antigravity_safe_request_body, AntigravityEnvelopeRequestType,
@@ -37,11 +37,7 @@ pub enum AntigravityRequestSideUnsupportedReason {
 }
 
 pub fn is_antigravity_provider_transport(transport: &GatewayProviderTransportSnapshot) -> bool {
-    transport
-        .provider
-        .provider_type
-        .trim()
-        .eq_ignore_ascii_case(ANTIGRAVITY_PROVIDER_TYPE)
+    is_antigravity_runtime_provider_type(&transport.provider.provider_type)
 }
 
 pub fn classify_local_antigravity_request_support(

--- a/crates/aether-provider-transport/src/provider_types.rs
+++ b/crates/aether-provider-transport/src/provider_types.rs
@@ -370,16 +370,27 @@ const VERTEX_AI_FIXED_PROVIDER_TEMPLATE: FixedProviderTemplate = FixedProviderTe
     runtime_policy: VERTEX_AI_RUNTIME_POLICY,
 };
 
-const ANTIGRAVITY_FIXED_PROVIDER_TEMPLATE: FixedProviderTemplate = FixedProviderTemplate {
-    provider_type: "antigravity",
-    version: 1,
-    base_url: "https://cloudcode-pa.googleapis.com",
-    endpoints: &[FixedProviderEndpointTemplate {
+const ANTIGRAVITY_FIXED_PROVIDER_ENDPOINTS: &[FixedProviderEndpointTemplate] =
+    &[FixedProviderEndpointTemplate {
         item_key: "gemini:generate_content",
         api_format: "gemini:generate_content",
         custom_path: None,
         config_defaults: EMPTY_ENDPOINT_CONFIG_DEFAULTS,
-    }],
+    }];
+
+const ANTIGRAVITY_FIXED_PROVIDER_TEMPLATE: FixedProviderTemplate = FixedProviderTemplate {
+    provider_type: "antigravity",
+    version: 1,
+    base_url: "https://cloudcode-pa.googleapis.com",
+    endpoints: ANTIGRAVITY_FIXED_PROVIDER_ENDPOINTS,
+    runtime_policy: ANTIGRAVITY_RUNTIME_POLICY,
+};
+
+const ANTIGRAVITY_CLI_FIXED_PROVIDER_TEMPLATE: FixedProviderTemplate = FixedProviderTemplate {
+    provider_type: "antigravity_cli",
+    version: 1,
+    base_url: "https://cloudcode-pa.googleapis.com",
+    endpoints: ANTIGRAVITY_FIXED_PROVIDER_ENDPOINTS,
     runtime_policy: ANTIGRAVITY_RUNTIME_POLICY,
 };
 
@@ -479,6 +490,7 @@ pub fn fixed_provider_template(provider_type: &str) -> Option<&'static FixedProv
         "gemini_cli" => Some(&GEMINI_CLI_FIXED_PROVIDER_TEMPLATE),
         "vertex_ai" => Some(&VERTEX_AI_FIXED_PROVIDER_TEMPLATE),
         "antigravity" => Some(&ANTIGRAVITY_FIXED_PROVIDER_TEMPLATE),
+        "antigravity_cli" => Some(&ANTIGRAVITY_CLI_FIXED_PROVIDER_TEMPLATE),
         "windsurf" => Some(&WINDSURF_FIXED_PROVIDER_TEMPLATE),
         _ => None,
     }
@@ -523,73 +535,32 @@ pub fn provider_type_is_fixed_for_admin_oauth(provider_type: &str) -> bool {
     provider_type_is_fixed(provider_type)
 }
 
+fn provider_oauth_template_from_generic_provider_type(
+    provider_type: &str,
+) -> Option<ProviderOAuthTemplate> {
+    let normalized = provider_type.trim();
+    let template = aether_oauth::provider::providers::GENERIC_PROVIDER_OAUTH_TEMPLATES
+        .iter()
+        .find(|template| normalized.eq_ignore_ascii_case(template.provider_type))?;
+    Some(ProviderOAuthTemplate {
+        provider_type: template.provider_type,
+        display_name: template.display_name,
+        authorize_url: template.authorize_url,
+        token_url: template.token_url,
+        client_id: template.client_id,
+        client_secret: template.client_secret,
+        scopes: template.scopes,
+        redirect_uri: template.redirect_uri,
+        use_pkce: template.use_pkce,
+    })
+}
+
 pub fn provider_type_admin_oauth_template(provider_type: &str) -> Option<ProviderOAuthTemplate> {
+    if let Some(template) = provider_oauth_template_from_generic_provider_type(provider_type) {
+        return Some(template);
+    }
+
     match provider_type.trim().to_ascii_lowercase().as_str() {
-        "claude_code" => Some(ProviderOAuthTemplate {
-            provider_type: "claude_code",
-            display_name: "ClaudeCode",
-            authorize_url: "https://claude.ai/oauth/authorize",
-            token_url: "https://console.anthropic.com/v1/oauth/token",
-            client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
-            client_secret: "",
-            scopes: &["org:create_api_key", "user:profile", "user:inference"],
-            redirect_uri: "http://localhost:54545/callback",
-            use_pkce: true,
-        }),
-        "codex" => Some(ProviderOAuthTemplate {
-            provider_type: "codex",
-            display_name: "Codex",
-            authorize_url: "https://auth.openai.com/oauth/authorize",
-            token_url: "https://auth.openai.com/oauth/token",
-            client_id: "app_EMoamEEZ73f0CkXaXp7hrann",
-            client_secret: "",
-            scopes: &["openid", "email", "profile", "offline_access"],
-            redirect_uri: "http://localhost:1455/auth/callback",
-            use_pkce: true,
-        }),
-        "chatgpt_web" => Some(ProviderOAuthTemplate {
-            provider_type: "chatgpt_web",
-            display_name: "ChatGPT Web",
-            authorize_url: "https://auth.openai.com/oauth/authorize",
-            token_url: "https://auth.openai.com/oauth/token",
-            client_id: "app_EMoamEEZ73f0CkXaXp7hrann",
-            client_secret: "",
-            scopes: &["openid", "email", "profile", "offline_access"],
-            redirect_uri: "http://localhost:1455/auth/callback",
-            use_pkce: true,
-        }),
-        "gemini_cli" => Some(ProviderOAuthTemplate {
-            provider_type: "gemini_cli",
-            display_name: "GeminiCli",
-            authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
-            token_url: "https://oauth2.googleapis.com/token",
-            client_id: "681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com",
-            client_secret: "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",
-            scopes: &[
-                "https://www.googleapis.com/auth/cloud-platform",
-                "https://www.googleapis.com/auth/userinfo.email",
-                "https://www.googleapis.com/auth/userinfo.profile",
-            ],
-            redirect_uri: "http://localhost:8085/oauth2callback",
-            use_pkce: false,
-        }),
-        "antigravity" => Some(ProviderOAuthTemplate {
-            provider_type: "antigravity",
-            display_name: "Antigravity",
-            authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
-            token_url: "https://oauth2.googleapis.com/token",
-            client_id: "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com",
-            client_secret: "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",
-            scopes: &[
-                "https://www.googleapis.com/auth/cloud-platform",
-                "https://www.googleapis.com/auth/userinfo.email",
-                "https://www.googleapis.com/auth/userinfo.profile",
-                "https://www.googleapis.com/auth/cclog",
-                "https://www.googleapis.com/auth/experimentsandconfigs",
-            ],
-            redirect_uri: "http://localhost:51121/oauth2callback",
-            use_pkce: true,
-        }),
         "windsurf" => Some(ProviderOAuthTemplate {
             provider_type: "windsurf",
             display_name: "Windsurf",
@@ -611,6 +582,7 @@ pub const ADMIN_PROVIDER_OAUTH_TEMPLATE_TYPES: &[&str] = &[
     "chatgpt_web",
     "gemini_cli",
     "antigravity",
+    "antigravity_cli",
     "windsurf",
 ];
 
@@ -752,6 +724,92 @@ mod tests {
         );
         assert_eq!(template.redirect_uri, "show-auth-token");
         assert!(ADMIN_PROVIDER_OAUTH_TEMPLATE_TYPES.contains(&"windsurf"));
+    }
+
+    #[test]
+    fn antigravity_admin_oauth_template_preserves_existing_antigravity_contract() {
+        let template =
+            provider_type_admin_oauth_template("antigravity").expect("antigravity oauth template");
+
+        assert_eq!(template.provider_type, "antigravity");
+        assert_eq!(template.display_name, "Antigravity");
+        assert_eq!(
+            template.authorize_url,
+            "https://accounts.google.com/o/oauth2/v2/auth"
+        );
+        assert_eq!(template.token_url, "https://oauth2.googleapis.com/token");
+        assert_eq!(
+            template.client_id,
+            "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
+        );
+        assert_eq!(
+            template.redirect_uri,
+            "http://localhost:51121/oauth2callback"
+        );
+        assert!(template.use_pkce);
+        assert!(!template.scopes.contains(&"openid"));
+        assert!(template
+            .scopes
+            .contains(&"https://www.googleapis.com/auth/cclog"));
+        assert!(template
+            .scopes
+            .contains(&"https://www.googleapis.com/auth/experimentsandconfigs"));
+        assert!(ADMIN_PROVIDER_OAUTH_TEMPLATE_TYPES.contains(&"antigravity"));
+    }
+
+    #[test]
+    fn antigravity_cli_admin_oauth_template_matches_cli_oauth_contract() {
+        let template = provider_type_admin_oauth_template("antigravity_cli")
+            .expect("antigravity cli oauth template");
+
+        assert_eq!(template.provider_type, "antigravity_cli");
+        assert_eq!(template.display_name, "Antigravity CLI");
+        assert_eq!(
+            template.authorize_url,
+            "https://accounts.google.com/o/oauth2/auth"
+        );
+        assert_eq!(template.token_url, "https://oauth2.googleapis.com/token");
+        assert_eq!(
+            template.client_id,
+            "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com"
+        );
+        assert_eq!(
+            template.redirect_uri,
+            "https://antigravity.google/oauth-callback"
+        );
+        assert!(template.use_pkce);
+        assert!(template.scopes.contains(&"openid"));
+        assert!(template
+            .scopes
+            .contains(&"https://www.googleapis.com/auth/cclog"));
+        assert!(template
+            .scopes
+            .contains(&"https://www.googleapis.com/auth/experimentsandconfigs"));
+        assert!(ADMIN_PROVIDER_OAUTH_TEMPLATE_TYPES.contains(&"antigravity_cli"));
+    }
+
+    #[test]
+    fn antigravity_and_antigravity_cli_fixed_provider_templates_are_separate_entries() {
+        let antigravity =
+            fixed_provider_template("antigravity").expect("antigravity fixed provider template");
+        let antigravity_cli = fixed_provider_template("antigravity_cli")
+            .expect("antigravity cli fixed provider template");
+
+        assert_eq!(antigravity.provider_type, "antigravity");
+        assert_eq!(antigravity_cli.provider_type, "antigravity_cli");
+        assert_eq!(antigravity.base_url, antigravity_cli.base_url);
+        assert_eq!(
+            antigravity
+                .endpoints
+                .iter()
+                .map(|item| item.api_format)
+                .collect::<Vec<_>>(),
+            antigravity_cli
+                .endpoints
+                .iter()
+                .map(|item| item.api_format)
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/aether-provider-transport/src/same_format_provider/mod.rs
+++ b/crates/aether-provider-transport/src/same_format_provider/mod.rs
@@ -553,6 +553,20 @@ mod tests {
         assert!(behavior.is_antigravity);
         assert!(behavior.upstream_is_stream);
         assert_eq!(behavior.report_kind, "gemini_chat_sync_finalize");
+
+        let antigravity_cli = sample_transport("antigravity_cli");
+        let behavior = classify_same_format_provider_request_behavior(
+            &antigravity_cli,
+            SameFormatProviderRequestBehaviorParams {
+                require_streaming: false,
+                provider_api_format: "gemini:generate_content",
+                report_kind: "gemini_chat_sync_success",
+            },
+        );
+
+        assert!(behavior.is_antigravity);
+        assert!(behavior.upstream_is_stream);
+        assert_eq!(behavior.report_kind, "gemini_chat_sync_finalize");
     }
 
     #[test]

--- a/frontend/src/api/endpoints/types/provider.ts
+++ b/frontend/src/api/endpoints/types/provider.ts
@@ -562,7 +562,7 @@ export interface PublicEndpointStatusMonitorResponse {
   formats: PublicEndpointStatusMonitor[]
 }
 
-export type ProviderType = 'custom' | 'claude_code' | 'codex' | 'chatgpt_web' | 'gemini_cli' | 'antigravity' | 'kiro' | 'grok' | 'windsurf' | 'vertex_ai'
+export type ProviderType = 'custom' | 'claude_code' | 'codex' | 'chatgpt_web' | 'gemini_cli' | 'antigravity' | 'antigravity_cli' | 'kiro' | 'grok' | 'windsurf' | 'vertex_ai'
 
 export interface ClaudeCodeAdvancedConfig {
   // 会话数量控制：null/undefined 表示不限制

--- a/frontend/src/features/providers/components/AntigravityQuotaDialog.vue
+++ b/frontend/src/features/providers/components/AntigravityQuotaDialog.vue
@@ -169,7 +169,7 @@ function buildItemsFromQuotaSnapshot(quota: QuotaStatusSnapshot | null | undefin
   if (!quota) return []
 
   const providerType = String(quota.provider_type || '').trim().toLowerCase()
-  if (providerType && providerType !== 'antigravity') return []
+  if (providerType && providerType !== 'antigravity' && providerType !== 'antigravity_cli') return []
 
   const windows = Array.isArray(quota.windows)
     ? quota.windows.filter(window => String(window?.scope || '').trim().toLowerCase() === 'model')

--- a/frontend/src/features/providers/components/PriorityManagementDialog.vue
+++ b/frontend/src/features/providers/components/PriorityManagementDialog.vue
@@ -857,6 +857,7 @@ const PROVIDER_TYPE_LABELS: Record<string, string> = {
   chatgpt_web: 'ChatGPT Web',
   gemini_cli: 'Gemini CLI',
   antigravity: 'Antigravity',
+  antigravity_cli: 'Antigravity CLI',
   kiro: 'Kiro',
   grok: 'Grok',
 }

--- a/frontend/src/features/providers/components/ProviderDetailDrawer.vue
+++ b/frontend/src/features/providers/components/ProviderDetailDrawer.vue
@@ -409,7 +409,7 @@
                             </template>
                             <!-- Antigravity 账号未激活提示 -->
                             <span
-                              v-if="provider.provider_type === 'antigravity' && key.is_active && isOAuthManagedCredential(key) && !hasAntigravityQuotaDisplayData(key)"
+                              v-if="isAntigravityRuntimeProviderType(provider.provider_type) && key.is_active && isOAuthManagedCredential(key) && !hasAntigravityQuotaDisplayData(key)"
                               class="text-[10px] text-orange-500 dark:text-orange-400"
                               title="该账号尚未完成 Gemini Code Assist 激活，无法获取配额和使用模型"
                             >
@@ -525,7 +525,7 @@
                           <Edit class="w-3.5 h-3.5" />
                         </Button>
                         <Button
-                          v-if="provider.provider_type === 'antigravity'"
+                          v-if="isAntigravityRuntimeProviderType(provider.provider_type)"
                           variant="ghost"
                           size="icon"
                           class="h-7 w-7"
@@ -740,7 +740,7 @@
                     </div>
                     <!-- Antigravity 上游额度摘要（按家族分组展示关键配额） -->
                     <div
-                      v-if="provider.provider_type === 'antigravity' && (hasAntigravityQuotaDisplayData(key) || isAntigravityForbiddenKey(key))"
+                      v-if="isAntigravityRuntimeProviderType(provider.provider_type) && (hasAntigravityQuotaDisplayData(key) || isAntigravityForbiddenKey(key))"
                       class="mt-2 p-2 rounded-md"
                       :class="isAntigravityForbiddenKey(key) ? 'bg-destructive/10 border border-destructive/30' : 'bg-muted/30'"
                     >
@@ -1433,7 +1433,11 @@ import type {
   QuotaWindowSnapshot,
 } from '@/api/endpoints/types'
 import { formatApiFormat, formatApiFormatShort } from '@/api/endpoints/types/api-format'
-import { isOAuthAccountProviderType, isKeyManagedProviderType } from '../utils/providerTypeUtils'
+import {
+  isAntigravityRuntimeProviderType,
+  isKeyManagedProviderType,
+  isOAuthAccountProviderType,
+} from '../utils/providerTypeUtils'
 import {
   isProviderQuotaAutoRefreshCoolingDown,
   markProviderQuotaAutoRefreshAttempt,
@@ -2100,13 +2104,19 @@ function quotaSnapshotHasDisplayData(quota: QuotaStatusSnapshot | null | undefin
 
 function getQuotaSnapshotForProvider(
   key: EndpointAPIKey,
-  providerType: 'codex' | 'kiro' | 'windsurf' | 'antigravity' | 'chatgpt_web' | 'gemini_cli' | 'grok',
+  providerType: 'codex' | 'kiro' | 'windsurf' | 'antigravity' | 'antigravity_cli' | 'chatgpt_web' | 'gemini_cli' | 'grok',
 ): QuotaStatusSnapshot | null {
   const quota = key.status_snapshot?.quota
   if (!quota) return null
 
   const snapshotProviderType = quota.provider_type?.trim().toLowerCase()
   if (snapshotProviderType) {
+    if (
+      isAntigravityRuntimeProviderType(providerType)
+      && isAntigravityRuntimeProviderType(snapshotProviderType)
+    ) {
+      return quota
+    }
     return snapshotProviderType === providerType ? quota : null
   }
 
@@ -2733,7 +2743,7 @@ function isTokenExpiringSoon(key: EndpointAPIKey, now: number): boolean {
 }
 
 function shouldAutoRefreshAntigravityQuota(): boolean {
-  if (provider.value?.provider_type !== 'antigravity') return false
+  if (!isAntigravityRuntimeProviderType(provider.value?.provider_type)) return false
   const now = Math.floor(Date.now() / 1000)
 
   for (const { key } of allKeys.value) {
@@ -2859,6 +2869,12 @@ function wrapQuotaMetadataForProvider(
   metadata: Record<string, unknown> | undefined,
 ): UpstreamMetadata | null {
   if (!metadata) return null
+  if (isAntigravityRuntimeProviderType(providerType)) {
+    if ('antigravity' in metadata) {
+      return metadata as UpstreamMetadata
+    }
+    return { antigravity: metadata } as UpstreamMetadata
+  }
   if (providerType in metadata) {
     return metadata as UpstreamMetadata
   }
@@ -2927,13 +2943,20 @@ async function autoRefreshQuotaInBackground(options: { ignoreCooldown?: boolean 
   if (refreshingQuota.value) return
 
   const providerType = provider.value?.provider_type
-  if (providerType !== 'codex' && providerType !== 'antigravity' && providerType !== 'kiro' && providerType !== 'windsurf' && providerType !== 'chatgpt_web' && providerType !== 'grok') return
+  if (
+    providerType !== 'codex'
+    && !isAntigravityRuntimeProviderType(providerType)
+    && providerType !== 'kiro'
+    && providerType !== 'windsurf'
+    && providerType !== 'chatgpt_web'
+    && providerType !== 'grok'
+  ) return
 
   // 检查是否需要刷新
   let shouldRefresh = false
   if (providerType === 'codex') {
     shouldRefresh = shouldAutoRefreshCodexQuota()
-  } else if (providerType === 'antigravity') {
+  } else if (isAntigravityRuntimeProviderType(providerType)) {
     shouldRefresh = shouldAutoRefreshAntigravityQuota()
   } else if (providerType === 'kiro') {
     shouldRefresh = shouldAutoRefreshKiroQuota()
@@ -2950,7 +2973,7 @@ async function autoRefreshQuotaInBackground(options: { ignoreCooldown?: boolean 
   let hadCachedQuota = false
   if (providerType === 'codex') {
     hadCachedQuota = allKeys.value.some(({ key }) => key.is_active && hasCodexQuotaDisplayData(key))
-  } else if (providerType === 'antigravity') {
+  } else if (isAntigravityRuntimeProviderType(providerType)) {
     hadCachedQuota = allKeys.value.some(({ key }) => key.is_active && hasAntigravityQuotaDisplayData(key))
   } else if (providerType === 'kiro') {
     hadCachedQuota = allKeys.value.some(({ key }) => key.is_active && hasKiroQuotaDisplayData(key))
@@ -2967,11 +2990,11 @@ async function autoRefreshQuotaInBackground(options: { ignoreCooldown?: boolean 
   try {
     const result = await refreshProviderQuota(providerId)
     const applied = applyQuotaResults(result.results)
-    if (result.success <= 0 && applied === 0 && !hadCachedQuota && providerType === 'antigravity') {
+    if (result.success <= 0 && applied === 0 && !hadCachedQuota && isAntigravityRuntimeProviderType(providerType)) {
       showError('没有获取到配额信息（请检查账号是否已授权、project_id 是否存在）', '提示')
     }
   } catch (err: unknown) {
-    if (!hadCachedQuota && providerType === 'antigravity') {
+    if (!hadCachedQuota && isAntigravityRuntimeProviderType(providerType)) {
       showError(parseApiError(err, '后台刷新配额失败'), '错误')
     }
   } finally {

--- a/frontend/src/features/providers/components/ProviderFormDialog.vue
+++ b/frontend/src/features/providers/components/ProviderFormDialog.vue
@@ -72,6 +72,9 @@
                   <SelectItem value="antigravity">
                     Antigravity
                   </SelectItem>
+                  <SelectItem value="antigravity_cli">
+                    Antigravity CLI
+                  </SelectItem>
                 </template>
                 <!-- 编辑模式：显示所有类型（兼容已有数据） -->
                 <template v-else>
@@ -104,6 +107,9 @@
                   </SelectItem>
                   <SelectItem value="antigravity">
                     Antigravity
+                  </SelectItem>
+                  <SelectItem value="antigravity_cli">
+                    Antigravity CLI
                   </SelectItem>
                 </template>
               </SelectContent>

--- a/frontend/src/features/providers/components/provider-tabs/ModelTestDialog.vue
+++ b/frontend/src/features/providers/components/provider-tabs/ModelTestDialog.vue
@@ -1384,6 +1384,7 @@ function formatAuthType(authType: string): string {
   if (lowered === 'oauth') return 'OAuth'
   if (lowered === 'codex') return 'Codex OAuth'
   if (lowered === 'antigravity') return 'Antigravity OAuth'
+  if (lowered === 'antigravity_cli') return 'Antigravity CLI OAuth'
   if (lowered === 'kiro') return 'Kiro OAuth'
   if (lowered === 'grok') return 'Grok OAuth'
   return authType

--- a/frontend/src/features/providers/components/provider-tabs/model-test-capabilities.ts
+++ b/frontend/src/features/providers/components/provider-tabs/model-test-capabilities.ts
@@ -33,6 +33,7 @@ const MODEL_TEST_OAUTH_INHERITS_PROVIDER_FORMATS = new Set([
   'gemini_cli',
   'vertex_ai',
   'antigravity',
+  'antigravity_cli',
   'kiro',
 ])
 

--- a/frontend/src/features/providers/utils/__tests__/providerTypeUtils.spec.ts
+++ b/frontend/src/features/providers/utils/__tests__/providerTypeUtils.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { normalizeBatchImportCredentials } from '@/api/endpoints/provider_oauth'
-import { isKeyManagedProviderType, isOAuthAccountProviderType } from '../providerTypeUtils'
+import { getProviderTypeDisplayName, isKeyManagedProviderType, isOAuthAccountProviderType } from '../providerTypeUtils'
 
 describe('providerTypeUtils', () => {
   it('treats ChatGPT-Web as an OAuth account provider', () => {
@@ -20,6 +20,16 @@ describe('providerTypeUtils', () => {
     expect(isOAuthAccountProviderType('windsurf')).toBe(true)
     expect(isOAuthAccountProviderType('Windsurf')).toBe(true)
     expect(isKeyManagedProviderType('windsurf')).toBe(false)
+  })
+
+  it('keeps Antigravity separate from Antigravity CLI in user-facing UI', () => {
+    expect(isOAuthAccountProviderType('antigravity')).toBe(true)
+    expect(isOAuthAccountProviderType('antigravity_cli')).toBe(true)
+    expect(isKeyManagedProviderType('antigravity_cli')).toBe(false)
+    expect(getProviderTypeDisplayName('antigravity')).toBe('Antigravity')
+    expect(getProviderTypeDisplayName('Antigravity')).toBe('Antigravity')
+    expect(getProviderTypeDisplayName('antigravity_cli')).toBe('Antigravity CLI')
+    expect(getProviderTypeDisplayName('Antigravity_CLI')).toBe('Antigravity CLI')
   })
 })
 

--- a/frontend/src/features/providers/utils/providerTypeUtils.ts
+++ b/frontend/src/features/providers/utils/providerTypeUtils.ts
@@ -10,13 +10,38 @@ const oauthAccountProviderTypes = new Set([
   'chatgpt_web',
   'gemini_cli',
   'antigravity',
+  'antigravity_cli',
   'kiro',
   'grok',
   'windsurf',
 ])
+
+export const PROVIDER_TYPE_DISPLAY_NAMES: Record<string, string> = {
+  custom: '自定义',
+  vertex_ai: 'Vertex AI',
+  claude_code: 'ClaudeCode',
+  codex: 'Codex',
+  chatgpt_web: 'ChatGPT Web',
+  gemini_cli: 'Gemini CLI',
+  antigravity: 'Antigravity',
+  antigravity_cli: 'Antigravity CLI',
+  kiro: 'Kiro',
+  grok: 'Grok',
+  windsurf: 'Windsurf',
+}
 
 export const isOAuthAccountProviderType = (providerType?: string | null): boolean =>
   oauthAccountProviderTypes.has((providerType || '').toLowerCase())
 
 export const isKeyManagedProviderType = (providerType?: string | null): boolean =>
   !isOAuthAccountProviderType(providerType)
+
+export const isAntigravityRuntimeProviderType = (providerType?: string | null): boolean => {
+  const normalized = (providerType || '').trim().toLowerCase()
+  return normalized === 'antigravity' || normalized === 'antigravity_cli'
+}
+
+export const getProviderTypeDisplayName = (providerType?: string | null): string => {
+  const normalized = (providerType || '').trim().toLowerCase()
+  return normalized ? (PROVIDER_TYPE_DISPLAY_NAMES[normalized] || providerType || normalized) : ''
+}

--- a/frontend/src/features/usage/components/HorizontalRequestTimeline.vue
+++ b/frontend/src/features/usage/components/HorizontalRequestTimeline.vue
@@ -853,6 +853,7 @@ const AUTH_TYPE_PROVIDER_LABEL_MAP: Record<string, string> = {
   codex: 'Codex',
   kiro: 'Kiro',
   antigravity: 'Antigravity',
+  antigravity_cli: 'Antigravity CLI',
   claude_code: 'Claude Code',
   gemini_cli: 'Gemini CLI',
 }
@@ -1486,6 +1487,7 @@ const formatAuthTypeWithPlan = (authType: string, planType?: string): string => 
     'kiro': 'Kiro',
     'codex': 'Codex',
     'antigravity': 'Antigravity',
+    'antigravity_cli': 'Antigravity CLI',
     'claude_code': 'Claude Code',
     'gemini_cli': 'Gemini CLI',
   }

--- a/frontend/src/features/usage/utils/poolTrace.ts
+++ b/frontend/src/features/usage/utils/poolTrace.ts
@@ -16,6 +16,8 @@ const PROVIDER_TYPE_LIKE_NAMES = new Set<string>([
   'codex',
   'kiro',
   'antigravity',
+  'antigravity_cli',
+  'antigravity cli',
   'claude_code',
   'claude code',
   'gemini_cli',

--- a/frontend/src/utils/providerKeyQuota.ts
+++ b/frontend/src/utils/providerKeyQuota.ts
@@ -381,6 +381,7 @@ export function getQuotaSnapshotFallbackText(
     case 'windsurf':
       return getWindsurfQuotaText(quota)
     case 'antigravity':
+    case 'antigravity_cli':
       return getAntigravityQuotaText(quota)
     case 'gemini_cli':
       return getGeminiCliQuotaText(quota)

--- a/frontend/src/views/admin/PoolManagement.vue
+++ b/frontend/src/views/admin/PoolManagement.vue
@@ -1625,6 +1625,7 @@ import {
   getLegacyAccountQuotaText,
   getQuotaDisplayText,
 } from '@/utils/providerKeyQuota'
+import { isAntigravityRuntimeProviderType } from '@/features/providers/utils/providerTypeUtils'
 
 type PoolKeyScore = NonNullable<PoolKeyDetail['pool_score']>
 
@@ -2077,7 +2078,7 @@ const showAccountQuotaColumn = computed(() => {
     || selectedProviderType.value === 'gemini_cli'
     || selectedProviderType.value === 'kiro'
     || selectedProviderType.value === 'windsurf'
-    || selectedProviderType.value === 'antigravity'
+    || isAntigravityRuntimeProviderType(selectedProviderType.value)
     || selectedProviderType.value === 'grok'
     || selectedProviderType.value === 'chatgpt_web'
 })
@@ -2477,7 +2478,7 @@ const quotaRefreshSupported = computed(() => {
   return selectedProviderType.value === 'codex'
     || selectedProviderType.value === 'kiro'
     || selectedProviderType.value === 'windsurf'
-    || selectedProviderType.value === 'antigravity'
+    || isAntigravityRuntimeProviderType(selectedProviderType.value)
     || selectedProviderType.value === 'grok'
     || selectedProviderType.value === 'chatgpt_web'
 })
@@ -4061,7 +4062,7 @@ function buildQuotaProgressItemsFromSnapshot(key: PoolKeyDetail): QuotaProgressI
     return items
   }
 
-  if (providerType === 'antigravity') {
+  if (isAntigravityRuntimeProviderType(providerType)) {
     const windows = getQuotaSnapshotWindowsByScope(quota, 'model')
     if (windows.length === 0) return []
 


### PR DESCRIPTION
## 变更说明

这次变更不是把现有 `antigravity` 改名，也不是把旧 Antigravity 入口替换成 CLI。`antigravity` 和 `antigravity_cli` 按两个独立 provider 类型处理：

- 保留现有 `antigravity` Provider、OAuth 名称、授权入口、回调地址和既有运行时行为。
- 新增独立的 `antigravity_cli` Provider，用于承接 Antigravity CLI 的 OAuth 登录和请求链路。
- 两者在 UI、admin provider type、OAuth supported types、pool/provider selection、quota refresh、model fetch、model test adapter、candidate selection、provider transport runtime surface 中都是可区分的独立入口。
- `antigravity_cli` 在运行时复用 Antigravity/Gemini generate-content 族的请求适配能力，但不会把旧 `antigravity` 重命名成 CLI，也不会用 “legacy” 概念混淆两个入口。

## OAuth 处理边界

PR 中只保留通用 OAuth 行为说明，不展开核验资料中的原始字段、固定标识或浏览器抓包细节：

- 新增 Provider 使用 Antigravity CLI 独立 OAuth 模板。
- 授权流程保持 Google OAuth、PKCE、离线授权和 consent 语义。
- 回调导入、token exchange 和 provider registry 都接入 Aether 现有 OAuth 架构。
- token exchange 行为由单元测试锁定，避免和 CLI OAuth 合同不一致。

## 主要修改范围

- OAuth provider registry 新增 `antigravity_cli`，并保持 `antigravity` 的原合同不变。
- Provider transport / AI formats / model fetch / model test / same-format provider 识别 `antigravity_cli` 为 Antigravity 运行时族，但 provider type 仍保持 `antigravity_cli`。
- Provider pool、candidate selection、quota refresh、quota snapshot、admin provider write/query 路径支持 `antigravity_cli`。
- 前端新增单独的 `Antigravity CLI` Provider 入口；现有 `Antigravity` 入口继续显示为 `Antigravity`。
- 公共指南中被错误改成 `Antigravity CLI` 的旧 Antigravity 文案已恢复，避免把两个产品入口混为一谈。

## 测试结果

已跑过以下验证：

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p aether-oauth antigravity -- --nocapture`
- `cargo test -p aether-provider-transport antigravity -- --nocapture`
- `cargo test -p aether-provider-transport classifies_streaming_and_report_kind_for_provider_private_transports -- --nocapture`
- `cargo test -p aether-ai-formats antigravity_cli -- --nocapture`
- `cargo test -p aether-model-fetch antigravity_cli -- --nocapture`
- `cargo test -p aether-provider-pool -- --nocapture`
- `cargo test -p aether-data candidate_selection -- --nocapture`
- `cargo test -p aether-gateway gateway_handles_admin_provider_oauth_supported_types_locally_with_trusted_admin_principal -- --nocapture`
- `cargo test -p aether-gateway gateway_starts_antigravity_oauth_with_existing_antigravity_authorization_url -- --nocapture`
- `cargo test -p aether-gateway gateway_starts_antigravity_cli_oauth_with_precise_cli_authorization_url -- --nocapture`
- `cargo test -p aether-gateway provider_key_status_snapshot_payload_uses_antigravity_cli_provider_type_with_antigravity_metadata -- --nocapture`
- `cargo test -p aether-gateway provider_query_test_adapter_routes_fixed_provider_endpoint_types -- --nocapture`
- `npm --prefix frontend ci --no-audit --no-fund`
- `npm --prefix frontend run test:run -- src/features/providers/utils/__tests__/providerTypeUtils.spec.ts src/features/usage/components/__tests__/HorizontalRequestTimeline.spec.ts src/features/usage/utils/__tests__/poolTrace.spec.ts`
- `npm --prefix frontend run type-check`
- `git diff --check`