### PR TITLE
fix: restore Rust CI after Gemini CLI merge

### DIFF
--- a/apps/aether-gateway/src/ai_serving/planner/passthrough/provider/family/payload.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/passthrough/provider/family/payload.rs
@@ -21,6 +21,7 @@ use crate::ai_serving::planner::{
 };
 use crate::ai_serving::transport::{
     resolve_transport_execution_timeouts, resolve_transport_profile,
+    GEMINI_CLI_V1INTERNAL_ENVELOPE_NAME,
 };
 use crate::{
     append_execution_contract_fields_to_value, append_local_failover_policy_to_value,
@@ -94,7 +95,7 @@ pub(crate) async fn maybe_build_local_same_format_provider_decision_payload_for_
     } else if resolved.is_gemini_cli {
         extra_fields.insert(
             "envelope_name".to_string(),
-            json!(aether_ai_formats::api::GEMINI_CLI_V1INTERNAL_ENVELOPE_NAME),
+            json!(GEMINI_CLI_V1INTERNAL_ENVELOPE_NAME),
         );
     } else if resolved.is_antigravity {
         extra_fields.insert(
@@ -105,11 +106,6 @@ pub(crate) async fn maybe_build_local_same_format_provider_decision_payload_for_
             &mut extra_fields,
             super::super::ANTIGRAVITY_ENVELOPE_NAME,
             parts.uri.path(),
-        );
-    } else if resolved.is_gemini_cli {
-        extra_fields.insert(
-            "envelope_name".to_string(),
-            json!(crate::ai_serving::transport::GEMINI_CLI_V1INTERNAL_ENVELOPE_NAME),
         );
     }
     let provider_api_format = resolved.provider_api_format.clone();

--- a/crates/aether-provider-transport/src/same_format_provider/mod.rs
+++ b/crates/aether-provider-transport/src/same_format_provider/mod.rs
@@ -128,13 +128,7 @@ pub fn classify_same_format_provider_request_behavior(
     );
     let report_kind = if is_kiro && !params.require_streaming {
         "claude_cli_sync_finalize"
-    } else if is_gemini_cli && !params.require_streaming {
-        match params.report_kind {
-            "gemini_chat_sync_success" => "gemini_chat_sync_finalize",
-            "gemini_cli_sync_success" => "gemini_cli_sync_finalize",
-            _ => params.report_kind,
-        }
-    } else if is_antigravity && !params.require_streaming {
+    } else if (is_gemini_cli || is_antigravity) && !params.require_streaming {
         match params.report_kind {
             "gemini_chat_sync_success" => "gemini_chat_sync_finalize",
             "gemini_cli_sync_success" => "gemini_cli_sync_finalize",


### PR DESCRIPTION
## Summary
- Collapse identical Gemini CLI and Antigravity same-format report-kind handling so clippy no longer fails on if_same_then_else.
- Route the Gemini CLI v1internal envelope constant through the gateway transport seam and remove a duplicate unreachable branch, restoring the ai_serving architecture boundary test.

## Verification
- cargo fmt --check
- git diff --check
- cargo clippy -p aether-provider-transport --lib -- -D warnings
- cargo test -p aether-gateway ai_serving_crate_api_is_confined_to_root_seams --lib
- cargo clippy -p aether-gateway --lib -- -D warnings