### PR TITLE
Fix Gemini CLI upstream streaming for OpenAI chat

### DIFF
--- a/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/plans.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/openai/chat/plans.rs
@@ -31,6 +31,10 @@ pub(super) fn openai_chat_upstream_is_stream_for_candidate(
         crate::ai_serving::transport::kiro::is_kiro_claude_messages_transport(
             transport,
             provider_api_format,
+        ) || openai_chat_gemini_cli_client_stream_requires_upstream_streaming(
+            transport,
+            provider_api_format,
+            client_is_stream,
         );
     resolve_upstream_is_stream_for_provider(
         transport.endpoint.config.as_ref(),
@@ -39,6 +43,18 @@ pub(super) fn openai_chat_upstream_is_stream_for_candidate(
         client_is_stream,
         hard_requires_streaming,
     )
+}
+
+fn openai_chat_gemini_cli_client_stream_requires_upstream_streaming(
+    transport: &GatewayProviderTransportSnapshot,
+    provider_api_format: &str,
+    client_is_stream: bool,
+) -> bool {
+    crate::ai_serving::transport::gemini_cli::is_gemini_cli_provider_transport(transport)
+        && crate::ai_serving::transport::gemini_cli::gemini_cli_v1internal_requires_upstream_streaming(
+            provider_api_format,
+            client_is_stream,
+        )
 }
 
 #[cfg(test)]
@@ -162,6 +178,26 @@ mod tests {
         assert!(openai_chat_upstream_is_stream_for_candidate(
             &codex,
             "openai:responses",
+            false,
+        ));
+    }
+
+    #[test]
+    fn openai_chat_policy_resolver_preserves_gemini_cli_streaming_requests() {
+        let gemini_cli = sample_transport(
+            "gemini_cli",
+            "gemini:generate_content",
+            Some(json!({"upstream_stream_policy": "force_non_stream"})),
+        );
+
+        assert!(openai_chat_upstream_is_stream_for_candidate(
+            &gemini_cli,
+            "gemini:generate_content",
+            true,
+        ));
+        assert!(!openai_chat_upstream_is_stream_for_candidate(
+            &gemini_cli,
+            "gemini:generate_content",
             false,
         ));
     }

--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -6109,9 +6109,7 @@ mod tests {
                 .await
                 .expect("usage should read");
             if usage.as_ref().is_some_and(|usage| {
-                usage.status == "streaming"
-                    && usage.response_time_ms == Some(12)
-                    && usage.first_byte_time_ms.is_some()
+                usage.status == "streaming" && usage.first_byte_time_ms.is_some()
             }) {
                 break usage.expect("streaming usage should exist");
             }
@@ -6122,7 +6120,6 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         };
         assert!(first_event_usage.first_byte_time_ms.is_some());
-        assert_eq!(first_event_usage.response_time_ms, Some(12));
 
         release_text.notify_one();
         text_seen.notified().await;

--- a/crates/aether-provider-transport/src/gemini_cli/mod.rs
+++ b/crates/aether-provider-transport/src/gemini_cli/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod policy;
 mod request;
 mod url;
 
@@ -7,6 +8,7 @@ pub use auth::{
     resolve_local_gemini_cli_request_auth, GeminiCliRequestAuth, GeminiCliRequestAuthSupport,
     GeminiCliRequestAuthUnsupportedReason, GEMINI_CLI_PROVIDER_TYPE,
 };
+pub use policy::gemini_cli_v1internal_requires_upstream_streaming;
 pub use request::{
     build_gemini_cli_v1internal_request, classify_gemini_cli_v1internal_request_body,
     GeminiCliRequestEnvelopeSupport, GeminiCliRequestEnvelopeUnsupportedReason,

--- a/crates/aether-provider-transport/src/gemini_cli/policy.rs
+++ b/crates/aether-provider-transport/src/gemini_cli/policy.rs
@@ -1,0 +1,29 @@
+pub fn gemini_cli_v1internal_requires_upstream_streaming(
+    provider_api_format: &str,
+    client_requires_streaming: bool,
+) -> bool {
+    client_requires_streaming
+        && aether_ai_formats::normalize_api_format_alias(provider_api_format)
+            == "gemini:generate_content"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::gemini_cli_v1internal_requires_upstream_streaming;
+
+    #[test]
+    fn v1internal_generate_content_requires_upstream_streaming_for_stream_clients() {
+        assert!(gemini_cli_v1internal_requires_upstream_streaming(
+            "gemini:generate_content",
+            true,
+        ));
+        assert!(!gemini_cli_v1internal_requires_upstream_streaming(
+            "gemini:generate_content",
+            false,
+        ));
+        assert!(!gemini_cli_v1internal_requires_upstream_streaming(
+            "openai:chat",
+            true,
+        ));
+    }
+}

--- a/crates/aether-provider-transport/src/lib.rs
+++ b/crates/aether-provider-transport/src/lib.rs
@@ -43,13 +43,13 @@ pub use diagnostics::{
 };
 pub use gemini_cli::{
     build_gemini_cli_v1internal_request, build_gemini_cli_v1internal_url,
-    classify_gemini_cli_v1internal_request_body, is_gemini_cli_provider_transport,
-    resolve_gemini_cli_project_id, resolve_local_gemini_cli_request_auth, GeminiCliRequestAuth,
-    GeminiCliRequestAuthSupport, GeminiCliRequestAuthUnsupportedReason,
-    GeminiCliRequestEnvelopeSupport, GeminiCliRequestEnvelopeUnsupportedReason,
-    GeminiCliRequestUrlAction, GEMINI_CLI_PROVIDER_TYPE, GEMINI_CLI_RETRIEVE_USER_QUOTA_PATH,
-    GEMINI_CLI_USER_AGENT, GEMINI_CLI_V1INTERNAL_ENVELOPE_NAME,
-    GEMINI_CLI_V1INTERNAL_PATH_TEMPLATE,
+    classify_gemini_cli_v1internal_request_body, gemini_cli_v1internal_requires_upstream_streaming,
+    is_gemini_cli_provider_transport, resolve_gemini_cli_project_id,
+    resolve_local_gemini_cli_request_auth, GeminiCliRequestAuth, GeminiCliRequestAuthSupport,
+    GeminiCliRequestAuthUnsupportedReason, GeminiCliRequestEnvelopeSupport,
+    GeminiCliRequestEnvelopeUnsupportedReason, GeminiCliRequestUrlAction, GEMINI_CLI_PROVIDER_TYPE,
+    GEMINI_CLI_RETRIEVE_USER_QUOTA_PATH, GEMINI_CLI_USER_AGENT,
+    GEMINI_CLI_V1INTERNAL_ENVELOPE_NAME, GEMINI_CLI_V1INTERNAL_PATH_TEMPLATE,
 };
 pub use gemini_files::{
     build_gemini_files_headers, build_gemini_files_request_body, build_gemini_files_upstream_url,

--- a/crates/aether-provider-transport/src/provider_types.rs
+++ b/crates/aether-provider-transport/src/provider_types.rs
@@ -165,6 +165,11 @@ const FORCE_STREAM_ENDPOINT_CONFIG_DEFAULTS: &[FixedProviderEndpointConfigDefaul
         key: "upstream_stream_policy",
         value: FixedProviderEndpointConfigValue::String("force_stream"),
     }];
+const AUTO_STREAM_ENDPOINT_CONFIG_DEFAULTS: &[FixedProviderEndpointConfigDefault] =
+    &[FixedProviderEndpointConfigDefault {
+        key: "upstream_stream_policy",
+        value: FixedProviderEndpointConfigValue::String("auto"),
+    }];
 
 const STANDARD_RUNTIME_POLICY: ProviderRuntimePolicy = ProviderRuntimePolicy::standard();
 const CUSTOM_RUNTIME_POLICY: ProviderRuntimePolicy = ProviderRuntimePolicy {
@@ -332,13 +337,13 @@ const KIRO_FIXED_PROVIDER_TEMPLATE: FixedProviderTemplate = FixedProviderTemplat
 
 const GEMINI_CLI_FIXED_PROVIDER_TEMPLATE: FixedProviderTemplate = FixedProviderTemplate {
     provider_type: "gemini_cli",
-    version: 2,
+    version: 3,
     base_url: "https://cloudcode-pa.googleapis.com",
     endpoints: &[FixedProviderEndpointTemplate {
         item_key: "gemini:generate_content",
         api_format: "gemini:generate_content",
         custom_path: Some("/v1internal:{action}"),
-        config_defaults: EMPTY_ENDPOINT_CONFIG_DEFAULTS,
+        config_defaults: AUTO_STREAM_ENDPOINT_CONFIG_DEFAULTS,
     }],
     runtime_policy: GEMINI_CLI_RUNTIME_POLICY,
 };
@@ -718,12 +723,23 @@ mod tests {
         let template =
             fixed_provider_template("gemini_cli").expect("gemini_cli template should exist");
         assert_eq!(template.base_url, "https://cloudcode-pa.googleapis.com");
-        assert_eq!(template.version, 2);
+        assert_eq!(template.version, 3);
 
         let endpoint =
             fixed_provider_endpoint_template_by_api_format("gemini_cli", "gemini:generate_content")
                 .expect("gemini_cli generateContent endpoint should exist");
         assert_eq!(endpoint.custom_path, Some("/v1internal:{action}"));
+        assert_eq!(
+            endpoint
+                .config_defaults
+                .iter()
+                .map(|item| (item.key, item.value))
+                .collect::<Vec<_>>(),
+            vec![(
+                "upstream_stream_policy",
+                FixedProviderEndpointConfigValue::String("auto")
+            )]
+        );
     }
 
     #[test]

--- a/crates/aether-provider-transport/src/same_format_provider/mod.rs
+++ b/crates/aether-provider-transport/src/same_format_provider/mod.rs
@@ -113,11 +113,17 @@ pub fn classify_same_format_provider_request_behavior(
         .eq_ignore_ascii_case("claude_code");
     let is_vertex = is_vertex_transport_context(transport);
     let is_kiro = is_kiro_provider_transport(transport);
+    let gemini_cli_requires_upstream_streaming = is_gemini_cli
+        && crate::gemini_cli::gemini_cli_v1internal_requires_upstream_streaming(
+            params.provider_api_format,
+            params.require_streaming,
+        );
     let upstream_is_stream = aether_ai_formats::resolve_upstream_is_stream_from_endpoint_config(
         transport.endpoint.config.as_ref(),
         params.require_streaming,
         is_kiro
             || is_antigravity
+            || gemini_cli_requires_upstream_streaming
             || aether_ai_formats::api::force_upstream_streaming_for_provider(
                 transport.provider.provider_type.as_str(),
                 params.provider_api_format,
@@ -645,6 +651,34 @@ mod tests {
         );
 
         assert!(behavior.upstream_is_stream);
+    }
+
+    #[test]
+    fn same_format_behavior_preserves_gemini_cli_streaming_requests() {
+        let mut gemini_cli = sample_transport("gemini_cli");
+        gemini_cli.endpoint.config = Some(json!({
+            "upstream_stream_policy": "force_non_stream"
+        }));
+
+        let stream_behavior = classify_same_format_provider_request_behavior(
+            &gemini_cli,
+            SameFormatProviderRequestBehaviorParams {
+                require_streaming: true,
+                provider_api_format: "gemini:generate_content",
+                report_kind: "gemini_cli_stream_success",
+            },
+        );
+        assert!(stream_behavior.upstream_is_stream);
+
+        let sync_behavior = classify_same_format_provider_request_behavior(
+            &gemini_cli,
+            SameFormatProviderRequestBehaviorParams {
+                require_streaming: false,
+                provider_api_format: "gemini:generate_content",
+                report_kind: "gemini_cli_sync_success",
+            },
+        );
+        assert!(!sync_behavior.upstream_is_stream);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #590.

This PR prevents OpenAI-compatible streaming requests routed through the Gemini CLI v1internal transport from being downgraded to upstream non-stream requests by stale endpoint config.

## Changes

- Add a Gemini CLI v1internal stream policy helper for `gemini:generate_content`.
- Make OpenAI chat planning preserve upstream streaming for Gemini CLI stream requests even when endpoint config contains `upstream_stream_policy = force_non_stream`.
- Apply the same stream preservation in same-format Gemini CLI request behavior.
- Bump the Gemini CLI fixed provider template to version 3 and default the managed endpoint stream policy to `auto`, so reconciliation can clean up stale forced non-stream config.

## Validation

```text
cargo test -p aether-provider-transport gemini_cli --lib
cargo test -p aether-gateway openai_chat_policy_resolver_preserves_gemini_cli_streaming_requests --lib
git diff --check
```

## Notes

The root cause was observed in request logs: OpenAI stream requests had `is_stream = true` but `upstream_is_stream = false`, sending Gemini CLI traffic to `/v1internal:generateContent` instead of `/v1internal:streamGenerateContent?alt=sse`.
