### PR TITLE
feat(usage): support output_config effort badge source

### DIFF
--- a/crates/aether-data-contracts/src/repository/usage/types.rs
+++ b/crates/aether-data-contracts/src/repository/usage/types.rs
@@ -17,6 +17,13 @@ pub fn extract_provider_reasoning_effort_from_body(value: Option<&Value>) -> Opt
                 .and_then(|reasoning| reasoning.get("effort"))
                 .and_then(Value::as_str)
         })
+        .or_else(|| {
+            object
+                .get("output_config")
+                .and_then(Value::as_object)
+                .and_then(|output_config| output_config.get("effort"))
+                .and_then(Value::as_str)
+        })
         .and_then(normalize_provider_reasoning_effort)
 }
 
@@ -2437,12 +2444,18 @@ mod tests {
 
         usage.request_metadata = None;
         usage.provider_request_body = Some(json!({
-            "reasoning_effort": "High",
+            "output_config": { "effort": "High" },
             "service_tier": "priority"
         }));
 
         assert_eq!(usage.provider_reasoning_effort().as_deref(), Some("high"));
         assert_eq!(usage.provider_service_tier().as_deref(), Some("priority"));
+
+        usage.provider_request_body = Some(json!({
+            "reasoning_effort": "medium"
+        }));
+
+        assert_eq!(usage.provider_reasoning_effort().as_deref(), Some("medium"));
 
         usage.request_metadata = Some(json!({
             "provider_reasoning_effort": "max",

--- a/crates/aether-data/src/repository/usage/postgres/queries/list_recent_usage_audits_prefix.sql
+++ b/crates/aether-data/src/repository/usage/postgres/queries/list_recent_usage_audits_prefix.sql
@@ -117,7 +117,8 @@ SELECT
       OR CASE
         WHEN jsonb_typeof("usage".provider_request_body::jsonb) = 'object' THEN COALESCE(
           NULLIF(BTRIM("usage".provider_request_body->>'reasoning_effort'), ''),
-          NULLIF(BTRIM("usage".provider_request_body->'reasoning'->>'effort'), '')
+          NULLIF(BTRIM("usage".provider_request_body->'reasoning'->>'effort'), ''),
+          NULLIF(BTRIM("usage".provider_request_body->'output_config'->>'effort'), '')
         )
         ELSE NULLIF(BTRIM("usage".request_metadata->>'provider_reasoning_effort'), '')
       END IS NOT NULL
@@ -140,7 +141,8 @@ SELECT
         CASE
           WHEN jsonb_typeof("usage".provider_request_body::jsonb) = 'object' THEN COALESCE(
             NULLIF(BTRIM("usage".provider_request_body->>'reasoning_effort'), ''),
-            NULLIF(BTRIM("usage".provider_request_body->'reasoning'->>'effort'), '')
+            NULLIF(BTRIM("usage".provider_request_body->'reasoning'->>'effort'), ''),
+            NULLIF(BTRIM("usage".provider_request_body->'output_config'->>'effort'), '')
           )
           ELSE NULLIF(BTRIM("usage".request_metadata->>'provider_reasoning_effort'), '')
         END,

--- a/crates/aether-data/src/repository/usage/postgres/queries/list_usage_audits_prefix.sql
+++ b/crates/aether-data/src/repository/usage/postgres/queries/list_usage_audits_prefix.sql
@@ -117,7 +117,8 @@ SELECT
       OR CASE
         WHEN jsonb_typeof("usage".provider_request_body::jsonb) = 'object' THEN COALESCE(
           NULLIF(BTRIM("usage".provider_request_body->>'reasoning_effort'), ''),
-          NULLIF(BTRIM("usage".provider_request_body->'reasoning'->>'effort'), '')
+          NULLIF(BTRIM("usage".provider_request_body->'reasoning'->>'effort'), ''),
+          NULLIF(BTRIM("usage".provider_request_body->'output_config'->>'effort'), '')
         )
         ELSE NULLIF(BTRIM("usage".request_metadata->>'provider_reasoning_effort'), '')
       END IS NOT NULL
@@ -140,7 +141,8 @@ SELECT
         CASE
           WHEN jsonb_typeof("usage".provider_request_body::jsonb) = 'object' THEN COALESCE(
             NULLIF(BTRIM("usage".provider_request_body->>'reasoning_effort'), ''),
-            NULLIF(BTRIM("usage".provider_request_body->'reasoning'->>'effort'), '')
+            NULLIF(BTRIM("usage".provider_request_body->'reasoning'->>'effort'), ''),
+            NULLIF(BTRIM("usage".provider_request_body->'output_config'->>'effort'), '')
           )
           ELSE NULLIF(BTRIM("usage".request_metadata->>'provider_reasoning_effort'), '')
         END,


### PR DESCRIPTION
- extract reasoning effort from provider request body output_config.effort
- include output_config.effort in usage list fallback SQL
- cover the new request body shape in usage metadata tests