### PR TITLE
让 Codex provider 支持 OpenAI Chat endpoint

### DIFF
--- a/crates/aether-provider-transport/src/conversion.rs
+++ b/crates/aether-provider-transport/src/conversion.rs
@@ -667,6 +667,21 @@ mod tests {
     }
 
     #[test]
+    fn codex_openai_chat_anchor_supports_responses_conversion_by_default() {
+        let transport = transport_snapshot("codex", "openai:chat", "oauth", true, None);
+
+        assert!(request_pair_allowed_for_transport(
+            &transport,
+            "openai:responses",
+            "openai:chat"
+        ));
+        assert!(request_conversion_transport_supported(
+            &transport,
+            RequestConversionKind::ToOpenAIChat
+        ));
+    }
+
+    #[test]
     fn candidate_common_transport_policy_checks_active_state_format_and_allowed_models() {
         let mut transport = transport_snapshot("custom", "openai:chat", "bearer", true, None);
         transport.key.allowed_models = Some(vec!["gpt-4.1-mini".to_string()]);

--- a/crates/aether-provider-transport/src/provider_types.rs
+++ b/crates/aether-provider-transport/src/provider_types.rs
@@ -208,7 +208,6 @@ const CODEX_RUNTIME_POLICY: ProviderRuntimePolicy = ProviderRuntimePolicy {
     api_format_inheritance: ProviderApiFormatInheritance::OAuth,
     enable_format_conversion_by_default: true,
     supports_model_fetch: false,
-    supports_local_openai_chat_transport: false,
     ..STANDARD_RUNTIME_POLICY
 };
 const CHATGPT_WEB_RUNTIME_POLICY: ProviderRuntimePolicy = ProviderRuntimePolicy {
@@ -284,9 +283,15 @@ const CLAUDE_CODE_FIXED_PROVIDER_TEMPLATE: FixedProviderTemplate = FixedProvider
 
 const CODEX_FIXED_PROVIDER_TEMPLATE: FixedProviderTemplate = FixedProviderTemplate {
     provider_type: "codex",
-    version: 1,
+    version: 2,
     base_url: "https://chatgpt.com/backend-api/codex",
     endpoints: &[
+        FixedProviderEndpointTemplate {
+            item_key: "openai:chat",
+            api_format: "openai:chat",
+            custom_path: None,
+            config_defaults: FORCE_STREAM_ENDPOINT_CONFIG_DEFAULTS,
+        },
         FixedProviderEndpointTemplate {
             item_key: "openai:responses",
             api_format: "openai:responses",
@@ -626,15 +631,16 @@ mod tests {
         fixed_provider_template, provider_runtime_policy, provider_type_admin_oauth_template,
         provider_type_allows_auth_channel_mismatch_by_default, provider_type_oauth_is_bearer_like,
         provider_type_supports_local_embedding_transport,
+        provider_type_supports_local_openai_chat_transport,
         provider_type_supports_local_same_format_transport, FixedProviderEndpointConfigValue,
         ADMIN_PROVIDER_OAUTH_TEMPLATE_TYPES,
     };
 
     #[test]
-    fn codex_fixed_provider_template_includes_openai_image() {
+    fn codex_fixed_provider_template_exposes_openai_chat_responses_and_image() {
         let template = fixed_provider_template("codex").expect("codex template should exist");
         assert_eq!(template.base_url, "https://chatgpt.com/backend-api/codex");
-        assert_eq!(template.version, 1);
+        assert_eq!(template.version, 2);
         assert_eq!(
             template
                 .endpoints
@@ -642,10 +648,25 @@ mod tests {
                 .map(|item| item.api_format)
                 .collect::<Vec<_>>(),
             vec![
+                "openai:chat",
                 "openai:responses",
                 "openai:responses:compact",
                 "openai:image"
             ]
+        );
+
+        let chat_template = fixed_provider_endpoint_template_by_api_format("codex", "openai:chat")
+            .expect("codex chat endpoint should exist");
+        assert_eq!(
+            chat_template
+                .config_defaults
+                .iter()
+                .map(|item| (item.key, item.value))
+                .collect::<Vec<_>>(),
+            vec![(
+                "upstream_stream_policy",
+                FixedProviderEndpointConfigValue::String("force_stream")
+            )]
         );
 
         let image_template =
@@ -845,7 +866,8 @@ mod tests {
         assert!(codex.enable_format_conversion_by_default);
         assert!(!codex.oauth_is_bearer_like);
         assert!(!codex.supports_model_fetch);
-        assert!(!codex.supports_local_openai_chat_transport);
+        assert!(codex.supports_local_openai_chat_transport);
+        assert!(provider_type_supports_local_openai_chat_transport("codex"));
         assert!(codex.supports_local_same_format_transport);
 
         let gemini_cli = provider_runtime_policy("gemini_cli");

--- a/crates/aether-provider-transport/src/url.rs
+++ b/crates/aether-provider-transport/src/url.rs
@@ -582,6 +582,21 @@ mod tests {
     }
 
     #[test]
+    fn openai_chat_url_preserves_codex_path_prefix() {
+        assert_eq!(
+            build_openai_chat_url("https://chatgpt.com/backend-api/codex", None),
+            "https://chatgpt.com/backend-api/codex/chat/completions"
+        );
+        assert_eq!(
+            build_openai_chat_url(
+                "https://tiger.bookapi.cc/codex?tenant=demo",
+                Some("trace=1")
+            ),
+            "https://tiger.bookapi.cc/codex/chat/completions?tenant=demo&trace=1"
+        );
+    }
+
+    #[test]
     fn openai_image_url_uses_images_surface() {
         assert_eq!(
             build_openai_image_url(


### PR DESCRIPTION
## 做了什么

这次把 Codex 固定 provider 的 OpenAI Chat 入口补上了：

- 给 `codex` provider 增加 `openai:chat` endpoint，模板版本从 `1` 升到 `2`，这样已有的固定 provider 对账逻辑能补齐新端点。
- 打开 `codex` 的本地 OpenAI Chat transport 支持，让 `/v1/chat/completions` 这条入口能走到 Codex provider。
- 保留原来的 `openai:responses`、`openai:responses:compact`、`openai:image` 行为，并补了测试，确认 chat/responses 转换和 Codex 后端 URL 前缀都不会跑偏。

## 为什么改

现在 Codex provider 只有 responses/image 入口，OpenAI Chat 请求不能直接用它。仓库里的格式转换矩阵本来已经支持 `openai:chat` 和 `openai:responses` 互转，所以这次不是重写转换逻辑，只是把 Codex provider 的端点声明和运行时开关补齐。

## 验证

- `cargo test -p aether-provider-transport`
- `cargo fmt --all -- --check`
- `git diff --check`