### PR TITLE
fix(stream): 修复上游流式中断后的终态处理

### DIFF
--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -3357,7 +3357,13 @@ async fn execute_stream_from_frame_stream(
                 "gateway skipped client stream flush after downstream disconnect"
             );
         }
-        if let Some(normalizer) = private_stream_normalizer.as_mut() {
+        // Buffered stream state is partial after a terminal failure; normal
+        // finish paths may synthesize successful terminal events.
+        let should_finish_stream_rewriters = terminal_failure.is_none();
+        if let Some(normalizer) = private_stream_normalizer
+            .as_mut()
+            .filter(|_| should_finish_stream_rewriters)
+        {
             match normalizer.finish() {
                 Ok(normalized_chunk) if !normalized_chunk.is_empty() => {
                     let provider_private_error_body_json =
@@ -3391,13 +3397,12 @@ async fn execute_stream_from_frame_stream(
                                         error = ?err,
                                         "gateway failed to rewrite normalized private stream chunk during flush"
                                     );
-                                    terminal_failure.get_or_insert_with(|| {
-                                        build_stream_failure_report(
-                                            "execution_runtime_stream_rewrite_flush_error",
-                                            format!("failed to rewrite normalized private stream chunk during flush: {err:?}"),
-                                            502,
-                                        )
-                                    });
+                                    let failure = build_stream_failure_report(
+                                        "execution_runtime_stream_rewrite_flush_error",
+                                        format!("failed to rewrite normalized private stream chunk during flush: {err:?}"),
+                                        502,
+                                    );
+                                    terminal_failure.get_or_insert(failure);
                                     Vec::new()
                                 }
                             }
@@ -3472,7 +3477,7 @@ async fn execute_stream_from_frame_stream(
                 }
             }
         }
-        if !downstream_dropped {
+        if !downstream_dropped && terminal_failure.is_none() {
             if let Some(rewriter) = local_stream_rewriter.as_mut() {
                 match rewriter.finish() {
                     Ok(flushed_chunk) if !flushed_chunk.is_empty() => {
@@ -3898,8 +3903,9 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use aether_contracts::{
-        ExecutionPlan, ExecutionStreamTerminalSummary, ExecutionTimeouts, RequestBody,
-        StandardizedUsage,
+        ExecutionError, ExecutionErrorKind, ExecutionPhase, ExecutionPlan,
+        ExecutionStreamTerminalSummary, ExecutionTimeouts, RequestBody, StandardizedUsage,
+        StreamFrame, StreamFramePayload, StreamFrameType,
     };
     use aether_data::repository::candidates::InMemoryRequestCandidateRepository;
     use aether_data::repository::usage::InMemoryUsageReadRepository;
@@ -3994,6 +4000,12 @@ mod tests {
         out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
         out.extend_from_slice(payload);
         out
+    }
+
+    fn ndjson_frame(frame: StreamFrame) -> Bytes {
+        let mut bytes = serde_json::to_vec(&frame).expect("stream frame should serialize");
+        bytes.push(b'\n');
+        Bytes::from(bytes)
     }
 
     #[test]
@@ -5015,6 +5027,154 @@ mod tests {
             .expect("stream should yield local keepalive")
             .expect("local keepalive should be ok");
         assert_eq!(first.as_ref(), b": aether-keepalive\n\n");
+    }
+
+    #[tokio::test]
+    async fn execute_stream_from_frame_stream_does_not_finalize_rewritten_tool_call_after_midstream_error(
+    ) {
+        let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
+        let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
+        let state = AppState::new()
+            .expect("app state should build")
+            .with_data_state_for_tests(
+                crate::data::GatewayDataState::with_request_candidate_and_usage_repository_for_tests(
+                    Arc::clone(&request_candidate_repository),
+                    Arc::clone(&usage_repository),
+                ),
+            )
+            .with_usage_runtime_for_tests(UsageRuntimeConfig {
+                enabled: true,
+                ..UsageRuntimeConfig::default()
+            });
+        let plan = ExecutionPlan {
+            request_id: "req-responses-tool-midstream-error".into(),
+            candidate_id: Some("cand-responses-tool-midstream-error".into()),
+            provider_name: Some("openai".into()),
+            provider_id: "provider-openai-responses".into(),
+            endpoint_id: "endpoint-openai-responses".into(),
+            key_id: "key-openai-responses".into(),
+            method: "POST".into(),
+            url: "https://api.openai.com/v1/responses".into(),
+            headers: BTreeMap::from([
+                ("content-type".into(), "application/json".into()),
+                ("accept".into(), "text/event-stream".into()),
+            ]),
+            content_type: Some("application/json".into()),
+            content_encoding: None,
+            body: RequestBody::from_json(json!({
+                "model": "gpt-5.5",
+                "input": [],
+                "stream": true
+            })),
+            stream: true,
+            client_api_format: "claude:messages".into(),
+            provider_api_format: "openai:responses".into(),
+            model_name: Some("gpt-5.5".into()),
+            proxy: None,
+            transport_profile: None,
+            timeouts: None,
+        };
+        let upstream_chunk = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_midstream_error\",\"model\":\"gpt-5.5\",\"status\":\"in_progress\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"lookup\",\"arguments\":\"\",\"status\":\"in_progress\"}}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"output_index\":0,\"item_id\":\"fc_1\",\"call_id\":\"call_1\",\"delta\":\"{\\\"query\\\":\\\"abc\"}\n\n"
+        );
+        let frame_stream = stream! {
+            yield Ok::<Bytes, std::io::Error>(ndjson_frame(StreamFrame {
+                frame_type: StreamFrameType::Headers,
+                payload: StreamFramePayload::Headers {
+                    status_code: 200,
+                    headers: BTreeMap::from([(
+                        "content-type".to_string(),
+                        "text/event-stream".to_string(),
+                    )]),
+                },
+            }));
+            yield Ok::<Bytes, std::io::Error>(ndjson_frame(StreamFrame {
+                frame_type: StreamFrameType::Data,
+                payload: StreamFramePayload::Data {
+                    chunk_b64: None,
+                    text: Some(upstream_chunk.to_string()),
+                },
+            }));
+            yield Ok::<Bytes, std::io::Error>(ndjson_frame(StreamFrame {
+                frame_type: StreamFrameType::Error,
+                payload: StreamFramePayload::Error {
+                    error: ExecutionError {
+                        kind: ExecutionErrorKind::Internal,
+                        phase: ExecutionPhase::StreamRead,
+                        message: "error reading a body from connection: stream error received: unexpected internal error encountered".to_string(),
+                        upstream_status: Some(200),
+                        retryable: false,
+                        failover_recommended: false,
+                    },
+                },
+            }));
+        }
+        .boxed();
+
+        let response = execute_stream_from_frame_stream(
+            &state,
+            plan,
+            "trace-responses-tool-midstream-error",
+            &test_decision(),
+            "openai_responses_stream",
+            Some("openai_responses_stream_success".to_string()),
+            Some(json!({
+                "request_id": "req-responses-tool-midstream-error",
+                "candidate_id": "cand-responses-tool-midstream-error",
+                "candidate_index": 0,
+                "retry_index": 0,
+                "provider_api_format": "openai:responses",
+                "client_api_format": "claude:messages",
+                "needs_conversion": true,
+            })),
+            crate::clock::current_unix_ms(),
+            Instant::now(),
+            frame_stream,
+            None,
+        )
+        .await
+        .expect("execution should succeed")
+        .expect("execution should return a client response");
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should read");
+        let body_text = String::from_utf8(body.to_vec()).expect("body should be utf8");
+        assert!(body_text.contains("event: content_block_start"));
+        assert!(body_text.contains("event: content_block_delta"));
+        assert!(body_text.contains("\"type\":\"tool_use\""));
+        assert!(!body_text.contains("event: content_block_stop"));
+        assert!(!body_text.contains("event: message_delta"));
+        assert!(!body_text.contains("event: message_stop"));
+        assert!(!body_text.contains("\"stop_reason\":\"tool_use\""));
+        assert!(body_text.contains("\"error\""));
+        assert!(body_text.contains("unexpected internal error encountered"));
+        assert!(body_text.contains("data: [DONE]"));
+
+        let candidates = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let candidates = request_candidate_repository
+                    .list_by_request_id("req-responses-tool-midstream-error")
+                    .await
+                    .expect("request candidates should read");
+                if candidates
+                    .first()
+                    .is_some_and(|candidate| candidate.status == RequestCandidateStatus::Failed)
+                {
+                    break candidates;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("candidate should be marked failed");
+        assert_eq!(candidates[0].status_code, Some(200));
+        assert_eq!(candidates[0].error_type.as_deref(), Some("internal"));
     }
 
     #[tokio::test]

--- a/apps/aether-gateway/src/tests/usage/direct.rs
+++ b/apps/aether-gateway/src/tests/usage/direct.rs
@@ -19,6 +19,27 @@ fn large_request_body(stream: bool) -> String {
     .expect("request body should encode")
 }
 
+fn run_async_test_on_large_stack<F>(name: &'static str, future: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    let handle = std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio runtime should build")
+                .block_on(future);
+        })
+        .expect("large-stack usage direct test thread should spawn");
+
+    if let Err(payload) = handle.join() {
+        std::panic::resume_unwind(payload);
+    }
+}
+
 #[tokio::test]
 async fn gateway_records_usage_for_execution_runtime_sync_when_runtime_enabled() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
@@ -131,8 +152,15 @@ async fn gateway_records_usage_for_execution_runtime_sync_when_runtime_enabled()
     upstream_handle.abort();
 }
 
-#[tokio::test]
-async fn gateway_records_pending_usage_before_execution_runtime_sync_result_arrives() {
+#[test]
+fn gateway_records_pending_usage_before_execution_runtime_sync_result_arrives() {
+    run_async_test_on_large_stack(
+        "gateway_records_pending_usage_before_execution_runtime_sync_result_arrives",
+        gateway_records_pending_usage_before_execution_runtime_sync_result_arrives_impl(),
+    );
+}
+
+async fn gateway_records_pending_usage_before_execution_runtime_sync_result_arrives_impl() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
     let execution_request_started = Arc::new(tokio::sync::Notify::new());

--- a/apps/aether-gateway/src/tests/usage/local.rs
+++ b/apps/aether-gateway/src/tests/usage/local.rs
@@ -85,8 +85,15 @@ where
     stored.expect("usage should be present once the expected status is observed")
 }
 
-#[tokio::test]
-async fn gateway_handles_local_openai_chat_sync_report_with_local_reporting_when_usage_runtime_enabled(
+#[test]
+fn gateway_handles_local_openai_chat_sync_report_with_local_reporting_when_usage_runtime_enabled() {
+    run_async_test_on_large_stack(
+        "gateway_handles_local_openai_chat_sync_report_with_local_reporting_when_usage_runtime_enabled",
+        gateway_handles_local_openai_chat_sync_report_with_local_reporting_when_usage_runtime_enabled_impl(),
+    );
+}
+
+async fn gateway_handles_local_openai_chat_sync_report_with_local_reporting_when_usage_runtime_enabled_impl(
 ) {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());

--- a/apps/aether-gateway/src/tests/usage/local.rs
+++ b/apps/aether-gateway/src/tests/usage/local.rs
@@ -559,8 +559,15 @@ async fn gateway_applies_system_max_request_body_size_to_local_openai_chat_sync_
     upstream_handle.abort();
 }
 
-#[tokio::test]
-async fn gateway_strips_request_and_response_bodies_when_request_record_level_is_base() {
+#[test]
+fn gateway_strips_request_and_response_bodies_when_request_record_level_is_base() {
+    run_async_test_on_large_stack(
+        "gateway_strips_request_and_response_bodies_when_request_record_level_is_base",
+        gateway_strips_request_and_response_bodies_when_request_record_level_is_base_impl(),
+    );
+}
+
+async fn gateway_strips_request_and_response_bodies_when_request_record_level_is_base_impl() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
 

--- a/apps/aether-gateway/src/tests/usage/wallet.rs
+++ b/apps/aether-gateway/src/tests/usage/wallet.rs
@@ -11,8 +11,36 @@ use super::{
 };
 use aether_data::repository::settlement::InMemorySettlementRepository;
 
-#[tokio::test]
-async fn gateway_settles_wallet_for_completed_execution_runtime_sync_usage() {
+fn run_async_test_on_large_stack<F>(name: &'static str, future: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    let handle = std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio runtime should build")
+                .block_on(future);
+        })
+        .expect("large-stack test thread should spawn");
+
+    if let Err(payload) = handle.join() {
+        std::panic::resume_unwind(payload);
+    }
+}
+
+#[test]
+fn gateway_settles_wallet_for_completed_execution_runtime_sync_usage() {
+    run_async_test_on_large_stack(
+        "gateway_settles_wallet_for_completed_execution_runtime_sync_usage",
+        gateway_settles_wallet_for_completed_execution_runtime_sync_usage_impl(),
+    );
+}
+
+async fn gateway_settles_wallet_for_completed_execution_runtime_sync_usage_impl() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
     let billing_repository = Arc::new(InMemoryBillingReadRepository::seed(vec![

--- a/crates/aether-ai-formats/src/formats/openai/chat/stream.rs
+++ b/crates/aether-ai-formats/src/formats/openai/chat/stream.rs
@@ -45,7 +45,7 @@ pub struct OpenAIResponsesProviderState {
     model: Option<String>,
     started: bool,
     finished: bool,
-    text: String,
+    text_parts: BTreeMap<String, String>,
     reasoning: String,
     reasoning_parts: BTreeMap<usize, String>,
     tool_calls: BTreeMap<usize, OpenAIResponsesProviderToolState>,
@@ -420,24 +420,87 @@ impl OpenAIResponsesProviderState {
         index
     }
 
+    fn text_part_key_from_event(value: &Value) -> String {
+        let item_key = value
+            .get("output_index")
+            .and_then(Value::as_u64)
+            .map(|value| format!("output:{value}"))
+            .or_else(|| {
+                value
+                    .get("item_id")
+                    .or_else(|| value.get("id"))
+                    .and_then(Value::as_str)
+                    .map(|value| format!("item:{value}"))
+            })
+            .unwrap_or_else(|| "output:default".to_string());
+        let content_index = value
+            .get("content_index")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        format!("{item_key}:content:{content_index}")
+    }
+
+    fn text_part_key_from_message_item(
+        output_index: Option<usize>,
+        item: &Map<String, Value>,
+        content_index: usize,
+    ) -> String {
+        let item_key = output_index
+            .map(|value| format!("output:{value}"))
+            .or_else(|| {
+                item.get("id")
+                    .and_then(Value::as_str)
+                    .map(|value| format!("item:{value}"))
+            })
+            .unwrap_or_else(|| "output:default".to_string());
+        format!("{item_key}:content:{content_index}")
+    }
+
+    fn emit_text_delta(
+        &mut self,
+        report_context: &Value,
+        out: &mut Vec<CanonicalStreamFrame>,
+        key: String,
+        text: &str,
+    ) {
+        if text.is_empty() {
+            return;
+        }
+        self.text_parts.entry(key).or_default().push_str(text);
+        self.ensure_started(report_context, out);
+        let (id, model) = self.identity(report_context);
+        out.push(CanonicalStreamFrame {
+            id,
+            model,
+            event: CanonicalStreamEvent::TextDelta(text.to_string()),
+        });
+    }
+
     fn emit_missing_text(
         &mut self,
         report_context: &Value,
         out: &mut Vec<CanonicalStreamFrame>,
+        key: String,
         text: &str,
     ) {
-        let missing = if text.starts_with(&self.text) {
-            text[self.text.len()..].to_string()
-        } else if self.text == text || self.text.starts_with(text) {
-            String::new()
-        } else {
-            text.to_string()
+        let missing = {
+            let current = self.text_parts.entry(key).or_default();
+            let missing = if text.starts_with(current.as_str()) {
+                text[current.len()..].to_string()
+            } else if current.as_str() == text || current.starts_with(text) {
+                String::new()
+            } else {
+                text.to_string()
+            };
+            if !missing.is_empty() {
+                current.push_str(&missing);
+            }
+            missing
         };
         if missing.is_empty() {
             return;
         }
         self.ensure_started(report_context, out);
-        self.text.push_str(&missing);
         let (id, model) = self.identity(report_context);
         out.push(CanonicalStreamFrame {
             id,
@@ -695,28 +758,33 @@ impl OpenAIResponsesProviderState {
         report_context: &Value,
         out: &mut Vec<CanonicalStreamFrame>,
         item: &Map<String, Value>,
+        output_index: Option<usize>,
     ) {
         if item.get("type").and_then(Value::as_str) != Some("message") {
             return;
         }
-        let mut completed_text = String::new();
-        for raw_content in item
+        for (content_index, raw_content) in item
             .get("content")
             .and_then(Value::as_array)
             .into_iter()
             .flatten()
+            .enumerate()
         {
             let Some(content) = raw_content.as_object() else {
                 continue;
             };
             if content.get("type").and_then(Value::as_str) == Some("output_text") {
                 if let Some(text) = content.get("text").and_then(Value::as_str) {
-                    completed_text.push_str(text);
+                    if !text.is_empty() {
+                        let key = Self::text_part_key_from_message_item(
+                            output_index,
+                            item,
+                            content_index,
+                        );
+                        self.emit_missing_text(report_context, out, key, text);
+                    }
                 }
             }
-        }
-        if !completed_text.is_empty() {
-            self.emit_missing_text(report_context, out, &completed_text);
         }
     }
 
@@ -831,18 +899,13 @@ impl OpenAIResponsesProviderState {
             }
             "response.output_text.delta" | "response.outtext.delta" => match value.get("delta") {
                 Some(Value::String(piece)) if !piece.is_empty() => {
-                    self.ensure_started(report_context, &mut out);
-                    self.text.push_str(piece);
-                    let (id, model) = self.identity(report_context);
-                    out.push(CanonicalStreamFrame {
-                        id,
-                        model,
-                        event: CanonicalStreamEvent::TextDelta(piece.clone()),
-                    });
+                    let key = Self::text_part_key_from_event(&value);
+                    self.emit_text_delta(report_context, &mut out, key, piece);
                 }
                 Some(Value::Object(delta)) => {
                     if let Some(text) = delta.get("text").and_then(Value::as_str) {
-                        self.emit_missing_text(report_context, &mut out, text);
+                        let key = Self::text_part_key_from_event(&value);
+                        self.emit_missing_text(report_context, &mut out, key, text);
                     }
                 }
                 _ => {}
@@ -852,7 +915,8 @@ impl OpenAIResponsesProviderState {
                     if part.get("type").and_then(Value::as_str) == Some("output_text") {
                         if let Some(text) = part.get("text").and_then(Value::as_str) {
                             if !text.is_empty() {
-                                self.emit_missing_text(report_context, &mut out, text);
+                                let key = Self::text_part_key_from_event(&value);
+                                self.emit_missing_text(report_context, &mut out, key, text);
                             }
                         }
                     }
@@ -890,7 +954,8 @@ impl OpenAIResponsesProviderState {
                     })
                     .unwrap_or_default();
                 if !text.is_empty() {
-                    self.emit_missing_text(report_context, &mut out, text);
+                    let key = Self::text_part_key_from_event(&value);
+                    self.emit_missing_text(report_context, &mut out, key, text);
                 }
             }
             "response.reasoning_summary_text.delta" => {
@@ -967,7 +1032,7 @@ impl OpenAIResponsesProviderState {
                         self.emit_tool_result_item(report_context, &mut out, item, output_index);
                     }
                     "message" => {
-                        self.emit_message_item(report_context, &mut out, item);
+                        self.emit_message_item(report_context, &mut out, item, output_index);
                     }
                     "reasoning" => {
                         self.ensure_started(report_context, &mut out);
@@ -1139,7 +1204,7 @@ impl OpenAIResponsesProviderState {
                         self.emit_tool_result_item(report_context, &mut out, item, output_index);
                     }
                     "message" => {
-                        self.emit_message_item(report_context, &mut out, item);
+                        self.emit_message_item(report_context, &mut out, item, output_index);
                     }
                     "reasoning" => {
                         self.emit_reasoning_item(report_context, &mut out, item);
@@ -1194,7 +1259,12 @@ impl OpenAIResponsesProviderState {
                     };
                     match item.get("type").and_then(Value::as_str).unwrap_or_default() {
                         "message" => {
-                            self.emit_message_item(report_context, &mut out, item);
+                            self.emit_message_item(
+                                report_context,
+                                &mut out,
+                                item,
+                                Some(output_index),
+                            );
                         }
                         "function_call" => {
                             self.emit_tool_call_item(
@@ -3233,6 +3303,102 @@ mod tests {
             })
             .collect::<String>();
         assert_eq!(text, "Hello world");
+    }
+
+    #[test]
+    fn openai_responses_provider_state_dedupes_text_snapshots_per_output_item() {
+        let mut state = OpenAIResponsesProviderState::default();
+        let report_context = json!({});
+        let mut frames = Vec::new();
+
+        for event in [
+            json!({
+                "type": "response.output_text.delta",
+                "response_id": "resp_multi_message",
+                "output_index": 0,
+                "item_id": "msg_1",
+                "content_index": 0,
+                "delta": "First message.",
+            }),
+            json!({
+                "type": "response.output_text.done",
+                "response_id": "resp_multi_message",
+                "output_index": 0,
+                "item_id": "msg_1",
+                "content_index": 0,
+                "text": "First message.",
+            }),
+            json!({
+                "type": "response.output_item.done",
+                "response_id": "resp_multi_message",
+                "output_index": 0,
+                "item": {
+                    "type": "message",
+                    "id": "msg_1",
+                    "status": "completed",
+                    "content": [{
+                        "type": "output_text",
+                        "text": "First message.",
+                    }],
+                },
+            }),
+            json!({
+                "type": "response.output_text.delta",
+                "response_id": "resp_multi_message",
+                "output_index": 1,
+                "item_id": "msg_2",
+                "content_index": 0,
+                "delta": "Second message.",
+            }),
+            json!({
+                "type": "response.output_text.done",
+                "response_id": "resp_multi_message",
+                "output_index": 1,
+                "item_id": "msg_2",
+                "content_index": 0,
+                "text": "Second message.",
+            }),
+            json!({
+                "type": "response.content_part.done",
+                "response_id": "resp_multi_message",
+                "output_index": 1,
+                "item_id": "msg_2",
+                "content_index": 0,
+                "part": {
+                    "type": "output_text",
+                    "text": "Second message.",
+                },
+            }),
+            json!({
+                "type": "response.output_item.done",
+                "response_id": "resp_multi_message",
+                "output_index": 1,
+                "item": {
+                    "type": "message",
+                    "id": "msg_2",
+                    "status": "completed",
+                    "content": [{
+                        "type": "output_text",
+                        "text": "Second message.",
+                    }],
+                },
+            }),
+        ] {
+            frames.extend(
+                state
+                    .push_line(&report_context, data_line(event))
+                    .expect("responses text event should parse"),
+            );
+        }
+
+        let text = frames
+            .iter()
+            .filter_map(|frame| match &frame.event {
+                CanonicalStreamEvent::TextDelta(text) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<String>();
+        assert_eq!(text, "First message.Second message.");
     }
 
     #[test]

--- a/crates/aether-usage-runtime/src/write.rs
+++ b/crates/aether-usage-runtime/src/write.rs
@@ -735,7 +735,10 @@ pub fn build_sync_terminal_usage_payload_seed(
         .and_then(|context| context.get(UPSTREAM_IS_STREAM_KEY))
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    let provider_response_full = if upstream_is_stream && payload.body_base64.is_some() {
+    let provider_response_full = if upstream_is_stream
+        && payload.body_base64.is_some()
+        && !body_json_has_terminal_error(payload.body_json.as_ref())
+    {
         decode_body_for_storage(payload.body_base64.as_deref())
             .or_else(|| payload.body_json.as_ref().cloned())
     } else {
@@ -784,6 +787,12 @@ pub fn build_sync_terminal_usage_payload_seed(
             client_response_body_state,
         ),
     }
+}
+
+fn body_json_has_terminal_error(body_json: Option<&Value>) -> bool {
+    body_json
+        .and_then(|value| value.get("error"))
+        .is_some_and(|error| !error.is_null())
 }
 
 pub fn build_stream_terminal_usage_payload_seed(
@@ -5105,6 +5114,87 @@ mod tests {
                     .and_then(Value::as_str)
             }),
             Some("Hello from upstream stream")
+        );
+    }
+
+    #[test]
+    fn sync_terminal_usage_prefers_error_body_over_partial_upstream_stream_body() {
+        let partial_sse_body = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_partial_123\",\"object\":\"response\",\"model\":\"gpt-5.5\",\"status\":\"in_progress\",\"output\":[]}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"name\":\"exec_command\"}}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"cmd\\\":\"}\n\n",
+        );
+        let plan = ExecutionPlan {
+            request_id: "req-sync-upstream-stream-error-1".to_string(),
+            candidate_id: Some("cand-sync-upstream-stream-error-1".to_string()),
+            provider_name: Some("OpenAI".to_string()),
+            provider_id: "provider-1".to_string(),
+            endpoint_id: "endpoint-1".to_string(),
+            key_id: "key-1".to_string(),
+            method: "POST".to_string(),
+            url: "https://example.com/v1/responses".to_string(),
+            headers: BTreeMap::new(),
+            content_type: None,
+            content_encoding: None,
+            body: RequestBody {
+                json_body: None,
+                body_bytes_b64: None,
+                body_ref: None,
+            },
+            stream: false,
+            client_api_format: "claude:messages".to_string(),
+            provider_api_format: "openai:responses".to_string(),
+            model_name: Some("gpt-5.5".to_string()),
+            proxy: None,
+            transport_profile: None,
+            timeouts: None,
+        };
+        let payload = GatewaySyncReportRequest {
+            trace_id: "trace-sync-upstream-stream-error-1".to_string(),
+            report_kind: "openai_responses_sync_error".to_string(),
+            report_context: Some(json!({
+                "client_api_format": "claude:messages",
+                "provider_api_format": "openai:responses",
+                "upstream_is_stream": true,
+                "needs_conversion": true
+            })),
+            status_code: 200,
+            headers: BTreeMap::from([(
+                "content-type".to_string(),
+                "text/event-stream".to_string(),
+            )]),
+            body_json: Some(json!({
+                "error": {
+                    "type": "internal",
+                    "message": "error decoding response body: stream error received"
+                }
+            })),
+            client_body_json: None,
+            body_base64: Some(base64::engine::general_purpose::STANDARD.encode(partial_sse_body)),
+            telemetry: None,
+        };
+
+        let event =
+            build_sync_terminal_usage_event(&plan, payload.report_context.as_ref(), &payload)
+                .expect("usage event should build");
+
+        assert_eq!(event.event_type, UsageEventType::Failed);
+        assert_eq!(event.data.status_code, Some(200));
+        assert_eq!(
+            event.data.error_message.as_deref(),
+            Some("error decoding response body: stream error received")
+        );
+        assert_eq!(
+            event
+                .data
+                .response_body
+                .as_ref()
+                .and_then(|value| value.pointer("/error/type"))
+                .and_then(Value::as_str),
+            Some("internal")
         );
     }
 


### PR DESCRIPTION
## 背景

线上 0.7.7 请求排查中发现，上游 OpenAI Responses 流式响应在已经返回 200 并开始推流后，如果中途读取失败，Aether 的终态处理存在几处不一致：

- usage 可能根据部分 upstream SSE body 误记为 completed / settled
- Claude Messages 下游可能收到半截 tool_use 后，又被本地 rewriter 合成正常 message_stop / stop_reason=tool_use
- OpenAI Responses 文本快照去重仍使用全局文本状态，多 message item / 多 content part 场景下可能互相污染

## 修改内容

1. 修复 sync usage 终态误判

当 sync error payload 同时包含合成错误体和部分 upstream stream body 时，优先使用合成错误体生成 usage 终态，避免把中途断流请求误记为成功。

2. 修复 stream failure 后的正常收尾合成

当 upstream stream 已进入 terminal failure 后，跳过 normalizer / rewriter 的正常 finish 路径，避免把不完整工具调用封装成正常完成的 Claude tool_use。

3. 加强 OpenAI Responses 文本快照去重

上游已有 8abedecb 处理单个 Responses 文本流中 delta 与 done/completed 快照重复输出的问题。本 PR 在此基础上把去重状态从全局文本扩展为按 output_index / item_id + content_index 分片记录，避免多个 message item 或多个 text content part 共用同一段快照状态。

4. 修复 usage 测试默认栈溢出

upstream/main 最新的 49f95269 已经修复 sync chat / PII redaction 相关栈溢出；本 PR 补充 CI 中仍会 stack overflow 的 usage direct / usage local / usage wallet 测试，用 large-stack tokio runtime 包装测试入口。

## 提交范围

该分支直接基于最新 upstream/main，compare 只包含本 PR 的 7 个提交，不包含 fork personal 分支上的 CI / sync 提交。

## 验证

本地已验证：

- cargo fmt --check
- git diff --check
- cargo test -p aether-ai-formats openai_responses_provider_state
- cargo test -p aether-usage-runtime sync_terminal_usage_prefers

CI：

- Rust CI 已通过
- run: https://github.com/fawney19/Aether/actions/runs/26692995005
