### PR TITLE
fix(provider): 修复 Chat reasoning_effort 值域与 Responses 扩展透传

### DIFF
--- a/crates/aether-ai-formats/src/formats/conversion/request.rs
+++ b/crates/aether-ai-formats/src/formats/conversion/request.rs
@@ -165,6 +165,7 @@ mod tests {
         convert_openai_chat_request_to_claude_request,
         convert_openai_chat_request_to_openai_responses_request,
         normalize_claude_request_to_openai_chat_request,
+        normalize_gemini_request_to_openai_chat_request,
         normalize_openai_responses_request_to_openai_chat_request,
     };
 
@@ -217,6 +218,43 @@ mod tests {
         assert_eq!(converted["model"], "claude-sonnet");
         assert_eq!(converted["messages"][0]["role"], "user");
         assert_eq!(converted["messages"][0]["content"], "hello");
+    }
+
+    #[test]
+    fn claude_request_to_chat_clamps_max_reasoning_effort_to_high() {
+        let body = json!({
+            "model": "claude-sonnet",
+            "messages": [{"role": "user", "content": "hello"}],
+            "thinking": {"type": "enabled", "budget_tokens": 1024},
+            "output_config": {"effort": "max"},
+            "max_tokens": 128,
+        });
+
+        let converted =
+            normalize_claude_request_to_openai_chat_request(&body).expect("openai chat request");
+
+        assert_eq!(converted["reasoning_effort"], "high");
+    }
+
+    #[test]
+    fn gemini_request_to_chat_clamps_xhigh_reasoning_effort_to_high() {
+        let body = json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{"text": "hello"}]
+            }],
+            "generationConfig": {
+                "thinkingConfig": {"thinkingBudget": 8192}
+            }
+        });
+
+        let converted = normalize_gemini_request_to_openai_chat_request(
+            &body,
+            "/v1beta/models/gemini-2.5-pro:generateContent",
+        )
+        .expect("openai chat request");
+
+        assert_eq!(converted["reasoning_effort"], "high");
     }
 
     #[test]
@@ -331,6 +369,34 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0]["role"], "assistant");
         assert_eq!(messages[0]["content"], "");
+    }
+
+    #[test]
+    fn responses_request_normalizer_clamps_chat_reasoning_effort_and_filters_extensions() {
+        let body = json!({
+            "model": "gpt-5.1",
+            "input": "hello",
+            "reasoning": {"effort": "xhigh"},
+            "text": {"verbosity": "high"},
+            "include": ["reasoning.encrypted_content"],
+            "store": false,
+            "service_tier": "priority",
+            "prompt_cache_key": "cache_123",
+            "safety_identifier": "user_123"
+        });
+
+        let converted = normalize_openai_responses_request_to_openai_chat_request(&body)
+            .expect("openai chat request");
+
+        assert_eq!(converted["reasoning_effort"], "high");
+        assert_eq!(converted["verbosity"], "high");
+        assert_eq!(converted["service_tier"], "priority");
+        assert_eq!(converted["prompt_cache_key"], "cache_123");
+        assert_eq!(converted["safety_identifier"], "user_123");
+        assert!(converted.get("include").is_none());
+        assert!(converted.get("store").is_none());
+        assert!(converted.get("text").is_none());
+        assert!(converted.get("reasoning").is_none());
     }
 
     #[test]

--- a/crates/aether-ai-formats/src/formats/openai/chat/request.rs
+++ b/crates/aether-ai-formats/src/formats/openai/chat/request.rs
@@ -1,4 +1,4 @@
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
 use crate::{
     formats::context::FormatContext,
@@ -194,6 +194,7 @@ pub fn to_raw(canonical: &CanonicalRequest) -> Value {
                     .and_then(|value| value.get("effort"))
                     .and_then(Value::as_str)
             })
+            .and_then(openai_chat_reasoning_effort)
         {
             output.insert(
                 "reasoning_effort".to_string(),
@@ -206,17 +207,42 @@ pub fn to_raw(canonical: &CanonicalRequest) -> Value {
         "openai",
         &output,
     ));
-    output.extend(namespace_extension_object(
+    output.extend(chat_compatible_openai_responses_extension_object(
         &canonical.extensions,
         OPENAI_RESPONSES_EXTENSION_NAMESPACE,
         &output,
     ));
-    output.extend(namespace_extension_object(
+    output.extend(chat_compatible_openai_responses_extension_object(
         &canonical.extensions,
         OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE,
         &output,
     ));
     Value::Object(output)
+}
+
+fn openai_chat_reasoning_effort(value: &str) -> Option<&'static str> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "low" => Some("low"),
+        "medium" => Some("medium"),
+        "high" | "xhigh" | "max" => Some("high"),
+        _ => None,
+    }
+}
+
+fn chat_compatible_openai_responses_extension_object(
+    extensions: &std::collections::BTreeMap<String, Value>,
+    namespace: &str,
+    existing: &Map<String, Value>,
+) -> Map<String, Value> {
+    namespace_extension_object(extensions, namespace, existing)
+        .into_iter()
+        .filter(|(key, _)| {
+            matches!(
+                key.as_str(),
+                "verbosity" | "service_tier" | "prompt_cache_key" | "safety_identifier" | "user"
+            )
+        })
+        .collect()
 }
 
 fn force_stream_options(body: &mut Value, upstream_is_stream: bool) {

--- a/crates/aether-ai-formats/src/formats/shared/model_directives.rs
+++ b/crates/aether-ai-formats/src/formats/shared/model_directives.rs
@@ -38,8 +38,7 @@ impl ReasoningEffort {
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
-            Self::XHigh => "xhigh",
-            Self::Max => "xhigh",
+            Self::XHigh | Self::Max => "high",
         }
     }
 
@@ -524,7 +523,7 @@ mod tests {
             "gpt-5.4-xhigh",
         )
         .expect("directive should apply");
-        assert_eq!(openai_chat["reasoning_effort"], "xhigh");
+        assert_eq!(openai_chat["reasoning_effort"], "high");
 
         let mut responses = json!({
             "model": "gpt-5-upstream",
@@ -597,7 +596,7 @@ mod tests {
             "gpt-5.4-fast-xhigh",
         )
         .expect("directive should apply");
-        assert_eq!(openai_chat["reasoning_effort"], "xhigh");
+        assert_eq!(openai_chat["reasoning_effort"], "high");
         assert_eq!(openai_chat["service_tier"], "priority");
 
         let mut reversed = json!({"model": "gpt-5-upstream", "reasoning_effort": "low"});

--- a/crates/aether-ai-formats/src/formats/shared/standard_normalize.rs
+++ b/crates/aether-ai-formats/src/formats/shared/standard_normalize.rs
@@ -738,7 +738,7 @@ mod tests {
         .expect("openai chat body should build");
 
         assert_eq!(provider_request_body["model"], "gpt-5-upstream");
-        assert_eq!(provider_request_body["reasoning_effort"], "xhigh");
+        assert_eq!(provider_request_body["reasoning_effort"], "high");
     }
 
     #[test]


### PR DESCRIPTION
## 背景

OpenAI Chat Completions 只接受 `reasoning_effort` 为 `low`、`medium`、`high`。当 Responses、Claude Messages、Gemini 或模型后缀指令产生 `xhigh` / `max` 后，再转换到 OpenAI Chat 时会透传非法值，导致上游返回 400。

同时，Responses 请求转换到 Chat 时，部分 Responses-only 字段可能被透传到 Chat 请求体，存在兼容性风险。

## 变更内容

- 修复 OpenAI Chat request 输出的 `reasoning_effort` 值域：
  - `low` 保持为 `low`
  - `medium` 保持为 `medium`
  - `high` 保持为 `high`
  - `xhigh` / `max` 转换为 `high`
  - 未知值不再透传到 Chat 请求体

- 覆盖所有转 Chat 的来源路径：
  - OpenAI Responses `reasoning.effort=xhigh` -> Chat `reasoning_effort=high`
  - Claude Messages `output_config.effort=max` -> Chat `reasoning_effort=high`
  - Gemini 高 thinking budget 推导出的 `xhigh` -> Chat `reasoning_effort=high`
  - 模型后缀 `-xhigh` / `-max` 用于 OpenAI Chat 时收敛为 `high`

- 过滤 Responses -> Chat 的扩展字段透传：
  - 保留 Chat 兼容字段：`verbosity`、`service_tier`、`prompt_cache_key`、`safety_identifier`、`user`
  - 不再透传 Responses-only 字段，例如 `include`、`store`、`text`、`reasoning`

- 补充回归测试：
  - Responses -> Chat 的 `xhigh` 收敛和扩展字段过滤
  - Claude Messages -> Chat 的 `max` 收敛
  - Gemini -> Chat 的 `xhigh` 收敛
  - 模型后缀指令到 Chat 的 `xhigh` 收敛

## 测试

- `cargo test -p aether-ai-formats`