### PR TITLE
Include admins in complete backup export

### DIFF
--- a/apps/aether-gateway/src/handlers/admin/request/system/export.rs
+++ b/apps/aether-gateway/src/handlers/admin/request/system/export.rs
@@ -168,7 +168,19 @@ impl<'a> AdminAppState<'a> {
     pub(crate) async fn build_admin_system_users_export_payload(
         &self,
     ) -> Result<serde_json::Value, GatewayError> {
-        let users = self.list_non_admin_export_users().await?;
+        self.build_admin_system_users_export_payload_with_admin_scope(false)
+            .await
+    }
+
+    async fn build_admin_system_users_export_payload_with_admin_scope(
+        &self,
+        include_admin_users: bool,
+    ) -> Result<serde_json::Value, GatewayError> {
+        let users = if include_admin_users {
+            self.list_export_users().await?
+        } else {
+            self.list_non_admin_export_users().await?
+        };
         let user_ids = users.iter().map(|user| user.id.clone()).collect::<Vec<_>>();
         let user_usage_totals = self
             .app
@@ -331,7 +343,9 @@ impl<'a> AdminAppState<'a> {
         &self,
     ) -> Result<serde_json::Value, GatewayError> {
         let config_data = self.build_admin_system_config_export_payload().await?;
-        let user_data = self.build_admin_system_users_export_payload().await?;
+        let user_data = self
+            .build_admin_system_users_export_payload_with_admin_scope(true)
+            .await?;
 
         Ok(json!({
             "version": ADMIN_SYSTEM_DATA_EXPORT_VERSION,

--- a/apps/aether-gateway/src/tests/control/admin/system.rs
+++ b/apps/aether-gateway/src/tests/control/admin/system.rs
@@ -890,6 +890,23 @@ async fn gateway_handles_admin_system_users_export_locally_with_trusted_admin_pr
             "specific".to_string(),
         )
         .expect("user policy modes should build"),
+        StoredUserAuthRecord::new(
+            "admin-1".to_string(),
+            Some("admin@example.com".to_string()),
+            true,
+            "admin".to_string(),
+            Some("admin-hash".to_string()),
+            "admin".to_string(),
+            "local".to_string(),
+            None,
+            None,
+            None,
+            true,
+            false,
+            Some(chrono::Utc::now()),
+            None,
+        )
+        .expect("admin export row should build"),
     ]));
     let user_group = user_repository
         .create_user_group(UpsertUserGroupRecord {
@@ -1028,6 +1045,13 @@ async fn gateway_handles_admin_system_users_export_locally_with_trusted_admin_pr
     let payload: serde_json::Value = response.json().await.expect("json body should parse");
     assert_eq!(payload["version"], "1.5");
     assert!(payload["exported_at"].as_str().is_some());
+    assert_eq!(
+        payload["users"]
+            .as_array()
+            .expect("users should be array")
+            .len(),
+        1
+    );
     assert_eq!(payload["user_groups"][0]["name"], "Restricted GPT");
     assert!(payload["user_groups"][0].get("priority").is_none());
     assert_eq!(
@@ -1095,6 +1119,94 @@ async fn gateway_handles_admin_system_users_export_locally_with_trusted_admin_pr
         payload["usage_aggregates"]["stats_daily_api_key"],
         json!([])
     );
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_handles_admin_system_data_export_includes_admin_users_in_complete_backup() {
+    let upstream_hits = Arc::new(Mutex::new(0usize));
+    let upstream_hits_clone = Arc::clone(&upstream_hits);
+    let upstream = Router::new().route(
+        "/api/admin/system/data/export",
+        any(move |_request: Request| {
+            let upstream_hits_inner = Arc::clone(&upstream_hits_clone);
+            async move {
+                *upstream_hits_inner.lock().expect("mutex should lock") += 1;
+                (StatusCode::OK, Body::from("unexpected upstream hit"))
+            }
+        }),
+    );
+
+    let user_repository = Arc::new(InMemoryUserReadRepository::seed_auth_users(vec![
+        StoredUserAuthRecord::new(
+            "admin-1".to_string(),
+            Some("admin@example.com".to_string()),
+            true,
+            "admin".to_string(),
+            Some("admin-hash".to_string()),
+            "admin".to_string(),
+            "local".to_string(),
+            None,
+            None,
+            None,
+            true,
+            false,
+            Some(chrono::Utc::now()),
+            None,
+        )
+        .expect("admin export row should build"),
+        StoredUserAuthRecord::new(
+            "user-1".to_string(),
+            Some("alice@example.com".to_string()),
+            true,
+            "alice".to_string(),
+            Some("user-hash".to_string()),
+            "user".to_string(),
+            "local".to_string(),
+            None,
+            None,
+            None,
+            true,
+            false,
+            Some(chrono::Utc::now()),
+            None,
+        )
+        .expect("user export row should build"),
+    ]));
+    let data_state = GatewayDataState::with_user_reader_for_tests(user_repository);
+
+    let (upstream_url, upstream_handle) = start_server(upstream).await;
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(data_state),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("{gateway_url}/api/admin/system/data/export"))
+        .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    let users = payload["user_data"]["users"]
+        .as_array()
+        .expect("complete backup user data should include users");
+    assert!(users
+        .iter()
+        .any(|user| user["id"] == json!("admin-1") && user["role"] == json!("admin")));
+    assert!(users
+        .iter()
+        .any(|user| user["id"] == json!("user-1") && user["role"] == json!("user")));
     assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
 
     gateway_handle.abort();


### PR DESCRIPTION
Summary: Include admin users when building the complete system data export, while keeping the standalone users export limited to non-admin users. Add gateway coverage for both paths.

Verification:
- cargo fmt --check
- git diff --check
- cargo test -p aether-gateway gateway_handles_admin_system_users_export_locally_with_trusted_admin_principal
- cargo test -p aether-gateway gateway_handles_admin_system_data_export_includes_admin_users_in_complete_backup
- cargo test -p aether-gateway admin_system_shared_configs_split_export_owners
- cargo test -p aether-gateway admin_system_owns_system_route_helpers