### PR TITLE
Add extra model directive alias

### DIFF
--- a/apps/aether-gateway/src/system_features.rs
+++ b/apps/aether-gateway/src/system_features.rs
@@ -124,7 +124,7 @@ pub(crate) async fn reasoning_model_directive_mapping_for_api_format_and_model(
 }
 
 const DEFAULT_MODEL_DIRECTIVE_SUFFIXES: &[&str] =
-    &["low", "medium", "high", "xhigh", "max", "fast"];
+    &["low", "medium", "high", "xhigh", "extra", "max", "fast"];
 
 #[derive(Debug, Clone, Default)]
 struct ReasoningModelDirectiveSettings {
@@ -236,7 +236,7 @@ enum ModelDirectiveSuffixKind {
 
 fn model_directive_suffix_kind(suffix: &str) -> Option<ModelDirectiveSuffixKind> {
     match suffix {
-        "low" | "medium" | "high" | "xhigh" | "max" => {
+        "low" | "medium" | "high" | "xhigh" | "extra" | "max" => {
             Some(ModelDirectiveSuffixKind::ReasoningEffort)
         }
         "fast" => Some(ModelDirectiveSuffixKind::ServiceTier),
@@ -355,7 +355,7 @@ fn openai_reasoning_effort_value(suffix: &str) -> Option<&'static str> {
         "low" => Some("low"),
         "medium" => Some("medium"),
         "high" => Some("high"),
-        "xhigh" | "max" => Some("xhigh"),
+        "xhigh" | "extra" | "max" => Some("xhigh"),
         _ => None,
     }
 }
@@ -434,6 +434,29 @@ mod tests {
             Some(json!({ "thinking": { "type": "enabled", "budget_tokens": 32768 } }))
         );
         assert_eq!(settings.api_format_enabled("gemini:generate_content"), None);
+    }
+
+    #[test]
+    fn default_extra_suffix_maps_to_openai_xhigh_effort() {
+        let suffixes = model_directive_suffixes_from_model("gpt-5.4-extra")
+            .expect("extra suffix should parse");
+        assert_eq!(suffixes, vec!["extra".to_string()]);
+        assert_eq!(
+            default_reasoning_mapping("openai:chat", "extra"),
+            Some(json!({ "reasoning_effort": "xhigh" }))
+        );
+        assert_eq!(
+            model_directive_mapping_for_suffixes("openai:chat", &suffixes, None),
+            Some(json!({ "reasoning_effort": "xhigh" }))
+        );
+        assert_eq!(
+            default_reasoning_mapping("openai:responses", "extra"),
+            Some(json!({ "reasoning": { "effort": "xhigh" } }))
+        );
+        assert_eq!(
+            default_reasoning_mapping("openai:responses:compact", "extra"),
+            Some(json!({ "reasoning": { "effort": "xhigh" } }))
+        );
     }
 
     #[test]

--- a/crates/aether-admin/src/system.rs
+++ b/crates/aether-admin/src/system.rs
@@ -1741,6 +1741,7 @@ pub fn admin_system_config_default_value(key: &str) -> Option<serde_json::Value>
                             "medium": { "reasoning_effort": "medium" },
                             "high": { "reasoning_effort": "high" },
                             "xhigh": { "reasoning_effort": "xhigh" },
+                            "extra": { "reasoning_effort": "xhigh" },
                             "max": { "reasoning_effort": "xhigh" },
                             "fast": { "service_tier": "priority" }
                         }
@@ -1752,6 +1753,7 @@ pub fn admin_system_config_default_value(key: &str) -> Option<serde_json::Value>
                             "medium": { "reasoning": { "effort": "medium" } },
                             "high": { "reasoning": { "effort": "high" } },
                             "xhigh": { "reasoning": { "effort": "xhigh" } },
+                            "extra": { "reasoning": { "effort": "xhigh" } },
                             "max": { "reasoning": { "effort": "xhigh" } },
                             "fast": { "service_tier": "priority" }
                         }
@@ -1763,6 +1765,7 @@ pub fn admin_system_config_default_value(key: &str) -> Option<serde_json::Value>
                             "medium": { "reasoning": { "effort": "medium" } },
                             "high": { "reasoning": { "effort": "high" } },
                             "xhigh": { "reasoning": { "effort": "xhigh" } },
+                            "extra": { "reasoning": { "effort": "xhigh" } },
                             "max": { "reasoning": { "effort": "xhigh" } },
                             "fast": { "service_tier": "priority" }
                         }

--- a/crates/aether-ai-formats/src/formats/shared/model_directives.rs
+++ b/crates/aether-ai-formats/src/formats/shared/model_directives.rs
@@ -27,7 +27,7 @@ impl ReasoningEffort {
             "low" => Some(Self::Low),
             "medium" => Some(Self::Medium),
             "high" => Some(Self::High),
-            "xhigh" => Some(Self::XHigh),
+            "xhigh" | "extra" => Some(Self::XHigh),
             "max" => Some(Self::Max),
             _ => None,
         }
@@ -478,6 +478,13 @@ mod tests {
                 overrides: vec![ModelOverride::ReasoningEffort(ReasoningEffort::Max)],
             })
         );
+        assert_eq!(
+            parse_model_directive("gpt-5.4-extra"),
+            Some(ModelDirective {
+                base_model: "gpt-5.4".to_string(),
+                overrides: vec![ModelOverride::ReasoningEffort(ReasoningEffort::XHigh)],
+            })
+        );
     }
 
     #[test]
@@ -533,7 +540,7 @@ mod tests {
             &mut responses,
             "openai:responses",
             "gpt-5-upstream",
-            "gpt-5.4-max",
+            "gpt-5.4-extra",
         )
         .expect("directive should apply");
         assert_eq!(responses["reasoning"]["effort"], "xhigh");


### PR DESCRIPTION
Summary: Add extra as a model directive suffix alias for xhigh. Update OpenAI model directive defaults for chat, responses, and compact responses. Cover the new suffix in unit tests. Tests: cargo test -p aether-ai-formats model_directives passed. cargo fmt --all passed. git diff --check passed. cargo test -p aether-gateway system_features was attempted and failed during compile because the local disk was out of space.