### PR TITLE
﻿fix(kiro): accept inline system messages

### DIFF
--- a/apps/aether-gateway/src/dispatch/pool_scheduler.rs
+++ b/apps/aether-gateway/src/dispatch/pool_scheduler.rs
@@ -1187,7 +1187,7 @@ fn build_pool_catalog_key_context(
         .filter(|count| *count > 0)
         .zip(key.total_response_time_ms)
         .map(|(success_count, total_response_time_ms)| {
-            f64::from(total_response_time_ms) / f64::from(success_count)
+            total_response_time_ms as f64 / f64::from(success_count)
         })
         .filter(|value| value.is_finite() && *value >= 0.0);
 

--- a/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models/model_test.rs
@@ -1202,7 +1202,7 @@ fn provider_query_pool_catalog_key_context(
         .filter(|count| *count > 0)
         .zip(key.total_response_time_ms)
         .map(|(success_count, total_response_time_ms)| {
-            f64::from(total_response_time_ms) / f64::from(success_count)
+            total_response_time_ms as f64 / f64::from(success_count)
         })
         .filter(|value| value.is_finite() && *value >= 0.0);
 

--- a/apps/aether-gateway/src/handlers/public/system_modules_helpers/keys_grouped.rs
+++ b/apps/aether-gateway/src/handlers/public/system_modules_helpers/keys_grouped.rs
@@ -101,7 +101,7 @@ pub(crate) async fn build_admin_keys_grouped_by_format_payload(
             None
         };
         let avg_response_time_ms = if success_count > 0 {
-            Some(f64::from(key.total_response_time_ms.unwrap_or(0)) / success_count as f64)
+            Some(key.total_response_time_ms.unwrap_or(0) as f64 / success_count as f64)
         } else {
             None
         };

--- a/apps/aether-gateway/src/handlers/shared/catalog.rs
+++ b/apps/aether-gateway/src/handlers/shared/catalog.rs
@@ -2176,7 +2176,7 @@ pub(crate) fn build_admin_provider_key_response(
     let request_count = u64::from(key.request_count.unwrap_or(0));
     let success_count = u64::from(key.success_count.unwrap_or(0));
     let error_count = u64::from(key.error_count.unwrap_or(0));
-    let total_response_time_ms = f64::from(key.total_response_time_ms.unwrap_or(0));
+    let total_response_time_ms = key.total_response_time_ms.unwrap_or(0) as f64;
     let success_rate = if request_count > 0 {
         success_count as f64 / request_count as f64
     } else {

--- a/crates/aether-data-contracts/src/repository/provider_catalog/types.rs
+++ b/crates/aether-data-contracts/src/repository/provider_catalog/types.rs
@@ -278,7 +278,7 @@ pub struct StoredProviderCatalogKey {
     pub total_cost_usd: f64,
     pub success_count: Option<u32>,
     pub error_count: Option<u32>,
-    pub total_response_time_ms: Option<u32>,
+    pub total_response_time_ms: Option<u64>,
     pub last_used_at_unix_secs: Option<u64>,
     pub auto_fetch_models: bool,
     pub last_models_fetch_at_unix_secs: Option<u64>,
@@ -444,7 +444,7 @@ impl StoredProviderCatalogKey {
     pub fn with_usage_fields(
         mut self,
         error_count: Option<u32>,
-        total_response_time_ms: Option<u32>,
+        total_response_time_ms: Option<u64>,
     ) -> Self {
         self.error_count = error_count;
         self.total_response_time_ms = total_response_time_ms;

--- a/crates/aether-data/src/repository/provider_catalog/memory.rs
+++ b/crates/aether-data/src/repository/provider_catalog/memory.rs
@@ -75,7 +75,7 @@ impl InMemoryProviderCatalogReadRepository {
         ));
         key.total_tokens = apply_i64_delta_to_u64(key.total_tokens, delta.total_tokens);
         key.total_cost_usd = apply_f64_delta(key.total_cost_usd, delta.total_cost_usd);
-        key.total_response_time_ms = Some(apply_i64_delta_to_u32(
+        key.total_response_time_ms = Some(apply_i64_delta_to_u64(
             key.total_response_time_ms.unwrap_or_default(),
             delta.total_response_time_ms,
         ));
@@ -123,7 +123,7 @@ impl InMemoryProviderCatalogReadRepository {
             key.total_tokens = clamp_i64_to_u64(contribution.total_tokens);
             key.total_cost_usd = contribution.total_cost_usd.max(0.0);
             key.total_response_time_ms =
-                Some(clamp_i64_to_u32(contribution.total_response_time_ms));
+                Some(clamp_i64_to_u64(contribution.total_response_time_ms));
             key.last_used_at_unix_secs = contribution.last_used_at_unix_secs;
         }
     }

--- a/crates/aether-data/src/repository/provider_catalog/mysql.rs
+++ b/crates/aether-data/src/repository/provider_catalog/mysql.rs
@@ -552,7 +552,13 @@ WHERE id = ?
             .bind(key.total_cost_usd)
             .bind(optional_i64_from_u32(key.success_count).unwrap_or(0))
             .bind(optional_i64_from_u32(key.error_count).unwrap_or(0))
-            .bind(optional_i64_from_u32(key.total_response_time_ms).unwrap_or(0))
+            .bind(
+                optional_i64_from_u64(
+                    key.total_response_time_ms,
+                    "provider_api_keys.total_response_time_ms",
+                )?
+                .unwrap_or(0),
+            )
             .bind(optional_i64_from_u64(
                 key.last_used_at_unix_secs,
                 "provider_api_keys.last_used_at",
@@ -1484,7 +1490,7 @@ fn map_key_row(row: &MySqlRow) -> Result<StoredProviderCatalogKey, DataLayerErro
                     row.try_get("error_count").map_sql_err()?,
                     "provider_api_keys.error_count",
                 )?,
-                optional_u32(
+                optional_u64(
                     row.try_get("total_response_time_ms").map_sql_err()?,
                     "provider_api_keys.total_response_time_ms",
                 )?,

--- a/crates/aether-data/src/repository/provider_catalog/postgres.rs
+++ b/crates/aether-data/src/repository/provider_catalog/postgres.rs
@@ -1315,7 +1315,17 @@ INSERT INTO provider_api_keys (
         .bind(key.total_cost_usd)
         .bind(key.success_count.map(i64::from))
         .bind(key.error_count.map(i64::from))
-        .bind(key.total_response_time_ms.map(i64::from))
+        .bind(
+            key.total_response_time_ms
+                .map(|value| {
+                    i64::try_from(value).map_err(|_| {
+                        DataLayerError::InvalidInput(format!(
+                            "provider catalog key.total_response_time_ms exceeds i64: {value}"
+                        ))
+                    })
+                })
+                .transpose()?,
+        )
         .bind(key.last_used_at_unix_secs.map(|value| value as f64))
         .bind(key.last_models_fetch_at_unix_secs.map(|value| value as f64))
         .bind(&key.last_models_fetch_error)
@@ -2384,7 +2394,7 @@ fn map_key_row(row: &PgRow) -> Result<StoredProviderCatalogKey, DataLayerError> 
         .transpose()?;
     let total_response_time_ms = row_get::<Option<i64>>(row, "total_response_time_ms")?
         .map(|value| {
-            u32::try_from(value).map_err(|_| {
+            u64::try_from(value).map_err(|_| {
                 DataLayerError::UnexpectedValue(format!(
                     "invalid provider_api_keys.total_response_time_ms: {value}"
                 ))

--- a/crates/aether-data/src/repository/provider_catalog/sqlite.rs
+++ b/crates/aether-data/src/repository/provider_catalog/sqlite.rs
@@ -976,7 +976,13 @@ WHERE id = ?
             .bind(key.total_cost_usd)
             .bind(optional_i64_from_u32(key.success_count).unwrap_or(0))
             .bind(optional_i64_from_u32(key.error_count).unwrap_or(0))
-            .bind(optional_i64_from_u32(key.total_response_time_ms).unwrap_or(0))
+            .bind(
+                optional_i64_from_u64(
+                    key.total_response_time_ms,
+                    "provider_api_keys.total_response_time_ms",
+                )?
+                .unwrap_or(0),
+            )
             .bind(optional_i64_from_u64(
                 key.last_used_at_unix_secs,
                 "provider_api_keys.last_used_at",
@@ -1950,7 +1956,7 @@ fn map_key_row(row: &SqliteRow) -> Result<StoredProviderCatalogKey, DataLayerErr
                     row.try_get("error_count").map_sql_err()?,
                     "provider_api_keys.error_count",
                 )?,
-                optional_u32(
+                optional_u64(
                     row.try_get("total_response_time_ms").map_sql_err()?,
                     "provider_api_keys.total_response_time_ms",
                 )?,
@@ -2093,6 +2099,7 @@ mod tests {
             .expect("keys should list");
         assert_eq!(keys.len(), 1);
         assert_eq!(keys[0].total_tokens, 1234);
+        assert_eq!(keys[0].total_response_time_ms, Some(u32::MAX as u64 + 1));
         assert_eq!(keys[0].concurrent_limit, Some(3));
 
         let page = repository
@@ -2245,7 +2252,7 @@ mod tests {
             Some(10),
             Some(9),
         )
-        .with_usage_fields(Some(1), Some(250))
+        .with_usage_fields(Some(1), Some(u32::MAX as u64 + 42))
         .with_usage_totals(1234, 1.5)
         .with_health_fields(
             Some(json!({"openai:chat":{"score":1}})),
@@ -2259,6 +2266,10 @@ mod tests {
             .expect("key should create");
         assert_eq!(created_key.concurrent_limit, Some(3));
         assert_eq!(created_key.total_tokens, 1234);
+        assert_eq!(
+            created_key.total_response_time_ms,
+            Some(u32::MAX as u64 + 42)
+        );
         assert_eq!(
             created_key.last_models_fetch_error.as_deref(),
             Some("stale models fetch error")
@@ -2385,7 +2396,7 @@ INSERT INTO provider_api_keys (
 ) VALUES (
   'key-1', 'provider-1', 'default', 'enc-key', 'api_key',
   '{"cache_1h":true}', 1, '["openai:chat"]', '{"openai:chat":"api_key"}',
-  5, 120, 3, 10, 1234, 1.5, 9, 1, 250, '{"openai:chat":{"score":1}}',
+  5, 120, 3, 10, 1234, 1.5, 9, 1, 4294967296, '{"openai:chat":{"score":1}}',
   5, 6
 )
 "#,

--- a/crates/aether-oauth/src/provider/providers/kiro.rs
+++ b/crates/aether-oauth/src/provider/providers/kiro.rs
@@ -17,6 +17,7 @@ pub const DEFAULT_NODE_VERSION: &str = "22.21.1";
 pub const DEFAULT_SYSTEM_VERSION: &str = "other#unknown";
 const IDC_AMZ_USER_AGENT: &str =
     "aws-sdk-js/3.738.0 ua/2.1 os/other lang/js md/browser#unknown_unknown api/sso-oidc#3.738.0 m/E KiroIDE";
+const KIRO_PROFILE_DISCOVERY_SDK_VERSION: &str = "1.0.0";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KiroAuthConfig {
@@ -179,9 +180,6 @@ impl KiroAuthConfig {
     }
 
     pub fn profile_arn_for_payload(&self) -> Option<&str> {
-        if self.is_idc_auth() {
-            return None;
-        }
         self.profile_arn
             .as_deref()
             .map(str::trim)
@@ -245,11 +243,28 @@ impl KiroProviderOAuthAdapter {
         ctx: &ProviderOAuthTransportContext,
         auth_config: &KiroAuthConfig,
     ) -> Result<KiroAuthConfig, OAuthError> {
-        if auth_config.is_idc_auth() {
+        let refreshed = if auth_config.is_idc_auth() {
             self.refresh_idc_token(executor, ctx, auth_config).await
         } else {
             self.refresh_social_token(executor, ctx, auth_config).await
+        }?;
+        self.with_discovered_profile_arn(executor, ctx, refreshed)
+            .await
+    }
+
+    async fn with_discovered_profile_arn(
+        &self,
+        executor: &dyn OAuthHttpExecutor,
+        ctx: &ProviderOAuthTransportContext,
+        mut auth_config: KiroAuthConfig,
+    ) -> Result<KiroAuthConfig, OAuthError> {
+        if auth_config.profile_arn_for_payload().is_some() {
+            return Ok(auth_config);
         }
+        if let Some(profile_arn) = discover_kiro_profile_arn(executor, ctx, &auth_config).await? {
+            auth_config.profile_arn = Some(profile_arn);
+        }
+        Ok(auth_config)
     }
 
     async fn refresh_social_token(
@@ -505,6 +520,180 @@ impl ProviderOAuthAdapter for KiroProviderOAuthAdapter {
     }
 }
 
+async fn discover_kiro_profile_arn(
+    executor: &dyn OAuthHttpExecutor,
+    ctx: &ProviderOAuthTransportContext,
+    auth_config: &KiroAuthConfig,
+) -> Result<Option<String>, OAuthError> {
+    let token = auth_config
+        .cached_access_token()
+        .ok_or_else(|| OAuthError::invalid_response("kiro profile discovery missing access_token"))?
+        .to_string();
+    let machine_id = generate_kiro_machine_id(auth_config, Some(token.as_str()))
+        .ok_or_else(|| OAuthError::invalid_request("missing machine_id seed"))?;
+
+    for region in profile_discovery_regions(auth_config) {
+        if let Some(profile_arn) = discover_kiro_profile_arn_in_region(
+            executor,
+            ctx,
+            auth_config,
+            token.as_str(),
+            machine_id.as_str(),
+            region.as_str(),
+        )
+        .await?
+        {
+            return Ok(Some(profile_arn));
+        }
+    }
+    Ok(None)
+}
+
+async fn discover_kiro_profile_arn_in_region(
+    executor: &dyn OAuthHttpExecutor,
+    ctx: &ProviderOAuthTransportContext,
+    auth_config: &KiroAuthConfig,
+    access_token: &str,
+    machine_id: &str,
+    region: &str,
+) -> Result<Option<String>, OAuthError> {
+    let mut next_token = None::<String>;
+    for _ in 0..4 {
+        let mut body = serde_json::Map::new();
+        if let Some(token) = next_token.as_deref() {
+            body.insert("nextToken".to_string(), Value::String(token.to_string()));
+        }
+        let response = executor
+            .execute(OAuthHttpRequest {
+                request_id: "provider-oauth:kiro-profile-discovery".to_string(),
+                method: reqwest::Method::POST,
+                url: format!(
+                    "https://{}/ListAvailableProfiles",
+                    kiro_runtime_host(region)
+                ),
+                headers: build_kiro_profile_discovery_headers(
+                    auth_config,
+                    access_token,
+                    machine_id,
+                    region,
+                ),
+                content_type: Some("application/json".to_string()),
+                json_body: Some(Value::Object(body)),
+                body_bytes: None,
+                network: ctx.network.clone(),
+            })
+            .await?;
+        if !(200..300).contains(&response.status_code) {
+            return Ok(None);
+        }
+        let payload = response
+            .json_body
+            .or_else(|| serde_json::from_str::<Value>(&response.body_text).ok())
+            .ok_or_else(|| {
+                OAuthError::invalid_response("kiro ListAvailableProfiles response is not json")
+            })?;
+        if let Some(profile_arn) = first_kiro_profile_arn(&payload) {
+            return Ok(Some(profile_arn));
+        }
+        next_token = payload
+            .get("nextToken")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        if next_token.is_none() {
+            return Ok(None);
+        }
+    }
+    Ok(None)
+}
+
+fn build_kiro_profile_discovery_headers(
+    auth_config: &KiroAuthConfig,
+    access_token: &str,
+    machine_id: &str,
+    region: &str,
+) -> BTreeMap<String, String> {
+    let kiro_version = auth_config.effective_kiro_version();
+    let system_version = auth_config.effective_system_version();
+    let node_version = auth_config.effective_node_version();
+    let ide_tag = build_kiro_ide_tag(kiro_version, machine_id);
+    BTreeMap::from([
+        ("accept".to_string(), "application/json".to_string()),
+        ("amz-sdk-invocation-id".to_string(), uuid::Uuid::new_v4().to_string()),
+        ("amz-sdk-request".to_string(), "attempt=1; max=1".to_string()),
+        ("authorization".to_string(), format!("Bearer {}", access_token.trim())),
+        ("connection".to_string(), "close".to_string()),
+        ("content-type".to_string(), "application/json".to_string()),
+        ("host".to_string(), kiro_runtime_host(region)),
+        (
+            "user-agent".to_string(),
+            format!(
+                "aws-sdk-js/{KIRO_PROFILE_DISCOVERY_SDK_VERSION} ua/2.1 os/{system_version} lang/js md/nodejs#{node_version} api/codewhispererruntime#1.0.0 m/N,E {ide_tag}"
+            ),
+        ),
+        (
+            "x-amz-user-agent".to_string(),
+            format!("aws-sdk-js/{KIRO_PROFILE_DISCOVERY_SDK_VERSION} {ide_tag}"),
+        ),
+    ])
+}
+
+fn build_kiro_ide_tag(kiro_version: &str, machine_id: &str) -> String {
+    if machine_id.trim().is_empty() {
+        format!("KiroIDE-{kiro_version}")
+    } else {
+        format!("KiroIDE-{kiro_version}-{machine_id}")
+    }
+}
+
+fn profile_discovery_regions(auth_config: &KiroAuthConfig) -> Vec<String> {
+    let mut regions = Vec::new();
+    push_unique_region(&mut regions, auth_config.effective_api_region());
+    push_unique_region(&mut regions, auth_config.effective_auth_region());
+    if auth_config.is_idc_auth() {
+        push_unique_region(&mut regions, DEFAULT_REGION);
+        push_unique_region(&mut regions, "eu-central-1");
+    }
+    regions
+}
+
+fn push_unique_region(regions: &mut Vec<String>, region: &str) {
+    let region = region.trim();
+    if region.is_empty() || regions.iter().any(|value| value == region) {
+        return;
+    }
+    regions.push(region.to_string());
+}
+
+fn kiro_runtime_host(region: &str) -> String {
+    match region {
+        "us-gov-east-1" | "us-gov-west-1" => format!("q-fips.{region}.amazonaws.com"),
+        "us-iso-east-1" => "q.us-iso-east-1.c2s.ic.gov".to_string(),
+        "us-isob-east-1" => "q.us-isob-east-1.sc2s.sgov.gov".to_string(),
+        "us-isof-south-1" => "q.us-isof-south-1.csp.hci.ic.gov".to_string(),
+        "us-isof-east-1" => "q.us-isof-east-1.csp.hci.ic.gov".to_string(),
+        _ => format!("q.{region}.amazonaws.com"),
+    }
+}
+
+fn first_kiro_profile_arn(payload: &Value) -> Option<String> {
+    payload
+        .get("profiles")
+        .or_else(|| payload.get("data"))?
+        .as_array()?
+        .iter()
+        .find_map(|profile| {
+            profile
+                .get("arn")
+                .or_else(|| profile.get("profileArn"))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        })
+}
+
 pub fn generate_kiro_machine_id(
     auth_config: &KiroAuthConfig,
     fallback_secret: Option<&str>,
@@ -674,6 +863,44 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone)]
+    struct RoutingExecutor {
+        seen_requests: Arc<Mutex<Vec<OAuthHttpRequest>>>,
+    }
+
+    #[async_trait]
+    impl OAuthHttpExecutor for RoutingExecutor {
+        async fn execute(
+            &self,
+            request: OAuthHttpRequest,
+        ) -> Result<OAuthHttpResponse, crate::core::OAuthError> {
+            let request_id = request.request_id.clone();
+            self.seen_requests
+                .lock()
+                .expect("mutex should lock")
+                .push(request);
+            let response = match request_id.as_str() {
+                "provider-oauth:kiro-idc-refresh" => json!({
+                    "accessToken": "new-idc-access-token",
+                    "refreshToken": "i".repeat(120),
+                    "expiresIn": 1800
+                }),
+                "provider-oauth:kiro-profile-discovery" => json!({
+                    "profiles": [{
+                        "arn": "arn:aws:codewhisperer:us-east-1:123456789012:profile/demo",
+                        "name": "demo"
+                    }]
+                }),
+                other => panic!("unexpected request id: {other}"),
+            };
+            Ok(OAuthHttpResponse {
+                status_code: 200,
+                body_text: response.to_string(),
+                json_body: Some(response),
+            })
+        }
+    }
+
     fn test_ctx() -> ProviderOAuthTransportContext {
         ProviderOAuthTransportContext {
             provider_id: "provider-1".to_string(),
@@ -831,6 +1058,10 @@ mod tests {
             refreshed.refresh_token.as_deref(),
             Some(expected_rotated_refresh_token.as_str())
         );
+        assert_eq!(
+            refreshed.profile_arn.as_deref(),
+            Some("arn:aws:bedrock:demo")
+        );
         assert!(refreshed.machine_id.is_some());
         assert!(refreshed.expires_at.is_some());
 
@@ -858,6 +1089,69 @@ mod tests {
         assert_eq!(
             body.get("refreshToken").and_then(serde_json::Value::as_str),
             Some(expected_refresh_token.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_discovers_missing_idc_profile_arn() {
+        let seen_requests = Arc::new(Mutex::new(Vec::new()));
+        let executor = RoutingExecutor {
+            seen_requests: Arc::clone(&seen_requests),
+        };
+        let adapter = KiroProviderOAuthAdapter::default()
+            .with_refresh_base_urls(None, Some("https://idc.example.test".to_string()));
+        let auth_config = KiroAuthConfig {
+            auth_method: Some("identity_center".to_string()),
+            refresh_token: Some("r".repeat(120)),
+            expires_at: Some(1),
+            profile_arn: None,
+            region: None,
+            auth_region: None,
+            api_region: Some("us-east-1".to_string()),
+            client_id: Some("client-id".to_string()),
+            client_secret: Some("client-secret".to_string()),
+            machine_id: Some("123e4567-e89b-12d3-a456-426614174000".to_string()),
+            kiro_version: Some("0.3.210".to_string()),
+            system_version: None,
+            node_version: None,
+            access_token: None,
+        };
+
+        let refreshed = adapter
+            .refresh_auth_config(&executor, &test_ctx(), &auth_config)
+            .await
+            .expect("idc refresh should discover profile arn");
+
+        assert_eq!(
+            refreshed.profile_arn.as_deref(),
+            Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/demo")
+        );
+        let seen_requests = seen_requests.lock().expect("mutex should lock").clone();
+        assert_eq!(seen_requests.len(), 2);
+        let discovery = seen_requests
+            .iter()
+            .find(|request| request.request_id == "provider-oauth:kiro-profile-discovery")
+            .expect("profile discovery request should be sent");
+        assert_eq!(discovery.method, reqwest::Method::POST);
+        assert_eq!(
+            discovery.url,
+            "https://q.us-east-1.amazonaws.com/ListAvailableProfiles"
+        );
+        assert_eq!(
+            discovery.headers.get("authorization").map(String::as_str),
+            Some("Bearer new-idc-access-token")
+        );
+        assert_eq!(
+            discovery.headers.get("host").map(String::as_str),
+            Some("q.us-east-1.amazonaws.com")
+        );
+        assert_eq!(
+            discovery
+                .json_body
+                .as_ref()
+                .and_then(serde_json::Value::as_object)
+                .map(|body| body.is_empty()),
+            Some(true)
         );
     }
 }

--- a/crates/aether-provider-transport/src/kiro/converter.rs
+++ b/crates/aether-provider-transport/src/kiro/converter.rs
@@ -37,7 +37,24 @@ pub fn convert_claude_messages_to_conversation_state(
     let thinking_prefix = generate_thinking_prefix(request_body);
 
     let mut history = Vec::new();
-    let system_text = system_to_text(request_body.get("system"));
+    let mut system_text = system_to_text(request_body.get("system"));
+    for message in messages {
+        let Some(message) = message.as_object() else {
+            continue;
+        };
+        if matches!(
+            message.get("role").and_then(Value::as_str),
+            Some("system" | "developer")
+        ) {
+            let text = system_to_text(message.get("content"));
+            if !text.is_empty() {
+                if !system_text.is_empty() {
+                    system_text.push('\n');
+                }
+                system_text.push_str(&text);
+            }
+        }
+    }
     if !system_text.is_empty() {
         history.push(json!({
             "userInputMessage": {
@@ -53,16 +70,22 @@ pub fn convert_claude_messages_to_conversation_state(
         }));
     }
 
-    let last_is_assistant = messages
-        .last()
-        .and_then(Value::as_object)
-        .and_then(|message| message.get("role"))
-        .and_then(Value::as_str)
-        .is_some_and(|role| role == "assistant");
+    let Some((last_message_index, last_message_role)) = messages.iter().enumerate().rev().find_map(
+        |(index, message)| {
+            let role = message
+                .as_object()
+                .and_then(|message| message.get("role"))
+                .and_then(Value::as_str)?;
+            matches!(role, "user" | "assistant").then_some((index, role))
+        },
+    ) else {
+        return None;
+    };
+    let last_is_assistant = last_message_role == "assistant";
     let history_end_index = if last_is_assistant {
         messages.len()
     } else {
-        messages.len().saturating_sub(1)
+        last_message_index
     };
 
     let mut user_buffer = Vec::new();
@@ -106,7 +129,7 @@ pub fn convert_claude_messages_to_conversation_state(
     let (mut text_content, images, tool_results) = if last_is_assistant {
         ("Continue.".to_string(), Vec::new(), Vec::new())
     } else {
-        let last = messages.last()?.as_object()?;
+        let last = messages.get(last_message_index)?.as_object()?;
         if last.get("role").and_then(Value::as_str) != Some("user") {
             return None;
         }
@@ -670,7 +693,7 @@ fn convert_assistant_message(message: &Map<String, Value>) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
+    use serde_json::{json, Value};
 
     use super::convert_claude_messages_to_conversation_state;
 
@@ -706,9 +729,42 @@ mod tests {
                 .and_then(|value| value.get("userInputMessage"))
                 .and_then(|value| value.get("userInputMessageContext"))
                 .and_then(|value| value.get("tools"))
-                .and_then(|value| value.as_array())
-                .map(Vec::len),
+            .and_then(|value| value.as_array())
+            .map(Vec::len),
             Some(1)
+        );
+    }
+
+    #[test]
+    fn folds_inline_system_messages_into_instructions_and_keeps_last_user_as_current_message() {
+        let conversation_state = convert_claude_messages_to_conversation_state(
+            &json!({
+                "messages": [
+                    {"role":"user","content":"hi"},
+                    {"role":"system","content":"Use the Kiro envelope."}
+                ]
+            }),
+            "claude-sonnet-4-upstream",
+        )
+        .expect("conversation state should build");
+
+        assert_eq!(
+            conversation_state
+                .get("currentMessage")
+                .and_then(|value| value.get("userInputMessage"))
+                .and_then(|value| value.get("content"))
+                .and_then(|value| value.as_str()),
+            Some("hi")
+        );
+        assert!(
+            conversation_state
+                .get("history")
+                .and_then(Value::as_array)
+                .and_then(|history| history.first())
+                .and_then(|value| value.get("userInputMessage"))
+                .and_then(|value| value.get("content"))
+                .and_then(Value::as_str)
+                .is_some_and(|content| content.contains("Use the Kiro envelope."))
         );
     }
 }

--- a/crates/aether-provider-transport/src/kiro/credentials.rs
+++ b/crates/aether-provider-transport/src/kiro/credentials.rs
@@ -78,7 +78,10 @@ mod tests {
         assert_eq!(auth_config.effective_node_version(), "22.21.1");
         assert_eq!(auth_config.access_token.as_deref(), Some("cached-token"));
         assert!(auth_config.is_idc_auth());
-        assert!(auth_config.profile_arn_for_payload().is_none());
+        assert_eq!(
+            auth_config.profile_arn_for_payload(),
+            Some("arn:aws:bedrock:demo")
+        );
         assert_eq!(auth_config.effective_auth_region(), "us-east-1");
         assert!(auth_config.can_refresh_access_token());
         assert_eq!(DEFAULT_REGION, "us-east-1");
@@ -100,7 +103,10 @@ mod tests {
         assert_eq!(auth_config.auth_method.as_deref(), Some("external_idp"));
         assert!(auth_config.is_idc_auth());
         assert!(auth_config.uses_external_idp_token_type());
-        assert!(auth_config.profile_arn_for_payload().is_none());
+        assert_eq!(
+            auth_config.profile_arn_for_payload(),
+            Some("arn:aws:bedrock:demo")
+        );
         assert_eq!(
             auth_config.profile_arn_for_mcp(),
             Some("arn:aws:bedrock:demo")
@@ -121,7 +127,10 @@ mod tests {
 
         assert!(auth_config.is_idc_auth());
         assert!(!auth_config.uses_external_idp_token_type());
-        assert!(auth_config.profile_arn_for_payload().is_none());
+        assert_eq!(
+            auth_config.profile_arn_for_payload(),
+            Some("arn:aws:bedrock:demo")
+        );
         assert_eq!(
             auth_config.profile_arn_for_mcp(),
             Some("arn:aws:bedrock:demo")

--- a/crates/aether-provider-transport/src/kiro/refresh.rs
+++ b/crates/aether-provider-transport/src/kiro/refresh.rs
@@ -90,6 +90,17 @@ impl KiroOAuthRefreshAdapter {
             .can_refresh_access_token()
             .then_some(auth_config)
     }
+
+    fn resolved_auth_if_complete(
+        auth: super::auth::KiroRequestAuth,
+    ) -> Option<LocalResolvedOAuthRequestAuth> {
+        if auth.auth_config.profile_arn_for_payload().is_none()
+            && auth.auth_config.can_refresh_access_token()
+        {
+            return None;
+        }
+        Some(LocalResolvedOAuthRequestAuth::Kiro(auth))
+    }
 }
 
 #[async_trait]
@@ -105,14 +116,14 @@ impl LocalOAuthRefreshAdapter for KiroOAuthRefreshAdapter {
     ) -> Option<LocalResolvedOAuthRequestAuth> {
         let auth_config = Self::auth_config_from_entry(entry)?;
         let request_auth = build_kiro_request_auth_from_config(auth_config, None)?;
-        Some(LocalResolvedOAuthRequestAuth::Kiro(request_auth))
+        Self::resolved_auth_if_complete(request_auth)
     }
 
     fn resolve_without_refresh(
         &self,
         transport: &GatewayProviderTransportSnapshot,
     ) -> Option<LocalResolvedOAuthRequestAuth> {
-        resolve_local_kiro_request_auth(transport).map(LocalResolvedOAuthRequestAuth::Kiro)
+        resolve_local_kiro_request_auth(transport).and_then(Self::resolved_auth_if_complete)
     }
 
     fn should_refresh(
@@ -435,7 +446,10 @@ mod tests {
         match resolved {
             LocalResolvedOAuthRequestAuth::Kiro(auth) => {
                 assert_eq!(auth.value, "Bearer cached-idc-access-token");
-                assert!(auth.auth_config.profile_arn_for_payload().is_none());
+                assert_eq!(
+                    auth.auth_config.profile_arn_for_payload(),
+                    Some("arn:aws:bedrock:demo")
+                );
                 assert!(auth.auth_config.expires_at.is_some());
             }
             other => panic!("unexpected resolved auth: {other:?}"),

--- a/crates/aether-provider-transport/src/kiro/request.rs
+++ b/crates/aether-provider-transport/src/kiro/request.rs
@@ -275,7 +275,7 @@ mod tests {
     }
 
     #[test]
-    fn omits_profile_arn_for_idc_auth() {
+    fn includes_profile_arn_for_idc_auth() {
         let auth_config = KiroAuthConfig {
             auth_method: Some("identity_center".to_string()),
             refresh_token: Some("r".repeat(128)),
@@ -304,6 +304,9 @@ mod tests {
         )
         .expect("payload should build");
 
-        assert!(payload.get("profileArn").is_none());
+        assert_eq!(
+            payload.get("profileArn"),
+            Some(&json!("arn:aws:bedrock:demo"))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- 修复 Kiro 请求体包装失败的问题：当 `messages[]` 里出现 `system` / `developer` 消息，且尾部不是 `user` / `assistant` 时，不再直接返回 `None`。
- 将内联的 `system` / `developer` 消息折叠进系统提示，保持 Kiro `conversationState` 的构建稳定。
- 增加回归测试，覆盖“尾部为 system 消息”时仍能正常构建 currentMessage 和 history 的场景。

## Test plan
- `cargo test -p aether-provider-transport folds_inline_system_messages_into_instructions_and_keeps_last_user_as_current_message -- --nocapture`
- `cargo test -p aether-provider-transport wraps_claude_request_into_kiro_payload_before_body_rules -- --nocapture`