### PR TITLE
feat: add provider cost attribution

### DIFF
--- a/apps/aether-gateway/src/control/route/admin/observability_families.rs
+++ b/apps/aether-gateway/src/control/route/admin/observability_families.rs
@@ -340,6 +340,19 @@ pub(super) fn classify_admin_observability_family_route(
     } else if method == http::Method::GET
         && matches!(
             normalized_path,
+            "/api/admin/usage/attribution" | "/api/admin/usage/attribution/"
+        )
+    {
+        Some(classified(
+            "admin_proxy",
+            "usage_manage",
+            "attribution",
+            "admin:usage",
+            false,
+        ))
+    } else if method == http::Method::GET
+        && matches!(
+            normalized_path,
             "/api/admin/usage/stats" | "/api/admin/usage/stats/"
         )
     {

--- a/apps/aether-gateway/src/handlers/admin/observability/usage/analytics_routes/aggregation.rs
+++ b/apps/aether-gateway/src/handlers/admin/observability/usage/analytics_routes/aggregation.rs
@@ -185,6 +185,8 @@ pub(super) async fn build_admin_usage_aggregation_stats_response(
             created_from_unix_secs,
             created_until_unix_secs,
             group_by: group_by_query,
+            provider_id: None,
+            provider_name: None,
             limit,
             exclude_reserved_provider_labels,
         })

--- a/apps/aether-gateway/src/handlers/admin/observability/usage/analytics_routes/attribution.rs
+++ b/apps/aether-gateway/src/handlers/admin/observability/usage/analytics_routes/attribution.rs
@@ -242,7 +242,7 @@ pub(super) async fn build_admin_usage_attribution_response(
             group_by: UsageAuditAggregationGroupBy::User,
             provider_id: provider_id.clone(),
             provider_name: provider_name.clone(),
-            limit: 10_000,
+            limit: 0,
             exclude_reserved_provider_labels: false,
         })
         .await?;

--- a/apps/aether-gateway/src/handlers/admin/observability/usage/analytics_routes/attribution.rs
+++ b/apps/aether-gateway/src/handlers/admin/observability/usage/analytics_routes/attribution.rs
@@ -1,0 +1,278 @@
+use super::super::super::stats::resolve_admin_usage_time_range;
+use crate::handlers::admin::request::{AdminAppState, AdminRequestContext};
+use crate::handlers::admin::shared::query_param_value;
+use crate::GatewayError;
+use aether_admin::observability::stats::round_to;
+use aether_admin::observability::usage::{
+    admin_usage_bad_request_response, admin_usage_data_unavailable_response,
+    admin_usage_parse_aggregation_limit, ADMIN_USAGE_DATA_UNAVAILABLE_DETAIL,
+};
+use aether_data_contracts::repository::usage::{
+    StoredUsageAuditAggregation, UsageAuditAggregationGroupBy, UsageAuditAggregationQuery,
+};
+use axum::{
+    body::Body,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum AttributionMetric {
+    ActualCost,
+    TotalCost,
+    Tokens,
+    Requests,
+}
+
+impl AttributionMetric {
+    fn parse(value: Option<String>) -> Result<Self, String> {
+        match value
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("actual_cost")
+        {
+            "actual_cost" => Ok(Self::ActualCost),
+            "total_cost" => Ok(Self::TotalCost),
+            "tokens" => Ok(Self::Tokens),
+            "requests" => Ok(Self::Requests),
+            _ => Err(
+                "Invalid metric value: must be one of actual_cost, total_cost, tokens, requests"
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ActualCost => "actual_cost",
+            Self::TotalCost => "total_cost",
+            Self::Tokens => "tokens",
+            Self::Requests => "requests",
+        }
+    }
+
+    fn value(self, row: &StoredUsageAuditAggregation) -> f64 {
+        match self {
+            Self::ActualCost => row.actual_total_cost_usd,
+            Self::TotalCost => row.total_cost_usd,
+            Self::Tokens => row.total_tokens as f64,
+            Self::Requests => row.request_count as f64,
+        }
+    }
+}
+
+fn parse_group_by(value: Option<String>) -> Result<&'static str, String> {
+    match value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("user")
+    {
+        "user" => Ok("user"),
+        "api_key" => Err("group_by=api_key is not supported yet".to_string()),
+        _ => Err("Invalid group_by value: must be user".to_string()),
+    }
+}
+
+fn attribution_metric_total(
+    metric: AttributionMetric,
+    rows: &[StoredUsageAuditAggregation],
+) -> f64 {
+    rows.iter().map(|row| metric.value(row).max(0.0)).sum()
+}
+
+fn attribution_share(value: f64, total: f64) -> f64 {
+    if total <= 0.0 {
+        0.0
+    } else {
+        round_to((value / total).clamp(0.0, 1.0), 6)
+    }
+}
+
+fn empty_others(total: f64) -> Value {
+    json!({
+        "id": "others",
+        "name": "Others",
+        "requests": 0,
+        "total_tokens": 0,
+        "total_cost": 0.0,
+        "actual_cost": 0.0,
+        "share": attribution_share(0.0, total),
+    })
+}
+
+fn aggregate_others(
+    rows: &[StoredUsageAuditAggregation],
+    metric: AttributionMetric,
+    total: f64,
+) -> Value {
+    if rows.is_empty() {
+        return empty_others(total);
+    }
+    let requests = rows
+        .iter()
+        .fold(0_u64, |sum, row| sum.saturating_add(row.request_count));
+    let total_tokens = rows
+        .iter()
+        .fold(0_u64, |sum, row| sum.saturating_add(row.total_tokens));
+    let total_cost = rows.iter().map(|row| row.total_cost_usd).sum::<f64>();
+    let actual_cost = rows
+        .iter()
+        .map(|row| row.actual_total_cost_usd)
+        .sum::<f64>();
+    let metric_value = rows
+        .iter()
+        .map(|row| metric.value(row).max(0.0))
+        .sum::<f64>();
+    json!({
+        "id": "others",
+        "name": "Others",
+        "requests": requests,
+        "total_tokens": total_tokens,
+        "total_cost": round_to(total_cost, 6),
+        "actual_cost": round_to(actual_cost, 6),
+        "share": attribution_share(metric_value, total),
+    })
+}
+
+async fn attribution_items_json(
+    state: &AdminAppState<'_>,
+    rows: &[StoredUsageAuditAggregation],
+    metric: AttributionMetric,
+    total: f64,
+) -> Result<Vec<Value>, GatewayError> {
+    let user_ids = rows
+        .iter()
+        .map(|row| row.group_key.clone())
+        .collect::<Vec<_>>();
+    let users = if state.has_user_data_reader() && !user_ids.is_empty() {
+        state
+            .list_users_by_ids(&user_ids)
+            .await?
+            .into_iter()
+            .map(|user| (user.id, (user.email, user.username)))
+            .collect::<BTreeMap<_, _>>()
+    } else {
+        BTreeMap::new()
+    };
+
+    Ok(rows
+        .iter()
+        .map(|row| {
+            let (email, username) = users
+                .get(&row.group_key)
+                .cloned()
+                .unwrap_or((None, String::new()));
+            let display_name = if username.trim().is_empty() {
+                email.clone().unwrap_or_else(|| row.group_key.clone())
+            } else {
+                username.clone()
+            };
+            let metric_value = metric.value(row).max(0.0);
+            json!({
+                "id": row.group_key,
+                "user_id": row.group_key,
+                "name": display_name,
+                "email": email,
+                "username": if username.is_empty() { Value::Null } else { json!(username) },
+                "requests": row.request_count,
+                "total_tokens": row.total_tokens,
+                "total_cost": round_to(row.total_cost_usd, 6),
+                "actual_cost": round_to(row.actual_total_cost_usd, 6),
+                "share": attribution_share(metric_value, total),
+            })
+        })
+        .collect())
+}
+
+pub(super) async fn build_admin_usage_attribution_response(
+    state: &AdminAppState<'_>,
+    request_context: &AdminRequestContext<'_>,
+) -> Result<Response<Body>, GatewayError> {
+    if !state.has_usage_data_reader() {
+        return Ok(admin_usage_data_unavailable_response(
+            ADMIN_USAGE_DATA_UNAVAILABLE_DETAIL,
+        ));
+    }
+
+    let query = request_context.request_query_string.as_deref();
+    let provider_id = query_param_value(query, "provider_id");
+    let provider_name = query_param_value(query, "provider_name");
+    if provider_id.is_none() && provider_name.is_none() {
+        return Ok(admin_usage_bad_request_response(
+            "provider_id or provider_name is required",
+        ));
+    }
+    let group_by = match parse_group_by(query_param_value(query, "group_by")) {
+        Ok(value) => value,
+        Err(detail) => return Ok(admin_usage_bad_request_response(detail)),
+    };
+    let metric = match AttributionMetric::parse(query_param_value(query, "metric")) {
+        Ok(value) => value,
+        Err(detail) => return Ok(admin_usage_bad_request_response(detail)),
+    };
+    let limit = match admin_usage_parse_aggregation_limit(query) {
+        Ok(value) => value,
+        Err(detail) => return Ok(admin_usage_bad_request_response(detail)),
+    };
+    let time_range = match resolve_admin_usage_time_range(query) {
+        Ok(value) => value,
+        Err(detail) => return Ok(admin_usage_bad_request_response(detail)),
+    };
+    let Some((created_from_unix_secs, created_until_unix_secs)) = time_range.to_unix_bounds()
+    else {
+        return Ok(Json(json!({
+            "provider": { "id": provider_id, "name": provider_name },
+            "group_by": group_by,
+            "metric": metric.as_str(),
+            "total": 0.0,
+            "items": [],
+            "others": empty_others(0.0),
+        }))
+        .into_response());
+    };
+
+    let mut rows = state
+        .aggregate_usage_audits(&UsageAuditAggregationQuery {
+            created_from_unix_secs,
+            created_until_unix_secs,
+            group_by: UsageAuditAggregationGroupBy::User,
+            provider_id: provider_id.clone(),
+            provider_name: provider_name.clone(),
+            limit: 10_000,
+            exclude_reserved_provider_labels: false,
+        })
+        .await?;
+    rows.sort_by(|left, right| {
+        metric
+            .value(right)
+            .partial_cmp(&metric.value(left))
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| right.request_count.cmp(&left.request_count))
+            .then_with(|| left.group_key.cmp(&right.group_key))
+    });
+    let total = attribution_metric_total(metric, &rows);
+    let (visible_rows, overflow_rows) = if rows.len() > limit {
+        rows.split_at(limit)
+    } else {
+        (rows.as_slice(), &[][..])
+    };
+    let items = attribution_items_json(state, visible_rows, metric, total).await?;
+    let others = aggregate_others(overflow_rows, metric, total);
+
+    Ok(Json(json!({
+        "provider": {
+            "id": provider_id,
+            "name": provider_name,
+        },
+        "group_by": group_by,
+        "metric": metric.as_str(),
+        "total": round_to(total, 6),
+        "items": items,
+        "others": others,
+    }))
+    .into_response())
+}

--- a/apps/aether-gateway/src/handlers/admin/observability/usage/analytics_routes/mod.rs
+++ b/apps/aether-gateway/src/handlers/admin/observability/usage/analytics_routes/mod.rs
@@ -1,4 +1,5 @@
 mod aggregation;
+mod attribution;
 mod cache_affinity_hit_analysis;
 mod cache_affinity_interval_timeline;
 mod cache_affinity_ttl_analysis;
@@ -31,6 +32,17 @@ pub(super) async fn maybe_build_local_admin_usage_analytics_response(
             )
             .await
             .map(Some);
+        }
+        Some("attribution")
+            if request_context.request_method == http::Method::GET
+                && matches!(
+                    request_context.request_path.as_str(),
+                    "/api/admin/usage/attribution" | "/api/admin/usage/attribution/"
+                ) =>
+        {
+            return attribution::build_admin_usage_attribution_response(state, request_context)
+                .await
+                .map(Some);
         }
         Some("heatmap")
             if request_context.request_method == http::Method::GET

--- a/apps/aether-gateway/src/handlers/public/support/dashboard_filters.rs
+++ b/apps/aether-gateway/src/handlers/public/support/dashboard_filters.rs
@@ -814,6 +814,8 @@ async fn dashboard_load_user_counts(
             created_from_unix_secs,
             created_until_unix_secs,
             group_by: UsageAuditAggregationGroupBy::User,
+            provider_id: None,
+            provider_name: None,
             limit: 10_000,
             exclude_reserved_provider_labels: false,
         })

--- a/apps/aether-gateway/src/tests/control/admin/usage.rs
+++ b/apps/aether-gateway/src/tests/control/admin/usage.rs
@@ -753,6 +753,135 @@ async fn gateway_handles_admin_usage_aggregation_stats_for_legacy_provider_name_
 }
 
 #[tokio::test]
+async fn gateway_handles_admin_usage_attribution_locally_with_metric_shares() {
+    let (upstream_url, upstream_hits, upstream_handle) =
+        start_usage_upstream("/api/admin/usage/attribution").await;
+
+    let mut usage_1 = sample_usage_row(
+        "usage-1",
+        "req-1",
+        Some("user-1"),
+        Some("key-1"),
+        Some("primary"),
+        "OpenAI",
+        "gpt-5",
+        "completed",
+        120,
+        30,
+        0.3,
+        0.6,
+        DAY_1_UNIX_SECS,
+    );
+    usage_1.provider_id = Some("provider-openai".to_string());
+    usage_1.total_tokens = usage_1.input_tokens;
+
+    let mut usage_2 = sample_usage_row(
+        "usage-2",
+        "req-2",
+        Some("user-2"),
+        Some("key-2"),
+        Some("secondary"),
+        "OpenAI",
+        "gpt-5",
+        "completed",
+        40,
+        10,
+        0.1,
+        0.3,
+        DAY_1_UNIX_SECS,
+    );
+    usage_2.provider_id = Some("provider-openai".to_string());
+    usage_2.total_tokens = usage_2.input_tokens;
+
+    let mut usage_3 = sample_usage_row(
+        "usage-3",
+        "req-3",
+        Some("user-3"),
+        Some("key-3"),
+        Some("tertiary"),
+        "OpenAI",
+        "gpt-5",
+        "completed",
+        80,
+        20,
+        0.2,
+        0.1,
+        DAY_1_UNIX_SECS,
+    );
+    usage_3.provider_id = Some("provider-openai".to_string());
+    usage_3.total_tokens = usage_3.input_tokens;
+
+    let mut other_provider_usage = sample_usage_row(
+        "usage-other",
+        "req-other",
+        Some("user-4"),
+        Some("key-4"),
+        Some("other"),
+        "Anthropic",
+        "claude-3-7",
+        "completed",
+        200,
+        50,
+        1.0,
+        1.0,
+        DAY_1_UNIX_SECS,
+    );
+    other_provider_usage.provider_id = Some("provider-anthropic".to_string());
+
+    let usage_repository = Arc::new(InMemoryUsageReadRepository::seed(vec![
+        usage_1,
+        usage_2,
+        usage_3,
+        other_provider_usage,
+    ]));
+    let user_repository = Arc::new(InMemoryUserReadRepository::seed(vec![
+        sample_user_summary("user-1", "alice"),
+        sample_user_summary("user-2", "bob"),
+        sample_user_summary("user-3", "carol"),
+        sample_user_summary("user-4", "dave"),
+    ]));
+
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(
+                GatewayDataState::with_usage_reader_for_tests(usage_repository)
+                    .with_user_reader(user_repository),
+            ),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = admin_request(reqwest::Client::new().get(format!(
+        "{gateway_url}/api/admin/usage/attribution?provider_id=provider-openai&metric=actual_cost&limit=2&start_date=2024-03-21&end_date=2024-03-22&tz_offset_minutes=0"
+    )))
+    .send()
+    .await
+    .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["provider"]["id"], "provider-openai");
+    assert_eq!(payload["group_by"], "user");
+    assert_eq!(payload["metric"], "actual_cost");
+    assert_eq!(payload["total"], 1.0);
+    let items = payload["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0]["id"], "user-1");
+    assert_eq!(items[0]["name"], "alice");
+    assert_eq!(items[0]["actual_cost"], 0.6);
+    assert_eq!(items[0]["share"], 0.6);
+    assert_eq!(items[1]["id"], "user-2");
+    assert_eq!(items[1]["share"], 0.3);
+    assert_eq!(payload["others"]["requests"], 1);
+    assert_eq!(payload["others"]["actual_cost"], 0.1);
+    assert_eq!(payload["others"]["share"], 0.1);
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn gateway_returns_service_unavailable_for_admin_usage_replay_without_provider_catalog_reader(
 ) {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::seed(vec![]));

--- a/apps/aether-gateway/src/tests/control/admin/usage.rs
+++ b/apps/aether-gateway/src/tests/control/admin/usage.rs
@@ -811,6 +811,24 @@ async fn gateway_handles_admin_usage_attribution_locally_with_metric_shares() {
     usage_3.provider_id = Some("provider-openai".to_string());
     usage_3.total_tokens = usage_3.input_tokens;
 
+    let mut usage_4 = sample_usage_row(
+        "usage-4",
+        "req-4",
+        Some("user-3"),
+        Some("key-3"),
+        Some("tertiary"),
+        "OpenAI",
+        "gpt-5",
+        "completed",
+        60,
+        20,
+        0.1,
+        0.0,
+        DAY_1_UNIX_SECS,
+    );
+    usage_4.provider_id = Some("provider-openai".to_string());
+    usage_4.total_tokens = usage_4.input_tokens;
+
     let mut other_provider_usage = sample_usage_row(
         "usage-other",
         "req-other",
@@ -832,6 +850,7 @@ async fn gateway_handles_admin_usage_attribution_locally_with_metric_shares() {
         usage_1,
         usage_2,
         usage_3,
+        usage_4,
         other_provider_usage,
     ]));
     let user_repository = Arc::new(InMemoryUserReadRepository::seed(vec![
@@ -872,9 +891,295 @@ async fn gateway_handles_admin_usage_attribution_locally_with_metric_shares() {
     assert_eq!(items[0]["share"], 0.6);
     assert_eq!(items[1]["id"], "user-2");
     assert_eq!(items[1]["share"], 0.3);
-    assert_eq!(payload["others"]["requests"], 1);
+    assert_eq!(payload["others"]["requests"], 2);
     assert_eq!(payload["others"]["actual_cost"], 0.1);
     assert_eq!(payload["others"]["share"], 0.1);
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_usage_attribution_provider_name_matches_legacy_rows_only() {
+    let mut legacy_usage = sample_usage_row(
+        "usage-legacy",
+        "req-legacy",
+        Some("legacy-user"),
+        Some("key-legacy"),
+        Some("legacy"),
+        "OpenAI",
+        "gpt-4o",
+        "completed",
+        10,
+        5,
+        0.4,
+        0.7,
+        DAY_1_UNIX_SECS,
+    );
+    legacy_usage.provider_id = None;
+
+    let mut modern_same_name_usage = sample_usage_row(
+        "usage-modern",
+        "req-modern",
+        Some("modern-user"),
+        Some("key-modern"),
+        Some("modern"),
+        "OpenAI",
+        "gpt-5",
+        "completed",
+        100,
+        50,
+        5.0,
+        9.0,
+        DAY_1_UNIX_SECS,
+    );
+    modern_same_name_usage.provider_id = Some("provider-openai".to_string());
+
+    let usage_repository = Arc::new(InMemoryUsageReadRepository::seed(vec![
+        legacy_usage,
+        modern_same_name_usage,
+    ]));
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(GatewayDataState::with_usage_reader_for_tests(
+                usage_repository,
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = admin_request(reqwest::Client::new().get(format!(
+        "{gateway_url}/api/admin/usage/attribution?provider_name=OpenAI&metric=actual_cost&limit=10&start_date=2024-03-21&end_date=2024-03-22&tz_offset_minutes=0"
+    )))
+    .send()
+    .await
+    .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["provider"]["name"], "OpenAI");
+    assert_eq!(payload["total"], 0.7);
+    let items = payload["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["id"], "legacy-user");
+    assert_eq!(items[0]["actual_cost"], 0.7);
+
+    gateway_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_usage_attribution_sorts_metric_before_visible_limit() {
+    let mut usage_rows = Vec::new();
+    for index in 0..10_001 {
+        let mut row = sample_usage_row(
+            &format!("usage-low-{index}"),
+            &format!("req-low-{index}"),
+            Some(&format!("user-low-{index:05}")),
+            Some(&format!("key-low-{index}")),
+            Some("low"),
+            "OpenAI",
+            "gpt-5",
+            "completed",
+            1,
+            0,
+            0.001,
+            0.001,
+            DAY_1_UNIX_SECS,
+        );
+        row.provider_id = Some("provider-openai".to_string());
+        usage_rows.push(row);
+    }
+
+    let mut high_cost_row = sample_usage_row(
+        "usage-high",
+        "req-high",
+        Some("user-zz-high-cost"),
+        Some("key-high"),
+        Some("high"),
+        "OpenAI",
+        "gpt-5",
+        "completed",
+        1,
+        0,
+        9.0,
+        9.0,
+        DAY_1_UNIX_SECS,
+    );
+    high_cost_row.provider_id = Some("provider-openai".to_string());
+    usage_rows.push(high_cost_row);
+
+    let usage_repository = Arc::new(InMemoryUsageReadRepository::seed(usage_rows));
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(GatewayDataState::with_usage_reader_for_tests(
+                usage_repository,
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = admin_request(reqwest::Client::new().get(format!(
+        "{gateway_url}/api/admin/usage/attribution?provider_id=provider-openai&metric=actual_cost&limit=1&start_date=2024-03-21&end_date=2024-03-22&tz_offset_minutes=0"
+    )))
+    .send()
+    .await
+    .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    let items = payload["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["id"], "user-zz-high-cost");
+    assert_eq!(items[0]["actual_cost"], 9.0);
+    assert_eq!(payload["others"]["requests"], 10_001);
+    assert_eq!(payload["total"], 19.001);
+
+    gateway_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_handles_admin_usage_attribution_for_legacy_provider_name_only() {
+    let (upstream_url, upstream_hits, upstream_handle) =
+        start_usage_upstream("/api/admin/usage/attribution").await;
+
+    let mut legacy_usage = sample_usage_row(
+        "legacy-usage",
+        "legacy-req",
+        Some("legacy-user"),
+        Some("legacy-key"),
+        Some("legacy"),
+        "OpenAI",
+        "legacy-model",
+        "completed",
+        10,
+        5,
+        0.4,
+        0.7,
+        DAY_1_UNIX_SECS,
+    );
+    legacy_usage.provider_id = None;
+
+    let mut modern_same_name_usage = sample_usage_row(
+        "modern-usage",
+        "modern-req",
+        Some("modern-user"),
+        Some("modern-key"),
+        Some("modern"),
+        "OpenAI",
+        "modern-model",
+        "completed",
+        10,
+        5,
+        4.0,
+        9.0,
+        DAY_1_UNIX_SECS,
+    );
+    modern_same_name_usage.provider_id = Some("provider-openai".to_string());
+
+    let usage_repository = Arc::new(InMemoryUsageReadRepository::seed(vec![
+        legacy_usage,
+        modern_same_name_usage,
+    ]));
+
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(GatewayDataState::with_usage_reader_for_tests(
+                usage_repository,
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = admin_request(reqwest::Client::new().get(format!(
+        "{gateway_url}/api/admin/usage/attribution?provider_name=OpenAI&metric=actual_cost&limit=10&start_date=2024-03-21&end_date=2024-03-22&tz_offset_minutes=0"
+    )))
+    .send()
+    .await
+    .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["provider"]["name"], "OpenAI");
+    assert_eq!(payload["total"], 0.7);
+    let items = payload["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["id"], "legacy-user");
+    assert_eq!(items[0]["actual_cost"], 0.7);
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_handles_admin_usage_attribution_without_internal_group_truncation() {
+    let (upstream_url, upstream_hits, upstream_handle) =
+        start_usage_upstream("/api/admin/usage/attribution").await;
+
+    let mut rows = Vec::with_capacity(10_002);
+    for index in 0..10_001 {
+        let mut usage = sample_usage_row(
+            &format!("usage-low-{index}"),
+            &format!("req-low-{index}"),
+            Some(&format!("user-{index:05}")),
+            Some("key-low"),
+            Some("low"),
+            "OpenAI",
+            "gpt-5",
+            "completed",
+            1,
+            1,
+            0.001,
+            0.001,
+            DAY_1_UNIX_SECS,
+        );
+        usage.provider_id = Some("provider-openai".to_string());
+        rows.push(usage);
+    }
+    let mut high_cost_usage = sample_usage_row(
+        "usage-high",
+        "req-high",
+        Some("user-zz-high-cost"),
+        Some("key-high"),
+        Some("high"),
+        "OpenAI",
+        "gpt-5",
+        "completed",
+        1,
+        1,
+        9.0,
+        9.0,
+        DAY_1_UNIX_SECS,
+    );
+    high_cost_usage.provider_id = Some("provider-openai".to_string());
+    rows.push(high_cost_usage);
+
+    let usage_repository = Arc::new(InMemoryUsageReadRepository::seed(rows));
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(GatewayDataState::with_usage_reader_for_tests(
+                usage_repository,
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = admin_request(reqwest::Client::new().get(format!(
+        "{gateway_url}/api/admin/usage/attribution?provider_id=provider-openai&metric=actual_cost&limit=1&start_date=2024-03-21&end_date=2024-03-22&tz_offset_minutes=0"
+    )))
+    .send()
+    .await
+    .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    let items = payload["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["id"], "user-zz-high-cost");
+    assert_eq!(items[0]["actual_cost"], 9.0);
+    assert_eq!(payload["total"], 19.001);
+    assert_eq!(payload["others"]["requests"], 10_001);
     assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
 
     gateway_handle.abort();

--- a/crates/aether-data-contracts/src/repository/usage/types.rs
+++ b/crates/aether-data-contracts/src/repository/usage/types.rs
@@ -775,6 +775,8 @@ pub struct UsageAuditAggregationQuery {
     pub created_from_unix_secs: u64,
     pub created_until_unix_secs: u64,
     pub group_by: UsageAuditAggregationGroupBy,
+    pub provider_id: Option<String>,
+    pub provider_name: Option<String>,
     pub limit: usize,
     pub exclude_reserved_provider_labels: bool,
 }

--- a/crates/aether-data/src/repository/usage/memory.rs
+++ b/crates/aether-data/src/repository/usage/memory.rs
@@ -817,6 +817,23 @@ fn usage_matches_leaderboard_query(
     true
 }
 
+fn usage_matches_aggregation_provider_filter(
+    item: &StoredRequestUsageAudit,
+    query: &UsageAuditAggregationQuery,
+) -> bool {
+    if let Some(provider_id) = query.provider_id.as_deref() {
+        if item.provider_id.as_deref() != Some(provider_id) {
+            return false;
+        }
+    }
+    if let Some(provider_name) = query.provider_name.as_deref() {
+        if item.provider_name != provider_name {
+            return false;
+        }
+    }
+    true
+}
+
 fn sort_usage_items(items: &mut [StoredRequestUsageAudit], newest_first: bool) {
     items.sort_by(|left, right| {
         let created_order = if newest_first {
@@ -1205,6 +1222,7 @@ impl UsageReadRepository for InMemoryUsageReadRepository {
                 || matches!(item.status.as_str(), "pending" | "streaming")
                 || (query.exclude_reserved_provider_labels
                     && usage_provider_aggregation_identity(item).is_none())
+                || !usage_matches_aggregation_provider_filter(item, query)
             {
                 continue;
             }
@@ -3229,6 +3247,8 @@ mod tests {
                 created_from_unix_secs: 0,
                 created_until_unix_secs: 1_000,
                 group_by: UsageAuditAggregationGroupBy::Provider,
+                provider_id: None,
+                provider_name: None,
                 limit: 10,
                 exclude_reserved_provider_labels: false,
             })
@@ -3290,6 +3310,8 @@ mod tests {
                 created_from_unix_secs: 0,
                 created_until_unix_secs: 1_000,
                 group_by: UsageAuditAggregationGroupBy::Model,
+                provider_id: None,
+                provider_name: None,
                 limit: 10,
                 exclude_reserved_provider_labels: true,
             })
@@ -3304,6 +3326,8 @@ mod tests {
                 created_from_unix_secs: 0,
                 created_until_unix_secs: 1_000,
                 group_by: UsageAuditAggregationGroupBy::ApiFormat,
+                provider_id: None,
+                provider_name: None,
                 limit: 10,
                 exclude_reserved_provider_labels: true,
             })

--- a/crates/aether-data/src/repository/usage/memory.rs
+++ b/crates/aether-data/src/repository/usage/memory.rs
@@ -830,6 +830,16 @@ fn usage_matches_aggregation_provider_filter(
         if item.provider_name != provider_name {
             return false;
         }
+        if query.provider_id.is_none()
+            && item
+                .provider_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .is_some()
+        {
+            return false;
+        }
     }
     true
 }
@@ -1342,7 +1352,9 @@ impl UsageReadRepository for InMemoryUsageReadRepository {
                 .cmp(&left.request_count)
                 .then_with(|| left.group_key.cmp(&right.group_key))
         });
-        items.truncate(query.limit);
+        if query.limit > 0 {
+            items.truncate(query.limit);
+        }
         Ok(items)
     }
 

--- a/crates/aether-data/src/repository/usage/postgres/mod.rs
+++ b/crates/aether-data/src/repository/usage/postgres/mod.rs
@@ -6968,6 +6968,16 @@ ORDER BY request_count DESC, group_key ASC
             } else {
                 ""
             };
+        let provider_id_filter = query
+            .provider_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let provider_name_filter = query
+            .provider_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
         let sql = format!(
             r#"
 WITH filtered_usage AS (
@@ -7013,6 +7023,8 @@ WITH filtered_usage AS (
     AND "usage".status NOT IN ('pending', 'streaming')
     {provider_extra_where}
     {filtered_extra_where}
+    AND ($4::text IS NULL OR "usage".provider_id = $4)
+    AND ($5::text IS NULL OR "usage".provider_name = $5)
 ),
 normalized_usage AS (
   SELECT
@@ -7129,6 +7141,8 @@ LIMIT $3
                     query.limit
                 ))
             })?)
+            .bind(provider_id_filter)
+            .bind(provider_name_filter)
             .fetch(&self.pool);
 
         let mut items = Vec::new();
@@ -7172,6 +7186,8 @@ LIMIT $3
                     created_from_unix_secs: dashboard_utc_to_unix_secs(raw_start),
                     created_until_unix_secs: dashboard_utc_to_unix_secs(raw_end),
                     group_by: query.group_by,
+                    provider_id: query.provider_id.clone(),
+                    provider_name: query.provider_name.clone(),
                     limit: raw_merge_limit,
                     exclude_reserved_provider_labels: query.exclude_reserved_provider_labels,
                 })
@@ -7194,6 +7210,8 @@ LIMIT $3
                     created_from_unix_secs: dashboard_utc_to_unix_secs(raw_start),
                     created_until_unix_secs: dashboard_utc_to_unix_secs(raw_end),
                     group_by: query.group_by,
+                    provider_id: query.provider_id.clone(),
+                    provider_name: query.provider_name.clone(),
                     limit: raw_merge_limit,
                     exclude_reserved_provider_labels: query.exclude_reserved_provider_labels,
                 })

--- a/crates/aether-data/src/repository/usage/postgres/mod.rs
+++ b/crates/aether-data/src/repository/usage/postgres/mod.rs
@@ -521,7 +521,9 @@ fn finalize_usage_audit_aggregation_rows(
             .cmp(&left.request_count)
             .then_with(|| left.group_key.cmp(&right.group_key))
     });
-    items.truncate(limit);
+    if limit > 0 {
+        items.truncate(limit);
+    }
     items
 }
 
@@ -6978,6 +6980,9 @@ ORDER BY request_count DESC, group_key ASC
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty());
+        let provider_name_requires_legacy =
+            provider_id_filter.is_none() && provider_name_filter.is_some();
+        let limit_sql = if query.limit > 0 { "LIMIT $3" } else { "" };
         let sql = format!(
             r#"
 WITH filtered_usage AS (
@@ -7024,7 +7029,17 @@ WITH filtered_usage AS (
     {provider_extra_where}
     {filtered_extra_where}
     AND ($4::text IS NULL OR "usage".provider_id = $4)
-    AND ($5::text IS NULL OR "usage".provider_name = $5)
+    AND (
+      $5::text IS NULL
+      OR (
+        "usage".provider_name = $5
+        AND (
+          $6::boolean = FALSE
+          OR "usage".provider_id IS NULL
+          OR TRIM("usage".provider_id) = ''
+        )
+      )
+    )
 ),
 normalized_usage AS (
   SELECT
@@ -7115,7 +7130,7 @@ SELECT
   success_count
 FROM aggregated_usage
 ORDER BY request_count DESC, group_key ASC
-LIMIT $3
+{limit_sql}
 "#,
             provider_extra_where = provider_extra_where,
             filtered_extra_where = fragments.filtered_extra_where,
@@ -7130,19 +7145,26 @@ LIMIT $3
             aggregate_secondary_name_expr = fragments.aggregate_secondary_name_expr,
             avg_response_time_expr = fragments.avg_response_time_expr,
             success_count_expr = fragments.success_count_expr,
+            limit_sql = limit_sql,
         );
 
-        let mut rows = sqlx::query(&sql)
-            .bind(query.created_from_unix_secs as f64)
-            .bind(query.created_until_unix_secs as f64)
-            .bind(i64::try_from(query.limit).map_err(|_| {
+        let limit_bind = if query.limit > 0 {
+            i64::try_from(query.limit).map_err(|_| {
                 DataLayerError::InvalidInput(format!(
                     "invalid usage aggregation limit: {}",
                     query.limit
                 ))
-            })?)
+            })?
+        } else {
+            0
+        };
+        let mut rows = sqlx::query(&sql)
+            .bind(query.created_from_unix_secs as f64)
+            .bind(query.created_until_unix_secs as f64)
+            .bind(limit_bind)
             .bind(provider_id_filter)
             .bind(provider_name_filter)
+            .bind(provider_name_requires_legacy)
             .fetch(&self.pool);
 
         let mut items = Vec::new();
@@ -7179,7 +7201,11 @@ LIMIT $3
         };
 
         let mut grouped = BTreeMap::<String, StoredUsageAuditAggregation>::new();
-        let raw_merge_limit = query.limit.max(10_000);
+        let raw_merge_limit = if query.limit == 0 {
+            0
+        } else {
+            query.limit.max(10_000)
+        };
         if let Some((raw_start, raw_end)) = split.raw_leading {
             let raw = self
                 .aggregate_usage_audits_raw(&UsageAuditAggregationQuery {

--- a/crates/aether-data/src/repository/usage/sqlite.rs
+++ b/crates/aether-data/src/repository/usage/sqlite.rs
@@ -1536,6 +1536,18 @@ FROM "usage"
             push_sqlite_usage_where(&mut builder, &mut has_where);
             builder.push(SQLITE_PROVIDER_IDENTITY_IS_NOT_RESERVED);
         }
+        push_sqlite_usage_optional_text_filter(
+            &mut builder,
+            &mut has_where,
+            "provider_id",
+            query.provider_id.as_deref(),
+        );
+        push_sqlite_usage_optional_text_filter(
+            &mut builder,
+            &mut has_where,
+            "provider_name",
+            query.provider_name.as_deref(),
+        );
         if matches!(query.group_by, UsageAuditAggregationGroupBy::User) {
             push_sqlite_usage_where(&mut builder, &mut has_where);
             builder.push("user_id IS NOT NULL AND TRIM(user_id) <> ''");

--- a/crates/aether-data/src/repository/usage/sqlite.rs
+++ b/crates/aether-data/src/repository/usage/sqlite.rs
@@ -1466,7 +1466,7 @@ FROM "usage"
         &self,
         query: &UsageAuditAggregationQuery,
     ) -> Result<Vec<StoredUsageAuditAggregation>, DataLayerError> {
-        if query.created_from_unix_secs >= query.created_until_unix_secs || query.limit == 0 {
+        if query.created_from_unix_secs >= query.created_until_unix_secs {
             return Ok(Vec::new());
         }
 
@@ -1548,15 +1548,27 @@ FROM "usage"
             "provider_name",
             query.provider_name.as_deref(),
         );
+        if query.provider_id.is_none()
+            && query
+                .provider_name
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .is_some()
+        {
+            push_sqlite_usage_where(&mut builder, &mut has_where);
+            builder.push("(provider_id IS NULL OR TRIM(provider_id) = '')");
+        }
         if matches!(query.group_by, UsageAuditAggregationGroupBy::User) {
             push_sqlite_usage_where(&mut builder, &mut has_where);
             builder.push("user_id IS NOT NULL AND TRIM(user_id) <> ''");
         }
         builder
             .push(" GROUP BY group_key")
-            .push(" ORDER BY request_count DESC, group_key ASC")
-            .push(" LIMIT ")
-            .push_bind(query.limit as i64);
+            .push(" ORDER BY request_count DESC, group_key ASC");
+        if query.limit > 0 {
+            builder.push(" LIMIT ").push_bind(query.limit as i64);
+        }
 
         let rows = builder.build().fetch_all(&self.pool).await.map_sql_err()?;
         rows.iter()

--- a/frontend/src/api/__tests__/usage-contract.spec.ts
+++ b/frontend/src/api/__tests__/usage-contract.spec.ts
@@ -153,4 +153,38 @@ describe('usageApi contract alignment', () => {
       timeout: 120000,
     })
   })
+
+  it('loads provider attribution through the admin usage attribution endpoint', async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        provider: { id: 'provider-openai', name: null },
+        group_by: 'user',
+        metric: 'actual_cost',
+        total: 1.2,
+        items: [{ id: 'user-1', name: 'alice', actual_cost: 1.2, share: 1 }],
+        others: null,
+      },
+    })
+
+    const result = await usageApi.getUsageAttribution({
+      provider_id: 'provider-openai',
+      group_by: 'user',
+      metric: 'actual_cost',
+      preset: 'last30days',
+      limit: 8,
+    })
+
+    expect(getMock).toHaveBeenCalledWith('/api/admin/usage/attribution', {
+      params: {
+        provider_id: 'provider-openai',
+        group_by: 'user',
+        metric: 'actual_cost',
+        preset: 'last30days',
+        limit: 8,
+      },
+      timeout: 120000,
+    })
+    expect(result.total).toBe(1.2)
+    expect(result.items[0].name).toBe('alice')
+  })
 })

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -92,6 +92,34 @@ export interface UsageByProvider {
   cache_hit_rate?: number
 }
 
+export type UsageAttributionMetric = 'actual_cost' | 'total_cost' | 'tokens' | 'requests'
+export type UsageAttributionGroupBy = 'user' | 'api_key'
+
+export interface UsageAttributionItem {
+  id: string
+  user_id?: string
+  name: string
+  email?: string | null
+  username?: string | null
+  requests: number
+  total_tokens: number
+  total_cost: number
+  actual_cost: number
+  share: number
+}
+
+export interface UsageAttributionResponse {
+  provider: {
+    id?: string | null
+    name?: string | null
+  }
+  group_by: UsageAttributionGroupBy
+  metric: UsageAttributionMetric
+  total: number
+  items: UsageAttributionItem[]
+  others: UsageAttributionItem | null
+}
+
 export interface UsageByApiFormat {
   api_format: string
   request_count: number
@@ -432,6 +460,41 @@ export const usageApi = {
     options?: UsageRequestOptions
   ): Promise<UsageByProvider[]> {
     return this.getUsageAggregation<UsageByProvider[]>('provider', filters, options)
+  },
+
+  async getUsageAttribution(
+    params: Pick<UsageFilters, 'start_date' | 'end_date' | 'preset' | 'timezone' | 'tz_offset_minutes'> & {
+      provider_id?: string | null
+      provider_name?: string | null
+      group_by?: UsageAttributionGroupBy
+      metric?: UsageAttributionMetric
+      limit?: number
+    },
+    options?: UsageRequestOptions
+  ): Promise<UsageAttributionResponse> {
+    if (!params.provider_id && !params.provider_name) {
+      throw new Error('getUsageAttribution requires provider_id or provider_name')
+    }
+    const requestParams = compactParams({
+      ...params,
+      provider_id: params.provider_id,
+      provider_name: params.provider_name,
+      group_by: params.group_by ?? 'user',
+      metric: params.metric ?? 'actual_cost',
+      limit: params.limit ?? 10,
+    })
+    const cacheKey = `usage-attribution-${JSON.stringify(requestParams)}${options?.skipCache ? ':fresh' : ''}`
+    return cachedRequest(
+      cacheKey,
+      async () => {
+        const response = await apiClient.get<UsageAttributionResponse>('/api/admin/usage/attribution', {
+          params: requestParams,
+          timeout: USAGE_ANALYTICS_REQUEST_TIMEOUT_MS,
+        })
+        return response.data
+      },
+      options?.skipCache ? 0 : USAGE_ANALYTICS_CACHE_TTL_MS
+    )
   },
 
   async getUsageByApiFormat(

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -93,7 +93,7 @@ export interface UsageByProvider {
 }
 
 export type UsageAttributionMetric = 'actual_cost' | 'total_cost' | 'tokens' | 'requests'
-export type UsageAttributionGroupBy = 'user' | 'api_key'
+export type UsageAttributionGroupBy = 'user'
 
 export interface UsageAttributionItem {
   id: string
@@ -165,6 +165,49 @@ type UsageListResponse = {
   total?: unknown
   limit?: unknown
   offset?: unknown
+}
+
+type AdminUsageRecordsResponse = {
+  records: Array<Record<string, unknown>>
+  total: number
+  limit: number
+  offset: number
+}
+
+type ActiveUsageRequestsResponse = {
+  requests: Array<{
+    id: string
+    status: 'pending' | 'streaming' | 'completed' | 'failed' | 'cancelled'
+    input_tokens: number
+    effective_input_tokens?: number | null
+    output_tokens: number
+    cache_creation_input_tokens?: number | null
+    cache_creation_ephemeral_5m_input_tokens?: number | null
+    cache_creation_ephemeral_1h_input_tokens?: number | null
+    cache_read_input_tokens?: number | null
+    cost: number
+    actual_cost?: number | null
+    rate_multiplier?: number | null
+    response_time_ms: number | null
+    first_byte_time_ms: number | null
+    status_code?: number | null
+    error_message?: string | null
+    provider?: string | null
+    api_key_name?: string | null
+    provider_key_name?: string | null
+    api_format?: string | null
+    endpoint_api_format?: string | null
+    is_stream?: boolean | null
+    upstream_is_stream?: boolean | null
+    client_requested_stream?: boolean | null
+    client_is_stream?: boolean | null
+    has_format_conversion?: boolean | null
+    has_fallback?: boolean | null
+    target_model?: string | null
+    reasoning_effort?: string | null
+    service_tier?: string | null
+    image_progress?: ImageProgress | null
+  }>
 }
 
 function assertPositiveInteger(value: number, field: string): number {
@@ -538,15 +581,10 @@ export const usageApi = {
     hide_unknown?: boolean
     limit?: number
     offset?: number
-  }): Promise<{
-    records: Array<Record<string, unknown>>
-    total: number
-    limit: number
-    offset: number
-  }> {
+  }): Promise<AdminUsageRecordsResponse> {
     const key = buildCacheKey('usage:records', params as Record<string, unknown> | undefined)
-    return dedupedRequest(key, async () => {
-      const response = await apiClient.get('/api/admin/usage/records', { params })
+    return dedupedRequest<AdminUsageRecordsResponse>(key, async () => {
+      const response = await apiClient.get<AdminUsageRecordsResponse>('/api/admin/usage/records', { params })
       return response.data
     })
   },
@@ -558,41 +596,7 @@ export const usageApi = {
   async getActiveRequests(
     ids?: string[],
     timeRange?: Pick<UsageFilters, 'start_date' | 'end_date' | 'preset' | 'timezone' | 'tz_offset_minutes'>
-  ): Promise<{
-    requests: Array<{
-      id: string
-      status: 'pending' | 'streaming' | 'completed' | 'failed' | 'cancelled'
-      input_tokens: number
-      effective_input_tokens?: number | null
-      output_tokens: number
-      cache_creation_input_tokens?: number | null
-      cache_creation_ephemeral_5m_input_tokens?: number | null
-      cache_creation_ephemeral_1h_input_tokens?: number | null
-      cache_read_input_tokens?: number | null
-      cost: number
-      actual_cost?: number | null
-      rate_multiplier?: number | null
-      response_time_ms: number | null
-      first_byte_time_ms: number | null
-      status_code?: number | null
-      error_message?: string | null
-      provider?: string | null
-      api_key_name?: string | null
-      provider_key_name?: string | null
-      api_format?: string | null
-      endpoint_api_format?: string | null
-      is_stream?: boolean | null
-      upstream_is_stream?: boolean | null
-      client_requested_stream?: boolean | null
-      client_is_stream?: boolean | null
-      has_format_conversion?: boolean | null
-      has_fallback?: boolean | null
-      target_model?: string | null
-      reasoning_effort?: string | null
-      service_tier?: string | null
-      image_progress?: ImageProgress | null
-    }>
-  }> {
+  ): Promise<ActiveUsageRequestsResponse> {
     const params: Record<string, string | number> = {}
     if (ids?.length) {
       params.ids = ids.join(',')
@@ -612,7 +616,7 @@ export const usageApi = {
     if (typeof timeRange?.tz_offset_minutes === 'number') {
       params.tz_offset_minutes = timeRange.tz_offset_minutes
     }
-    const response = await apiClient.get('/api/admin/usage/active', { params })
+    const response = await apiClient.get<ActiveUsageRequestsResponse>('/api/admin/usage/active', { params })
     return response.data
   },
 

--- a/frontend/src/views/admin/CostAnalysis.vue
+++ b/frontend/src/views/admin/CostAnalysis.vue
@@ -93,10 +93,106 @@
       </template>
     </LeaderboardTable>
 
-    <UsageProviderTable
-      :data="providerStats"
-      :is-admin="true"
-    />
+    <div class="grid grid-cols-1 xl:grid-cols-2 gap-4">
+      <UsageProviderTable
+        :data="providerStats"
+        :is-admin="true"
+      />
+
+      <Card class="p-4 space-y-4">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 class="text-sm font-medium">
+              提供商成本归因
+            </h3>
+            <p class="text-xs text-muted-foreground">
+              查看选定提供商在当前时间范围内的用户贡献占比
+            </p>
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <select
+              v-model="selectedProviderKey"
+              class="h-8 rounded-md border border-input bg-background px-2 text-xs"
+            >
+              <option
+                v-for="provider in providerStats"
+                :key="provider.providerKey ?? provider.providerId ?? provider.provider"
+                :value="provider.providerKey ?? provider.providerId ?? provider.provider"
+              >
+                {{ provider.provider }}
+              </option>
+            </select>
+            <select
+              v-model="attributionMetric"
+              class="h-8 rounded-md border border-input bg-background px-2 text-xs"
+            >
+              <option value="actual_cost">实际成本</option>
+              <option value="total_cost">展示成本</option>
+              <option value="tokens">Tokens</option>
+              <option value="requests">请求数</option>
+            </select>
+          </div>
+        </div>
+
+        <div
+          v-if="providerAttributionLoading"
+          class="py-8 text-center text-xs text-muted-foreground"
+        >
+          正在加载归因数据...
+        </div>
+        <div
+          v-else-if="!selectedProvider"
+          class="py-8 text-center text-xs text-muted-foreground"
+        >
+          暂无可归因的提供商数据
+        </div>
+        <div
+          v-else-if="providerAttributionItems.length === 0"
+          class="py-8 text-center text-xs text-muted-foreground"
+        >
+          当前时间范围内暂无用户贡献数据
+        </div>
+        <div
+          v-else
+          class="space-y-3"
+        >
+          <div class="rounded-lg border p-3">
+            <div class="flex items-center justify-between text-xs text-muted-foreground">
+              <span>{{ selectedProvider.provider }}</span>
+              <span>{{ attributionMetricLabel }}</span>
+            </div>
+            <div class="mt-1 text-lg font-semibold">
+              {{ formatAttributionMetric(providerAttribution?.total ?? 0) }}
+            </div>
+          </div>
+
+          <div class="space-y-2">
+            <div
+              v-for="item in providerAttributionDisplayItems"
+              :key="item.id"
+              class="space-y-1"
+            >
+              <div class="flex items-center justify-between gap-3 text-xs">
+                <span class="truncate font-medium">{{ item.name }}</span>
+                <span class="text-muted-foreground">{{ formatShare(item.share) }}</span>
+              </div>
+              <div class="h-2 overflow-hidden rounded-full bg-muted">
+                <div
+                  class="h-full rounded-full bg-primary"
+                  :style="{ width: `${Math.min(item.share * 100, 100)}%` }"
+                />
+              </div>
+              <div class="flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+                <span>请求 {{ item.requests }}</span>
+                <span>Tokens {{ formatTokens(item.total_tokens) }}</span>
+                <span>展示 {{ formatCurrency(item.total_cost) }}</span>
+                <span>实际 {{ formatCurrency(item.actual_cost) }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Card>
+    </div>
   </div>
 </template>
 
@@ -108,7 +204,7 @@ import { TimeRangePicker } from '@/components/common'
 import { CostForecastChart, LeaderboardControls, LeaderboardTable, QuotaProgressCard } from '@/components/stats'
 import { UsageProviderTable } from '@/features/usage/components'
 import { adminApi, type CostForecastResponse, type CostSavingsResponse, type LeaderboardItem, type QuotaUsageProvider } from '@/api/admin'
-import { usageApi } from '@/api/usage'
+import { usageApi, type UsageAttributionItem, type UsageAttributionMetric, type UsageAttributionResponse } from '@/api/usage'
 import { formatCurrency, formatTokens } from '@/utils/format'
 import { getDateRangeFromPeriod } from '@/features/usage/composables'
 import { normalizeUsageProviderStats } from '@/features/usage/utils/providerStats'
@@ -121,6 +217,9 @@ const forecast = ref<CostForecastResponse | null>(null)
 const costSavings = ref<CostSavingsResponse | null>(null)
 const quotaProviders = ref<QuotaUsageProvider[]>([])
 const providerStats = ref<ProviderStatsItem[]>([])
+const selectedProviderKey = ref('')
+const providerAttribution = ref<UsageAttributionResponse | null>(null)
+const attributionMetric = ref<UsageAttributionMetric>('actual_cost')
 const apiKeyLeaderboard = ref<LeaderboardItem[]>([])
 const apiKeyLeaderboardMetric = ref<'requests' | 'tokens' | 'cost'>('cost')
 const apiKeyLeaderboardTimeRange = ref<DateRangeParams>(getDateRangeFromPeriod('last30days'))
@@ -131,19 +230,41 @@ const apiKeyLeaderboardPageSizeOptions = [10, 20, 50, 100]
 
 const forecastLoading = ref(false)
 const quotaLoading = ref(false)
+const providerAttributionLoading = ref(false)
 const apiKeyLeaderboardLoading = ref(false)
 let forecastRequestId = 0
 let savingsRequestId = 0
 let quotaRequestId = 0
 let providerStatsRequestId = 0
+let providerAttributionRequestId = 0
 let apiKeyLeaderboardRequestId = 0
 let loadAllPromise: Promise<void> | null = null
 let hasPendingLoadAll = false
 let loadAllDebounceTimer: ReturnType<typeof setTimeout> | null = null
+let providerAttributionDebounceTimer: ReturnType<typeof setTimeout> | null = null
 let apiKeyLeaderboardDebounceTimer: ReturnType<typeof setTimeout> | null = null
 
 const forecastHistory = computed(() => forecast.value?.history || [])
 const forecastFuture = computed(() => forecast.value?.forecast || [])
+const selectedProvider = computed(() => providerStats.value.find(provider => providerSelectionKey(provider) === selectedProviderKey.value))
+const providerAttributionItems = computed(() => providerAttribution.value?.items ?? [])
+const providerAttributionDisplayItems = computed<UsageAttributionItem[]>(() => {
+  const items = [...providerAttributionItems.value]
+  const others = providerAttribution.value?.others
+  if (others && others.requests > 0) {
+    items.push({ ...others, id: 'others', name: others.name || 'Others' })
+  }
+  return items
+})
+const attributionMetricLabel = computed(() => {
+  switch (attributionMetric.value) {
+    case 'actual_cost': return '实际成本'
+    case 'total_cost': return '展示成本'
+    case 'tokens': return 'Tokens'
+    case 'requests': return '请求数'
+    default: return '指标'
+  }
+})
 
 function buildTimeRangeParams() {
   return {
@@ -153,6 +274,24 @@ function buildTimeRangeParams() {
     timezone: timeRange.value.timezone,
     tz_offset_minutes: timeRange.value.tz_offset_minutes
   }
+}
+
+function providerSelectionKey(provider: ProviderStatsItem) {
+  return provider.providerKey ?? provider.providerId ?? provider.provider
+}
+
+function formatShare(share: number) {
+  return `${(share * 100).toFixed(1)}%`
+}
+
+function formatAttributionMetric(value: number) {
+  if (attributionMetric.value === 'actual_cost' || attributionMetric.value === 'total_cost') {
+    return formatCurrency(value)
+  }
+  if (attributionMetric.value === 'tokens') {
+    return formatTokens(value)
+  }
+  return Math.round(value).toLocaleString('zh-CN')
 }
 
 async function loadForecast() {
@@ -198,6 +337,36 @@ async function loadProviderStats() {
   })
   if (requestId !== providerStatsRequestId) return
   providerStats.value = normalizeUsageProviderStats(stats)
+  if (!providerStats.value.some(provider => providerSelectionKey(provider) === selectedProviderKey.value)) {
+    selectedProviderKey.value = providerStats.value[0] ? providerSelectionKey(providerStats.value[0]) : ''
+  }
+  scheduleProviderAttributionLoad()
+}
+
+async function loadProviderAttribution() {
+  const provider = selectedProvider.value
+  if (!provider) {
+    providerAttribution.value = null
+    return
+  }
+  const requestId = ++providerAttributionRequestId
+  providerAttributionLoading.value = true
+  try {
+    const response = await usageApi.getUsageAttribution({
+      ...buildTimeRangeParams(),
+      provider_id: provider.providerId && provider.providerIdentitySource !== 'legacy_name' ? provider.providerId : undefined,
+      provider_name: provider.providerIdentitySource === 'legacy_name' || !provider.providerId ? provider.provider : undefined,
+      group_by: 'user',
+      metric: attributionMetric.value,
+      limit: 8,
+    })
+    if (requestId !== providerAttributionRequestId) return
+    providerAttribution.value = response
+  } finally {
+    if (requestId === providerAttributionRequestId) {
+      providerAttributionLoading.value = false
+    }
+  }
 }
 
 async function loadApiKeyLeaderboard() {
@@ -247,6 +416,7 @@ async function loadAll() {
     loadSavings(),
     loadQuotaUsage(),
     loadProviderStats(),
+    loadProviderAttribution(),
     loadApiKeyLeaderboard()
   ])
     .then(() => undefined)
@@ -280,6 +450,16 @@ function scheduleApiKeyLeaderboardLoad() {
   }, 120)
 }
 
+function scheduleProviderAttributionLoad() {
+  if (providerAttributionDebounceTimer) {
+    clearTimeout(providerAttributionDebounceTimer)
+  }
+  providerAttributionDebounceTimer = setTimeout(() => {
+    providerAttributionDebounceTimer = null
+    void loadProviderAttribution()
+  }, 120)
+}
+
 function resetApiKeyLeaderboardPage() {
   if (apiKeyLeaderboardPage.value === 1) {
     return
@@ -290,7 +470,9 @@ function resetApiKeyLeaderboardPage() {
 watch(timeRange, () => {
   resetApiKeyLeaderboardPage()
   scheduleLoadAll()
+  scheduleProviderAttributionLoad()
 }, { deep: true })
+watch([selectedProviderKey, attributionMetric], scheduleProviderAttributionLoad)
 watch(apiKeyLeaderboardMetric, () => {
   resetApiKeyLeaderboardPage()
   scheduleApiKeyLeaderboardLoad()
@@ -314,12 +496,17 @@ onUnmounted(() => {
     clearTimeout(apiKeyLeaderboardDebounceTimer)
     apiKeyLeaderboardDebounceTimer = null
   }
+  if (providerAttributionDebounceTimer) {
+    clearTimeout(providerAttributionDebounceTimer)
+    providerAttributionDebounceTimer = null
+  }
   hasPendingLoadAll = false
   loadAllPromise = null
   forecastRequestId += 1
   savingsRequestId += 1
   quotaRequestId += 1
   providerStatsRequestId += 1
+  providerAttributionRequestId += 1
   apiKeyLeaderboardRequestId += 1
 })
 </script>

--- a/frontend/src/views/admin/CostAnalysis.vue
+++ b/frontend/src/views/admin/CostAnalysis.vue
@@ -147,7 +147,7 @@
           暂无可归因的提供商数据
         </div>
         <div
-          v-else-if="providerAttributionItems.length === 0"
+          v-else-if="providerAttributionVisibleItems.length === 0"
           class="py-8 text-center text-xs text-muted-foreground"
         >
           当前时间范围内暂无用户贡献数据
@@ -178,7 +178,7 @@
             </div>
             <div class="space-y-2">
               <div
-                v-for="(item, index) in providerAttributionDisplayItems"
+                v-for="(item, index) in providerAttributionVisibleItems"
                 :key="item.id"
                 class="flex items-center justify-between gap-3 rounded-md border bg-muted/20 px-3 py-2 text-xs"
               >
@@ -206,7 +206,7 @@
             class="space-y-2"
           >
             <div
-              v-for="item in providerAttributionDisplayItems"
+              v-for="item in providerAttributionVisibleItems"
               :key="item.id"
               class="space-y-1"
             >
@@ -267,7 +267,7 @@ const apiKeyLeaderboardPage = ref(1)
 const apiKeyLeaderboardPageSize = ref(10)
 const apiKeyLeaderboardTotal = ref(0)
 const apiKeyLeaderboardPageSizeOptions = [10, 20, 50, 100]
-const ATTRIBUTION_DONUT_THRESHOLD = 6
+const ATTRIBUTION_DONUT_THRESHOLD = 8
 const ATTRIBUTION_DONUT_COLORS = [
   'rgba(59, 130, 246, 0.82)',
   'rgba(239, 68, 68, 0.82)',
@@ -308,15 +308,18 @@ const providerAttributionDisplayItems = computed<UsageAttributionItem[]>(() => {
   }
   return items
 })
+const providerAttributionVisibleItems = computed<UsageAttributionItem[]>(() =>
+  providerAttributionDisplayItems.value.filter(item => attributionMetricValue(item) > 0)
+)
 const showAttributionDonut = computed(() => {
-  const items = providerAttributionDisplayItems.value
-  return items.length > 0 && items.length <= ATTRIBUTION_DONUT_THRESHOLD
+  const items = providerAttributionVisibleItems.value
+  return items.length > 0 && items.length < ATTRIBUTION_DONUT_THRESHOLD
 })
 const providerAttributionDonutData = computed<ChartData<'doughnut'>>(() => ({
-  labels: providerAttributionDisplayItems.value.map(item => item.name),
+  labels: providerAttributionVisibleItems.value.map(item => item.name),
   datasets: [{
-    data: providerAttributionDisplayItems.value.map(item => attributionMetricValue(item)),
-    backgroundColor: providerAttributionDisplayItems.value.map((_, index) => ATTRIBUTION_DONUT_COLORS[index % ATTRIBUTION_DONUT_COLORS.length]),
+    data: providerAttributionVisibleItems.value.map(item => attributionMetricValue(item)),
+    backgroundColor: providerAttributionVisibleItems.value.map((_, index) => ATTRIBUTION_DONUT_COLORS[index % ATTRIBUTION_DONUT_COLORS.length]),
     borderWidth: 2,
     borderColor: 'rgba(255, 255, 255, 0.12)'
   }]
@@ -457,7 +460,7 @@ async function loadProviderAttribution() {
       provider_name: provider.providerIdentitySource === 'legacy_name' || !provider.providerId ? provider.provider : undefined,
       group_by: 'user',
       metric: attributionMetric.value,
-      limit: 8,
+      limit: ATTRIBUTION_DONUT_THRESHOLD,
     })
     if (requestId !== providerAttributionRequestId) return
     providerAttribution.value = response

--- a/frontend/src/views/admin/CostAnalysis.vue
+++ b/frontend/src/views/admin/CostAnalysis.vue
@@ -166,7 +166,45 @@
             </div>
           </div>
 
-          <div class="space-y-2">
+          <div
+            v-if="showAttributionDonut"
+            class="grid gap-4 lg:grid-cols-[minmax(0,220px)_1fr] lg:items-center"
+          >
+            <div class="h-[220px] min-w-0">
+              <DoughnutChart
+                :data="providerAttributionDonutData"
+                :options="providerAttributionDonutOptions"
+              />
+            </div>
+            <div class="space-y-2">
+              <div
+                v-for="(item, index) in providerAttributionDisplayItems"
+                :key="item.id"
+                class="flex items-center justify-between gap-3 rounded-md border bg-muted/20 px-3 py-2 text-xs"
+              >
+                <div class="flex min-w-0 items-center gap-2">
+                  <span
+                    class="h-2.5 w-2.5 shrink-0 rounded-full"
+                    :style="{ backgroundColor: ATTRIBUTION_DONUT_COLORS[index % ATTRIBUTION_DONUT_COLORS.length] }"
+                  />
+                  <span class="truncate font-medium">{{ item.name }}</span>
+                </div>
+                <div class="shrink-0 text-right">
+                  <div class="font-medium">
+                    {{ formatAttributionMetricValue(item) }}
+                  </div>
+                  <div class="text-[11px] text-muted-foreground">
+                    {{ formatShare(item.share) }}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-else
+            class="space-y-2"
+          >
             <div
               v-for="item in providerAttributionDisplayItems"
               :key="item.id"
@@ -198,9 +236,11 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import type { ChartData, ChartOptions } from 'chart.js'
 import Card from '@/components/ui/card.vue'
 import { Pagination } from '@/components/ui'
 import { TimeRangePicker } from '@/components/common'
+import DoughnutChart from '@/components/charts/DoughnutChart.vue'
 import { CostForecastChart, LeaderboardControls, LeaderboardTable, QuotaProgressCard } from '@/components/stats'
 import { UsageProviderTable } from '@/features/usage/components'
 import { adminApi, type CostForecastResponse, type CostSavingsResponse, type LeaderboardItem, type QuotaUsageProvider } from '@/api/admin'
@@ -227,6 +267,18 @@ const apiKeyLeaderboardPage = ref(1)
 const apiKeyLeaderboardPageSize = ref(10)
 const apiKeyLeaderboardTotal = ref(0)
 const apiKeyLeaderboardPageSizeOptions = [10, 20, 50, 100]
+const ATTRIBUTION_DONUT_THRESHOLD = 6
+const ATTRIBUTION_DONUT_COLORS = [
+  'rgba(59, 130, 246, 0.82)',
+  'rgba(239, 68, 68, 0.82)',
+  'rgba(16, 185, 129, 0.82)',
+  'rgba(245, 158, 11, 0.82)',
+  'rgba(139, 92, 246, 0.82)',
+  'rgba(6, 182, 212, 0.82)',
+  'rgba(132, 204, 22, 0.82)',
+  'rgba(249, 115, 22, 0.82)',
+  'rgba(148, 163, 184, 0.82)'
+]
 
 const forecastLoading = ref(false)
 const quotaLoading = ref(false)
@@ -256,6 +308,39 @@ const providerAttributionDisplayItems = computed<UsageAttributionItem[]>(() => {
   }
   return items
 })
+const showAttributionDonut = computed(() => {
+  const items = providerAttributionDisplayItems.value
+  return items.length > 0 && items.length <= ATTRIBUTION_DONUT_THRESHOLD
+})
+const providerAttributionDonutData = computed<ChartData<'doughnut'>>(() => ({
+  labels: providerAttributionDisplayItems.value.map(item => item.name),
+  datasets: [{
+    data: providerAttributionDisplayItems.value.map(item => attributionMetricValue(item)),
+    backgroundColor: providerAttributionDisplayItems.value.map((_, index) => ATTRIBUTION_DONUT_COLORS[index % ATTRIBUTION_DONUT_COLORS.length]),
+    borderWidth: 2,
+    borderColor: 'rgba(255, 255, 255, 0.12)'
+  }]
+}))
+const providerAttributionDonutOptions = computed<ChartOptions<'doughnut'>>(() => ({
+  responsive: true,
+  maintainAspectRatio: false,
+  cutout: '64%',
+  plugins: {
+    legend: {
+      display: false
+    },
+    tooltip: {
+      callbacks: {
+        label: (context) => {
+          const value = typeof context.raw === 'number' ? context.raw : 0
+          const total = (context.dataset.data as number[]).reduce((sum, current) => sum + current, 0)
+          const percentage = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0'
+          return `${context.label}: ${formatAttributionMetric(value)} (${percentage}%)`
+        }
+      }
+    }
+  }
+}))
 const attributionMetricLabel = computed(() => {
   switch (attributionMetric.value) {
     case 'actual_cost': return '实际成本'
@@ -292,6 +377,20 @@ function formatAttributionMetric(value: number) {
     return formatTokens(value)
   }
   return Math.round(value).toLocaleString('zh-CN')
+}
+
+function attributionMetricValue(item: UsageAttributionItem) {
+  switch (attributionMetric.value) {
+    case 'actual_cost': return item.actual_cost
+    case 'total_cost': return item.total_cost
+    case 'tokens': return item.total_tokens
+    case 'requests': return item.requests
+    default: return 0
+  }
+}
+
+function formatAttributionMetricValue(item: UsageAttributionItem) {
+  return formatAttributionMetric(attributionMetricValue(item))
 }
 
 async function loadForecast() {


### PR DESCRIPTION
## Summary
- add provider_id/provider_name filters to usage aggregation repositories
- add GET /api/admin/usage/attribution with provider-scoped user attribution, selected metric sorting, share calculation, and Others bucket
- add Cost Analysis provider attribution UI and frontend API contract coverage
- fix review-blocking edge cases for legacy provider-name attribution and unbounded internal attribution totals before visible-limit sorting

Closes #637

## Verification
- cargo fmt --all -- --check
- BINDGEN_EXTRA_CLANG_ARGS=-isystem/usr/lib/gcc/x86_64-linux-gnu/13/include cargo test -p aether-gateway usage_attribution
- npm run test:run -- src/api/__tests__/usage-contract.spec.ts
- npm run type-check

Note: local Rust tests require BINDGEN_EXTRA_CLANG_ARGS because this environment lacks clang and bindgen otherwise cannot find stddef.h. npm ci reported existing dependency advisories (1 moderate, 2 critical) unrelated to this change.