### PR TITLE
Fix usage heatmap render and OAuth module gate

### DIFF
--- a/apps/aether-gateway/src/oauth/identity_repo.rs
+++ b/apps/aether-gateway/src/oauth/identity_repo.rs
@@ -1,4 +1,7 @@
-use crate::handlers::shared::decrypt_catalog_secret_with_fallbacks;
+use crate::handlers::shared::{
+    decrypt_catalog_secret_with_fallbacks, module_available_from_env,
+    system_config_bool as system_config_bool_with_default,
+};
 use crate::{AppState, GatewayError};
 use aether_data::repository::oauth_providers::StoredOAuthProviderConfig;
 use aether_data::repository::users::{StoredUserAuthRecord, StoredUserOAuthLinkSummary};
@@ -71,6 +74,10 @@ impl IdentityOAuthAccountError {
 pub(crate) async fn list_enabled_identity_oauth_providers(
     state: &AppState,
 ) -> Result<Vec<IdentityOAuthProviderSummary>, GatewayError> {
+    if !identity_oauth_module_enabled(state).await? {
+        return Ok(Vec::new());
+    }
+
     let mut providers = state
         .list_oauth_provider_configs()
         .await?
@@ -90,6 +97,13 @@ pub(crate) async fn get_enabled_identity_oauth_provider_config(
     state: &AppState,
     provider_type: &str,
 ) -> Result<Option<IdentityOAuthProviderConfig>, IdentityOAuthAccountError> {
+    if !identity_oauth_module_enabled(state)
+        .await
+        .map_err(|err| IdentityOAuthAccountError::Storage(format!("{err:?}")))?
+    {
+        return Ok(None);
+    }
+
     let provider_type = provider_type.trim().to_ascii_lowercase();
     let config = state
         .get_oauth_provider_config(&provider_type)
@@ -99,6 +113,17 @@ pub(crate) async fn get_enabled_identity_oauth_provider_config(
         return Ok(None);
     };
     stored_provider_config_to_identity_config(state, config).map(Some)
+}
+
+async fn identity_oauth_module_enabled(state: &AppState) -> Result<bool, GatewayError> {
+    if !module_available_from_env("OAUTH_AVAILABLE", true) {
+        return Ok(false);
+    }
+
+    let enabled = state
+        .read_system_config_json_value("module.oauth.enabled")
+        .await?;
+    Ok(system_config_bool_with_default(enabled.as_ref(), false))
 }
 
 pub(crate) async fn list_identity_oauth_links(

--- a/apps/aether-gateway/src/tests/frontdoor/oauth.rs
+++ b/apps/aether-gateway/src/tests/frontdoor/oauth.rs
@@ -1,6 +1,32 @@
 use crate::tests::{
-    any, build_router, start_server, Arc, Body, Mutex, Request, Router, StatusCode,
+    any, build_router, build_router_with_state, start_server, AppState, Arc, Body, Mutex, Request,
+    Router, StatusCode,
 };
+use aether_data::repository::oauth_providers::{
+    InMemoryOAuthProviderRepository, StoredOAuthProviderConfig,
+};
+
+fn sample_identity_oauth_provider(provider_type: &str) -> StoredOAuthProviderConfig {
+    StoredOAuthProviderConfig::new(
+        provider_type.to_string(),
+        "Linux DO".to_string(),
+        "client-id".to_string(),
+        "https://backend.example.com/oauth/callback".to_string(),
+        "https://frontend.example.com/auth/callback".to_string(),
+    )
+    .expect("oauth provider config should build")
+    .with_config_fields(
+        None,
+        Some("https://connect.linux.do/oauth2/authorize".to_string()),
+        Some("https://connect.linux.do/oauth2/token".to_string()),
+        Some("https://connect.linux.do/api/user".to_string()),
+        Some(vec!["openid".to_string()]),
+        Some(serde_json::json!({"email": "email"})),
+        None,
+        None,
+        true,
+    )
+}
 
 #[tokio::test]
 async fn gateway_serves_oauth_public_providers_locally_without_hitting_upstream() {
@@ -65,6 +91,152 @@ async fn gateway_accepts_oauth_authorize_device_id_header_without_hitting_upstre
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let payload: serde_json::Value = response.json().await.expect("json body should parse");
     assert_eq!(payload["detail"], "OAuth Provider 不存在或已禁用");
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_blocks_configured_oauth_provider_when_oauth_module_disabled() {
+    let upstream_hits = Arc::new(Mutex::new(0usize));
+    let upstream_hits_clone = Arc::clone(&upstream_hits);
+    let upstream = Router::new().route(
+        "/{*path}",
+        any(move |_request: Request| {
+            let upstream_hits_inner = Arc::clone(&upstream_hits_clone);
+            async move {
+                *upstream_hits_inner.lock().expect("mutex should lock") += 1;
+                (StatusCode::OK, Body::from("proxied"))
+            }
+        }),
+    );
+
+    let repository = Arc::new(InMemoryOAuthProviderRepository::seed(vec![
+        sample_identity_oauth_provider("linuxdo"),
+    ]));
+    let data_state =
+        crate::data::GatewayDataState::with_oauth_provider_repository_for_tests(repository)
+            .with_system_config_values_for_tests(vec![(
+                "module.oauth.enabled".to_string(),
+                serde_json::json!(false),
+            )]);
+
+    let (upstream_url, upstream_handle) = start_server(upstream).await;
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(data_state),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let providers_response = reqwest::Client::new()
+        .get(format!("{gateway_url}/api/oauth/providers"))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(providers_response.status(), StatusCode::OK);
+    let providers_payload: serde_json::Value = providers_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(
+        providers_payload["providers"].as_array().map(Vec::len),
+        Some(0)
+    );
+
+    let authorize_response = reqwest::Client::new()
+        .get(format!("{gateway_url}/api/oauth/linuxdo/authorize"))
+        .header("x-client-device-id", "device-123")
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(authorize_response.status(), StatusCode::NOT_FOUND);
+    let authorize_payload: serde_json::Value = authorize_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(authorize_payload["detail"], "OAuth Provider 不存在或已禁用");
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_serves_configured_oauth_provider_when_oauth_module_enabled() {
+    let upstream_hits = Arc::new(Mutex::new(0usize));
+    let upstream_hits_clone = Arc::clone(&upstream_hits);
+    let upstream = Router::new().route(
+        "/{*path}",
+        any(move |_request: Request| {
+            let upstream_hits_inner = Arc::clone(&upstream_hits_clone);
+            async move {
+                *upstream_hits_inner.lock().expect("mutex should lock") += 1;
+                (StatusCode::OK, Body::from("proxied"))
+            }
+        }),
+    );
+
+    let repository = Arc::new(InMemoryOAuthProviderRepository::seed(vec![
+        sample_identity_oauth_provider("linuxdo"),
+    ]));
+    let data_state =
+        crate::data::GatewayDataState::with_oauth_provider_repository_for_tests(repository)
+            .with_system_config_values_for_tests(vec![(
+                "module.oauth.enabled".to_string(),
+                serde_json::json!(true),
+            )]);
+
+    let (upstream_url, upstream_handle) = start_server(upstream).await;
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(data_state),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let providers_response = reqwest::Client::new()
+        .get(format!("{gateway_url}/api/oauth/providers"))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(providers_response.status(), StatusCode::OK);
+    let providers_payload: serde_json::Value = providers_response
+        .json()
+        .await
+        .expect("json body should parse");
+    assert_eq!(
+        providers_payload["providers"],
+        serde_json::json!([{
+            "provider_type": "linuxdo",
+            "display_name": "Linux DO"
+        }])
+    );
+
+    let authorize_client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("client should build");
+    let authorize_response = authorize_client
+        .get(format!("{gateway_url}/api/oauth/linuxdo/authorize"))
+        .header("x-client-device-id", "device-123")
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(authorize_response.status(), StatusCode::FOUND);
+    let location = authorize_response
+        .headers()
+        .get(http::header::LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .expect("location should exist");
+    assert!(location.starts_with("https://connect.linux.do/oauth2/authorize?"));
+    assert!(location.contains("client_id=client-id"));
+    assert!(location.contains("redirect_uri=https%3A%2F%2Fbackend.example.com%2Foauth%2Fcallback"));
     assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
 
     gateway_handle.abort();

--- a/frontend/src/components/stats/ActivityHeatmap.vue
+++ b/frontend/src/components/stats/ActivityHeatmap.vue
@@ -410,17 +410,10 @@ function buildTooltip(day: ActivityHeatmapDay): string {
   return parts.join(' · ')
 }
 
-// 生成完全随机的动画延迟，每个格子独立随机弹出
-const cellDelayMap = new Map<string, number>()
-
 function getCellAnimationDelay(weekIndex: number, dayIndex: number) {
-  const key = `${weekIndex}-${dayIndex}`
-  if (!cellDelayMap.has(key)) {
-    // 完全随机延迟，范围 0-800ms
-    cellDelayMap.set(key, Math.random() * 800)
-  }
+  const delay = Math.min(120, weekIndex * 2 + dayIndex * 4)
   return {
-    animationDelay: `${cellDelayMap.get(key)}ms`
+    animationDelay: `${delay}ms`
   }
 }
 </script>
@@ -428,7 +421,7 @@ function getCellAnimationDelay(weekIndex: number, dayIndex: number) {
 <style scoped>
 .cell-emerge {
   opacity: 0;
-  animation: cellEmerge 0.35s ease-out forwards;
+  animation: cellEmerge 0.18s ease-out forwards;
 }
 
 @keyframes cellEmerge {

--- a/frontend/src/views/shared/Usage.vue
+++ b/frontend/src/views/shared/Usage.vue
@@ -799,7 +799,11 @@ onMounted(async () => {
   document.addEventListener('visibilitychange', handleVisibilityChange)
 
   if (isAdminPage.value) {
-    // 管理员页面优先加载记录，统计面板在后台顺序刷新，避免瞬时并发打满后端。
+    // 管理员页面优先启动热力图加载，避免被统计聚合链路阻塞。
+    const heatmapPromise = loadHeatmapData().catch(err => {
+      log.error('加载热力图数据失败:', err)
+    })
+
     await loadRecords(
       { page: currentPage.value, pageSize: pageSize.value },
       getCurrentFilters(),
@@ -807,7 +811,7 @@ onMounted(async () => {
     )
     void (async () => {
       await refreshAdminAnalytics({ force: true, preserveOnFailure: false })
-      await loadHeatmapData()
+      await heatmapPromise
       await loadAdminUsers()
     })()
   } else {


### PR DESCRIPTION
## Summary
- speed up the admin usage activity heatmap by loading it earlier and shortening cell animation delays
- enforce the OAuth module enabled state at the server-side identity OAuth provider lookup boundary
- add frontdoor coverage for OAuth module disabled/enabled behavior

## Verification
- npm run type-check
- npm run test:run -- src/features/usage/composables/__tests__/useUsageData.spec.ts src/features/usage/components/__tests__/UsageRecordsTable.spec.ts
- npm run build
- cargo fmt --package aether-gateway -- --check
- git diff --check
