### PR TITLE
fix(usage): align cleanup loop break conditions with candidate row count

### DIFF
--- a/crates/aether-data/src/repository/usage/postgres/cleanup.rs
+++ b/crates/aether-data/src/repository/usage/postgres/cleanup.rs
@@ -683,7 +683,7 @@ async fn cleanup_usage_raw_body_fields(
             .rows_affected();
         let cleaned = usize::try_from(cleaned).unwrap_or(usize::MAX);
         total_cleaned += cleaned;
-        if cleaned == 0 || cleaned < batch_size {
+        if rows.len() < batch_size {
             break;
         }
     }
@@ -736,7 +736,7 @@ async fn cleanup_usage_compressed_body_fields(
             .map_err(postgres_error)?;
         let cleaned = usize::try_from(cleaned).unwrap_or(usize::MAX);
         total_cleaned += cleaned;
-        if cleaned == 0 || cleaned < batch_size {
+        if rows.len() < batch_size {
             break;
         }
     }
@@ -1143,7 +1143,7 @@ async fn cleanup_usage_header_fields(
             .map_err(postgres_error)?;
         let cleaned = usize::try_from(cleaned).unwrap_or(usize::MAX);
         total_cleaned += cleaned;
-        if cleaned == 0 || cleaned < batch_size {
+        if rows.len() < batch_size {
             break;
         }
     }
@@ -1213,7 +1213,7 @@ async fn cleanup_usage_stale_body_fields(
             .map_err(postgres_error)?;
         let cleaned = usize::try_from(cleaned).unwrap_or(usize::MAX);
         total_cleaned += cleaned;
-        if cleaned == 0 || cleaned < batch_size {
+        if rows.len() < batch_size {
             break;
         }
     }


### PR DESCRIPTION
## Summary

The PostgreSQL usage cleanup loop's break condition used `rows_affected()` from the first `UPDATE usage` statement, but for candidate rows that only had blob/audit refs (no inline compressed body data), the UPDATE reported 0 affected rows. This caused the loop to exit after the first batch, skipping the majority of cleanup candidates.

## Root cause

Each cleanup function follows the pattern: `SELECT` candidate rows → execute multiple `UPDATE`/`DELETE` statements across `usage`, `usage_body_blobs`, and `usage_http_audits`. The original break condition `if cleaned == 0 || cleaned < batch_size` relied on `rows_affected()` of the first `UPDATE usage` statement, which:

- Returns 0 when a `usage` row's fields are already `NULL` (e.g. only `usage_body_blobs` or `usage_http_audits` entries exist), causing premature exit after one batch
- Does not reflect the actual candidate count returned by the `SELECT`

## Fix

Changed the break condition in all 4 affected functions from:

```rust
if cleaned == 0 || cleaned < batch_size
```

to:

```rust
if rows.len() < batch_size
```

This uses the candidate row count from `SELECT` as the pagination signal, ensuring the loop continues as long as a full batch is returned, regardless of how many rows the `UPDATE` actually modified.

## Affected functions

`crates/aether-data/src/repository/usage/postgres/cleanup.rs`
1. `cleanup_usage_raw_body_fields` (line 686)
2. `cleanup_usage_compressed_body_fields` (line 739)
3. `cleanup_usage_header_fields` (line 1146)
4. `cleanup_usage_stale_body_fields` (line 1216)

## Verification

- `cargo check -p aether-data` passes
- `cargo test -p aether-data --lib` — 451 passed, 0 failed
- `cargo fmt --all --check` passes