### PR TITLE
修复 OpenAI Chat/Responses/Messages 转换兼容性并透传 Codex cyber_policy 错误

### DIFF
--- a/apps/aether-gateway/src/execution_runtime/fallback.rs
+++ b/apps/aether-gateway/src/execution_runtime/fallback.rs
@@ -937,6 +937,7 @@ mod tests {
                 continue_status_codes: [409, 429].into_iter().collect(),
                 success_failover_patterns: Vec::new(),
                 error_stop_patterns: Vec::new(),
+                stop_cyber_policy_errors: false,
             }
         );
     }

--- a/apps/aether-gateway/src/handlers/admin/provider/summary/value.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/summary/value.rs
@@ -1,5 +1,6 @@
 use crate::handlers::admin::shared::unix_secs_to_rfc3339;
 use crate::handlers::public::{request_candidate_event_unix_ms, request_candidate_status_label};
+use crate::orchestration::codex_cyber_flag_passthrough_enabled;
 use crate::provider_key_auth::provider_key_effective_api_formats;
 use aether_data_contracts::repository::candidates::{
     RequestCandidateStatus, StoredRequestCandidate,
@@ -204,6 +205,7 @@ pub(crate) fn build_admin_provider_summary_value(
         "ops_configured": ops_configured,
         "ops_architecture_id": ops_architecture_id,
         "kiro_simulated_cache_enabled": kiro_simulated_cache_enabled,
+        "codex_cyber_flag_passthrough_enabled": codex_cyber_flag_passthrough_enabled(&provider.provider_type, provider.config.as_ref()),
         "ops_quota_alert_enabled": ops_quota_alert_enabled,
         "created_at": endpoint_timestamp_or_now(provider.created_at_unix_ms, now_unix_secs),
         "updated_at": endpoint_timestamp_or_now(provider.updated_at_unix_secs, now_unix_secs),

--- a/apps/aether-gateway/src/orchestration/classifier.rs
+++ b/apps/aether-gateway/src/orchestration/classifier.rs
@@ -33,6 +33,7 @@ pub(crate) enum LocalFailoverClassification {
     StopStatusCode,
     StopErrorPattern,
     StopExecutionError,
+    StopCyberPolicy,
     RetrySuccessPattern,
     RetryStatusCode,
     RetryUpstreamFailure,
@@ -45,6 +46,7 @@ impl LocalFailoverClassification {
             Self::StopStatusCode => "stop_status_code",
             Self::StopErrorPattern => "stop_error_pattern",
             Self::StopExecutionError => "stop_execution_error",
+            Self::StopCyberPolicy => "stop_cyber_policy",
             Self::RetrySuccessPattern => "retry_success_pattern",
             Self::RetryStatusCode => "retry_status_code",
             Self::RetryUpstreamFailure => "retry_upstream_failure",
@@ -58,6 +60,13 @@ pub(crate) fn classify_local_failover(
 ) -> LocalFailoverClassification {
     if policy.stop_status_codes.contains(&input.status_code) {
         return LocalFailoverClassification::StopStatusCode;
+    }
+
+    if policy.stop_cyber_policy_errors
+        && input.status_code >= 400
+        && local_error_response_has_cyber_policy_code(input.response_text)
+    {
+        return LocalFailoverClassification::StopCyberPolicy;
     }
 
     if input.status_code >= 400
@@ -102,6 +111,44 @@ pub(crate) fn local_failover_error_message(response_text: Option<&str>) -> Optio
 
 fn should_failover_local_upstream_status(status_code: u16) -> bool {
     status_code >= 400
+}
+
+fn local_error_response_has_cyber_policy_code(response_text: Option<&str>) -> bool {
+    let Some(response_text) = response_text else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<Value>(response_text) else {
+        return false;
+    };
+    json_value_has_cyber_policy_code(&value, 0)
+}
+
+fn json_value_has_cyber_policy_code(value: &Value, depth: usize) -> bool {
+    if depth > 16 {
+        return false;
+    }
+    match value {
+        Value::Object(object) => object.iter().any(|(key, value)| {
+            (key == "code"
+                && value
+                    .as_str()
+                    .is_some_and(|code| code.eq_ignore_ascii_case("cyber_policy")))
+                || json_value_has_cyber_policy_code(value, depth + 1)
+        }),
+        Value::Array(values) => values
+            .iter()
+            .any(|value| json_value_has_cyber_policy_code(value, depth + 1)),
+        Value::String(text) => {
+            let text = text.trim_start();
+            if !text.starts_with('{') && !text.starts_with('[') {
+                return false;
+            }
+            serde_json::from_str::<Value>(text)
+                .ok()
+                .is_some_and(|value| json_value_has_cyber_policy_code(&value, depth + 1))
+        }
+        _ => false,
+    }
 }
 
 fn parse_local_error_response(response_text: Option<&str>) -> ParsedLocalErrorResponse {
@@ -306,6 +353,58 @@ mod tests {
         );
         assert_eq!(
             classify_local_failover(&policy, LocalFailoverInput::new(503, None)),
+            LocalFailoverClassification::RetryUpstreamFailure
+        );
+    }
+
+    #[test]
+    fn classifier_stops_cyber_policy_when_policy_enabled() {
+        let policy = LocalFailoverPolicy {
+            stop_cyber_policy_errors: true,
+            ..LocalFailoverPolicy::default()
+        };
+
+        assert_eq!(
+            classify_local_failover(
+                &policy,
+                LocalFailoverInput::new(
+                    400,
+                    Some(
+                        r#"{"type":"error","error":{"type":"invalid_request","code":"cyber_policy","message":"flagged"}}"#,
+                    )
+                )
+            ),
+            LocalFailoverClassification::StopCyberPolicy
+        );
+        assert_eq!(
+            classify_local_failover(
+                &policy,
+                LocalFailoverInput::new(
+                    400,
+                    Some(r#"{"outer":{"error":{"code":"cyber_policy"}}}"#)
+                )
+            ),
+            LocalFailoverClassification::StopCyberPolicy
+        );
+        assert_eq!(
+            classify_local_failover(
+                &policy,
+                LocalFailoverInput::new(400, Some(r#"{"error":{"code":"other"}}"#))
+            ),
+            LocalFailoverClassification::RetryUpstreamFailure
+        );
+    }
+
+    #[test]
+    fn classifier_retries_cyber_policy_when_policy_disabled() {
+        assert_eq!(
+            classify_local_failover(
+                &LocalFailoverPolicy::default(),
+                LocalFailoverInput::new(
+                    400,
+                    Some(r#"{"error":{"code":"cyber_policy","message":"flagged"}}"#)
+                )
+            ),
             LocalFailoverClassification::RetryUpstreamFailure
         );
     }

--- a/apps/aether-gateway/src/orchestration/effects.rs
+++ b/apps/aether-gateway/src/orchestration/effects.rs
@@ -903,7 +903,8 @@ fn local_candidate_failure_should_invalidate_affinity(
             status_code >= 500
         }
         LocalFailoverClassification::StopErrorPattern
-        | LocalFailoverClassification::StopExecutionError => false,
+        | LocalFailoverClassification::StopExecutionError
+        | LocalFailoverClassification::StopCyberPolicy => false,
     }
 }
 

--- a/apps/aether-gateway/src/orchestration/health.rs
+++ b/apps/aether-gateway/src/orchestration/health.rs
@@ -332,7 +332,8 @@ fn local_candidate_failure_should_project_health(
             status_code >= 500
         }
         LocalFailoverClassification::StopErrorPattern
-        | LocalFailoverClassification::StopExecutionError => false,
+        | LocalFailoverClassification::StopExecutionError
+        | LocalFailoverClassification::StopCyberPolicy => false,
     }
 }
 

--- a/apps/aether-gateway/src/orchestration/mod.rs
+++ b/apps/aether-gateway/src/orchestration/mod.rs
@@ -38,9 +38,9 @@ pub(crate) use self::health::{
     project_local_key_circuit_failure, project_local_success_health,
 };
 pub(crate) use self::policy::{
-    append_local_failover_policy_to_value, local_failover_policy_from_report_context,
-    local_failover_policy_from_transport, resolve_local_failover_policy, LocalFailoverPolicy,
-    LocalFailoverRegexRule,
+    append_local_failover_policy_to_value, codex_cyber_flag_passthrough_enabled,
+    local_failover_policy_from_report_context, local_failover_policy_from_transport,
+    resolve_local_failover_policy, LocalFailoverPolicy, LocalFailoverRegexRule,
 };
 pub(crate) use self::recovery::{
     analyze_local_failover, recover_local_failover_decision, LocalFailoverAnalysis,
@@ -95,6 +95,7 @@ pub(crate) fn build_local_error_flow_metadata(
         LocalFailoverClassification::StopStatusCode
             | LocalFailoverClassification::StopErrorPattern
             | LocalFailoverClassification::StopExecutionError
+            | LocalFailoverClassification::StopCyberPolicy
     );
     let propagation = match analysis.decision {
         LocalFailoverDecision::RetryNextCandidate => "suppressed",

--- a/apps/aether-gateway/src/orchestration/policy.rs
+++ b/apps/aether-gateway/src/orchestration/policy.rs
@@ -14,6 +14,7 @@ pub(crate) struct LocalFailoverPolicy {
     pub(crate) continue_status_codes: BTreeSet<u16>,
     pub(crate) success_failover_patterns: Vec<LocalFailoverRegexRule>,
     pub(crate) error_stop_patterns: Vec<LocalFailoverRegexRule>,
+    pub(crate) stop_cyber_policy_errors: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -80,6 +81,10 @@ pub(crate) fn local_failover_policy_from_transport(
 
     LocalFailoverPolicy {
         max_retries,
+        stop_cyber_policy_errors: codex_cyber_flag_passthrough_enabled(
+            &transport.provider.provider_type,
+            transport.provider.config.as_ref(),
+        ),
         stop_status_codes: rules
             .map(|value| {
                 parse_status_code_set(
@@ -135,6 +140,10 @@ pub(crate) fn local_failover_policy_from_report_context(
             .unwrap_or_default(),
         success_failover_patterns: parse_regex_rules(object, "success_failover_patterns"),
         error_stop_patterns: parse_regex_rules(object, "error_stop_patterns"),
+        stop_cyber_policy_errors: object
+            .get("stop_cyber_policy_errors")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
     })
 }
 
@@ -168,7 +177,27 @@ fn local_failover_policy_to_value(policy: &LocalFailoverPolicy) -> Value {
         "continue_status_codes": policy.continue_status_codes.iter().copied().collect::<Vec<_>>(),
         "success_failover_patterns": policy.success_failover_patterns.iter().map(local_failover_regex_rule_to_value).collect::<Vec<_>>(),
         "error_stop_patterns": policy.error_stop_patterns.iter().map(local_failover_regex_rule_to_value).collect::<Vec<_>>(),
+        "stop_cyber_policy_errors": policy.stop_cyber_policy_errors,
     })
+}
+
+pub(crate) fn codex_cyber_flag_passthrough_enabled(
+    provider_type: &str,
+    provider_config: Option<&Value>,
+) -> bool {
+    if !provider_type.trim().eq_ignore_ascii_case("codex") {
+        return false;
+    }
+    provider_config
+        .and_then(|config| config.get("codex"))
+        .and_then(Value::as_object)
+        .and_then(|codex| {
+            codex
+                .get("pass_through_cyber_flag_interrupt")
+                .or_else(|| codex.get("passthrough_cyber_flag_interrupt"))
+                .and_then(Value::as_bool)
+        })
+        .unwrap_or(true)
 }
 
 fn local_failover_regex_rule_to_value(rule: &LocalFailoverRegexRule) -> Value {
@@ -345,7 +374,28 @@ mod tests {
                     pattern: "validation".to_string(),
                     status_codes: [422].into_iter().collect(),
                 }],
+                stop_cyber_policy_errors: false,
             })
         );
+    }
+
+    #[test]
+    fn codex_cyber_policy_passthrough_defaults_on_and_can_be_disabled() {
+        let mut transport = sample_transport(None, None, None);
+        transport.provider.provider_type = "codex".to_string();
+        assert!(local_failover_policy_from_transport(&transport).stop_cyber_policy_errors);
+
+        transport.provider.config = Some(json!({
+            "codex": {"pass_through_cyber_flag_interrupt": false}
+        }));
+        assert!(!local_failover_policy_from_transport(&transport).stop_cyber_policy_errors);
+
+        transport.provider.config = Some(json!({
+            "codex": {"passthrough_cyber_flag_interrupt": true}
+        }));
+        assert!(local_failover_policy_from_transport(&transport).stop_cyber_policy_errors);
+
+        transport.provider.provider_type = "llm".to_string();
+        assert!(!local_failover_policy_from_transport(&transport).stop_cyber_policy_errors);
     }
 }

--- a/apps/aether-gateway/src/orchestration/policy.rs
+++ b/apps/aether-gateway/src/orchestration/policy.rs
@@ -271,7 +271,7 @@ mod tests {
 
     use super::{
         append_local_failover_policy_to_value, local_failover_policy_from_report_context,
-        LocalFailoverPolicy, LocalFailoverRegexRule,
+        local_failover_policy_from_transport, LocalFailoverPolicy, LocalFailoverRegexRule,
     };
     use crate::provider_transport::snapshot::{
         GatewayProviderTransportEndpoint, GatewayProviderTransportKey,

--- a/apps/aether-gateway/src/orchestration/recovery.rs
+++ b/apps/aether-gateway/src/orchestration/recovery.rs
@@ -58,9 +58,8 @@ const fn decision_from_classification(
         LocalFailoverClassification::UseDefault => LocalFailoverDecision::UseDefault,
         LocalFailoverClassification::StopStatusCode
         | LocalFailoverClassification::StopErrorPattern
-        | LocalFailoverClassification::StopExecutionError => {
-            LocalFailoverDecision::StopLocalFailover
-        }
+        | LocalFailoverClassification::StopExecutionError
+        | LocalFailoverClassification::StopCyberPolicy => LocalFailoverDecision::StopLocalFailover,
         LocalFailoverClassification::RetrySuccessPattern
         | LocalFailoverClassification::RetryStatusCode
         | LocalFailoverClassification::RetryUpstreamFailure => {
@@ -142,6 +141,24 @@ mod tests {
         assert_eq!(
             analysis.classification,
             LocalFailoverClassification::RetryUpstreamFailure
+        );
+    }
+
+    #[test]
+    fn recovery_stops_cyber_policy_failover() {
+        let policy = LocalFailoverPolicy {
+            stop_cyber_policy_errors: true,
+            ..LocalFailoverPolicy::default()
+        };
+        let analysis = analyze_local_failover(
+            &policy,
+            LocalFailoverInput::new(400, Some(r#"{"error":{"code":"cyber_policy"}}"#)),
+        );
+
+        assert_eq!(analysis.decision, LocalFailoverDecision::StopLocalFailover);
+        assert_eq!(
+            analysis.classification,
+            LocalFailoverClassification::StopCyberPolicy
         );
     }
 }

--- a/apps/aether-gateway/src/tests/audit.rs
+++ b/apps/aether-gateway/src/tests/audit.rs
@@ -32,6 +32,27 @@ fn hash_api_key(value: &str) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+fn run_async_test_on_large_stack<F>(name: &'static str, future: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    let handle = std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("tokio runtime should build")
+                .block_on(future);
+        })
+        .expect("large-stack audit test thread should spawn");
+
+    if let Err(payload) = handle.join() {
+        std::panic::resume_unwind(payload);
+    }
+}
+
 fn sample_local_openai_auth_snapshot(api_key_id: &str, user_id: &str) -> StoredAuthApiKeySnapshot {
     StoredAuthApiKeySnapshot::new(
         user_id.to_string(),
@@ -158,8 +179,15 @@ fn sample_local_openai_key() -> StoredProviderCatalogKey {
     .expect("key transport should build")
 }
 
-#[tokio::test]
-async fn gateway_exposes_request_id_header_for_local_execution_response() {
+#[test]
+fn gateway_exposes_request_id_header_for_local_execution_response() {
+    run_async_test_on_large_stack(
+        "gateway_exposes_request_id_header_for_local_execution_response",
+        gateway_exposes_request_id_header_for_local_execution_response_impl(),
+    );
+}
+
+async fn gateway_exposes_request_id_header_for_local_execution_response_impl() {
     let auth_repository = Arc::new(InMemoryAuthApiKeySnapshotRepository::seed(vec![(
         Some(hash_api_key("sk-client-openai-audit-bundle")),
         sample_local_openai_auth_snapshot("api-key-1", "user-1"),

--- a/apps/aether-gateway/src/tests/usage/direct.rs
+++ b/apps/aether-gateway/src/tests/usage/direct.rs
@@ -40,8 +40,15 @@ where
     }
 }
 
-#[tokio::test]
-async fn gateway_records_usage_for_execution_runtime_sync_when_runtime_enabled() {
+#[test]
+fn gateway_records_usage_for_execution_runtime_sync_when_runtime_enabled() {
+    run_async_test_on_large_stack(
+        "gateway_records_usage_for_execution_runtime_sync_when_runtime_enabled",
+        gateway_records_usage_for_execution_runtime_sync_when_runtime_enabled_impl(),
+    );
+}
+
+async fn gateway_records_usage_for_execution_runtime_sync_when_runtime_enabled_impl() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
 
@@ -312,8 +319,15 @@ async fn gateway_records_pending_usage_before_execution_runtime_sync_result_arri
     upstream_handle.abort();
 }
 
-#[tokio::test]
-async fn gateway_keeps_pending_sync_usage_lightweight_for_large_request_body() {
+#[test]
+fn gateway_keeps_pending_sync_usage_lightweight_for_large_request_body() {
+    run_async_test_on_large_stack(
+        "gateway_keeps_pending_sync_usage_lightweight_for_large_request_body",
+        gateway_keeps_pending_sync_usage_lightweight_for_large_request_body_impl(),
+    );
+}
+
+async fn gateway_keeps_pending_sync_usage_lightweight_for_large_request_body_impl() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
     let execution_request_started = Arc::new(tokio::sync::Notify::new());
@@ -576,8 +590,15 @@ async fn gateway_records_usage_for_execution_runtime_stream_when_runtime_enabled
     upstream_handle.abort();
 }
 
-#[tokio::test]
-async fn gateway_records_pending_usage_before_execution_runtime_stream_headers_arrive() {
+#[test]
+fn gateway_records_pending_usage_before_execution_runtime_stream_headers_arrive() {
+    run_async_test_on_large_stack(
+        "gateway_records_pending_usage_before_execution_runtime_stream_headers_arrive",
+        gateway_records_pending_usage_before_execution_runtime_stream_headers_arrive_impl(),
+    );
+}
+
+async fn gateway_records_pending_usage_before_execution_runtime_stream_headers_arrive_impl() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
     let execution_request_started = Arc::new(tokio::sync::Notify::new());
@@ -725,8 +746,15 @@ async fn gateway_records_pending_usage_before_execution_runtime_stream_headers_a
     upstream_handle.abort();
 }
 
-#[tokio::test]
-async fn gateway_keeps_pending_stream_usage_lightweight_for_large_request_body() {
+#[test]
+fn gateway_keeps_pending_stream_usage_lightweight_for_large_request_body() {
+    run_async_test_on_large_stack(
+        "gateway_keeps_pending_stream_usage_lightweight_for_large_request_body",
+        gateway_keeps_pending_stream_usage_lightweight_for_large_request_body_impl(),
+    );
+}
+
+async fn gateway_keeps_pending_stream_usage_lightweight_for_large_request_body_impl() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
     let execution_request_started = Arc::new(tokio::sync::Notify::new());

--- a/apps/aether-gateway/src/tests/usage/local.rs
+++ b/apps/aether-gateway/src/tests/usage/local.rs
@@ -31,7 +31,7 @@ where
 {
     let handle = std::thread::Builder::new()
         .name(name.to_string())
-        .stack_size(8 * 1024 * 1024)
+        .stack_size(16 * 1024 * 1024)
         .spawn(move || {
             tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -421,8 +421,15 @@ async fn gateway_truncates_deep_request_echo_for_local_openai_chat_sync_usage_im
     upstream_handle.abort();
 }
 
-#[tokio::test]
-async fn gateway_applies_system_max_request_body_size_to_local_openai_chat_sync_usage() {
+#[test]
+fn gateway_applies_system_max_request_body_size_to_local_openai_chat_sync_usage() {
+    run_async_test_on_large_stack(
+        "gateway_applies_system_max_request_body_size_to_local_openai_chat_sync_usage",
+        gateway_applies_system_max_request_body_size_to_local_openai_chat_sync_usage_impl(),
+    );
+}
+
+async fn gateway_applies_system_max_request_body_size_to_local_openai_chat_sync_usage_impl() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
 
@@ -711,8 +718,16 @@ async fn gateway_strips_request_and_response_bodies_when_request_record_level_is
     upstream_handle.abort();
 }
 
-#[tokio::test]
-async fn gateway_records_failed_usage_when_all_local_openai_chat_candidates_exhaust_after_retryable_sync_failure(
+#[test]
+fn gateway_records_failed_usage_when_all_local_openai_chat_candidates_exhaust_after_retryable_sync_failure(
+) {
+    run_async_test_on_large_stack(
+        "gateway_records_failed_usage_when_all_local_openai_chat_candidates_exhaust_after_retryable_sync_failure",
+        gateway_records_failed_usage_when_all_local_openai_chat_candidates_exhaust_after_retryable_sync_failure_impl(),
+    );
+}
+
+async fn gateway_records_failed_usage_when_all_local_openai_chat_candidates_exhaust_after_retryable_sync_failure_impl(
 ) {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
@@ -854,8 +869,15 @@ async fn gateway_records_failed_usage_when_all_local_openai_chat_candidates_exha
     assert_eq!(stored_candidates[0].status_code, Some(503));
 }
 
-#[tokio::test]
-async fn gateway_records_failed_usage_when_sync_runtime_transport_is_unavailable_without_plan_fallback(
+#[test]
+fn gateway_records_failed_usage_when_sync_runtime_transport_is_unavailable_without_plan_fallback() {
+    run_async_test_on_large_stack(
+        "gateway_records_failed_usage_when_sync_runtime_transport_is_unavailable_without_plan_fallback",
+        gateway_records_failed_usage_when_sync_runtime_transport_is_unavailable_without_plan_fallback_impl(),
+    );
+}
+
+async fn gateway_records_failed_usage_when_sync_runtime_transport_is_unavailable_without_plan_fallback_impl(
 ) {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
@@ -1166,8 +1188,16 @@ async fn gateway_records_failed_usage_for_claude_runtime_miss_without_execution_
     execution_runtime_handle.abort();
 }
 
-#[tokio::test]
-async fn gateway_handles_local_openai_chat_stream_report_with_local_reporting_when_usage_runtime_enabled(
+#[test]
+fn gateway_handles_local_openai_chat_stream_report_with_local_reporting_when_usage_runtime_enabled()
+{
+    run_async_test_on_large_stack(
+        "gateway_handles_local_openai_chat_stream_report_with_local_reporting_when_usage_runtime_enabled",
+        gateway_handles_local_openai_chat_stream_report_with_local_reporting_when_usage_runtime_enabled_impl(),
+    );
+}
+
+async fn gateway_handles_local_openai_chat_stream_report_with_local_reporting_when_usage_runtime_enabled_impl(
 ) {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
@@ -1333,8 +1363,15 @@ async fn gateway_handles_local_openai_chat_stream_report_with_local_reporting_wh
     upstream_handle.abort();
 }
 
-#[tokio::test]
-async fn gateway_preserves_stream_usage_when_max_response_body_size_truncates_capture() {
+#[test]
+fn gateway_preserves_stream_usage_when_max_response_body_size_truncates_capture() {
+    run_async_test_on_large_stack(
+        "gateway_preserves_stream_usage_when_max_response_body_size_truncates_capture",
+        gateway_preserves_stream_usage_when_max_response_body_size_truncates_capture_impl(),
+    );
+}
+
+async fn gateway_preserves_stream_usage_when_max_response_body_size_truncates_capture_impl() {
     let usage_repository = Arc::new(InMemoryUsageReadRepository::default());
     let request_candidate_repository = Arc::new(InMemoryRequestCandidateRepository::default());
 

--- a/crates/aether-ai-formats/src/formats/conversion/request.rs
+++ b/crates/aether-ai-formats/src/formats/conversion/request.rs
@@ -221,7 +221,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_request_to_chat_clamps_max_reasoning_effort_to_high() {
+    fn claude_request_to_chat_maps_max_reasoning_effort_to_xhigh() {
         let body = json!({
             "model": "claude-sonnet",
             "messages": [{"role": "user", "content": "hello"}],
@@ -233,11 +233,11 @@ mod tests {
         let converted =
             normalize_claude_request_to_openai_chat_request(&body).expect("openai chat request");
 
-        assert_eq!(converted["reasoning_effort"], "high");
+        assert_eq!(converted["reasoning_effort"], "xhigh");
     }
 
     #[test]
-    fn gemini_request_to_chat_clamps_xhigh_reasoning_effort_to_high() {
+    fn gemini_request_to_chat_preserves_xhigh_reasoning_effort() {
         let body = json!({
             "contents": [{
                 "role": "user",
@@ -254,7 +254,7 @@ mod tests {
         )
         .expect("openai chat request");
 
-        assert_eq!(converted["reasoning_effort"], "high");
+        assert_eq!(converted["reasoning_effort"], "xhigh");
     }
 
     #[test]
@@ -372,7 +372,8 @@ mod tests {
     }
 
     #[test]
-    fn responses_request_normalizer_clamps_chat_reasoning_effort_and_filters_extensions() {
+    fn responses_request_normalizer_preserves_official_chat_reasoning_effort_and_filters_extensions(
+    ) {
         let body = json!({
             "model": "gpt-5.1",
             "input": "hello",
@@ -388,7 +389,7 @@ mod tests {
         let converted = normalize_openai_responses_request_to_openai_chat_request(&body)
             .expect("openai chat request");
 
-        assert_eq!(converted["reasoning_effort"], "high");
+        assert_eq!(converted["reasoning_effort"], "xhigh");
         assert_eq!(converted["verbosity"], "high");
         assert_eq!(converted["service_tier"], "priority");
         assert_eq!(converted["prompt_cache_key"], "cache_123");
@@ -397,6 +398,22 @@ mod tests {
         assert!(converted.get("store").is_none());
         assert!(converted.get("text").is_none());
         assert!(converted.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn responses_request_normalizer_preserves_none_and_minimal_chat_reasoning_effort() {
+        for effort in ["none", "minimal"] {
+            let body = json!({
+                "model": "gpt-5.1",
+                "input": "hello",
+                "reasoning": {"effort": effort},
+            });
+
+            let converted = normalize_openai_responses_request_to_openai_chat_request(&body)
+                .expect("openai chat request");
+
+            assert_eq!(converted["reasoning_effort"], effort);
+        }
     }
 
     #[test]

--- a/crates/aether-ai-formats/src/formats/openai/chat/request.rs
+++ b/crates/aether-ai-formats/src/formats/openai/chat/request.rs
@@ -2,16 +2,19 @@ use serde_json::{json, Map, Value};
 
 use crate::{
     formats::context::FormatContext,
+    formats::openai::shared::OpenAiChatReasoningEffort,
     protocol::canonical::{
         canonical_extension_object_mut, canonical_message_to_openai_chat_messages,
         canonical_response_format_to_openai, canonical_tool_choice_to_openai,
-        canonical_tool_to_openai, is_claude_tool_result, namespace_extension_object,
-        openai_content_text, openai_extensions, openai_generation_config,
-        openai_message_content_blocks, openai_response_format_to_canonical,
-        openai_responses_extension, openai_role_to_canonical, openai_tool_choice_to_canonical,
-        openai_tools_to_canonical, write_openai_generation_config, CanonicalContentBlock,
-        CanonicalInstruction, CanonicalRequest, CanonicalRole, CanonicalThinkingConfig,
-        OPENAI_RESPONSES_EXTENSION_NAMESPACE, OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE,
+        canonical_tool_is_openai_custom, canonical_tool_to_openai, is_claude_tool_result,
+        namespace_extension_object, openai_content_text, openai_extensions,
+        openai_generation_config, openai_message_content_blocks,
+        openai_response_format_to_canonical, openai_responses_extension, openai_role_to_canonical,
+        openai_tool_choice_raw_to_chat, openai_tool_choice_to_canonical, openai_tools_to_canonical,
+        write_openai_generation_config, CanonicalContentBlock, CanonicalInstruction,
+        CanonicalRequest, CanonicalRole, CanonicalThinkingConfig, CanonicalToolChoice,
+        CanonicalToolDefinition, OPENAI_RESPONSES_EXTENSION_NAMESPACE,
+        OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE,
     },
 };
 
@@ -108,7 +111,6 @@ pub fn from_raw(body_json: &Value) -> Option<CanonicalRequest> {
             "top_k",
             "stop",
             "tools",
-            "tool_choice",
             "parallel_tool_calls",
             "metadata",
             "response_format",
@@ -121,6 +123,9 @@ pub fn from_raw(body_json: &Value) -> Option<CanonicalRequest> {
             "top_logprobs",
         ],
     );
+    if canonical.tool_choice.is_some() {
+        remove_tool_choice_extension(&mut canonical.extensions, "openai");
+    }
     if let Some(verbosity) = request.get("verbosity").cloned() {
         canonical_extension_object_mut(
             &mut canonical.extensions,
@@ -168,11 +173,8 @@ pub fn to_raw(canonical: &CanonicalRequest) -> Value {
             ),
         );
     }
-    if let Some(tool_choice) = &canonical.tool_choice {
-        output.insert(
-            "tool_choice".to_string(),
-            canonical_tool_choice_to_openai(tool_choice),
-        );
+    if let Some(tool_choice) = canonical_tool_choice_to_openai_for_request(canonical) {
+        output.insert("tool_choice".to_string(), tool_choice);
     }
     if let Some(value) = canonical.parallel_tool_calls {
         output.insert("parallel_tool_calls".to_string(), Value::Bool(value));
@@ -221,6 +223,60 @@ pub fn to_raw(canonical: &CanonicalRequest) -> Value {
         &output,
     ));
     Value::Object(output)
+}
+
+fn canonical_tool_choice_to_openai_for_request(canonical: &CanonicalRequest) -> Option<Value> {
+    canonical
+        .tool_choice
+        .as_ref()
+        .map(|tool_choice| canonical_tool_choice_to_openai_for_tools(tool_choice, &canonical.tools))
+        .or_else(|| raw_tool_choice_extension(canonical).map(openai_tool_choice_raw_to_chat))
+}
+
+fn canonical_tool_choice_to_openai_for_tools(
+    choice: &CanonicalToolChoice,
+    tools: &[CanonicalToolDefinition],
+) -> Value {
+    match choice {
+        CanonicalToolChoice::Tool { name }
+            if tools
+                .iter()
+                .any(|tool| tool.name == *name && canonical_tool_is_openai_custom(tool)) =>
+        {
+            json!({
+                "type": "custom",
+                "custom": { "name": name },
+            })
+        }
+        _ => canonical_tool_choice_to_openai(choice),
+    }
+}
+
+fn raw_tool_choice_extension(canonical: &CanonicalRequest) -> Option<&Value> {
+    canonical
+        .extensions
+        .get("openai")
+        .and_then(|value| value.get("tool_choice"))
+        .or_else(|| {
+            openai_responses_extension(&canonical.extensions)
+                .and_then(|value| value.get("tool_choice"))
+        })
+}
+
+fn remove_tool_choice_extension(
+    extensions: &mut std::collections::BTreeMap<String, Value>,
+    namespace: &str,
+) {
+    let should_remove_namespace = extensions
+        .get_mut(namespace)
+        .and_then(Value::as_object_mut)
+        .is_some_and(|object| {
+            object.remove("tool_choice");
+            object.is_empty()
+        });
+    if should_remove_namespace {
+        extensions.remove(namespace);
+    }
 }
 
 fn canonical_request_has_unrepresentable_claude_tool_result_for_openai_chat(
@@ -312,12 +368,10 @@ fn non_empty_source_str<'a>(source: &'a Map<String, Value>, key: &str) -> Option
 }
 
 fn openai_chat_reasoning_effort(value: &str) -> Option<&'static str> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "low" => Some("low"),
-        "medium" => Some("medium"),
-        "high" | "xhigh" | "max" => Some("high"),
-        _ => None,
+    if value.trim().eq_ignore_ascii_case("max") {
+        return Some("xhigh");
     }
+    OpenAiChatReasoningEffort::parse(value).map(OpenAiChatReasoningEffort::as_str)
 }
 
 fn chat_compatible_openai_responses_extension_object(

--- a/crates/aether-ai-formats/src/formats/openai/chat/stream.rs
+++ b/crates/aether-ai-formats/src/formats/openai/chat/stream.rs
@@ -1528,6 +1528,48 @@ impl OpenAIResponsesProviderState {
                     &content,
                 );
             }
+            event_type if openai_responses_hosted_tool_output_item_type(event_type).is_some() => {
+                let item_type = openai_responses_hosted_tool_output_item_type(event_type)
+                    .expect("guarded by is_some");
+                let tool_use_id = value
+                    .get("call_id")
+                    .or_else(|| value.get("tool_call_id"))
+                    .or_else(|| value.get("item_id"))
+                    .or_else(|| value.get("id"))
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or("call_auto_0")
+                    .to_string();
+                let output_index = value
+                    .get("output_index")
+                    .and_then(Value::as_u64)
+                    .map(|value| value as usize);
+                let index = self
+                    .tool_index_for_key(Some(format!("{item_type}:{tool_use_id}")), output_index);
+                let content = openai_tool_result_content_from_value(
+                    value
+                        .get("delta")
+                        .or_else(|| value.get("output"))
+                        .or_else(|| value.get("content")),
+                );
+                let name = openai_responses_hosted_tool_output_name(item_type)
+                    .map(ToOwned::to_owned)
+                    .or_else(|| {
+                        value
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .filter(|value| !value.trim().is_empty())
+                            .map(ToOwned::to_owned)
+                    });
+                self.emit_missing_tool_result(
+                    report_context,
+                    &mut out,
+                    index,
+                    tool_use_id,
+                    name,
+                    &content,
+                );
+            }
             "response.output_item.done" => {
                 let Some(item) = value.get("item").and_then(Value::as_object) else {
                     return Ok(out);
@@ -3114,7 +3156,54 @@ fn openai_responses_stream_event_is_known_noop(event_type: &str) -> bool {
             | "response.web_search_call.in_progress"
             | "response.web_search_call.searching"
             | "response.web_search_call.completed"
+            | "response.local_shell_call.in_progress"
+            | "response.local_shell_call.running"
+            | "response.local_shell_call.completed"
+            | "response.local_shell_call.failed"
+            | "response.shell_call.in_progress"
+            | "response.shell_call.running"
+            | "response.shell_call.completed"
+            | "response.shell_call.failed"
+            | "response.apply_patch_call.in_progress"
+            | "response.apply_patch_call.running"
+            | "response.apply_patch_call.completed"
+            | "response.apply_patch_call.failed"
+            | "response.computer_call.in_progress"
+            | "response.computer_call.running"
+            | "response.computer_call.completed"
+            | "response.computer_call.failed"
     )
+}
+
+fn openai_responses_hosted_tool_output_item_type(event_type: &str) -> Option<&'static str> {
+    match event_type {
+        "response.custom_tool_call_output.delta" | "response.custom_tool_call_output.done" => {
+            Some("custom_tool_call_output")
+        }
+        "response.local_shell_call_output.delta" | "response.local_shell_call_output.done" => {
+            Some("local_shell_call_output")
+        }
+        "response.shell_call_output.delta" | "response.shell_call_output.done" => {
+            Some("shell_call_output")
+        }
+        "response.apply_patch_call_output.delta" | "response.apply_patch_call_output.done" => {
+            Some("apply_patch_call_output")
+        }
+        "response.computer_call_output.delta" | "response.computer_call_output.done" => {
+            Some("computer_call_output")
+        }
+        _ => None,
+    }
+}
+
+fn openai_responses_hosted_tool_output_name(item_type: &str) -> Option<&'static str> {
+    match item_type {
+        "local_shell_call_output" => Some("local_shell"),
+        "shell_call_output" => Some("shell"),
+        "apply_patch_call_output" => Some("apply_patch"),
+        "computer_call_output" => Some("computer"),
+        _ => None,
+    }
 }
 
 fn openai_responses_incomplete_finish_reason(payload: &Value) -> String {
@@ -4008,6 +4097,78 @@ mod tests {
                 name: Some(ref name),
                 ref content,
             } if tool_use_id == "call_123" && name == "lookup" && content == "{\"ok\":true}"
+        )));
+    }
+
+    #[test]
+    fn openai_responses_provider_state_ignores_hosted_tool_progress_events() {
+        let mut state = OpenAIResponsesProviderState::default();
+        let report_context = json!({});
+        let mut frames = Vec::new();
+
+        for event_type in [
+            "response.local_shell_call.in_progress",
+            "response.local_shell_call.running",
+            "response.local_shell_call.completed",
+            "response.apply_patch_call.in_progress",
+            "response.apply_patch_call.completed",
+            "response.computer_call.in_progress",
+            "response.computer_call.completed",
+        ] {
+            frames.extend(
+                state
+                    .push_line(
+                        &report_context,
+                        data_line(json!({
+                            "type": event_type,
+                            "response_id": "resp_123",
+                            "output_index": 0,
+                            "item_id": "call_123",
+                        })),
+                    )
+                    .expect("hosted tool progress event should parse"),
+            );
+        }
+
+        assert!(frames
+            .iter()
+            .any(|frame| matches!(frame.event, CanonicalStreamEvent::Start)));
+        assert!(!frames
+            .iter()
+            .any(|frame| matches!(frame.event, CanonicalStreamEvent::UnknownEvent { .. })));
+    }
+
+    #[test]
+    fn openai_responses_provider_state_parses_hosted_tool_output_as_tool_result() {
+        let mut state = OpenAIResponsesProviderState::default();
+        let report_context = json!({});
+        let frames = state
+            .push_line(
+                &report_context,
+                data_line(json!({
+                    "type": "response.local_shell_call_output.done",
+                    "response_id": "resp_123",
+                    "output_index": 3,
+                    "call_id": "call_shell_123",
+                    "output": {
+                        "stdout": "ok\n",
+                        "stderr": "",
+                        "outcome": "success"
+                    },
+                })),
+            )
+            .expect("hosted tool result should parse");
+
+        assert!(frames.iter().any(|frame| matches!(
+            frame.event,
+            CanonicalStreamEvent::ToolResultDelta {
+                index: 3,
+                ref tool_use_id,
+                name: Some(ref name),
+                ref content,
+            } if tool_use_id == "call_shell_123"
+                && name == "local_shell"
+                && content.contains("\"stdout\":\"ok\\n\"")
         )));
     }
 

--- a/crates/aether-ai-formats/src/formats/openai/chat/stream.rs
+++ b/crates/aether-ai-formats/src/formats/openai/chat/stream.rs
@@ -3087,6 +3087,7 @@ fn openai_responses_stream_event_is_known_noop(event_type: &str) -> bool {
     matches!(
         event_type,
         "response.queued"
+            | "response.metadata"
             | "response.output_text.annotation.added"
             | "response.audio.delta"
             | "response.audio.done"

--- a/crates/aether-ai-formats/src/formats/openai/responses/request.rs
+++ b/crates/aether-ai-formats/src/formats/openai/responses/request.rs
@@ -1431,6 +1431,7 @@ mod tests {
 
         assert_eq!(body["input"].as_array().expect("input").len(), 2);
         assert_eq!(body["input"][0]["type"], "function_call");
+        assert_eq!(body["input"][0]["id"], "fc_call_auto_0");
         assert_eq!(body["input"][0]["call_id"], "call_auto_0");
         assert_eq!(body["input"][0]["name"], "unknown");
         assert_eq!(body["input"][0]["arguments"], "{\"q\":\"rust\"}");

--- a/crates/aether-ai-formats/src/formats/openai/responses/request.rs
+++ b/crates/aether-ai-formats/src/formats/openai/responses/request.rs
@@ -1430,7 +1430,7 @@ mod tests {
 
         assert_eq!(body["input"].as_array().expect("input").len(), 2);
         assert_eq!(body["input"][0]["type"], "function_call");
-        assert_eq!(body["input"][0]["id"], "fc_call_auto_0");
+        assert_eq!(body["input"][0]["id"], "call_auto_0");
         assert_eq!(body["input"][0]["call_id"], "call_auto_0");
         assert_eq!(body["input"][0]["name"], "unknown");
         assert_eq!(body["input"][0]["arguments"], "{\"q\":\"rust\"}");

--- a/crates/aether-ai-formats/src/formats/openai/responses/request.rs
+++ b/crates/aether-ai-formats/src/formats/openai/responses/request.rs
@@ -8,12 +8,14 @@ use crate::{
         map_thinking_budget_to_openai_reasoning_effort, OpenAiResponsesReasoningEffort,
     },
     protocol::canonical::{
-        canonical_response_format_to_openai, canonicalize_tool_arguments,
-        is_claude_messages_request, is_claude_system_instruction, is_claude_thinking_block,
-        is_claude_tool_result, media_data_or_url, namespace_extension_object, openai_content_text,
-        openai_extensions, openai_response_format_to_canonical, openai_responses_extension,
-        openai_responses_generation_config, openai_responses_input_to_canonical_messages,
-        openai_responses_tool_choice_to_canonical, openai_responses_tools_to_canonical,
+        canonical_response_format_to_openai_responses, canonical_tool_is_openai_custom,
+        canonical_tool_use_to_openai_responses_item, is_claude_messages_request,
+        is_claude_system_instruction, is_claude_thinking_block, is_claude_tool_result,
+        is_openai_thinking_block, media_data_or_url, namespace_extension_object,
+        openai_content_text, openai_extensions, openai_response_format_to_canonical,
+        openai_responses_extension, openai_responses_generation_config,
+        openai_responses_input_to_canonical_messages, openai_responses_tool_choice_to_canonical,
+        openai_responses_tools_to_canonical, openai_tool_choice_raw_to_responses,
         CanonicalContentBlock, CanonicalInstruction, CanonicalRequest, CanonicalRole,
         CanonicalThinkingConfig, CanonicalToolChoice, CanonicalToolDefinition,
         OPENAI_RESPONSES_EXTENSION_NAMESPACE, OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE,
@@ -98,7 +100,6 @@ pub fn from_raw(body_json: &Value) -> Option<CanonicalRequest> {
             "top_p",
             "metadata",
             "tools",
-            "tool_choice",
             "parallel_tool_calls",
             "text",
             "reasoning",
@@ -108,6 +109,12 @@ pub fn from_raw(body_json: &Value) -> Option<CanonicalRequest> {
         canonical
             .extensions
             .insert(OPENAI_RESPONSES_EXTENSION_NAMESPACE.to_string(), raw);
+    }
+    if canonical.tool_choice.is_some() {
+        remove_tool_choice_extension(
+            &mut canonical.extensions,
+            OPENAI_RESPONSES_EXTENSION_NAMESPACE,
+        );
     }
     if let Some(verbosity) = request
         .get("text")
@@ -174,11 +181,8 @@ pub fn to_raw(
             Value::Array(canonical_tools_to_responses(canonical)),
         );
     }
-    if let Some(tool_choice) = canonical.tool_choice.as_ref() {
-        output.insert(
-            "tool_choice".to_string(),
-            canonical_tool_choice_to_responses(tool_choice),
-        );
+    if let Some(tool_choice) = canonical_tool_choice_to_responses_for_request(canonical) {
+        output.insert("tool_choice".to_string(), tool_choice);
     }
     if let Some(reasoning) = canonical_reasoning_config_to_responses(canonical) {
         output.insert("reasoning".to_string(), reasoning);
@@ -313,19 +317,16 @@ fn canonical_messages_to_responses_input(canonical: &CanonicalRequest) -> Option
                     id,
                     name,
                     input: arguments,
-                    ..
+                    extensions,
                 } => {
                     flush_responses_message(&mut input, role, &mut content);
                     saw_tool_item = true;
                     let call_id = responses_tool_call_id(id, &mut next_generated_tool_call_index);
                     let tool_name = responses_tool_name(name);
                     pending_tool_call_ids.push_back(call_id.clone());
-                    input.push(json!({
-                        "type": "function_call",
-                        "call_id": call_id,
-                        "name": tool_name,
-                        "arguments": canonicalize_tool_arguments(arguments),
-                    }));
+                    input.push(canonical_tool_use_to_openai_responses_item(
+                        &call_id, &tool_name, arguments, extensions,
+                    ));
                 }
                 CanonicalContentBlock::ToolResult {
                     tool_use_id,
@@ -344,7 +345,8 @@ fn canonical_messages_to_responses_input(canonical: &CanonicalRequest) -> Option
                     let call_id =
                         responses_tool_result_call_id(tool_use_id, &mut pending_tool_call_ids)?;
                     input.push(json!({
-                        "type": "function_call_output",
+                        "type": responses_tool_result_item_type(extensions)
+                            .unwrap_or("function_call_output"),
                         "call_id": call_id,
                         "output": tool_output,
                     }));
@@ -357,9 +359,26 @@ fn canonical_messages_to_responses_input(canonical: &CanonicalRequest) -> Option
                     }
                 }
                 CanonicalContentBlock::Thinking {
-                    text, extensions, ..
+                    text,
+                    encrypted_content,
+                    extensions,
+                    ..
                 } => {
                     if is_claude_thinking_block(extensions) {
+                        continue;
+                    }
+                    if role == "assistant"
+                        && is_openai_responses_reasoning_history_block(extensions)
+                    {
+                        flush_responses_message(&mut input, role, &mut content);
+                        if let Some(reasoning_item) = canonical_thinking_to_responses_reasoning_item(
+                            text,
+                            encrypted_content.as_deref(),
+                            extensions,
+                        ) {
+                            input.push(reasoning_item);
+                            saw_tool_item = true;
+                        }
                         continue;
                     }
                     if role == "assistant" && !text.trim().is_empty() {
@@ -526,6 +545,43 @@ fn flush_responses_message(input: &mut Vec<Value>, role: &str, content: &mut Vec
     }));
 }
 
+fn canonical_thinking_to_responses_reasoning_item(
+    text: &str,
+    encrypted_content: Option<&str>,
+    extensions: &BTreeMap<String, Value>,
+) -> Option<Value> {
+    let mut item = openai_responses_extension(extensions)
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    item.remove("item_type");
+    item.insert("type".to_string(), Value::String("reasoning".to_string()));
+    if !text.trim().is_empty() {
+        item.entry("summary".to_string()).or_insert_with(|| {
+            json!([{
+                "type": "summary_text",
+                "text": text,
+            }])
+        });
+    }
+    if let Some(value) = encrypted_content.filter(|value| !value.is_empty()) {
+        item.insert(
+            "encrypted_content".to_string(),
+            Value::String(value.to_string()),
+        );
+    }
+    (item.len() > 1).then_some(Value::Object(item))
+}
+
+fn is_openai_responses_reasoning_history_block(extensions: &BTreeMap<String, Value>) -> bool {
+    is_openai_thinking_block(extensions)
+        && openai_responses_extension(extensions)
+            .and_then(Value::as_object)
+            .and_then(|object| object.get("item_type"))
+            .and_then(Value::as_str)
+            == Some("reasoning")
+}
+
 fn canonical_block_to_responses_input_part(
     block: &CanonicalContentBlock,
     role: &str,
@@ -579,10 +635,14 @@ fn canonical_block_to_responses_input_part(
                 item.insert("file_id".to_string(), Value::String(value.clone()));
             }
             if data.is_some() || file_url.is_some() {
-                item.insert(
-                    "file_data".to_string(),
-                    Value::String(media_data_or_url(media_type, data, file_url)),
-                );
+                if data.is_some() {
+                    item.insert(
+                        "file_data".to_string(),
+                        Value::String(media_data_or_url(media_type, data, file_url)),
+                    );
+                } else if let Some(value) = file_url {
+                    item.insert("file_url".to_string(), Value::String(value.clone()));
+                }
             }
             if let Some(value) = filename {
                 item.insert("filename".to_string(), Value::String(value.clone()));
@@ -714,7 +774,7 @@ fn canonical_text_config_to_responses(canonical: &CanonicalRequest) -> Option<Va
     if let Some(response_format) = &canonical.response_format {
         text.insert(
             "format".to_string(),
-            canonical_response_format_to_openai(response_format),
+            canonical_response_format_to_openai_responses(response_format),
         );
     }
     if let Some(verbosity) = canonical
@@ -757,6 +817,14 @@ fn canonical_tool_to_responses(tool: &CanonicalToolDefinition) -> Value {
     {
         return raw.clone();
     }
+    if let Some(raw) = tool.extensions.get("openai").filter(|value| {
+        value
+            .get("type")
+            .and_then(Value::as_str)
+            .is_some_and(|tool_type| tool_type.eq_ignore_ascii_case("custom"))
+    }) {
+        return openai_chat_custom_tool_to_responses_tool(tool, raw);
+    }
     let mut out = Map::new();
     out.insert("type".to_string(), Value::String("function".to_string()));
     out.insert("name".to_string(), Value::String(tool.name.clone()));
@@ -781,6 +849,22 @@ fn canonical_tool_to_responses(tool: &CanonicalToolDefinition) -> Value {
     Value::Object(out)
 }
 
+fn openai_chat_custom_tool_to_responses_tool(tool: &CanonicalToolDefinition, raw: &Value) -> Value {
+    let mut out = raw
+        .get("custom")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    out.insert("type".to_string(), Value::String("custom".to_string()));
+    out.entry("name".to_string())
+        .or_insert_with(|| Value::String(tool.name.clone()));
+    if let Some(description) = &tool.description {
+        out.entry("description".to_string())
+            .or_insert_with(|| Value::String(description.clone()));
+    }
+    Value::Object(out)
+}
+
 fn responses_tool_parameters_schema(parameters: Option<&Value>) -> Value {
     match parameters {
         Some(Value::Object(schema)) => {
@@ -800,11 +884,59 @@ fn responses_tool_parameters_schema(parameters: Option<&Value>) -> Value {
     }
 }
 
-fn canonical_tool_choice_to_responses(choice: &CanonicalToolChoice) -> Value {
+fn canonical_tool_choice_to_responses_for_request(canonical: &CanonicalRequest) -> Option<Value> {
+    canonical
+        .tool_choice
+        .as_ref()
+        .map(|tool_choice| canonical_tool_choice_to_responses(tool_choice, &canonical.tools))
+        .or_else(|| raw_tool_choice_extension(canonical).map(openai_tool_choice_raw_to_responses))
+}
+
+fn raw_tool_choice_extension(canonical: &CanonicalRequest) -> Option<&Value> {
+    canonical
+        .extensions
+        .get("openai")
+        .and_then(|value| value.get("tool_choice"))
+        .or_else(|| {
+            openai_responses_extension(&canonical.extensions)
+                .and_then(|value| value.get("tool_choice"))
+        })
+}
+
+fn remove_tool_choice_extension(
+    extensions: &mut std::collections::BTreeMap<String, Value>,
+    namespace: &str,
+) {
+    let should_remove_namespace = extensions
+        .get_mut(namespace)
+        .and_then(Value::as_object_mut)
+        .is_some_and(|object| {
+            object.remove("tool_choice");
+            object.is_empty()
+        });
+    if should_remove_namespace {
+        extensions.remove(namespace);
+    }
+}
+
+fn canonical_tool_choice_to_responses(
+    choice: &CanonicalToolChoice,
+    tools: &[CanonicalToolDefinition],
+) -> Value {
     match choice {
         CanonicalToolChoice::Auto => Value::String("auto".to_string()),
         CanonicalToolChoice::None => Value::String("none".to_string()),
         CanonicalToolChoice::Required => Value::String("required".to_string()),
+        CanonicalToolChoice::Tool { name }
+            if tools
+                .iter()
+                .any(|tool| tool.name == *name && canonical_tool_is_openai_custom(tool)) =>
+        {
+            json!({
+                "type": "custom",
+                "name": name,
+            })
+        }
         CanonicalToolChoice::Tool { name } => json!({
             "type": "function",
             "name": name,
@@ -817,15 +949,129 @@ fn responses_tool_result_payload(
     content_text: Option<&str>,
     extensions: &BTreeMap<String, Value>,
 ) -> Option<(Value, Vec<Value>)> {
-    if is_claude_tool_result(extensions) {
-        if let Some(Value::Array(parts)) = output {
+    if let Some(Value::Array(parts)) = output {
+        if is_claude_tool_result(extensions) {
             return claude_tool_result_parts_to_responses_payload(parts);
+        }
+        if let Some(output) = openai_chat_tool_result_parts_to_responses_output(parts) {
+            return Some((output, Vec::new()));
         }
     }
     Some((
         responses_tool_result_output(output, content_text),
         Vec::new(),
     ))
+}
+
+fn responses_tool_result_item_type(extensions: &BTreeMap<String, Value>) -> Option<&str> {
+    let item_type = extensions
+        .get(OPENAI_RESPONSES_EXTENSION_NAMESPACE)
+        .or_else(|| extensions.get(OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE))
+        .and_then(|value| value.get("item_type"))
+        .and_then(Value::as_str)?;
+    matches!(
+        item_type,
+        "custom_tool_call_output"
+            | "local_shell_call_output"
+            | "shell_call_output"
+            | "apply_patch_call_output"
+            | "computer_call_output"
+    )
+    .then_some(item_type)
+}
+
+fn openai_chat_tool_result_parts_to_responses_output(parts: &[Value]) -> Option<Value> {
+    if parts.is_empty()
+        || !parts.iter().all(|part| {
+            part.as_object()
+                .and_then(|object| object.get("type"))
+                .and_then(Value::as_str)
+                .is_some()
+        })
+    {
+        return None;
+    }
+    parts
+        .iter()
+        .map(openai_chat_tool_result_part_to_responses_output_part)
+        .collect::<Option<Vec<_>>>()
+        .map(Value::Array)
+}
+
+fn openai_chat_tool_result_part_to_responses_output_part(part: &Value) -> Option<Value> {
+    let part_object = part.as_object()?;
+    match part_object
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+    {
+        "input_text" | "input_image" | "input_file" => Some(part.clone()),
+        "text" => part_object
+            .get("text")
+            .and_then(Value::as_str)
+            .map(|text| json!({ "type": "input_text", "text": text }))
+            .or_else(|| Some(openai_chat_tool_result_fallback_part(part))),
+        "image_url" => openai_chat_tool_result_image_part(part_object)
+            .or_else(|| Some(openai_chat_tool_result_fallback_part(part))),
+        "file" => openai_chat_tool_result_file_part(part_object)
+            .or_else(|| Some(openai_chat_tool_result_fallback_part(part))),
+        _ => Some(openai_chat_tool_result_fallback_part(part)),
+    }
+}
+
+fn openai_chat_tool_result_image_part(part_object: &Map<String, Value>) -> Option<Value> {
+    let image_value = part_object.get("image_url")?;
+    let image_object = image_value.as_object();
+    let image_url = image_value.as_str().or_else(|| {
+        image_object
+            .and_then(|image| image.get("url"))
+            .and_then(Value::as_str)
+    });
+    let file_id = image_object
+        .and_then(|image| image.get("file_id"))
+        .and_then(Value::as_str)
+        .or_else(|| part_object.get("file_id").and_then(Value::as_str));
+    if image_url.is_none() && file_id.is_none() {
+        return None;
+    }
+    let mut part = Map::new();
+    part.insert("type".to_string(), Value::String("input_image".to_string()));
+    if let Some(value) = image_url {
+        part.insert("image_url".to_string(), Value::String(value.to_string()));
+    }
+    if let Some(value) = file_id {
+        part.insert("file_id".to_string(), Value::String(value.to_string()));
+    }
+    if let Some(detail) = image_object
+        .and_then(|image| image.get("detail"))
+        .and_then(Value::as_str)
+        .or_else(|| part_object.get("detail").and_then(Value::as_str))
+    {
+        part.insert("detail".to_string(), Value::String(detail.to_string()));
+    }
+    Some(Value::Object(part))
+}
+
+fn openai_chat_tool_result_file_part(part_object: &Map<String, Value>) -> Option<Value> {
+    let file_object = part_object
+        .get("file")
+        .and_then(Value::as_object)
+        .unwrap_or(part_object);
+    let mut part = Map::new();
+    part.insert("type".to_string(), Value::String("input_file".to_string()));
+    for field in ["file_id", "file_data", "file_url", "filename"] {
+        if let Some(value) = file_object.get(field).and_then(Value::as_str) {
+            part.insert(field.to_string(), Value::String(value.to_string()));
+        }
+    }
+    (part.len() > 1).then_some(Value::Object(part))
+}
+
+fn openai_chat_tool_result_fallback_part(part: &Value) -> Value {
+    json!({
+        "type": "input_text",
+        "text": serde_json::to_string(part).unwrap_or_else(|_| part.to_string()),
+    })
 }
 
 fn responses_tool_result_output(output: Option<&Value>, content_text: Option<&str>) -> Value {

--- a/crates/aether-ai-formats/src/formats/openai/responses/request.rs
+++ b/crates/aether-ai-formats/src/formats/openai/responses/request.rs
@@ -11,14 +11,15 @@ use crate::{
         canonical_response_format_to_openai_responses, canonical_tool_is_openai_custom,
         canonical_tool_use_to_openai_responses_item, is_claude_messages_request,
         is_claude_system_instruction, is_claude_thinking_block, is_claude_tool_result,
-        is_openai_thinking_block, media_data_or_url, namespace_extension_object,
-        openai_content_text, openai_extensions, openai_response_format_to_canonical,
-        openai_responses_extension, openai_responses_generation_config,
-        openai_responses_input_to_canonical_messages, openai_responses_tool_choice_to_canonical,
-        openai_responses_tools_to_canonical, openai_tool_choice_raw_to_responses,
-        CanonicalContentBlock, CanonicalInstruction, CanonicalRequest, CanonicalRole,
-        CanonicalThinkingConfig, CanonicalToolChoice, CanonicalToolDefinition,
-        OPENAI_RESPONSES_EXTENSION_NAMESPACE, OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE,
+        is_openai_responses_input_message, is_openai_thinking_block, media_data_or_url,
+        namespace_extension_object, openai_content_text, openai_extensions,
+        openai_response_format_to_canonical, openai_responses_extension,
+        openai_responses_generation_config, openai_responses_input_to_canonical_messages,
+        openai_responses_tool_choice_to_canonical, openai_responses_tools_to_canonical,
+        openai_tool_choice_raw_to_responses, CanonicalContentBlock, CanonicalInstruction,
+        CanonicalRequest, CanonicalRole, CanonicalThinkingConfig, CanonicalToolChoice,
+        CanonicalToolDefinition, OPENAI_RESPONSES_EXTENSION_NAMESPACE,
+        OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE,
     },
 };
 
@@ -307,6 +308,12 @@ fn canonical_messages_to_responses_input(canonical: &CanonicalRequest) -> Option
         let role = match message.role {
             CanonicalRole::Assistant => "assistant",
             CanonicalRole::Tool | CanonicalRole::User | CanonicalRole::Unknown => "user",
+            CanonicalRole::System if is_openai_responses_input_message(&message.extensions) => {
+                "system"
+            }
+            CanonicalRole::Developer if is_openai_responses_input_message(&message.extensions) => {
+                "developer"
+            }
             CanonicalRole::System | CanonicalRole::Developer => continue,
         };
         let mut content = Vec::new();
@@ -805,14 +812,6 @@ fn canonical_tool_to_responses(tool: &CanonicalToolDefinition) -> Value {
         .or_else(|| {
             tool.extensions
                 .get(OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE)
-        })
-        .filter(|value| {
-            value
-                .get("type")
-                .and_then(Value::as_str)
-                .is_some_and(|tool_type| {
-                    tool_type == "custom" || tool_type.starts_with("web_search")
-                })
         })
     {
         return raw.clone();

--- a/crates/aether-ai-formats/src/formats/openai/responses/request.rs
+++ b/crates/aether-ai-formats/src/formats/openai/responses/request.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     protocol::canonical::{
         canonical_response_format_to_openai_responses, canonical_tool_is_openai_custom,
-        canonical_tool_use_to_openai_responses_item, is_claude_messages_request,
+        canonical_tool_use_to_openai_responses_input_item, is_claude_messages_request,
         is_claude_system_instruction, is_claude_thinking_block, is_claude_tool_result,
         is_openai_responses_input_message, is_openai_thinking_block, media_data_or_url,
         namespace_extension_object, openai_content_text, openai_extensions,
@@ -331,7 +331,7 @@ fn canonical_messages_to_responses_input(canonical: &CanonicalRequest) -> Option
                     let call_id = responses_tool_call_id(id, &mut next_generated_tool_call_index);
                     let tool_name = responses_tool_name(name);
                     pending_tool_call_ids.push_back(call_id.clone());
-                    input.push(canonical_tool_use_to_openai_responses_item(
+                    input.push(canonical_tool_use_to_openai_responses_input_item(
                         &call_id, &tool_name, arguments, extensions,
                     ));
                 }
@@ -1430,7 +1430,7 @@ mod tests {
 
         assert_eq!(body["input"].as_array().expect("input").len(), 2);
         assert_eq!(body["input"][0]["type"], "function_call");
-        assert_eq!(body["input"][0]["id"], "call_auto_0");
+        assert!(body["input"][0].get("id").is_none());
         assert_eq!(body["input"][0]["call_id"], "call_auto_0");
         assert_eq!(body["input"][0]["name"], "unknown");
         assert_eq!(body["input"][0]["arguments"], "{\"q\":\"rust\"}");

--- a/crates/aether-ai-formats/src/formats/openai/responses/response.rs
+++ b/crates/aether-ai-formats/src/formats/openai/responses/response.rs
@@ -10,11 +10,12 @@ use crate::{
     protocol::canonical::{
         canonical_content_block_to_openai_responses_part, canonical_extension_object_mut,
         canonical_tool_use_to_openai_responses_item, canonical_usage_to_openai_responses_usage,
-        flush_openai_responses_message_item, is_openai_thinking_block, namespace_extension_object,
-        openai_responses_extensions, openai_responses_output_to_canonical_blocks,
-        openai_usage_to_canonical, CanonicalContentBlock, CanonicalResponse,
-        CanonicalResponseOutput, CanonicalRole, CanonicalStopReason,
-        OPENAI_RESPONSES_EXTENSION_NAMESPACE, OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE,
+        flush_openai_responses_message_item, is_openai_responses_raw_block,
+        is_openai_thinking_block, namespace_extension_object, openai_responses_extensions,
+        openai_responses_output_to_canonical_blocks, openai_usage_to_canonical,
+        CanonicalContentBlock, CanonicalResponse, CanonicalResponseOutput, CanonicalRole,
+        CanonicalStopReason, OPENAI_RESPONSES_EXTENSION_NAMESPACE,
+        OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE,
     },
 };
 
@@ -272,6 +273,19 @@ pub fn to_raw(canonical: &CanonicalResponse, report_context: &Value, _compact: b
                         }));
                     }
                 }
+            }
+            CanonicalContentBlock::Unknown {
+                payload,
+                extensions,
+                ..
+            } if is_openai_responses_raw_block(extensions) => {
+                flush_openai_responses_message_item(
+                    &mut output,
+                    &mut message_content,
+                    &response_id,
+                    &mut message_index,
+                );
+                output.push(payload.clone());
             }
             CanonicalContentBlock::Unknown { .. } => {}
         }

--- a/crates/aether-ai-formats/src/formats/openai/responses/response.rs
+++ b/crates/aether-ai-formats/src/formats/openai/responses/response.rs
@@ -9,7 +9,7 @@ use crate::{
     formats::context::FormatContext,
     protocol::canonical::{
         canonical_content_block_to_openai_responses_part, canonical_extension_object_mut,
-        canonical_usage_to_openai_responses_usage, canonicalize_tool_arguments,
+        canonical_tool_use_to_openai_responses_item, canonical_usage_to_openai_responses_usage,
         flush_openai_responses_message_item, is_openai_thinking_block, namespace_extension_object,
         openai_responses_extensions, openai_responses_output_to_canonical_blocks,
         openai_usage_to_canonical, CanonicalContentBlock, CanonicalResponse,
@@ -199,7 +199,10 @@ pub fn to_raw(canonical: &CanonicalResponse, report_context: &Value, _compact: b
                 output.push(Value::Object(item));
             }
             CanonicalContentBlock::ToolUse {
-                id, name, input, ..
+                id,
+                name,
+                input,
+                extensions,
             } => {
                 flush_openai_responses_message_item(
                     &mut output,
@@ -218,13 +221,9 @@ pub fn to_raw(canonical: &CanonicalResponse, report_context: &Value, _compact: b
                         },
                     }));
                 } else {
-                    output.push(json!({
-                        "type": "function_call",
-                        "id": id,
-                        "call_id": id,
-                        "name": name,
-                        "arguments": canonicalize_tool_arguments(input),
-                    }));
+                    output.push(canonical_tool_use_to_openai_responses_item(
+                        id, name, input, extensions,
+                    ));
                 }
             }
             CanonicalContentBlock::ToolResult {
@@ -232,6 +231,7 @@ pub fn to_raw(canonical: &CanonicalResponse, report_context: &Value, _compact: b
                 output: result_output,
                 content_text,
                 is_error,
+                extensions,
                 ..
             } => {
                 flush_openai_responses_message_item(
@@ -243,7 +243,11 @@ pub fn to_raw(canonical: &CanonicalResponse, report_context: &Value, _compact: b
                 let mut item = Map::new();
                 item.insert(
                     "type".to_string(),
-                    Value::String("function_call_output".to_string()),
+                    Value::String(
+                        responses_tool_result_item_type(extensions)
+                            .unwrap_or("function_call_output")
+                            .to_string(),
+                    ),
                 );
                 item.insert("call_id".to_string(), Value::String(tool_use_id.clone()));
                 item.insert(
@@ -329,6 +333,23 @@ pub fn to_raw(canonical: &CanonicalResponse, report_context: &Value, _compact: b
     response.extend(legacy_extension_fields);
     ensure_modern_openai_responses_response_fields(&mut response);
     Value::Object(response)
+}
+
+fn responses_tool_result_item_type(extensions: &BTreeMap<String, Value>) -> Option<&str> {
+    let item_type = extensions
+        .get(OPENAI_RESPONSES_EXTENSION_NAMESPACE)
+        .or_else(|| extensions.get(OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE))
+        .and_then(|value| value.get("item_type"))
+        .and_then(Value::as_str)?;
+    matches!(
+        item_type,
+        "custom_tool_call_output"
+            | "local_shell_call_output"
+            | "shell_call_output"
+            | "apply_patch_call_output"
+            | "computer_call_output"
+    )
+    .then_some(item_type)
 }
 
 pub(crate) fn ensure_modern_openai_responses_response_fields(

--- a/crates/aether-ai-formats/src/formats/registry.rs
+++ b/crates/aether-ai-formats/src/formats/registry.rs
@@ -2580,6 +2580,7 @@ mod tests {
             .value;
 
         assert_eq!(converted["input"][0]["type"], "function_call");
+        assert_eq!(converted["input"][0]["id"], "fc_call_lookup_1");
         assert_eq!(converted["input"][0]["call_id"], "call_lookup_1");
         assert_eq!(converted["input"][1]["type"], "function_call_output");
         assert_eq!(converted["input"][1]["call_id"], "call_lookup_1");

--- a/crates/aether-ai-formats/src/formats/registry.rs
+++ b/crates/aether-ai-formats/src/formats/registry.rs
@@ -356,7 +356,36 @@ fn validate_response_conversion(
     }
 
     validate_source_response_stop_enums(source, target, body)?;
+    validate_response_content_has_no_unknown_blocks(source, target, response)?;
     validate_canonical_response_stop_reasons(source, target, response)
+}
+
+fn validate_response_content_has_no_unknown_blocks(
+    source: FormatId,
+    target: FormatId,
+    response: &CanonicalResponse,
+) -> Result<(), FormatError> {
+    for block in response.content.iter().chain(
+        response
+            .outputs
+            .iter()
+            .flat_map(|output| output.content.iter()),
+    ) {
+        if let CanonicalContentBlock::Unknown { raw_type, .. } = block {
+            if raw_type == "refusal" {
+                continue;
+            }
+            return Err(FormatError::LossyConversionBlocked {
+                source_format: source.as_str().to_string(),
+                target_format: target.as_str().to_string(),
+                field: "output[].type".to_string(),
+                reason: format!(
+                    "target format has no lossless mapping for unknown source output item type {raw_type:?}"
+                ),
+            });
+        }
+    }
+    Ok(())
 }
 
 fn validate_known_standard_request_root_fields(
@@ -3131,6 +3160,44 @@ mod tests {
     }
 
     #[test]
+    fn pure_openai_responses_request_same_format_preserves_raw_tools_and_roles() {
+        let body = json!({
+            "model": "gpt-source",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": "Use policy"}]
+                },
+                {"role": "user", "content": "hello"}
+            ],
+            "tools": [
+                {
+                    "type": "file_search",
+                    "vector_store_ids": ["vs_123"],
+                    "max_num_results": 3
+                },
+                {
+                    "type": "mcp",
+                    "server_label": "docs",
+                    "server_url": "https://example.com/mcp"
+                }
+            ]
+        });
+
+        let converted = convert_request_pure("openai:responses", "openai:responses", &body)
+            .expect("same-format Responses request should preserve official raw fields")
+            .value;
+
+        assert_eq!(converted["input"][0]["role"], "developer");
+        assert_eq!(converted["input"][0]["content"][0]["text"], "Use policy");
+        assert_eq!(converted["tools"][0]["type"], "file_search");
+        assert_eq!(converted["tools"][0]["vector_store_ids"][0], "vs_123");
+        assert_eq!(converted["tools"][1]["type"], "mcp");
+        assert_eq!(converted["tools"][1]["server_label"], "docs");
+    }
+
+    #[test]
     fn pure_openai_chat_to_claude_blocks_target_unsupported_generation_field() {
         let body = json!({
             "model": "gpt-source",
@@ -3451,6 +3518,72 @@ mod tests {
             converted["incomplete_details"]["reason"],
             "max_output_tokens"
         );
+    }
+
+    #[test]
+    fn pure_openai_responses_response_same_format_preserves_raw_output_items() {
+        let body = json!({
+            "id": "resp_raw_items",
+            "object": "response",
+            "model": "gpt-source",
+            "status": "completed",
+            "output": [
+                {
+                    "type": "file_search_call",
+                    "id": "fs_123",
+                    "status": "completed",
+                    "queries": ["rust"],
+                    "results": [{"file_id": "file_123", "text": "Rust"}]
+                },
+                {
+                    "type": "code_interpreter_call",
+                    "id": "ci_123",
+                    "status": "completed",
+                    "code": "print('hi')",
+                    "outputs": []
+                },
+                {
+                    "type": "message",
+                    "id": "msg_123",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "done"}]
+                }
+            ]
+        });
+
+        let converted = convert_response_pure("openai:responses", "openai:responses", &body)
+            .expect("same-format Responses response should preserve raw output items")
+            .value;
+
+        assert_eq!(converted["output"][0]["type"], "file_search_call");
+        assert_eq!(converted["output"][0]["results"][0]["file_id"], "file_123");
+        assert_eq!(converted["output"][1]["type"], "code_interpreter_call");
+        assert_eq!(converted["output"][2]["content"][0]["text"], "done");
+    }
+
+    #[test]
+    fn pure_openai_responses_response_cross_format_blocks_raw_output_items() {
+        let body = json!({
+            "id": "resp_raw_items",
+            "object": "response",
+            "model": "gpt-source",
+            "status": "completed",
+            "output": [{
+                "type": "mcp_call",
+                "id": "mcp_123",
+                "status": "completed",
+                "name": "lookup"
+            }]
+        });
+
+        let error = convert_response_pure("openai:responses", "openai:chat", &body)
+            .expect_err("cross-format raw Responses output items should fail closed");
+
+        assert!(matches!(
+            error,
+            super::FormatError::LossyConversionBlocked { ref field, .. }
+                if field == "output[].type"
+        ));
     }
 
     #[test]

--- a/crates/aether-ai-formats/src/formats/registry.rs
+++ b/crates/aether-ai-formats/src/formats/registry.rs
@@ -2681,7 +2681,7 @@ mod tests {
             .expect("pure conversion should succeed")
             .value;
 
-        assert_eq!(converted["reasoning_effort"], "high");
+        assert_eq!(converted["reasoning_effort"], "xhigh");
     }
 
     #[test]

--- a/crates/aether-ai-formats/src/formats/registry.rs
+++ b/crates/aether-ai-formats/src/formats/registry.rs
@@ -2609,7 +2609,7 @@ mod tests {
             .value;
 
         assert_eq!(converted["input"][0]["type"], "function_call");
-        assert_eq!(converted["input"][0]["id"], "fc_call_lookup_1");
+        assert_eq!(converted["input"][0]["id"], "call_lookup_1");
         assert_eq!(converted["input"][0]["call_id"], "call_lookup_1");
         assert_eq!(converted["input"][1]["type"], "function_call_output");
         assert_eq!(converted["input"][1]["call_id"], "call_lookup_1");

--- a/crates/aether-ai-formats/src/formats/registry.rs
+++ b/crates/aether-ai-formats/src/formats/registry.rs
@@ -2609,7 +2609,7 @@ mod tests {
             .value;
 
         assert_eq!(converted["input"][0]["type"], "function_call");
-        assert_eq!(converted["input"][0]["id"], "call_lookup_1");
+        assert!(converted["input"][0].get("id").is_none());
         assert_eq!(converted["input"][0]["call_id"], "call_lookup_1");
         assert_eq!(converted["input"][1]["type"], "function_call_output");
         assert_eq!(converted["input"][1]["call_id"], "call_lookup_1");

--- a/crates/aether-ai-formats/src/formats/shared/model_directives.rs
+++ b/crates/aether-ai-formats/src/formats/shared/model_directives.rs
@@ -44,7 +44,7 @@ impl ReasoningEffort {
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
-            Self::XHigh | Self::Max => "high",
+            Self::XHigh | Self::Max => "xhigh",
         }
     }
 
@@ -534,7 +534,7 @@ mod tests {
             "gpt-5.4-xhigh",
         )
         .expect("directive should apply");
-        assert_eq!(openai_chat["reasoning_effort"], "high");
+        assert_eq!(openai_chat["reasoning_effort"], "xhigh");
 
         let mut responses = json!({
             "model": "gpt-5-upstream",
@@ -607,7 +607,7 @@ mod tests {
             "gpt-5.4-fast-xhigh",
         )
         .expect("directive should apply");
-        assert_eq!(openai_chat["reasoning_effort"], "high");
+        assert_eq!(openai_chat["reasoning_effort"], "xhigh");
         assert_eq!(openai_chat["service_tier"], "priority");
 
         let mut reversed = json!({"model": "gpt-5-upstream", "reasoning_effort": "low"});

--- a/crates/aether-ai-formats/src/formats/shared/standard_normalize.rs
+++ b/crates/aether-ai-formats/src/formats/shared/standard_normalize.rs
@@ -738,7 +738,7 @@ mod tests {
         .expect("openai chat body should build");
 
         assert_eq!(provider_request_body["model"], "gpt-5-upstream");
-        assert_eq!(provider_request_body["reasoning_effort"], "high");
+        assert_eq!(provider_request_body["reasoning_effort"], "xhigh");
     }
 
     #[test]

--- a/crates/aether-ai-formats/src/formats/shared/stream_core/common.rs
+++ b/crates/aether-ai-formats/src/formats/shared/stream_core/common.rs
@@ -331,7 +331,14 @@ pub fn canonical_usage_from_claude_usage(value: Option<&Value>) -> Option<Canoni
         .and_then(Value::as_u64)
         .unwrap_or(0);
     let reasoning_tokens = usage
-        .get("reasoning_tokens")
+        .get("output_tokens_details")
+        .and_then(Value::as_object)
+        .and_then(|details| {
+            details
+                .get("thinking_tokens")
+                .or_else(|| details.get("reasoning_tokens"))
+        })
+        .or_else(|| usage.get("reasoning_tokens"))
         .and_then(Value::as_u64)
         .unwrap_or(0);
     Some(CanonicalUsage {

--- a/crates/aether-ai-formats/src/formats/shared/stream_core/format_matrix.rs
+++ b/crates/aether-ai-formats/src/formats/shared/stream_core/format_matrix.rs
@@ -1122,6 +1122,14 @@ mod tests {
                 "output_index": 0,
             })),
             data_line(json!({
+                "type": "response.metadata",
+                "response_id": "resp_sidecar_123",
+                "sequence_number": 4,
+                "metadata": {
+                    "candidate_id": "provider-a",
+                },
+            })),
+            data_line(json!({
                 "type": "response.output_text.annotation.added",
                 "response_id": "resp_sidecar_123",
                 "output_index": 1,

--- a/crates/aether-ai-formats/src/formats/shared/sync_products.rs
+++ b/crates/aether-ai-formats/src/formats/shared/sync_products.rs
@@ -1974,7 +1974,7 @@ pub fn aggregate_openai_responses_stream_sync_response(body: &[u8]) -> Option<Va
                         reasoning_states.entry(output_index).or_default(),
                         item,
                     ),
-                    "function_call" => {
+                    "function_call" | "custom_tool_call" => {
                         merge_openai_responses_tool_item(
                             tool_states.entry(output_index).or_default(),
                             item,
@@ -1991,7 +1991,7 @@ pub fn aggregate_openai_responses_stream_sync_response(body: &[u8]) -> Option<Va
                     _ => {}
                 }
             }
-            "response.function_call_arguments.delta" => {
+            "response.function_call_arguments.delta" | "response.custom_tool_call_input.delta" => {
                 let Some(output_index) =
                     resolve_openai_responses_tool_output_index(event_object, &item_output_indexes)
                 else {
@@ -2004,18 +2004,43 @@ pub fn aggregate_openai_responses_stream_sync_response(body: &[u8]) -> Option<Va
                 if delta.is_empty() {
                     continue;
                 }
-                tool_states
-                    .entry(output_index)
-                    .or_default()
-                    .arguments
-                    .push_str(delta);
+                let state = tool_states.entry(output_index).or_default();
+                if event_object
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| value.starts_with("response.custom_tool_call_input."))
+                {
+                    state
+                        .item
+                        .entry("type".to_string())
+                        .or_insert_with(|| Value::String("custom_tool_call".to_string()));
+                    if let Some(name) = event_object.get("name").and_then(Value::as_str) {
+                        state
+                            .item
+                            .entry("name".to_string())
+                            .or_insert_with(|| Value::String(name.to_string()));
+                    }
+                    if let Some(item_id) = event_object.get("item_id").and_then(Value::as_str) {
+                        state
+                            .item
+                            .entry("id".to_string())
+                            .or_insert_with(|| Value::String(item_id.to_string()));
+                    }
+                    if let Some(call_id) = event_object.get("call_id").and_then(Value::as_str) {
+                        state
+                            .item
+                            .entry("call_id".to_string())
+                            .or_insert_with(|| Value::String(call_id.to_string()));
+                    }
+                }
+                state.arguments.push_str(delta);
                 register_openai_responses_tool_event_aliases(
                     &mut item_output_indexes,
                     event_object,
                     output_index,
                 );
             }
-            "response.function_call_arguments.done" => {
+            "response.function_call_arguments.done" | "response.custom_tool_call_input.done" => {
                 let Some(output_index) =
                     resolve_openai_responses_tool_output_index(event_object, &item_output_indexes)
                 else {
@@ -2032,14 +2057,44 @@ pub fn aggregate_openai_responses_stream_sync_response(body: &[u8]) -> Option<Va
                         item,
                     );
                 }
+                if event_object
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| value.starts_with("response.custom_tool_call_input."))
+                {
+                    let state = tool_states.entry(output_index).or_default();
+                    state
+                        .item
+                        .entry("type".to_string())
+                        .or_insert_with(|| Value::String("custom_tool_call".to_string()));
+                    if let Some(name) = event_object.get("name").and_then(Value::as_str) {
+                        state
+                            .item
+                            .entry("name".to_string())
+                            .or_insert_with(|| Value::String(name.to_string()));
+                    }
+                    if let Some(item_id) = event_object.get("item_id").and_then(Value::as_str) {
+                        state
+                            .item
+                            .entry("id".to_string())
+                            .or_insert_with(|| Value::String(item_id.to_string()));
+                    }
+                    if let Some(call_id) = event_object.get("call_id").and_then(Value::as_str) {
+                        state
+                            .item
+                            .entry("call_id".to_string())
+                            .or_insert_with(|| Value::String(call_id.to_string()));
+                    }
+                }
                 let arguments = event_object
                     .get("arguments")
+                    .or_else(|| event_object.get("input"))
                     .and_then(Value::as_str)
                     .or_else(|| {
                         event_object
                             .get("item")
                             .and_then(Value::as_object)
-                            .and_then(|item| item.get("arguments"))
+                            .and_then(|item| item.get("arguments").or_else(|| item.get("input")))
                             .and_then(Value::as_str)
                     })
                     .unwrap_or_default();
@@ -2076,7 +2131,7 @@ pub fn aggregate_openai_responses_stream_sync_response(body: &[u8]) -> Option<Va
                                 reasoning_states.entry(output_index).or_default(),
                                 item,
                             ),
-                            "function_call" => {
+                            "function_call" | "custom_tool_call" => {
                                 merge_openai_responses_tool_item(
                                     tool_states.entry(output_index).or_default(),
                                     item,
@@ -2644,6 +2699,12 @@ fn materialize_openai_responses_tool_item(
     state: OpenAIResponsesSyncToolState,
 ) -> Value {
     let mut item = state.item;
+    let item_type = item
+        .get("type")
+        .and_then(Value::as_str)
+        .filter(|value| *value == "custom_tool_call")
+        .unwrap_or("function_call")
+        .to_string();
     let generated_id = format!("call_auto_{output_index}");
     let call_id = item
         .get("call_id")
@@ -2660,10 +2721,7 @@ fn materialize_openai_responses_tool_item(
         })
         .unwrap_or(generated_id.clone());
 
-    item.insert(
-        "type".to_string(),
-        Value::String("function_call".to_string()),
-    );
+    item.insert("type".to_string(), Value::String(item_type.clone()));
     item.entry("id".to_string())
         .or_insert_with(|| Value::String(call_id.clone()));
     item.insert("call_id".to_string(), Value::String(call_id));
@@ -2672,9 +2730,19 @@ fn materialize_openai_responses_tool_item(
     item.entry("status".to_string())
         .or_insert_with(|| Value::String("completed".to_string()));
     if !state.arguments.is_empty() {
-        item.insert("arguments".to_string(), Value::String(state.arguments));
+        let argument_key = if item_type == "custom_tool_call" {
+            "input"
+        } else {
+            "arguments"
+        };
+        item.insert(argument_key.to_string(), Value::String(state.arguments));
     } else {
-        item.entry("arguments".to_string())
+        let argument_key = if item_type == "custom_tool_call" {
+            "input"
+        } else {
+            "arguments"
+        };
+        item.entry(argument_key.to_string())
             .or_insert_with(|| Value::String(String::new()));
     }
     Value::Object(item)
@@ -4287,6 +4355,27 @@ mod tests {
         assert_eq!(result["output"][0]["call_id"], "call_done_weather");
         assert_eq!(result["output"][0]["name"], "get_weather");
         assert_eq!(result["output"][0]["arguments"], r#"{"location": "Tokyo"}"#);
+    }
+
+    #[test]
+    fn custom_tool_call_input_events_materialize_custom_tool_call() {
+        let body = concat!(
+            "event: response.custom_tool_call_input.delta\n",
+            "data: {\"type\":\"response.custom_tool_call_input.delta\",\"output_index\":0,\"item_id\":\"ctc_123\",\"name\":\"code_exec\",\"delta\":\"print\"}\n\n",
+            "event: response.custom_tool_call_input.done\n",
+            "data: {\"type\":\"response.custom_tool_call_input.done\",\"output_index\":0,\"item_id\":\"ctc_123\",\"call_id\":\"call_custom_123\",\"name\":\"code_exec\",\"input\":\"print('hi')\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_custom_123\",\"object\":\"response\",\"model\":\"gpt-5\",\"status\":\"completed\",\"output\":[]}}\n\n",
+        );
+
+        let result = aggregate_openai_responses_stream_sync_response(body.as_bytes())
+            .expect("custom tool stream should aggregate into a sync body");
+
+        assert_eq!(result["output"][0]["type"], "custom_tool_call");
+        assert_eq!(result["output"][0]["call_id"], "call_custom_123");
+        assert_eq!(result["output"][0]["name"], "code_exec");
+        assert_eq!(result["output"][0]["input"], "print('hi')");
+        assert!(result["output"][0].get("arguments").is_none());
     }
 
     #[test]

--- a/crates/aether-ai-formats/src/protocol/canonical.rs
+++ b/crates/aether-ai-formats/src/protocol/canonical.rs
@@ -788,16 +788,17 @@ pub(crate) fn canonical_tool_use_to_openai_responses_item(
         return Value::Object(item);
     }
     if is_openai_custom_tool_call(extensions) {
+        let item_id = openai_responses_tool_call_item_id(id, extensions);
         return json!({
             "type": "custom_tool_call",
-            "id": id,
+            "id": item_id,
             "call_id": id,
             "status": "completed",
             "name": name,
             "input": openai_custom_tool_input_text(input),
         });
     }
-    let item_id = openai_responses_function_call_item_id(id);
+    let item_id = openai_responses_tool_call_item_id(id, extensions);
     json!({
         "type": "function_call",
         "id": item_id,
@@ -807,14 +808,23 @@ pub(crate) fn canonical_tool_use_to_openai_responses_item(
     })
 }
 
-fn openai_responses_function_call_item_id(call_id: &str) -> String {
+fn openai_responses_tool_call_item_id(
+    call_id: &str,
+    extensions: &BTreeMap<String, Value>,
+) -> String {
+    if let Some(item_id) = openai_responses_extension(extensions)
+        .and_then(|value| value.get("item_id").or_else(|| value.get("id")))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return item_id.to_string();
+    }
     let trimmed = call_id.trim();
-    if trimmed.starts_with("fc") {
-        trimmed.to_string()
-    } else if trimmed.is_empty() {
-        "fc_auto".to_string()
+    if trimmed.is_empty() {
+        "call_auto".to_string()
     } else {
-        format!("fc_{trimmed}")
+        trimmed.to_string()
     }
 }
 
@@ -1938,14 +1948,16 @@ pub(crate) fn openai_responses_input_to_canonical_messages(
                                 next_generated_tool_call_index += 1;
                                 generated
                             });
+                        let mut extensions = openai_responses_extensions(
+                            item_object,
+                            &["type", "call_id", "id", "name", "arguments"],
+                        );
+                        remember_openai_responses_tool_call_item_id(&mut extensions, item_object);
                         let tool_use = CanonicalContentBlock::ToolUse {
                             id,
                             name,
                             input: parse_jsonish_value(item_object.get("arguments")),
-                            extensions: openai_responses_extensions(
-                                item_object,
-                                &["type", "call_id", "id", "name", "arguments"],
-                            ),
+                            extensions,
                         };
                         append_openai_responses_tool_use(
                             &mut messages,
@@ -1986,6 +1998,7 @@ pub(crate) fn openai_responses_input_to_canonical_messages(
                                 "status",
                             ],
                         );
+                        remember_openai_responses_tool_call_item_id(&mut extensions, item_object);
                         mark_openai_custom_tool_call(&mut extensions);
                         let tool_use = CanonicalContentBlock::ToolUse {
                             id,
@@ -2328,14 +2341,16 @@ pub(crate) fn openai_responses_output_to_canonical_blocks(
                     .filter(|value| !value.is_empty())
                     .map(ToOwned::to_owned)
                     .unwrap_or_else(|| format!("call_auto_{index}"));
+                let mut extensions = openai_responses_extensions(
+                    item_object,
+                    &["type", "id", "call_id", "name", "arguments", "status"],
+                );
+                remember_openai_responses_tool_call_item_id(&mut extensions, item_object);
                 blocks.push(CanonicalContentBlock::ToolUse {
                     id,
                     name: name.to_string(),
                     input: parse_jsonish_value(item_object.get("arguments")),
-                    extensions: openai_responses_extensions(
-                        item_object,
-                        &["type", "id", "call_id", "name", "arguments", "status"],
-                    ),
+                    extensions,
                 });
             }
             "custom_tool_call" => {
@@ -2365,6 +2380,7 @@ pub(crate) fn openai_responses_output_to_canonical_blocks(
                         "status",
                     ],
                 );
+                remember_openai_responses_tool_call_item_id(&mut extensions, item_object);
                 mark_openai_custom_tool_call(&mut extensions);
                 blocks.push(CanonicalContentBlock::ToolUse {
                     id,
@@ -3234,6 +3250,21 @@ fn mark_openai_custom_tool_call(extensions: &mut BTreeMap<String, Value>) {
         "source".to_string(),
         Value::String(OPENAI_CUSTOM_TOOL_CALL_SOURCE_MARKER.to_string()),
     );
+}
+
+fn remember_openai_responses_tool_call_item_id(
+    extensions: &mut BTreeMap<String, Value>,
+    item_object: &Map<String, Value>,
+) {
+    if let Some(item_id) = item_object
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        canonical_extension_object_mut(extensions, OPENAI_RESPONSES_EXTENSION_NAMESPACE)
+            .insert("item_id".to_string(), Value::String(item_id.to_string()));
+    }
 }
 
 fn mark_openai_output_audio(extensions: &mut BTreeMap<String, Value>) {
@@ -7420,6 +7451,8 @@ mod tests {
         let rebuilt = canonical_to_openai_responses_request(&canonical, "gpt-5-upstream", false)
             .expect("openai responses request");
         assert_eq!(rebuilt["input"][0]["type"], "custom_tool_call");
+        assert_eq!(rebuilt["input"][0]["id"], "ctc_1");
+        assert_eq!(rebuilt["input"][0]["call_id"], "call_custom_1");
         assert_eq!(rebuilt["input"][0]["name"], "shell_command");
         assert_eq!(rebuilt["input"][0]["input"], "ls -la");
         assert_eq!(rebuilt["input"][1]["type"], "custom_tool_call_output");

--- a/crates/aether-ai-formats/src/protocol/canonical.rs
+++ b/crates/aether-ai-formats/src/protocol/canonical.rs
@@ -766,10 +766,11 @@ pub(crate) fn canonical_tool_use_to_openai_responses_item(
     input: &Value,
     extensions: &BTreeMap<String, Value>,
 ) -> Value {
+    let item_id = openai_responses_tool_call_item_id(id);
     if let Some(item_type) = openai_responses_hosted_tool_call_item_type(extensions) {
         let mut item = Map::new();
         item.insert("type".to_string(), Value::String(item_type.to_string()));
-        item.insert("id".to_string(), Value::String(id.to_string()));
+        item.insert("id".to_string(), Value::String(item_id));
         item.insert("call_id".to_string(), Value::String(id.to_string()));
         item.insert("status".to_string(), Value::String("completed".to_string()));
         if let Some(input_object) = input.as_object() {
@@ -788,7 +789,7 @@ pub(crate) fn canonical_tool_use_to_openai_responses_item(
     if is_openai_custom_tool_call(extensions) {
         return json!({
             "type": "custom_tool_call",
-            "id": id,
+            "id": item_id,
             "call_id": id,
             "status": "completed",
             "name": name,
@@ -797,11 +798,22 @@ pub(crate) fn canonical_tool_use_to_openai_responses_item(
     }
     json!({
         "type": "function_call",
-        "id": id,
+        "id": item_id,
         "call_id": id,
         "name": name,
         "arguments": canonicalize_tool_arguments(input),
     })
+}
+
+fn openai_responses_tool_call_item_id(call_id: &str) -> String {
+    let trimmed = call_id.trim();
+    if trimmed.starts_with("fc") {
+        trimmed.to_string()
+    } else if trimmed.is_empty() {
+        "fc_auto".to_string()
+    } else {
+        format!("fc_{trimmed}")
+    }
 }
 
 fn openai_responses_hosted_tool_call_item_type(

--- a/crates/aether-ai-formats/src/protocol/canonical.rs
+++ b/crates/aether-ai-formats/src/protocol/canonical.rs
@@ -22,6 +22,8 @@ const OPENAI_CUSTOM_TOOL_CALL_SOURCE_MARKER: &str = "openai_custom_tool_call";
 const OPENAI_OUTPUT_AUDIO_SOURCE_MARKER: &str = "openai_output_audio";
 const OPENAI_CHAT_TOOL_RESULT_SOURCE_MARKER: &str = "openai_chat_tool_result";
 const OPENAI_RESPONSES_TOOL_RESULT_SOURCE_MARKER: &str = "openai_responses_tool_result";
+const OPENAI_RESPONSES_INPUT_MESSAGE_SOURCE_MARKER: &str = "openai_responses_input_message";
+const OPENAI_RESPONSES_RAW_SOURCE_MARKER: &str = "openai_responses_raw";
 const OPENAI_CHAT_TOOL_ERROR_PREFIX: &str = "[tool error]";
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -1879,16 +1881,18 @@ pub(crate) fn openai_responses_input_to_canonical_messages(
                         if matches!(role, CanonicalRole::System | CanonicalRole::Developer) {
                             let text = openai_content_text(item_object.get("content"));
                             if !text.trim().is_empty() {
+                                let mut extensions = openai_responses_extensions(
+                                    item_object,
+                                    &["type", "role", "content"],
+                                );
+                                mark_openai_responses_input_message(&mut extensions);
                                 messages.push(CanonicalMessage {
                                     role,
                                     content: vec![CanonicalContentBlock::Text {
                                         text,
                                         extensions: BTreeMap::new(),
                                     }],
-                                    extensions: openai_responses_extensions(
-                                        item_object,
-                                        &["type", "role", "content"],
-                                    ),
+                                    extensions,
                                 });
                             }
                             pending_reasoning = None;
@@ -2235,7 +2239,7 @@ pub(crate) fn openai_responses_output_to_canonical_blocks(
             blocks.push(CanonicalContentBlock::Unknown {
                 raw_type: String::new(),
                 payload: item.clone(),
-                extensions: BTreeMap::new(),
+                extensions: openai_responses_raw_extensions(BTreeMap::new()),
             });
             continue;
         };
@@ -2306,7 +2310,7 @@ pub(crate) fn openai_responses_output_to_canonical_blocks(
                     blocks.push(CanonicalContentBlock::Unknown {
                         raw_type: item_type,
                         payload: item.clone(),
-                        extensions: BTreeMap::new(),
+                        extensions: openai_responses_raw_extensions(BTreeMap::new()),
                     });
                 }
             }
@@ -2466,7 +2470,7 @@ pub(crate) fn openai_responses_output_to_canonical_blocks(
             _ => blocks.push(CanonicalContentBlock::Unknown {
                 raw_type: item_type,
                 payload: item.clone(),
-                extensions: BTreeMap::new(),
+                extensions: openai_responses_raw_extensions(BTreeMap::new()),
             }),
         }
     }
@@ -3207,6 +3211,16 @@ fn claude_raw_extensions(mut extensions: BTreeMap<String, Value>) -> BTreeMap<St
     extensions
 }
 
+fn openai_responses_raw_extensions(
+    mut extensions: BTreeMap<String, Value>,
+) -> BTreeMap<String, Value> {
+    canonical_extension_object_mut(&mut extensions, AETHER_EXTENSION_NAMESPACE).insert(
+        "source".to_string(),
+        Value::String(OPENAI_RESPONSES_RAW_SOURCE_MARKER.to_string()),
+    );
+    extensions
+}
+
 fn openai_thinking_extensions(mut extensions: BTreeMap<String, Value>) -> BTreeMap<String, Value> {
     canonical_extension_object_mut(&mut extensions, AETHER_EXTENSION_NAMESPACE).insert(
         "source".to_string(),
@@ -3229,6 +3243,13 @@ fn mark_openai_output_audio(extensions: &mut BTreeMap<String, Value>) {
     );
 }
 
+fn mark_openai_responses_input_message(extensions: &mut BTreeMap<String, Value>) {
+    canonical_extension_object_mut(extensions, AETHER_EXTENSION_NAMESPACE).insert(
+        "source".to_string(),
+        Value::String(OPENAI_RESPONSES_INPUT_MESSAGE_SOURCE_MARKER.to_string()),
+    );
+}
+
 pub(crate) fn is_claude_thinking_block(extensions: &BTreeMap<String, Value>) -> bool {
     extensions
         .get(AETHER_EXTENSION_NAMESPACE)
@@ -3243,6 +3264,22 @@ fn is_claude_raw_block(extensions: &BTreeMap<String, Value>) -> bool {
         .and_then(|value| value.get("source"))
         .and_then(Value::as_str)
         == Some(CLAUDE_RAW_SOURCE_MARKER)
+}
+
+pub(crate) fn is_openai_responses_raw_block(extensions: &BTreeMap<String, Value>) -> bool {
+    extensions
+        .get(AETHER_EXTENSION_NAMESPACE)
+        .and_then(|value| value.get("source"))
+        .and_then(Value::as_str)
+        == Some(OPENAI_RESPONSES_RAW_SOURCE_MARKER)
+}
+
+pub(crate) fn is_openai_responses_input_message(extensions: &BTreeMap<String, Value>) -> bool {
+    extensions
+        .get(AETHER_EXTENSION_NAMESPACE)
+        .and_then(|value| value.get("source"))
+        .and_then(Value::as_str)
+        == Some(OPENAI_RESPONSES_INPUT_MESSAGE_SOURCE_MARKER)
 }
 
 pub(crate) fn is_openai_thinking_block(extensions: &BTreeMap<String, Value>) -> bool {
@@ -4535,6 +4572,26 @@ pub(crate) fn openai_responses_tools_to_canonical(
             canonical.push(CanonicalToolDefinition {
                 name: tool_type,
                 description: None,
+                parameters: None,
+                strict: None,
+                extensions: BTreeMap::from([(
+                    OPENAI_RESPONSES_EXTENSION_NAMESPACE.to_string(),
+                    tool.clone(),
+                )]),
+            });
+        } else {
+            let name = tool_object
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or(tool_type.as_str());
+            canonical.push(CanonicalToolDefinition {
+                name: name.to_string(),
+                description: tool_object
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
                 parameters: None,
                 strict: None,
                 extensions: BTreeMap::from([(

--- a/crates/aether-ai-formats/src/protocol/canonical.rs
+++ b/crates/aether-ai-formats/src/protocol/canonical.rs
@@ -17,6 +17,8 @@ const CLAUDE_SYSTEM_SOURCE_MARKER: &str = "claude_system";
 const CLAUDE_THINKING_SOURCE_MARKER: &str = "claude_thinking";
 const CLAUDE_TOOL_RESULT_SOURCE_MARKER: &str = "claude_tool_result";
 const OPENAI_THINKING_SOURCE_MARKER: &str = "openai_thinking";
+const OPENAI_CUSTOM_TOOL_CALL_SOURCE_MARKER: &str = "openai_custom_tool_call";
+const OPENAI_OUTPUT_AUDIO_SOURCE_MARKER: &str = "openai_output_audio";
 const OPENAI_CHAT_TOOL_RESULT_SOURCE_MARKER: &str = "openai_chat_tool_result";
 const OPENAI_RESPONSES_TOOL_RESULT_SOURCE_MARKER: &str = "openai_responses_tool_result";
 const OPENAI_CHAT_TOOL_ERROR_PREFIX: &str = "[tool error]";
@@ -597,6 +599,7 @@ pub(crate) fn canonical_blocks_to_openai_chat_message(content: &[CanonicalConten
     let mut tool_calls = Vec::new();
     let mut annotations = Vec::new();
     let mut refusal = Vec::new();
+    let mut audio = None;
     let mut text_offset = 0_i64;
     for block in content {
         match block {
@@ -643,16 +646,17 @@ pub(crate) fn canonical_blocks_to_openai_chat_message(content: &[CanonicalConten
                 }
             }
             CanonicalContentBlock::ToolUse {
-                id, name, input, ..
-            } => {
-                tool_calls.push(json!({
-                    "id": id,
-                    "type": "function",
-                    "function": {
-                        "name": name,
-                        "arguments": canonicalize_tool_arguments(input),
-                    }
-                }));
+                id,
+                name,
+                input,
+                extensions,
+            } => tool_calls.push(canonical_tool_use_to_openai_chat_tool_call(
+                id, name, input, extensions,
+            )),
+            CanonicalContentBlock::Audio {
+                data, extensions, ..
+            } if is_openai_output_audio_block(extensions) => {
+                audio = canonical_audio_to_openai_chat_audio(data.as_deref(), extensions);
             }
             CanonicalContentBlock::Text { text, extensions } => {
                 if let Some(raw_annotations) = extensions
@@ -708,6 +712,9 @@ pub(crate) fn canonical_blocks_to_openai_chat_message(content: &[CanonicalConten
     if !refusal.is_empty() {
         message.insert("refusal".to_string(), Value::String(refusal.join("\n")));
     }
+    if let Some(audio) = audio {
+        message.insert("audio".to_string(), audio);
+    }
     if !annotations.is_empty() {
         message.insert("annotations".to_string(), Value::Array(annotations));
     }
@@ -716,6 +723,140 @@ pub(crate) fn canonical_blocks_to_openai_chat_message(content: &[CanonicalConten
         openai_content_value_from_parts(visible_blocks, !tool_calls.is_empty()),
     );
     Value::Object(message)
+}
+
+fn canonical_tool_use_to_openai_chat_tool_call(
+    id: &str,
+    name: &str,
+    input: &Value,
+    extensions: &BTreeMap<String, Value>,
+) -> Value {
+    if is_openai_custom_tool_call(extensions) {
+        let mut custom = extensions
+            .get("openai")
+            .and_then(|value| value.get("custom"))
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        custom.insert("name".to_string(), Value::String(name.to_string()));
+        custom.insert(
+            "input".to_string(),
+            Value::String(openai_custom_tool_input_text(input)),
+        );
+        return json!({
+            "id": id,
+            "type": "custom",
+            "custom": Value::Object(custom),
+        });
+    }
+    json!({
+        "id": id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": canonicalize_tool_arguments(input),
+        }
+    })
+}
+
+pub(crate) fn canonical_tool_use_to_openai_responses_item(
+    id: &str,
+    name: &str,
+    input: &Value,
+    extensions: &BTreeMap<String, Value>,
+) -> Value {
+    if let Some(item_type) = openai_responses_hosted_tool_call_item_type(extensions) {
+        let mut item = Map::new();
+        item.insert("type".to_string(), Value::String(item_type.to_string()));
+        item.insert("id".to_string(), Value::String(id.to_string()));
+        item.insert("call_id".to_string(), Value::String(id.to_string()));
+        item.insert("status".to_string(), Value::String("completed".to_string()));
+        if let Some(input_object) = input.as_object() {
+            for field in openai_responses_hosted_tool_input_fields(item_type) {
+                if let Some(value) = input_object.get(*field) {
+                    item.insert((*field).to_string(), value.clone());
+                }
+            }
+        } else if item_type == "apply_patch_call" {
+            item.insert("operation".to_string(), input.clone());
+        } else if !name.trim().is_empty() {
+            item.insert("name".to_string(), Value::String(name.to_string()));
+        }
+        return Value::Object(item);
+    }
+    if is_openai_custom_tool_call(extensions) {
+        return json!({
+            "type": "custom_tool_call",
+            "id": id,
+            "call_id": id,
+            "status": "completed",
+            "name": name,
+            "input": openai_custom_tool_input_text(input),
+        });
+    }
+    json!({
+        "type": "function_call",
+        "id": id,
+        "call_id": id,
+        "name": name,
+        "arguments": canonicalize_tool_arguments(input),
+    })
+}
+
+fn openai_responses_hosted_tool_call_item_type(
+    extensions: &BTreeMap<String, Value>,
+) -> Option<&str> {
+    let item_type = openai_responses_extension(extensions)
+        .and_then(|value| value.get("item_type"))
+        .and_then(Value::as_str)?;
+    openai_responses_hosted_tool_name(item_type).map(|_| item_type)
+}
+
+fn openai_responses_hosted_tool_input_fields(item_type: &str) -> &'static [&'static str] {
+    match item_type {
+        "local_shell_call" | "shell_call" => &[
+            "action",
+            "environment",
+            "status",
+            "created_by",
+            "max_output_length",
+        ],
+        "apply_patch_call" => &["operation", "status"],
+        "computer_call" => &["action", "actions", "pending_safety_checks", "status"],
+        _ => &[],
+    }
+}
+
+fn openai_custom_tool_input_text(input: &Value) -> String {
+    match input {
+        Value::String(text) => text.clone(),
+        Value::Null => String::new(),
+        value => value.to_string(),
+    }
+}
+
+fn canonical_audio_to_openai_chat_audio(
+    data: Option<&str>,
+    extensions: &BTreeMap<String, Value>,
+) -> Option<Value> {
+    let mut audio = extensions
+        .get("openai")
+        .and_then(|value| value.get("audio"))
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(data) = data.filter(|value| !value.is_empty()) {
+        audio.insert("data".to_string(), Value::String(data.to_string()));
+    }
+    if !audio.contains_key("transcript") {
+        if let Some(transcript) = openai_responses_extension(extensions)
+            .and_then(|value| value.get("transcript"))
+            .cloned()
+        {
+            audio.insert("transcript".to_string(), transcript);
+        }
+    }
+    (!audio.is_empty()).then_some(Value::Object(audio))
 }
 
 pub(crate) fn canonical_to_openai_responses_response_with_profile(
@@ -1466,27 +1607,56 @@ pub(crate) fn openai_message_content_blocks(
                 },
             );
         }
+        if let Some(audio_object) = message.get("audio").and_then(Value::as_object) {
+            blocks.push(openai_chat_audio_to_canonical_block(audio_object));
+        }
     }
     let mut saw_tool_calls = false;
     if let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) {
         for tool_call in tool_calls {
             let tool_call = tool_call.as_object()?;
-            let function = tool_call.get("function").and_then(Value::as_object)?;
+            let tool_call_type = tool_call
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("function")
+                .trim()
+                .to_ascii_lowercase();
             saw_tool_calls = true;
-            blocks.push(CanonicalContentBlock::ToolUse {
-                id: tool_call
-                    .get("id")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_string(),
-                name: function
+            let id = tool_call
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            if tool_call_type == "custom" {
+                let custom = tool_call.get("custom").and_then(Value::as_object)?;
+                let name = custom
                     .get("name")
                     .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_string(),
-                input: parse_jsonish_value(function.get("arguments")),
-                extensions: openai_extensions(tool_call, &["id", "type", "function"]),
-            });
+                    .unwrap_or("custom_tool")
+                    .to_string();
+                let mut extensions = openai_extensions(tool_call, &["id", "type"]);
+                mark_openai_custom_tool_call(&mut extensions);
+                blocks.push(CanonicalContentBlock::ToolUse {
+                    id,
+                    name,
+                    input: parse_jsonish_value(
+                        custom.get("input").or_else(|| custom.get("arguments")),
+                    ),
+                    extensions,
+                });
+            } else {
+                let function = tool_call.get("function").and_then(Value::as_object)?;
+                blocks.push(CanonicalContentBlock::ToolUse {
+                    id,
+                    name: function
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                    input: parse_jsonish_value(function.get("arguments")),
+                    extensions: openai_extensions(tool_call, &["id", "type", "function"]),
+                });
+            }
         }
     }
     if role == CanonicalRole::Assistant && !saw_tool_calls {
@@ -1544,6 +1714,25 @@ pub(crate) fn openai_message_content_blocks(
         });
     }
     Some(blocks)
+}
+
+fn openai_chat_audio_to_canonical_block(
+    audio_object: &Map<String, Value>,
+) -> CanonicalContentBlock {
+    let mut extensions = BTreeMap::from([(
+        "openai".to_string(),
+        json!({ "audio": Value::Object(audio_object.clone()) }),
+    )]);
+    mark_openai_output_audio(&mut extensions);
+    CanonicalContentBlock::Audio {
+        data: audio_object
+            .get("data")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        media_type: None,
+        format: None,
+        extensions,
+    }
 }
 
 pub(crate) fn openai_reasoning_blocks(message: &Map<String, Value>) -> Vec<CanonicalContentBlock> {
@@ -1637,7 +1826,7 @@ pub(crate) fn openai_responses_input_to_canonical_messages(
         Value::Array(items) => {
             let mut messages = Vec::new();
             let mut next_generated_tool_call_index = 0usize;
-            let mut pending_reasoning: Option<String> = None;
+            let mut pending_reasoning: Option<CanonicalContentBlock> = None;
             for item in items {
                 if let Some(text) = item.as_str() {
                     if !text.trim().is_empty() {
@@ -1665,10 +1854,7 @@ pub(crate) fn openai_responses_input_to_canonical_messages(
                     .to_ascii_lowercase();
                 match item_type.as_str() {
                     "reasoning" => {
-                        let reasoning = openai_responses_reasoning_text(item_object);
-                        if !reasoning.is_empty() {
-                            pending_reasoning = Some(reasoning);
-                        }
+                        pending_reasoning = openai_responses_reasoning_block_from_item(item_object);
                     }
                     "message" => {
                         let role = openai_role_to_canonical(
@@ -1696,7 +1882,7 @@ pub(crate) fn openai_responses_input_to_canonical_messages(
                             continue;
                         }
                         let is_assistant = role == CanonicalRole::Assistant;
-                        messages.push(CanonicalMessage {
+                        let mut message = CanonicalMessage {
                             role,
                             content: openai_responses_chat_safe_content_to_blocks(
                                 item_object.get("content"),
@@ -1705,10 +1891,15 @@ pub(crate) fn openai_responses_input_to_canonical_messages(
                                 item_object,
                                 &["type", "role", "content"],
                             ),
-                        });
-                        if !is_assistant {
+                        };
+                        if is_assistant {
+                            if let Some(reasoning) = pending_reasoning.take() {
+                                prepend_openai_responses_reasoning_block(&mut message, reasoning);
+                            }
+                        } else {
                             pending_reasoning = None;
                         }
+                        messages.push(message);
                     }
                     "function_call" => {
                         let name = item_object
@@ -1738,6 +1929,56 @@ pub(crate) fn openai_responses_input_to_canonical_messages(
                                 item_object,
                                 &["type", "call_id", "id", "name", "arguments"],
                             ),
+                        };
+                        append_openai_responses_tool_use(
+                            &mut messages,
+                            tool_use,
+                            &mut pending_reasoning,
+                        );
+                    }
+                    "custom_tool_call" => {
+                        let name = item_object
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())
+                            .unwrap_or("custom_tool")
+                            .to_string();
+                        let id = item_object
+                            .get("call_id")
+                            .or_else(|| item_object.get("id"))
+                            .and_then(Value::as_str)
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())
+                            .map(ToOwned::to_owned)
+                            .unwrap_or_else(|| {
+                                let generated =
+                                    format!("call_auto_{next_generated_tool_call_index}");
+                                next_generated_tool_call_index += 1;
+                                generated
+                            });
+                        let mut extensions = openai_responses_extensions(
+                            item_object,
+                            &[
+                                "type",
+                                "call_id",
+                                "id",
+                                "name",
+                                "input",
+                                "arguments",
+                                "status",
+                            ],
+                        );
+                        mark_openai_custom_tool_call(&mut extensions);
+                        let tool_use = CanonicalContentBlock::ToolUse {
+                            id,
+                            name,
+                            input: parse_jsonish_value(
+                                item_object
+                                    .get("input")
+                                    .or_else(|| item_object.get("arguments")),
+                            ),
+                            extensions,
                         };
                         append_openai_responses_tool_use(
                             &mut messages,
@@ -1794,12 +2035,31 @@ pub(crate) fn openai_responses_input_to_canonical_messages(
                         });
                         pending_reasoning = None;
                     }
+                    "custom_tool_call_output"
+                    | "local_shell_call_output"
+                    | "shell_call_output"
+                    | "apply_patch_call_output"
+                    | "computer_call_output" => {
+                        messages.push(CanonicalMessage {
+                            role: CanonicalRole::Tool,
+                            content: vec![openai_responses_hosted_tool_result_to_block(
+                                item_object,
+                                item_type.as_str(),
+                                next_generated_tool_call_index,
+                            )],
+                            extensions: BTreeMap::new(),
+                        });
+                        pending_reasoning = None;
+                    }
                     _ => {
                         pending_reasoning = None;
                     }
                 }
             }
             Some(messages)
+        }
+        Value::Object(_) => {
+            openai_responses_input_to_canonical_messages(Some(&Value::Array(vec![input.clone()])))
         }
         _ => None,
     }
@@ -1808,9 +2068,9 @@ pub(crate) fn openai_responses_input_to_canonical_messages(
 fn append_openai_responses_tool_use(
     messages: &mut Vec<CanonicalMessage>,
     tool_use: CanonicalContentBlock,
-    pending_reasoning: &mut Option<String>,
+    pending_reasoning: &mut Option<CanonicalContentBlock>,
 ) {
-    let reasoning = pending_reasoning.take().filter(|value| !value.is_empty());
+    let reasoning = pending_reasoning.take();
     if let Some(last_message) = messages.last_mut() {
         if last_message.role == CanonicalRole::Assistant {
             if let Some(reasoning) = reasoning {
@@ -1823,7 +2083,7 @@ fn append_openai_responses_tool_use(
 
     let mut content = Vec::new();
     if let Some(reasoning) = reasoning {
-        content.push(openai_responses_reasoning_block(reasoning));
+        content.push(reasoning);
     }
     content.push(tool_use);
     messages.push(CanonicalMessage {
@@ -1833,7 +2093,10 @@ fn append_openai_responses_tool_use(
     });
 }
 
-fn prepend_openai_responses_reasoning_block(message: &mut CanonicalMessage, reasoning: String) {
+fn prepend_openai_responses_reasoning_block(
+    message: &mut CanonicalMessage,
+    reasoning: CanonicalContentBlock,
+) {
     if message
         .content
         .iter()
@@ -1841,22 +2104,46 @@ fn prepend_openai_responses_reasoning_block(message: &mut CanonicalMessage, reas
     {
         return;
     }
-    message
-        .content
-        .insert(0, openai_responses_reasoning_block(reasoning));
+    message.content.insert(0, reasoning);
 }
 
-fn openai_responses_reasoning_block(text: String) -> CanonicalContentBlock {
+fn openai_responses_reasoning_block_from_item(
+    item_object: &Map<String, Value>,
+) -> Option<CanonicalContentBlock> {
+    let text = openai_responses_reasoning_text(item_object);
+    let encrypted_content = item_object
+        .get("encrypted_content")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    if text.is_empty() && encrypted_content.is_none() {
+        return None;
+    }
     let mut extensions = BTreeMap::new();
+    extensions.extend(openai_responses_extensions(
+        item_object,
+        &[
+            "type",
+            "id",
+            "status",
+            "summary",
+            "content",
+            "encrypted_content",
+        ],
+    ));
+    canonical_extension_object_mut(&mut extensions, OPENAI_RESPONSES_EXTENSION_NAMESPACE).insert(
+        "item_type".to_string(),
+        Value::String("reasoning".to_string()),
+    );
     canonical_extension_object_mut(&mut extensions, "openai")
         .insert("omit_reasoning_parts".to_string(), Value::Bool(true));
     let extensions = openai_thinking_extensions(extensions);
-    CanonicalContentBlock::Thinking {
+    Some(CanonicalContentBlock::Thinking {
         text,
         signature: None,
-        encrypted_content: None,
+        encrypted_content,
         extensions,
-    }
+    })
 }
 
 fn openai_responses_reasoning_text(item_object: &Map<String, Value>) -> String {
@@ -2034,6 +2321,45 @@ pub(crate) fn openai_responses_output_to_canonical_blocks(
                     ),
                 });
             }
+            "custom_tool_call" => {
+                let name = item_object
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("custom_tool");
+                let id = item_object
+                    .get("call_id")
+                    .or_else(|| item_object.get("id"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| format!("call_auto_{index}"));
+                let mut extensions = openai_responses_extensions(
+                    item_object,
+                    &[
+                        "type",
+                        "id",
+                        "call_id",
+                        "name",
+                        "input",
+                        "arguments",
+                        "status",
+                    ],
+                );
+                mark_openai_custom_tool_call(&mut extensions);
+                blocks.push(CanonicalContentBlock::ToolUse {
+                    id,
+                    name: name.to_string(),
+                    input: parse_jsonish_value(
+                        item_object
+                            .get("input")
+                            .or_else(|| item_object.get("arguments")),
+                    ),
+                    extensions,
+                });
+            }
             "web_search_call" => {
                 let id = item_object
                     .get("id")
@@ -2057,6 +2383,13 @@ pub(crate) fn openai_responses_output_to_canonical_blocks(
                         &["type", "id", "status", "action"],
                     ),
                 });
+            }
+            "local_shell_call" | "shell_call" | "apply_patch_call" | "computer_call" => {
+                blocks.push(openai_responses_hosted_tool_call_to_block(
+                    item_object,
+                    item_type.as_str(),
+                    index,
+                )?);
             }
             "function_call_output" => {
                 let id = item_object
@@ -2097,13 +2430,26 @@ pub(crate) fn openai_responses_output_to_canonical_blocks(
                     extensions,
                 });
             }
+            "custom_tool_call_output"
+            | "local_shell_call_output"
+            | "shell_call_output"
+            | "apply_patch_call_output"
+            | "computer_call_output" => {
+                blocks.push(openai_responses_hosted_tool_result_to_block(
+                    item_object,
+                    item_type.as_str(),
+                    index,
+                ));
+            }
             "image_generation_call" => {
                 blocks.push(openai_responses_image_generation_call_to_block(
                     item_object,
                 )?);
             }
             "output_text" | "text" | "output_image" | "image_url" | "file" | "input_file"
-            | "input_audio" => blocks.push(openai_responses_part_to_canonical_block(item)?),
+            | "input_audio" | "output_audio" => {
+                blocks.push(openai_responses_part_to_canonical_block(item)?)
+            }
             _ => blocks.push(CanonicalContentBlock::Unknown {
                 raw_type: item_type,
                 payload: item.clone(),
@@ -2112,6 +2458,141 @@ pub(crate) fn openai_responses_output_to_canonical_blocks(
         }
     }
     Some(blocks)
+}
+
+fn openai_responses_hosted_tool_call_to_block(
+    item_object: &Map<String, Value>,
+    item_type: &str,
+    index: usize,
+) -> Option<CanonicalContentBlock> {
+    let name = openai_responses_hosted_tool_name(item_type)?;
+    let id = item_object
+        .get("call_id")
+        .or_else(|| item_object.get("id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("call_auto_{index}"));
+    let input = openai_responses_hosted_tool_input(item_object, item_type);
+    let mut extensions = openai_responses_extensions(
+        item_object,
+        &[
+            "type",
+            "id",
+            "call_id",
+            "status",
+            "action",
+            "actions",
+            "environment",
+            "created_by",
+            "max_output_length",
+            "operation",
+            "pending_safety_checks",
+        ],
+    );
+    canonical_extension_object_mut(&mut extensions, OPENAI_RESPONSES_EXTENSION_NAMESPACE).insert(
+        "item_type".to_string(),
+        Value::String(item_type.to_string()),
+    );
+    Some(CanonicalContentBlock::ToolUse {
+        id,
+        name: name.to_string(),
+        input,
+        extensions,
+    })
+}
+
+fn openai_responses_hosted_tool_result_to_block(
+    item_object: &Map<String, Value>,
+    item_type: &str,
+    index: usize,
+) -> CanonicalContentBlock {
+    let id = item_object
+        .get("call_id")
+        .or_else(|| item_object.get("tool_call_id"))
+        .or_else(|| item_object.get("id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("call_auto_{index}"));
+    let raw_output = item_object
+        .get("output")
+        .or_else(|| item_object.get("content"));
+    let mut extensions = openai_responses_extensions(
+        item_object,
+        &[
+            "type",
+            "id",
+            "call_id",
+            "tool_call_id",
+            "output",
+            "content",
+            "is_error",
+        ],
+    );
+    extensions.insert(
+        AETHER_EXTENSION_NAMESPACE.to_string(),
+        json!({ "source": OPENAI_RESPONSES_TOOL_RESULT_SOURCE_MARKER }),
+    );
+    canonical_extension_object_mut(&mut extensions, OPENAI_RESPONSES_EXTENSION_NAMESPACE).insert(
+        "item_type".to_string(),
+        Value::String(item_type.to_string()),
+    );
+    CanonicalContentBlock::ToolResult {
+        tool_use_id: id,
+        name: openai_responses_hosted_tool_result_name(item_type).map(ToOwned::to_owned),
+        output: raw_output.map(|_| parse_jsonish_value(raw_output)),
+        content_text: raw_output.map(openai_responses_tool_output_text),
+        is_error: item_object
+            .get("is_error")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        extensions,
+    }
+}
+
+fn openai_responses_hosted_tool_name(item_type: &str) -> Option<&'static str> {
+    match item_type {
+        "local_shell_call" => Some("local_shell"),
+        "shell_call" => Some("shell"),
+        "apply_patch_call" => Some("apply_patch"),
+        "computer_call" => Some("computer"),
+        _ => None,
+    }
+}
+
+fn openai_responses_hosted_tool_result_name(item_type: &str) -> Option<&'static str> {
+    match item_type {
+        "local_shell_call_output" => Some("local_shell"),
+        "shell_call_output" => Some("shell"),
+        "apply_patch_call_output" => Some("apply_patch"),
+        "computer_call_output" => Some("computer"),
+        _ => None,
+    }
+}
+
+fn openai_responses_hosted_tool_input(item_object: &Map<String, Value>, item_type: &str) -> Value {
+    let fields = match item_type {
+        "local_shell_call" | "shell_call" => &[
+            "action",
+            "environment",
+            "status",
+            "created_by",
+            "max_output_length",
+        ][..],
+        "apply_patch_call" => &["operation", "status"][..],
+        "computer_call" => &["action", "actions", "pending_safety_checks", "status"][..],
+        _ => &[][..],
+    };
+    let mut input = Map::new();
+    for field in fields {
+        if let Some(value) = item_object.get(*field) {
+            input.insert((*field).to_string(), value.clone());
+        }
+    }
+    Value::Object(input)
 }
 
 fn openai_responses_image_generation_call_to_block(
@@ -2331,6 +2812,24 @@ pub(crate) fn openai_responses_part_to_canonical_block(
                     .or_else(|| format.as_ref().map(|value| format!("audio/{value}"))),
                 format,
                 extensions: openai_responses_extensions(part_object, &["type", "input_audio"]),
+            })
+        }
+        "output_audio" => {
+            let mut extensions = openai_responses_extensions(part_object, &["type", "data"]);
+            canonical_extension_object_mut(&mut extensions, OPENAI_RESPONSES_EXTENSION_NAMESPACE)
+                .insert(
+                    "item_type".to_string(),
+                    Value::String("output_audio".to_string()),
+                );
+            mark_openai_output_audio(&mut extensions);
+            Some(CanonicalContentBlock::Audio {
+                data: part_object
+                    .get("data")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                media_type: None,
+                format: None,
+                extensions,
             })
         }
         "refusal" => Some(CanonicalContentBlock::Unknown {
@@ -2592,15 +3091,13 @@ fn canonical_message_blocks_to_openai_chat(
                 }
             }
             CanonicalContentBlock::ToolUse {
-                id, name, input, ..
-            } => tool_calls.push(json!({
-                "id": id,
-                "type": "function",
-                "function": {
-                    "name": name,
-                    "arguments": canonicalize_tool_arguments(input),
-                }
-            })),
+                id,
+                name,
+                input,
+                extensions,
+            } => tool_calls.push(canonical_tool_use_to_openai_chat_tool_call(
+                id, name, input, extensions,
+            )),
             CanonicalContentBlock::ToolResult { .. } => {}
             other => {
                 if let Some(part) = canonical_content_block_to_openai_part(other) {
@@ -2697,6 +3194,20 @@ fn openai_thinking_extensions(mut extensions: BTreeMap<String, Value>) -> BTreeM
     extensions
 }
 
+fn mark_openai_custom_tool_call(extensions: &mut BTreeMap<String, Value>) {
+    canonical_extension_object_mut(extensions, AETHER_EXTENSION_NAMESPACE).insert(
+        "source".to_string(),
+        Value::String(OPENAI_CUSTOM_TOOL_CALL_SOURCE_MARKER.to_string()),
+    );
+}
+
+fn mark_openai_output_audio(extensions: &mut BTreeMap<String, Value>) {
+    canonical_extension_object_mut(extensions, AETHER_EXTENSION_NAMESPACE).insert(
+        "source".to_string(),
+        Value::String(OPENAI_OUTPUT_AUDIO_SOURCE_MARKER.to_string()),
+    );
+}
+
 pub(crate) fn is_claude_thinking_block(extensions: &BTreeMap<String, Value>) -> bool {
     extensions
         .get(AETHER_EXTENSION_NAMESPACE)
@@ -2711,6 +3222,22 @@ pub(crate) fn is_openai_thinking_block(extensions: &BTreeMap<String, Value>) -> 
         .and_then(|value| value.get("source"))
         .and_then(Value::as_str)
         == Some(OPENAI_THINKING_SOURCE_MARKER)
+}
+
+pub(crate) fn is_openai_custom_tool_call(extensions: &BTreeMap<String, Value>) -> bool {
+    extensions
+        .get(AETHER_EXTENSION_NAMESPACE)
+        .and_then(|value| value.get("source"))
+        .and_then(Value::as_str)
+        == Some(OPENAI_CUSTOM_TOOL_CALL_SOURCE_MARKER)
+}
+
+fn is_openai_output_audio_block(extensions: &BTreeMap<String, Value>) -> bool {
+    extensions
+        .get(AETHER_EXTENSION_NAMESPACE)
+        .and_then(|value| value.get("source"))
+        .and_then(Value::as_str)
+        == Some(OPENAI_OUTPUT_AUDIO_SOURCE_MARKER)
 }
 
 pub(crate) fn is_claude_tool_result(extensions: &BTreeMap<String, Value>) -> bool {
@@ -2961,10 +3488,14 @@ pub(crate) fn canonical_content_block_to_openai_part(
                 file.insert("file_id".to_string(), Value::String(value.clone()));
             }
             if data.is_some() || file_url.is_some() {
-                file.insert(
-                    "file_data".to_string(),
-                    Value::String(media_data_or_url(media_type, data, file_url)),
-                );
+                if data.is_some() {
+                    file.insert(
+                        "file_data".to_string(),
+                        Value::String(media_data_or_url(media_type, data, file_url)),
+                    );
+                } else if let Some(value) = file_url {
+                    file.insert("file_url".to_string(), Value::String(value.clone()));
+                }
             }
             if let Some(value) = filename {
                 file.insert("filename".to_string(), Value::String(value.clone()));
@@ -3043,10 +3574,14 @@ pub(crate) fn canonical_content_block_to_openai_responses_part(
                 file.insert("file_id".to_string(), Value::String(value.clone()));
             }
             if data.is_some() || file_url.is_some() {
-                file.insert(
-                    "file_data".to_string(),
-                    Value::String(media_data_or_url(media_type, data, file_url)),
-                );
+                if data.is_some() {
+                    file.insert(
+                        "file_data".to_string(),
+                        Value::String(media_data_or_url(media_type, data, file_url)),
+                    );
+                } else if let Some(value) = file_url {
+                    file.insert("file_url".to_string(), Value::String(value.clone()));
+                }
             }
             if let Some(value) = filename {
                 file.insert("filename".to_string(), Value::String(value.clone()));
@@ -3056,13 +3591,49 @@ pub(crate) fn canonical_content_block_to_openai_responses_part(
                 "file": Value::Object(file),
             }))
         }
-        CanonicalContentBlock::Audio { data, format, .. } => Some(json!({
-            "type": "input_audio",
-            "input_audio": {
-                "data": data.clone().unwrap_or_default(),
-                "format": format.clone().unwrap_or_else(|| "mp3".to_string()),
+        CanonicalContentBlock::Audio {
+            data,
+            format,
+            extensions,
+            ..
+        } => {
+            if is_openai_output_audio_block(extensions) {
+                let mut part = Map::new();
+                part.insert(
+                    "type".to_string(),
+                    Value::String("output_audio".to_string()),
+                );
+                if let Some(data) = data.as_ref().filter(|value| !value.is_empty()) {
+                    part.insert("data".to_string(), Value::String(data.clone()));
+                } else if let Some(raw_data) = openai_responses_extension(extensions)
+                    .and_then(|value| value.get("data"))
+                    .cloned()
+                {
+                    part.insert("data".to_string(), raw_data);
+                }
+                if let Some(transcript) = openai_responses_extension(extensions)
+                    .and_then(|value| value.get("transcript"))
+                    .cloned()
+                    .or_else(|| {
+                        extensions
+                            .get("openai")
+                            .and_then(|value| value.get("audio"))
+                            .and_then(|value| value.get("transcript"))
+                            .cloned()
+                    })
+                {
+                    part.insert("transcript".to_string(), transcript);
+                }
+                return Some(Value::Object(part));
             }
-        })),
+            Some(json!({
+                "type": "input_audio",
+                "input_audio": {
+                    "data": data.clone().unwrap_or_default(),
+                    "format": format.clone().unwrap_or_else(|| "mp3".to_string()),
+                }
+            }))
+        }
         CanonicalContentBlock::Thinking { .. }
         | CanonicalContentBlock::ToolUse { .. }
         | CanonicalContentBlock::ToolResult { .. }
@@ -3790,12 +4361,18 @@ pub(crate) fn openai_tools_to_canonical(
         return Some(Vec::new());
     };
     let tools = value.as_array()?;
-    tools
-        .iter()
-        .map(|tool| {
-            let tool_object = tool.as_object()?;
+    let mut canonical = Vec::new();
+    for tool in tools {
+        let tool_object = tool.as_object()?;
+        let tool_type = tool_object
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("function")
+            .trim()
+            .to_ascii_lowercase();
+        if tool_type == "function" {
             let function = tool_object.get("function").and_then(Value::as_object)?;
-            Some(CanonicalToolDefinition {
+            canonical.push(CanonicalToolDefinition {
                 name: function.get("name").and_then(Value::as_str)?.to_string(),
                 description: function
                     .get("description")
@@ -3804,9 +4381,29 @@ pub(crate) fn openai_tools_to_canonical(
                 parameters: function.get("parameters").cloned(),
                 strict: function.get("strict").and_then(Value::as_bool),
                 extensions: openai_extensions(tool_object, &["type", "function"]),
-            })
-        })
-        .collect()
+            });
+        } else if tool_type == "custom" {
+            let custom = tool_object.get("custom").and_then(Value::as_object)?;
+            let name = custom
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())?;
+            canonical.push(CanonicalToolDefinition {
+                name: name.to_string(),
+                description: custom
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                parameters: custom.get("parameters").cloned(),
+                strict: custom.get("strict").and_then(Value::as_bool),
+                extensions: BTreeMap::from([("openai".to_string(), tool.clone())]),
+            });
+        } else {
+            return None;
+        }
+    }
+    Some(canonical)
 }
 
 pub(crate) fn openai_responses_tools_to_canonical(
@@ -3935,6 +4532,24 @@ fn merge_tool_extensions(target: &mut BTreeMap<String, Value>, source: BTreeMap<
 }
 
 pub(crate) fn canonical_tool_to_openai(tool: &CanonicalToolDefinition) -> Value {
+    if let Some(raw) = tool
+        .extensions
+        .get("openai")
+        .filter(|value| openai_tool_raw_type_is(value, "custom"))
+    {
+        return raw.clone();
+    }
+    if let Some(raw) = tool
+        .extensions
+        .get(OPENAI_RESPONSES_EXTENSION_NAMESPACE)
+        .or_else(|| {
+            tool.extensions
+                .get(OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE)
+        })
+        .filter(|value| openai_tool_raw_type_is(value, "custom"))
+    {
+        return openai_responses_custom_tool_to_chat_tool(tool, raw);
+    }
     let mut function = Map::new();
     function.insert("name".to_string(), Value::String(tool.name.clone()));
     if let Some(description) = &tool.description {
@@ -3955,6 +4570,54 @@ pub(crate) fn canonical_tool_to_openai(tool: &CanonicalToolDefinition) -> Value 
     })
 }
 
+pub(crate) fn canonical_tool_is_openai_custom(tool: &CanonicalToolDefinition) -> bool {
+    tool.extensions
+        .get("openai")
+        .or_else(|| tool.extensions.get(OPENAI_RESPONSES_EXTENSION_NAMESPACE))
+        .or_else(|| {
+            tool.extensions
+                .get(OPENAI_RESPONSES_LEGACY_EXTENSION_NAMESPACE)
+        })
+        .is_some_and(|value| openai_tool_raw_type_is(value, "custom"))
+}
+
+fn openai_tool_raw_type_is(value: &Value, expected_type: &str) -> bool {
+    value
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|tool_type| tool_type.eq_ignore_ascii_case(expected_type))
+}
+
+fn openai_responses_custom_tool_to_chat_tool(tool: &CanonicalToolDefinition, raw: &Value) -> Value {
+    let mut custom = raw
+        .get("custom")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_else(|| {
+            raw.as_object()
+                .map(|object| {
+                    object
+                        .iter()
+                        .filter(|(key, _)| key.as_str() != "type")
+                        .map(|(key, value)| (key.clone(), value.clone()))
+                        .collect()
+                })
+                .unwrap_or_default()
+        });
+    custom
+        .entry("name".to_string())
+        .or_insert_with(|| Value::String(tool.name.clone()));
+    if let Some(description) = &tool.description {
+        custom
+            .entry("description".to_string())
+            .or_insert_with(|| Value::String(description.clone()));
+    }
+    json!({
+        "type": "custom",
+        "custom": Value::Object(custom),
+    })
+}
+
 pub(crate) fn openai_tool_choice_to_canonical(
     value: Option<&Value>,
 ) -> Option<CanonicalToolChoice> {
@@ -3970,6 +4633,15 @@ pub(crate) fn openai_tool_choice_to_canonical(
             .and_then(Value::as_object)
             .and_then(|function| function.get("name"))
             .and_then(Value::as_str)
+            .or_else(|| {
+                object
+                    .get("custom")
+                    .and_then(Value::as_object)
+                    .and_then(|custom| custom.get("name"))
+                    .and_then(Value::as_str)
+            })
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
             .map(|name| CanonicalToolChoice::Tool {
                 name: name.to_string(),
             }),
@@ -4043,6 +4715,168 @@ pub(crate) fn canonical_tool_choice_to_openai(choice: &CanonicalToolChoice) -> V
             "type": "function",
             "function": { "name": name },
         }),
+    }
+}
+
+pub(crate) fn openai_tool_choice_raw_to_chat(value: &Value) -> Value {
+    let Some(object) = value.as_object() else {
+        return value.clone();
+    };
+    match object
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "function" => {
+            raw_named_tool_choice_to_chat(object, "function").unwrap_or_else(|| value.clone())
+        }
+        "custom" => {
+            raw_named_tool_choice_to_chat(object, "custom").unwrap_or_else(|| value.clone())
+        }
+        "allowed_tools" => raw_allowed_tool_choice_to_chat(object),
+        _ => value.clone(),
+    }
+}
+
+pub(crate) fn openai_tool_choice_raw_to_responses(value: &Value) -> Value {
+    let Some(object) = value.as_object() else {
+        return value.clone();
+    };
+    match object
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "function" => {
+            raw_named_tool_choice_to_responses(object, "function").unwrap_or_else(|| value.clone())
+        }
+        "custom" => {
+            raw_named_tool_choice_to_responses(object, "custom").unwrap_or_else(|| value.clone())
+        }
+        "allowed_tools" => raw_allowed_tool_choice_to_responses(object),
+        _ => value.clone(),
+    }
+}
+
+fn raw_named_tool_choice_to_chat(object: &Map<String, Value>, tool_type: &str) -> Option<Value> {
+    let name = raw_tool_choice_name(object, tool_type)?;
+    let mut named_tool = Map::new();
+    named_tool.insert("name".to_string(), Value::String(name));
+    let mut out = Map::new();
+    out.insert("type".to_string(), Value::String(tool_type.to_string()));
+    out.insert(tool_type.to_string(), Value::Object(named_tool));
+    Some(Value::Object(out))
+}
+
+fn raw_named_tool_choice_to_responses(
+    object: &Map<String, Value>,
+    tool_type: &str,
+) -> Option<Value> {
+    let name = raw_tool_choice_name(object, tool_type)?;
+    Some(json!({
+        "type": tool_type,
+        "name": name,
+    }))
+}
+
+fn raw_tool_choice_name(object: &Map<String, Value>, tool_type: &str) -> Option<String> {
+    object
+        .get("name")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            object
+                .get(tool_type)
+                .and_then(Value::as_object)
+                .and_then(|tool| tool.get("name"))
+                .and_then(Value::as_str)
+        })
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn raw_allowed_tool_choice_to_chat(object: &Map<String, Value>) -> Value {
+    let mut allowed = object
+        .get("allowed_tools")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_else(|| raw_allowed_tool_choice_payload(object));
+    if let Some(tools) = allowed.get("tools").and_then(Value::as_array) {
+        allowed.insert(
+            "tools".to_string(),
+            Value::Array(tools.iter().map(raw_allowed_tool_to_chat).collect()),
+        );
+    }
+    json!({
+        "type": "allowed_tools",
+        "allowed_tools": Value::Object(allowed),
+    })
+}
+
+fn raw_allowed_tool_choice_to_responses(object: &Map<String, Value>) -> Value {
+    let mut out = object
+        .get("allowed_tools")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_else(|| raw_allowed_tool_choice_payload(object));
+    out.insert(
+        "type".to_string(),
+        Value::String("allowed_tools".to_string()),
+    );
+    if let Some(tools) = out.get("tools").and_then(Value::as_array) {
+        out.insert(
+            "tools".to_string(),
+            Value::Array(tools.iter().map(raw_allowed_tool_to_responses).collect()),
+        );
+    }
+    Value::Object(out)
+}
+
+fn raw_allowed_tool_choice_payload(object: &Map<String, Value>) -> Map<String, Value> {
+    object
+        .iter()
+        .filter(|(key, _)| key.as_str() != "type")
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
+fn raw_allowed_tool_to_chat(value: &Value) -> Value {
+    let Some(object) = value.as_object() else {
+        return value.clone();
+    };
+    let tool_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    if tool_type == "function" || tool_type == "custom" {
+        raw_named_tool_choice_to_chat(object, &tool_type).unwrap_or_else(|| value.clone())
+    } else {
+        value.clone()
+    }
+}
+
+fn raw_allowed_tool_to_responses(value: &Value) -> Value {
+    let Some(object) = value.as_object() else {
+        return value.clone();
+    };
+    let tool_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    if tool_type == "function" || tool_type == "custom" {
+        raw_named_tool_choice_to_responses(object, &tool_type).unwrap_or_else(|| value.clone())
+    } else {
+        value.clone()
     }
 }
 
@@ -4661,15 +5495,49 @@ pub(crate) fn openai_response_format_to_canonical(
     value: Option<&Value>,
 ) -> Option<CanonicalResponseFormat> {
     let object = value?.as_object()?;
+    let format_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("text")
+        .to_string();
+    let json_schema = openai_response_format_json_schema(object, &format_type);
+    let excluded_fields =
+        if json_schema.is_some() && format_type.eq_ignore_ascii_case("json_schema") {
+            &[
+                "type",
+                "json_schema",
+                "name",
+                "description",
+                "schema",
+                "strict",
+            ][..]
+        } else {
+            &["type", "json_schema"][..]
+        };
     Some(CanonicalResponseFormat {
-        format_type: object
-            .get("type")
-            .and_then(Value::as_str)
-            .unwrap_or("text")
-            .to_string(),
-        json_schema: object.get("json_schema").cloned(),
-        extensions: openai_extensions(object, &["type", "json_schema"]),
+        format_type,
+        json_schema,
+        extensions: openai_extensions(object, excluded_fields),
     })
+}
+
+fn openai_response_format_json_schema(
+    object: &Map<String, Value>,
+    format_type: &str,
+) -> Option<Value> {
+    if let Some(json_schema) = object.get("json_schema").cloned() {
+        return Some(json_schema);
+    }
+    if !format_type.eq_ignore_ascii_case("json_schema") {
+        return None;
+    }
+    let mut schema = Map::new();
+    for field in ["name", "description", "schema", "strict"] {
+        if let Some(value) = object.get(field) {
+            schema.insert(field.to_string(), value.clone());
+        }
+    }
+    (!schema.is_empty()).then_some(Value::Object(schema))
 }
 
 pub(crate) fn canonical_response_format_to_openai(value: &CanonicalResponseFormat) -> Value {
@@ -4677,6 +5545,25 @@ pub(crate) fn canonical_response_format_to_openai(value: &CanonicalResponseForma
     output.insert("type".to_string(), Value::String(value.format_type.clone()));
     if let Some(json_schema) = &value.json_schema {
         output.insert("json_schema".to_string(), json_schema.clone());
+    }
+    Value::Object(output)
+}
+
+pub(crate) fn canonical_response_format_to_openai_responses(
+    value: &CanonicalResponseFormat,
+) -> Value {
+    let mut output = Map::new();
+    output.insert("type".to_string(), Value::String(value.format_type.clone()));
+    if let Some(json_schema) = &value.json_schema {
+        if value.format_type.eq_ignore_ascii_case("json_schema") {
+            if let Some(schema_object) = json_schema.as_object() {
+                output.extend(schema_object.clone());
+            } else {
+                output.insert("schema".to_string(), json_schema.clone());
+            }
+        } else {
+            output.insert("json_schema".to_string(), json_schema.clone());
+        }
     }
     Value::Object(output)
 }
@@ -5780,6 +6667,100 @@ mod tests {
     }
 
     #[test]
+    fn openai_chat_request_adapter_preserves_custom_tools_and_choices() {
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "run a custom tool"}],
+            "tools": [{
+                "type": "custom",
+                "custom": {
+                    "name": "shell_command",
+                    "description": "Run a shell command",
+                    "format": {
+                        "type": "text"
+                    }
+                }
+            }],
+            "tool_choice": {
+                "type": "custom",
+                "custom": {"name": "shell_command"}
+            }
+        });
+
+        let canonical = from_openai_chat_to_canonical_request(&request).expect("canonical request");
+        assert_eq!(canonical.tools.len(), 1);
+        assert_eq!(canonical.tools[0].name, "shell_command");
+        assert!(matches!(
+            canonical.tool_choice,
+            Some(super::CanonicalToolChoice::Tool { ref name }) if name == "shell_command"
+        ));
+
+        let rebuilt = canonical_to_openai_chat_request(&canonical).expect("openai chat request");
+        assert_eq!(rebuilt["tools"][0]["type"], "custom");
+        assert_eq!(rebuilt["tools"][0]["custom"]["name"], "shell_command");
+        assert_eq!(rebuilt["tools"][0]["custom"]["format"]["type"], "text");
+        assert_eq!(rebuilt["tool_choice"]["type"], "custom");
+        assert_eq!(rebuilt["tool_choice"]["custom"]["name"], "shell_command");
+
+        let responses = canonical_to_openai_responses_request(&canonical, "gpt-5-upstream", false)
+            .expect("openai responses request");
+        assert_eq!(responses["tools"][0]["type"], "custom");
+        assert_eq!(responses["tools"][0]["name"], "shell_command");
+        assert_eq!(responses["tools"][0]["format"]["type"], "text");
+        assert_eq!(responses["tool_choice"]["type"], "custom");
+        assert_eq!(responses["tool_choice"]["name"], "shell_command");
+    }
+
+    #[test]
+    fn openai_chat_request_adapter_preserves_allowed_tool_choice_for_responses() {
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "choose an allowed tool"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {"name": "lookup_weather", "parameters": {"type": "object"}}
+                },
+                {
+                    "type": "custom",
+                    "custom": {"name": "shell_command", "format": {"type": "text"}}
+                }
+            ],
+            "tool_choice": {
+                "type": "allowed_tools",
+                "allowed_tools": {
+                    "mode": "required",
+                    "tools": [
+                        {"type": "function", "function": {"name": "lookup_weather"}},
+                        {"type": "custom", "custom": {"name": "shell_command"}}
+                    ]
+                }
+            }
+        });
+
+        let canonical = from_openai_chat_to_canonical_request(&request).expect("canonical request");
+        assert!(canonical.tool_choice.is_none());
+
+        let rebuilt = canonical_to_openai_chat_request(&canonical).expect("openai chat request");
+        assert_eq!(rebuilt["tool_choice"], request["tool_choice"]);
+
+        let responses = canonical_to_openai_responses_request(&canonical, "gpt-5-upstream", false)
+            .expect("openai responses request");
+        assert_eq!(responses["tool_choice"]["type"], "allowed_tools");
+        assert_eq!(responses["tool_choice"]["mode"], "required");
+        assert_eq!(responses["tool_choice"]["tools"][0]["type"], "function");
+        assert_eq!(
+            responses["tool_choice"]["tools"][0]["name"],
+            "lookup_weather"
+        );
+        assert_eq!(responses["tool_choice"]["tools"][1]["type"], "custom");
+        assert_eq!(
+            responses["tool_choice"]["tools"][1]["name"],
+            "shell_command"
+        );
+    }
+
+    #[test]
     fn canonical_response_roundtrips_reasoning_tool_usage_and_unknown_extensions() {
         let response = json!({
             "id": "chatcmpl_1",
@@ -5841,6 +6822,164 @@ mod tests {
             rebuilt["usage"]["completion_tokens_details"]["reasoning_tokens"],
             1
         );
+    }
+
+    #[test]
+    fn openai_chat_response_preserves_custom_tool_calls_for_responses() {
+        let response = json!({
+            "id": "chatcmpl_custom",
+            "object": "chat.completion",
+            "model": "gpt-5",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_custom_1",
+                        "type": "custom",
+                        "custom": {
+                            "name": "shell_command",
+                            "input": "ls -la"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let canonical =
+            from_openai_chat_to_canonical_response(&response).expect("canonical response");
+        assert!(matches!(
+            canonical.content[0],
+            CanonicalContentBlock::ToolUse { ref id, ref name, ref input, .. }
+                if id == "call_custom_1" && name == "shell_command" && input == "ls -la"
+        ));
+
+        let rebuilt_chat = canonical_to_openai_chat_response(&canonical);
+        assert_eq!(
+            rebuilt_chat["choices"][0]["message"]["tool_calls"][0]["type"],
+            "custom"
+        );
+        assert_eq!(
+            rebuilt_chat["choices"][0]["message"]["tool_calls"][0]["custom"]["name"],
+            "shell_command"
+        );
+
+        let responses = canonical_to_openai_responses_response(&canonical, &json!({}));
+        assert_eq!(responses["output"][0]["type"], "custom_tool_call");
+        assert_eq!(responses["output"][0]["name"], "shell_command");
+        assert_eq!(responses["output"][0]["input"], "ls -la");
+    }
+
+    #[test]
+    fn openai_responses_response_preserves_custom_tool_calls_for_chat() {
+        let response = json!({
+            "id": "resp_custom",
+            "object": "response",
+            "status": "completed",
+            "model": "gpt-5",
+            "output": [{
+                "type": "custom_tool_call",
+                "id": "call_custom_1",
+                "call_id": "call_custom_1",
+                "status": "completed",
+                "name": "shell_command",
+                "input": "pwd"
+            }]
+        });
+
+        let canonical =
+            from_openai_responses_to_canonical_response(&response).expect("canonical response");
+        assert!(matches!(
+            canonical.content[0],
+            CanonicalContentBlock::ToolUse { ref id, ref name, ref input, .. }
+                if id == "call_custom_1" && name == "shell_command" && input == "pwd"
+        ));
+
+        let chat = canonical_to_openai_chat_response(&canonical);
+        assert_eq!(
+            chat["choices"][0]["message"]["tool_calls"][0]["type"],
+            "custom"
+        );
+        assert_eq!(
+            chat["choices"][0]["message"]["tool_calls"][0]["custom"]["name"],
+            "shell_command"
+        );
+        assert_eq!(
+            chat["choices"][0]["message"]["tool_calls"][0]["custom"]["input"],
+            "pwd"
+        );
+
+        let rebuilt = canonical_to_openai_responses_response(&canonical, &json!({}));
+        assert_eq!(rebuilt["output"][0]["type"], "custom_tool_call");
+        assert_eq!(rebuilt["output"][0]["input"], "pwd");
+    }
+
+    #[test]
+    fn openai_response_adapters_preserve_audio_output_shapes() {
+        let chat_response = json!({
+            "id": "chatcmpl_audio",
+            "object": "chat.completion",
+            "model": "gpt-5-audio",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "hello",
+                    "audio": {
+                        "id": "audio_1",
+                        "data": "QUJDRA==",
+                        "expires_at": 123,
+                        "transcript": "hello"
+                    }
+                },
+                "finish_reason": "stop"
+            }]
+        });
+
+        let canonical =
+            from_openai_chat_to_canonical_response(&chat_response).expect("canonical response");
+        assert!(canonical.content.iter().any(
+            |block| matches!(block, CanonicalContentBlock::Audio { data, .. } if data.as_deref() == Some("QUJDRA=="))
+        ));
+
+        let rebuilt_chat = canonical_to_openai_chat_response(&canonical);
+        assert_eq!(
+            rebuilt_chat["choices"][0]["message"]["audio"]["id"],
+            "audio_1"
+        );
+        assert_eq!(
+            rebuilt_chat["choices"][0]["message"]["audio"]["transcript"],
+            "hello"
+        );
+
+        let responses = canonical_to_openai_responses_response(&canonical, &json!({}));
+        assert_eq!(responses["output"][0]["content"][1]["type"], "output_audio");
+        assert_eq!(responses["output"][0]["content"][1]["data"], "QUJDRA==");
+        assert_eq!(responses["output"][0]["content"][1]["transcript"], "hello");
+
+        let responses_response = json!({
+            "id": "resp_audio",
+            "object": "response",
+            "status": "completed",
+            "model": "gpt-5-audio",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{
+                    "type": "output_audio",
+                    "data": "RUZHSA==",
+                    "transcript": "hi"
+                }]
+            }]
+        });
+
+        let canonical = from_openai_responses_to_canonical_response(&responses_response)
+            .expect("canonical response");
+        let chat = canonical_to_openai_chat_response(&canonical);
+        assert_eq!(chat["choices"][0]["message"]["audio"]["data"], "RUZHSA==");
+        assert_eq!(chat["choices"][0]["message"]["audio"]["transcript"], "hi");
     }
 
     #[test]
@@ -5930,7 +7069,9 @@ mod tests {
             "text": {
                 "format": {
                     "type": "json_schema",
-                    "json_schema": {"name": "answer", "schema": {"type": "object"}}
+                    "name": "answer",
+                    "schema": {"type": "object"},
+                    "strict": true
                 },
                 "verbosity": "low"
             },
@@ -5967,11 +7108,39 @@ mod tests {
                 .and_then(Value::as_str),
             Some("high")
         );
+        assert_eq!(
+            canonical
+                .response_format
+                .as_ref()
+                .and_then(|format| format.json_schema.as_ref())
+                .and_then(|schema| schema.get("name"))
+                .and_then(Value::as_str),
+            Some("answer")
+        );
+        assert_eq!(
+            canonical
+                .response_format
+                .as_ref()
+                .and_then(|format| format.json_schema.as_ref())
+                .and_then(|schema| schema.get("strict"))
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+
+        let rebuilt_chat =
+            canonical_to_openai_chat_request(&canonical).expect("openai chat request");
+        assert_eq!(rebuilt_chat["response_format"]["type"], "json_schema");
+        assert_eq!(
+            rebuilt_chat["response_format"]["json_schema"]["name"],
+            "answer"
+        );
 
         let rebuilt = canonical_to_openai_responses_request(&canonical, "gpt-5-upstream", false)
             .expect("openai responses request");
         assert_eq!(rebuilt["model"], "gpt-5-upstream");
-        assert_eq!(rebuilt["text"]["format"]["json_schema"]["name"], "answer");
+        assert_eq!(rebuilt["text"]["format"]["name"], "answer");
+        assert_eq!(rebuilt["text"]["format"]["strict"], true);
+        assert!(rebuilt["text"]["format"].get("json_schema").is_none());
         assert_eq!(rebuilt["text"]["verbosity"], "low");
         assert_eq!(rebuilt["tool_choice"]["name"], "lookup");
     }
@@ -6043,6 +7212,231 @@ mod tests {
     }
 
     #[test]
+    fn openai_responses_request_adapter_preserves_custom_tool_choice_for_chat() {
+        let request = json!({
+            "model": "gpt-5",
+            "input": "Use the custom tool",
+            "tools": [{
+                "type": "custom",
+                "name": "shell_command",
+                "description": "Run a shell command",
+                "format": {"type": "text"}
+            }],
+            "tool_choice": {
+                "type": "custom",
+                "name": "shell_command"
+            }
+        });
+
+        let canonical =
+            from_openai_responses_to_canonical_request(&request).expect("canonical request");
+        assert!(matches!(
+            canonical.tool_choice,
+            Some(super::CanonicalToolChoice::Tool { ref name }) if name == "shell_command"
+        ));
+
+        let chat = canonical_to_openai_chat_request(&canonical).expect("openai chat request");
+        assert_eq!(chat["tools"][0]["type"], "custom");
+        assert_eq!(chat["tools"][0]["custom"]["name"], "shell_command");
+        assert_eq!(chat["tools"][0]["custom"]["format"]["type"], "text");
+        assert_eq!(chat["tool_choice"]["type"], "custom");
+        assert_eq!(chat["tool_choice"]["custom"]["name"], "shell_command");
+
+        let rebuilt = canonical_to_openai_responses_request(&canonical, "gpt-5-upstream", false)
+            .expect("openai responses request");
+        assert_eq!(rebuilt["tools"][0]["type"], "custom");
+        assert_eq!(rebuilt["tools"][0]["name"], "shell_command");
+        assert_eq!(rebuilt["tool_choice"]["type"], "custom");
+        assert_eq!(rebuilt["tool_choice"]["name"], "shell_command");
+    }
+
+    #[test]
+    fn openai_responses_request_adapter_accepts_single_input_item_object() {
+        let request = json!({
+            "model": "gpt-5",
+            "input": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}]
+            }
+        });
+
+        let canonical =
+            from_openai_responses_to_canonical_request(&request).expect("canonical request");
+        assert_eq!(canonical.messages.len(), 1);
+        assert_eq!(canonical.messages[0].role, CanonicalRole::User);
+
+        let rebuilt = canonical_to_openai_responses_request(&canonical, "gpt-5-upstream", false)
+            .expect("openai responses request");
+        assert_eq!(rebuilt["input"][0]["type"], "message");
+        assert_eq!(rebuilt["input"][0]["role"], "user");
+        assert_eq!(rebuilt["input"][0]["content"][0]["text"], "hello");
+    }
+
+    #[test]
+    fn openai_responses_request_adapter_preserves_custom_tool_history() {
+        let request = json!({
+            "model": "gpt-5",
+            "input": [
+                {
+                    "type": "custom_tool_call",
+                    "id": "ctc_1",
+                    "call_id": "call_custom_1",
+                    "name": "shell_command",
+                    "input": "ls -la",
+                    "status": "completed"
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_custom_1",
+                    "output": "ok"
+                }
+            ]
+        });
+
+        let canonical =
+            from_openai_responses_to_canonical_request(&request).expect("canonical request");
+
+        let chat = canonical_to_openai_chat_request(&canonical).expect("openai chat request");
+        assert_eq!(chat["messages"][0]["tool_calls"][0]["type"], "custom");
+        assert_eq!(
+            chat["messages"][0]["tool_calls"][0]["custom"]["name"],
+            "shell_command"
+        );
+        assert_eq!(
+            chat["messages"][0]["tool_calls"][0]["custom"]["input"],
+            "ls -la"
+        );
+
+        let rebuilt = canonical_to_openai_responses_request(&canonical, "gpt-5-upstream", false)
+            .expect("openai responses request");
+        assert_eq!(rebuilt["input"][0]["type"], "custom_tool_call");
+        assert_eq!(rebuilt["input"][0]["name"], "shell_command");
+        assert_eq!(rebuilt["input"][0]["input"], "ls -la");
+        assert_eq!(rebuilt["input"][1]["type"], "custom_tool_call_output");
+        assert_eq!(rebuilt["input"][1]["output"], "ok");
+    }
+
+    #[test]
+    fn openai_responses_request_adapter_preserves_reasoning_encrypted_content_history() {
+        let request = json!({
+            "model": "gpt-5",
+            "input": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [{"type": "summary_text", "text": "think"}],
+                    "encrypted_content": "enc_reasoning"
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "done"}]
+                }
+            ]
+        });
+
+        let canonical =
+            from_openai_responses_to_canonical_request(&request).expect("canonical request");
+        assert!(matches!(
+            canonical.messages[0].content[0],
+            CanonicalContentBlock::Thinking { ref text, ref encrypted_content, .. }
+                if text == "think" && encrypted_content.as_deref() == Some("enc_reasoning")
+        ));
+
+        let rebuilt = canonical_to_openai_responses_request(&canonical, "gpt-5-upstream", false)
+            .expect("openai responses request");
+        assert_eq!(rebuilt["input"][0]["type"], "reasoning");
+        assert_eq!(rebuilt["input"][0]["summary"][0]["text"], "think");
+        assert_eq!(rebuilt["input"][0]["encrypted_content"], "enc_reasoning");
+        assert_eq!(rebuilt["input"][1]["type"], "message");
+        assert_eq!(rebuilt["input"][1]["content"][0]["text"], "done");
+    }
+
+    #[test]
+    fn openai_responses_request_adapter_preserves_file_url_and_tool_output_parts() {
+        let request = json!({
+            "model": "gpt-5",
+            "messages": [
+                {"role": "user", "content": [
+                    {"type": "file", "file": {"file_url": "https://example.com/input.pdf", "filename": "input.pdf"}}
+                ]},
+                {"role": "assistant", "content": null, "tool_calls": [{
+                    "id": "call_render",
+                    "type": "function",
+                    "function": {"name": "render", "arguments": "{}"}
+                }]},
+                {"role": "tool", "tool_call_id": "call_render", "content": [
+                    {"type": "text", "text": "Rendered result attached."},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/out.png", "detail": "high"}},
+                    {"type": "file", "file": {"file_url": "https://example.com/report.pdf", "filename": "report.pdf"}}
+                ]}
+            ]
+        });
+
+        let canonical = from_openai_chat_to_canonical_request(&request).expect("canonical request");
+        let rebuilt = canonical_to_openai_responses_request(&canonical, "gpt-5-upstream", false)
+            .expect("openai responses request");
+
+        assert_eq!(
+            rebuilt["input"][0]["content"][0]["file_url"],
+            "https://example.com/input.pdf"
+        );
+        assert!(rebuilt["input"][0]["content"][0].get("file_data").is_none());
+        assert_eq!(rebuilt["input"][2]["type"], "function_call_output");
+        assert_eq!(rebuilt["input"][2]["output"][0]["type"], "input_text");
+        assert_eq!(
+            rebuilt["input"][2]["output"][1]["image_url"],
+            "https://example.com/out.png"
+        );
+        assert_eq!(rebuilt["input"][2]["output"][1]["detail"], "high");
+        assert_eq!(
+            rebuilt["input"][2]["output"][2]["file_url"],
+            "https://example.com/report.pdf"
+        );
+    }
+
+    #[test]
+    fn openai_responses_request_adapter_preserves_allowed_tool_choice_for_chat() {
+        let request = json!({
+            "model": "gpt-5",
+            "input": "choose an allowed tool",
+            "tools": [
+                {"type": "function", "name": "lookup_weather", "parameters": {"type": "object"}},
+                {"type": "custom", "name": "shell_command", "format": {"type": "text"}}
+            ],
+            "tool_choice": {
+                "type": "allowed_tools",
+                "mode": "auto",
+                "tools": [
+                    {"type": "function", "name": "lookup_weather"},
+                    {"type": "custom", "name": "shell_command"}
+                ]
+            }
+        });
+
+        let canonical =
+            from_openai_responses_to_canonical_request(&request).expect("canonical request");
+        assert!(canonical.tool_choice.is_none());
+
+        let chat = canonical_to_openai_chat_request(&canonical).expect("openai chat request");
+        assert_eq!(chat["tool_choice"]["type"], "allowed_tools");
+        assert_eq!(chat["tool_choice"]["allowed_tools"]["mode"], "auto");
+        assert_eq!(
+            chat["tool_choice"]["allowed_tools"]["tools"][0]["function"]["name"],
+            "lookup_weather"
+        );
+        assert_eq!(
+            chat["tool_choice"]["allowed_tools"]["tools"][1]["custom"]["name"],
+            "shell_command"
+        );
+
+        let rebuilt = canonical_to_openai_responses_request(&canonical, "gpt-5-upstream", false)
+            .expect("openai responses request");
+        assert_eq!(rebuilt["tool_choice"], request["tool_choice"]);
+    }
+
+    #[test]
     fn openai_responses_response_adapter_preserves_output_items_reasoning_tools_and_usage() {
         let response = json!({
             "id": "resp_123",
@@ -6099,6 +7493,25 @@ mod tests {
                     "output": {"ok": true}
                 },
                 {
+                    "type": "local_shell_call",
+                    "id": "lsc_1",
+                    "call_id": "call_shell_1",
+                    "status": "completed",
+                    "action": {
+                        "type": "exec",
+                        "command": ["pwd"]
+                    }
+                },
+                {
+                    "type": "local_shell_call_output",
+                    "call_id": "call_shell_1",
+                    "output": {
+                        "stdout": "/tmp/project\n",
+                        "stderr": "",
+                        "outcome": "success"
+                    }
+                },
+                {
                     "type": "future_item",
                     "payload": true
                 }
@@ -6124,7 +7537,15 @@ mod tests {
             |block| matches!(block, CanonicalContentBlock::ToolUse { name, .. } if name == "lookup")
         ));
         assert!(canonical.content.iter().any(
+            |block| matches!(block, CanonicalContentBlock::ToolUse { name, input, .. }
+                if name == "local_shell" && input["action"]["command"][0] == "pwd")
+        ));
+        assert!(canonical.content.iter().any(
             |block| matches!(block, CanonicalContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "call_1")
+        ));
+        assert!(canonical.content.iter().any(
+            |block| matches!(block, CanonicalContentBlock::ToolResult { tool_use_id, name: Some(name), .. }
+                if tool_use_id == "call_shell_1" && name == "local_shell")
         ));
         assert_eq!(canonical_response_unknown_block_count(&canonical), 2);
         assert_eq!(canonical.usage.as_ref().unwrap().cache_read_tokens, 2);
@@ -6148,6 +7569,10 @@ mod tests {
         assert_eq!(rebuilt["output"][1]["content"][1]["type"], "refusal");
         assert_eq!(rebuilt["output"][2]["type"], "function_call");
         assert_eq!(rebuilt["output"][3]["type"], "function_call_output");
+        assert_eq!(rebuilt["output"][4]["type"], "local_shell_call");
+        assert_eq!(rebuilt["output"][4]["action"]["command"][0], "pwd");
+        assert_eq!(rebuilt["output"][5]["type"], "local_shell_call_output");
+        assert_eq!(rebuilt["output"][5]["call_id"], "call_shell_1");
         assert_eq!(rebuilt["usage"]["input_tokens_details"]["cached_tokens"], 2);
         assert_eq!(
             rebuilt["usage"]["output_tokens_details"]["reasoning_tokens"],

--- a/crates/aether-ai-formats/src/protocol/canonical.rs
+++ b/crates/aether-ai-formats/src/protocol/canonical.rs
@@ -16,6 +16,7 @@ const CLAUDE_MESSAGES_REQUEST_SOURCE_MARKER: &str = "claude_messages_request";
 const CLAUDE_SYSTEM_SOURCE_MARKER: &str = "claude_system";
 const CLAUDE_THINKING_SOURCE_MARKER: &str = "claude_thinking";
 const CLAUDE_TOOL_RESULT_SOURCE_MARKER: &str = "claude_tool_result";
+const CLAUDE_RAW_SOURCE_MARKER: &str = "claude_raw";
 const OPENAI_THINKING_SOURCE_MARKER: &str = "openai_thinking";
 const OPENAI_CUSTOM_TOOL_CALL_SOURCE_MARKER: &str = "openai_custom_tool_call";
 const OPENAI_OUTPUT_AUDIO_SOURCE_MARKER: &str = "openai_output_audio";
@@ -1483,7 +1484,7 @@ pub(crate) fn claude_block_to_canonical_block(block: &Value) -> Option<Canonical
         _ => Some(CanonicalContentBlock::Unknown {
             raw_type,
             payload: block.clone(),
-            extensions: BTreeMap::new(),
+            extensions: claude_raw_extensions(BTreeMap::new()),
         }),
     }
 }
@@ -1570,7 +1571,7 @@ pub(crate) fn claude_media_block_to_canonical(
                 .unwrap_or_default()
                 .to_string(),
             payload: Value::Object(block.clone()),
-            extensions: BTreeMap::new(),
+            extensions: claude_raw_extensions(BTreeMap::new()),
         }),
     }
 }
@@ -3186,6 +3187,14 @@ fn claude_thinking_extensions(mut extensions: BTreeMap<String, Value>) -> BTreeM
     extensions
 }
 
+fn claude_raw_extensions(mut extensions: BTreeMap<String, Value>) -> BTreeMap<String, Value> {
+    canonical_extension_object_mut(&mut extensions, AETHER_EXTENSION_NAMESPACE).insert(
+        "source".to_string(),
+        Value::String(CLAUDE_RAW_SOURCE_MARKER.to_string()),
+    );
+    extensions
+}
+
 fn openai_thinking_extensions(mut extensions: BTreeMap<String, Value>) -> BTreeMap<String, Value> {
     canonical_extension_object_mut(&mut extensions, AETHER_EXTENSION_NAMESPACE).insert(
         "source".to_string(),
@@ -3214,6 +3223,14 @@ pub(crate) fn is_claude_thinking_block(extensions: &BTreeMap<String, Value>) -> 
         .and_then(|value| value.get("source"))
         .and_then(Value::as_str)
         == Some(CLAUDE_THINKING_SOURCE_MARKER)
+}
+
+fn is_claude_raw_block(extensions: &BTreeMap<String, Value>) -> bool {
+    extensions
+        .get(AETHER_EXTENSION_NAMESPACE)
+        .and_then(|value| value.get("source"))
+        .and_then(Value::as_str)
+        == Some(CLAUDE_RAW_SOURCE_MARKER)
 }
 
 pub(crate) fn is_openai_thinking_block(extensions: &BTreeMap<String, Value>) -> bool {
@@ -5121,6 +5138,11 @@ pub(crate) fn canonical_block_to_claude(
             out.extend(namespace_extension_object(extensions, "claude", &out));
             Some(Some(Value::Object(out)))
         }
+        CanonicalContentBlock::Unknown {
+            payload,
+            extensions,
+            ..
+        } if is_claude_raw_block(extensions) => Some(Some(payload.clone())),
         CanonicalContentBlock::Unknown { .. } => Some(None),
     }
 }
@@ -5642,6 +5664,17 @@ pub(crate) fn claude_usage_to_canonical(value: Option<&Value>) -> Option<Canonic
         .get("cache_creation_input_tokens")
         .and_then(Value::as_u64)
         .unwrap_or(0);
+    let reasoning_tokens = usage
+        .get("output_tokens_details")
+        .and_then(Value::as_object)
+        .and_then(|details| {
+            details
+                .get("thinking_tokens")
+                .or_else(|| details.get("reasoning_tokens"))
+        })
+        .or_else(|| usage.get("reasoning_tokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
     Some(CanonicalUsage {
         input_tokens,
         input_tokens_include_cache: false,
@@ -5669,9 +5702,11 @@ pub(crate) fn claude_usage_to_canonical(value: Option<&Value>) -> Option<Canonic
                 "cache_read_input_tokens",
                 "cache_creation_input_tokens",
                 "cache_creation",
+                "output_tokens_details",
+                "reasoning_tokens",
             ],
         ),
-        ..CanonicalUsage::default()
+        reasoning_tokens,
     })
 }
 
@@ -5800,6 +5835,11 @@ pub(crate) fn canonical_usage_to_claude(value: &CanonicalUsage) -> Value {
         output["cache_creation"] = json!({
             "ephemeral_5m_input_tokens": value.cache_creation_ephemeral_5m_tokens,
             "ephemeral_1h_input_tokens": value.cache_creation_ephemeral_1h_tokens,
+        });
+    }
+    if value.reasoning_tokens > 0 {
+        output["output_tokens_details"] = json!({
+            "thinking_tokens": value.reasoning_tokens,
         });
     }
     output
@@ -7794,6 +7834,52 @@ mod tests {
     }
 
     #[test]
+    fn claude_request_adapter_preserves_official_raw_content_blocks() {
+        let request = json!({
+            "model": "claude-sonnet-4-5",
+            "messages": [{
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "server_tool_use",
+                        "id": "srvu_1",
+                        "name": "web_search",
+                        "input": {"query": "rust"}
+                    },
+                    {
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "srvu_1",
+                        "content": [{
+                            "type": "web_search_result",
+                            "title": "Rust",
+                            "url": "https://www.rust-lang.org/",
+                            "encrypted_content": "enc"
+                        }]
+                    }
+                ]
+            }]
+        });
+
+        let canonical = from_claude_to_canonical_request(&request).expect("canonical request");
+        assert_eq!(canonical_request_unknown_block_count(&canonical), 2);
+
+        let rebuilt = canonical_to_claude_request(&canonical, "claude-upstream", false)
+            .expect("claude request");
+        assert_eq!(
+            rebuilt["messages"][1]["content"][0]["type"],
+            "server_tool_use"
+        );
+        assert_eq!(
+            rebuilt["messages"][1]["content"][1]["type"],
+            "web_search_tool_result"
+        );
+        assert_eq!(
+            rebuilt["messages"][1]["content"][1]["content"][0]["encrypted_content"],
+            "enc"
+        );
+    }
+
+    #[test]
     fn canonical_to_openai_chat_request_rejects_unrepresentable_claude_tool_result() {
         let request = json!({
             "model": "claude-sonnet",
@@ -7845,7 +7931,8 @@ mod tests {
                 "input_tokens": 11,
                 "output_tokens": 7,
                 "cache_read_input_tokens": 3,
-                "cache_creation_input_tokens": 2
+                "cache_creation_input_tokens": 2,
+                "output_tokens_details": {"thinking_tokens": 4}
             }
         });
 
@@ -7865,6 +7952,7 @@ mod tests {
         ));
         assert_eq!(canonical.usage.as_ref().unwrap().cache_read_tokens, 3);
         assert_eq!(canonical.usage.as_ref().unwrap().cache_write_tokens, 2);
+        assert_eq!(canonical.usage.as_ref().unwrap().reasoning_tokens, 4);
 
         let rebuilt = canonical_to_claude_response(&canonical);
         assert_eq!(rebuilt["content"][0]["signature"], "sig_123");
@@ -7872,8 +7960,22 @@ mod tests {
         assert_eq!(rebuilt["stop_reason"], "tool_use");
         assert_eq!(rebuilt["usage"]["cache_read_input_tokens"], 3);
         assert_eq!(rebuilt["usage"]["cache_creation_input_tokens"], 2);
+        assert_eq!(
+            rebuilt["usage"]["output_tokens_details"]["thinking_tokens"],
+            4
+        );
+
+        let rebuilt_chat = canonical_to_openai_chat_response(&canonical);
+        assert_eq!(
+            rebuilt_chat["usage"]["completion_tokens_details"]["reasoning_tokens"],
+            4
+        );
 
         let rebuilt_openai = canonical_to_openai_responses_response(&canonical, &json!({}));
+        assert_eq!(
+            rebuilt_openai["usage"]["output_tokens_details"]["reasoning_tokens"],
+            4
+        );
         assert_eq!(rebuilt_openai["usage"]["input_tokens"], 16);
         assert_eq!(
             rebuilt_openai["usage"]["input_tokens_details"]["cached_tokens"],

--- a/crates/aether-ai-formats/src/protocol/canonical.rs
+++ b/crates/aether-ai-formats/src/protocol/canonical.rs
@@ -808,6 +808,66 @@ pub(crate) fn canonical_tool_use_to_openai_responses_item(
     })
 }
 
+pub(crate) fn canonical_tool_use_to_openai_responses_input_item(
+    id: &str,
+    name: &str,
+    input: &Value,
+    extensions: &BTreeMap<String, Value>,
+) -> Value {
+    if let Some(item_type) = openai_responses_hosted_tool_call_item_type(extensions) {
+        let mut item = Map::new();
+        item.insert("type".to_string(), Value::String(item_type.to_string()));
+        item.insert("id".to_string(), Value::String(id.to_string()));
+        item.insert("call_id".to_string(), Value::String(id.to_string()));
+        item.insert("status".to_string(), Value::String("completed".to_string()));
+        if let Some(input_object) = input.as_object() {
+            for field in openai_responses_hosted_tool_input_fields(item_type) {
+                if let Some(value) = input_object.get(*field) {
+                    item.insert((*field).to_string(), value.clone());
+                }
+            }
+        } else if item_type == "apply_patch_call" {
+            item.insert("operation".to_string(), input.clone());
+        } else if !name.trim().is_empty() {
+            item.insert("name".to_string(), Value::String(name.to_string()));
+        }
+        return Value::Object(item);
+    }
+    if is_openai_custom_tool_call(extensions) {
+        let mut item = Map::new();
+        item.insert(
+            "type".to_string(),
+            Value::String("custom_tool_call".to_string()),
+        );
+        if let Some(item_id) = openai_responses_request_tool_call_item_id(extensions, "ctc") {
+            item.insert("id".to_string(), Value::String(item_id));
+        }
+        item.insert("call_id".to_string(), Value::String(id.to_string()));
+        item.insert("status".to_string(), Value::String("completed".to_string()));
+        item.insert("name".to_string(), Value::String(name.to_string()));
+        item.insert(
+            "input".to_string(),
+            Value::String(openai_custom_tool_input_text(input)),
+        );
+        return Value::Object(item);
+    }
+    let mut item = Map::new();
+    item.insert(
+        "type".to_string(),
+        Value::String("function_call".to_string()),
+    );
+    if let Some(item_id) = openai_responses_request_tool_call_item_id(extensions, "fc") {
+        item.insert("id".to_string(), Value::String(item_id));
+    }
+    item.insert("call_id".to_string(), Value::String(id.to_string()));
+    item.insert("name".to_string(), Value::String(name.to_string()));
+    item.insert(
+        "arguments".to_string(),
+        Value::String(canonicalize_tool_arguments(input)),
+    );
+    Value::Object(item)
+}
+
 fn openai_responses_tool_call_item_id(
     call_id: &str,
     extensions: &BTreeMap<String, Value>,
@@ -826,6 +886,18 @@ fn openai_responses_tool_call_item_id(
     } else {
         trimmed.to_string()
     }
+}
+
+fn openai_responses_request_tool_call_item_id(
+    extensions: &BTreeMap<String, Value>,
+    prefix: &str,
+) -> Option<String> {
+    openai_responses_extension(extensions)
+        .and_then(|value| value.get("item_id").or_else(|| value.get("id")))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| value.starts_with(prefix))
+        .map(ToString::to_string)
 }
 
 fn openai_responses_hosted_tool_call_item_type(

--- a/crates/aether-ai-formats/src/protocol/canonical.rs
+++ b/crates/aether-ai-formats/src/protocol/canonical.rs
@@ -795,13 +795,25 @@ pub(crate) fn canonical_tool_use_to_openai_responses_item(
             "input": openai_custom_tool_input_text(input),
         });
     }
+    let item_id = openai_responses_function_call_item_id(id);
     json!({
         "type": "function_call",
-        "id": id,
+        "id": item_id,
         "call_id": id,
         "name": name,
         "arguments": canonicalize_tool_arguments(input),
     })
+}
+
+fn openai_responses_function_call_item_id(call_id: &str) -> String {
+    let trimmed = call_id.trim();
+    if trimmed.starts_with("fc") {
+        trimmed.to_string()
+    } else if trimmed.is_empty() {
+        "fc_auto".to_string()
+    } else {
+        format!("fc_{trimmed}")
+    }
 }
 
 fn openai_responses_hosted_tool_call_item_type(


### PR DESCRIPTION
## 背景

本 PR 根据 OpenAI 官方 Chat Completions、Responses API 以及迁移文档，修复当前格式转换中多处不兼容或信息丢失的问题，并调整 Codex/OpenAI `cyber_policy` 错误的本地 failover 行为。

## 主要改动

- 修复 OpenAI Chat ↔ Responses 的 `response_format` / `text.format` 结构差异，Chat 使用嵌套 `json_schema`，Responses 使用扁平 `json_schema` 字段。
- 补齐 Responses request history 转换能力，支持单个 `input` item object、`custom_tool_call`、`custom_tool_call_output` 和 `reasoning.encrypted_content`。
- 修复文件输入输出字段映射，外部文件 URL 使用 `file_url`，内联数据才使用 `file_data`。
- 保留 Chat tool result 的多模态 content array，转换为 Responses `function_call_output.output` 中的 `input_text` / `input_image` / `input_file` 数组，避免被 JSON 字符串化。
- 补齐 Responses stream 中官方 sidecar/no-op 事件处理，避免 `response.metadata` 等事件触发不必要的转换错误。
- 修复 custom tools、custom tool calls、hosted tool items、audio output 等 Chat/Responses 转换中的结构保留问题。
- 对 Codex/OpenAI `error.code = "cyber_policy"` 增加结构化识别：遇到该错误时停止本地 failover，透传原始错误响应给客户端，不再继续调度其他账号。
- 避免 `cyber_policy` 被计入普通 provider health/affinity 失败，并在 provider summary 中暴露相关开关。

## 验证

- `cargo fmt --package aether-ai-formats --package aether-gateway`
- `cargo test -p aether-ai-formats`
- `cargo test -p aether-ai-formats openai_responses_request_adapter --lib`
- `git -C .\Aether diff --check`


二次变更：

支持 Claude 官方 usage.output_tokens_details.thinking_tokens，同步映射到 canonical/OpenAI 的 reasoning_tokens。
Claude usage 回写时使用官方 output_tokens_details.thinking_tokens，避免 reasoning/thinking token 统计丢失。
流式 Claude usage parser 同步支持 thinking_tokens，保持同步/流式统计一致。
Claude 来源的未知官方内容块增加 claude_raw 来源标记，回写 Claude 时原样保留。
补充 server_tool_use、web_search_tool_result 等官方 raw content block 的回归测试，避免被静默丢弃。
补充 Claude response → OpenAI Chat/Responses 的 reasoning usage 回归断言。
影响范围：

Claude Messages → OpenAI Chat/Responses：thinking token 会正确体现在 OpenAI usage 的 reasoning_tokens。
Claude Messages → Claude Messages：官方新增内容块不再因 canonical 中转被丢弃。
OpenAI/Gemini 目标不会盲目接收 Claude raw block，仍保持现有 unknown/fail-closed 策略。
