### PR TITLE
fix: unify simulated cache handling and expose usage to proxy clients

### DIFF
--- a/apps/aether-gateway/src/control/auth/resolution.rs
+++ b/apps/aether-gateway/src/control/auth/resolution.rs
@@ -517,7 +517,16 @@ pub(crate) async fn refresh_execution_runtime_auth_context(
     auth_context: GatewayControlAuthContext,
     auth_endpoint_signature: Option<&str>,
 ) -> Result<GatewayControlAuthContext, GatewayError> {
-    if auth_context.local_rejection.is_some() || !auth_context.access_allowed {
+    let should_refresh_wallet_rejection = matches!(
+        auth_context.local_rejection,
+        Some(
+            GatewayLocalAuthRejection::BalanceDenied { .. }
+                | GatewayLocalAuthRejection::WalletUnavailable
+        )
+    );
+    if !should_refresh_wallet_rejection
+        && (auth_context.local_rejection.is_some() || !auth_context.access_allowed)
+    {
         return Ok(auth_context);
     }
     let Some(auth_endpoint_signature) = auth_endpoint_signature
@@ -1329,6 +1338,103 @@ mod tests {
             })
         );
         assert!(!second.access_allowed);
+    }
+
+    #[tokio::test]
+    async fn execution_runtime_auth_context_revalidates_cached_unlimited_wallet_state() {
+        let api_key = "sk-test-runtime-wallet-unlimited";
+        let auth_repository = Arc::new(InMemoryAuthApiKeySnapshotRepository::seed(vec![(
+            Some(hash_api_key(api_key)),
+            sample_snapshot(
+                "key-runtime-wallet-unlimited",
+                "user-runtime-wallet-unlimited",
+            ),
+        )]));
+        let wallet_repository = Arc::new(InMemoryWalletRepository::seed(vec![
+            StoredWalletSnapshot::new(
+                "wallet-runtime-unlimited".to_string(),
+                Some("user-runtime-wallet-unlimited".to_string()),
+                None,
+                0.0,
+                0.0,
+                "finite".to_string(),
+                "USD".to_string(),
+                "active".to_string(),
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                100,
+            )
+            .expect("wallet should build"),
+        ]));
+        let data = GatewayDataState::with_auth_and_wallet_for_tests(
+            auth_repository,
+            Arc::clone(&wallet_repository),
+        );
+        let state = AppState::new()
+            .expect("state should build")
+            .with_data_state_for_tests(data);
+        let decision = GatewayControlDecision::synthetic(
+            "/v1/chat/completions",
+            Some("ai_public".to_string()),
+            Some("openai".to_string()),
+            Some("chat".to_string()),
+            Some("openai:chat".to_string()),
+        );
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", api_key.parse().unwrap());
+
+        let first = resolve_execution_runtime_auth_context(
+            &state,
+            &decision,
+            &headers,
+            &uri("/v1/chat/completions"),
+            "trace-runtime-wallet-unlimited",
+        )
+        .await
+        .expect("resolution should succeed")
+        .expect("auth context should exist");
+        assert_eq!(
+            first.local_rejection,
+            Some(GatewayLocalAuthRejection::BalanceDenied {
+                remaining: Some(0.0),
+            })
+        );
+        assert!(!first.access_allowed);
+
+        wallet_repository
+            .update_auth_user_wallet_snapshot(
+                "user-runtime-wallet-unlimited",
+                0.0,
+                0.0,
+                "unlimited",
+                "USD",
+                "active",
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                Some(101),
+            )
+            .await
+            .expect("wallet update should succeed")
+            .expect("wallet should exist");
+
+        let second = resolve_execution_runtime_auth_context(
+            &state,
+            &decision,
+            &headers,
+            &uri("/v1/chat/completions"),
+            "trace-runtime-wallet-unlimited",
+        )
+        .await
+        .expect("resolution should succeed")
+        .expect("auth context should exist");
+
+        assert_eq!(second.local_rejection, None);
+        assert!(second.access_allowed);
+        assert_eq!(second.balance_remaining, None);
     }
 
     #[tokio::test]

--- a/apps/aether-gateway/src/execution_runtime/kiro_cache.rs
+++ b/apps/aether-gateway/src/execution_runtime/kiro_cache.rs
@@ -20,6 +20,15 @@ const TOKENS_PER_TOOL: u64 = 150;
 const TOKENS_PER_MESSAGE: u64 = 4;
 const INLINE_IMAGE_DATA_TOKEN_PLACEHOLDER: &str = "[inline-image-data]";
 pub(crate) const KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD: &str = "kiro_simulated_cache_enabled";
+pub(crate) const SIMULATED_CACHE_ENABLED_CONTEXT_FIELD: &str = "simulated_cache_enabled";
+pub(crate) const SIMULATED_CACHE_MIN_PERCENT_CONTEXT_FIELD: &str = "simulated_cache_min_percent";
+pub(crate) const SIMULATED_CACHE_MAX_PERCENT_CONTEXT_FIELD: &str = "simulated_cache_max_percent";
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct SimulatedCacheConfig {
+    pub(crate) min_percent: f64,
+    pub(crate) max_percent: f64,
+}
 
 static KIRO_PROMPT_CACHE_TRACKER: OnceLock<KiroPromptCacheTracker> = OnceLock::new();
 
@@ -411,6 +420,10 @@ fn build_lookback_match_candidates(
 }
 
 pub(crate) fn kiro_simulated_cache_enabled_from_provider_config(config: Option<&Value>) -> bool {
+    if simulated_cache_config_from_provider_config(config).is_some() {
+        return true;
+    }
+
     config
         .and_then(Value::as_object)
         .and_then(|config| config.get("kiro"))
@@ -420,9 +433,74 @@ pub(crate) fn kiro_simulated_cache_enabled_from_provider_config(config: Option<&
         .unwrap_or(false)
 }
 
+pub(crate) fn simulated_cache_config_from_provider_config(
+    config: Option<&Value>,
+) -> Option<SimulatedCacheConfig> {
+    let object = config.and_then(Value::as_object)?;
+    let simulated_cache = object.get("simulated_cache").and_then(Value::as_object)?;
+    if !simulated_cache
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    let min_percent = json_number_as_f64(simulated_cache.get("min_percent")).unwrap_or(90.0);
+    let max_percent = json_number_as_f64(simulated_cache.get("max_percent")).unwrap_or(100.0);
+    normalize_simulated_cache_config(min_percent, max_percent)
+}
+
+pub(crate) fn simulated_cache_config_from_report_context(
+    report_context: Option<&Value>,
+) -> Option<SimulatedCacheConfig> {
+    let context = report_context.and_then(Value::as_object)?;
+    if !context
+        .get(SIMULATED_CACHE_ENABLED_CONTEXT_FIELD)
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    let min_percent =
+        json_number_as_f64(context.get(SIMULATED_CACHE_MIN_PERCENT_CONTEXT_FIELD)).unwrap_or(90.0);
+    let max_percent =
+        json_number_as_f64(context.get(SIMULATED_CACHE_MAX_PERCENT_CONTEXT_FIELD)).unwrap_or(100.0);
+    normalize_simulated_cache_config(min_percent, max_percent)
+}
+
+fn normalize_simulated_cache_config(
+    min_percent: f64,
+    max_percent: f64,
+) -> Option<SimulatedCacheConfig> {
+    if !min_percent.is_finite() || !max_percent.is_finite() {
+        return None;
+    }
+    let min_percent = min_percent.clamp(0.0, 100.0);
+    let max_percent = max_percent.clamp(0.0, 100.0);
+    if min_percent > max_percent {
+        return None;
+    }
+    Some(SimulatedCacheConfig {
+        min_percent,
+        max_percent,
+    })
+}
+
+fn json_number_as_f64(value: Option<&Value>) -> Option<f64> {
+    value.and_then(|value| match value {
+        Value::Number(number) => number.as_f64(),
+        Value::String(text) => text.trim().parse::<f64>().ok(),
+        _ => None,
+    })
+}
+
 pub(crate) fn kiro_simulated_cache_enabled_from_report_context(
     report_context: Option<&Value>,
 ) -> bool {
+    if simulated_cache_config_from_report_context(report_context).is_some() {
+        return true;
+    }
+
     report_context
         .and_then(Value::as_object)
         .and_then(|context| context.get(KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD))
@@ -1546,6 +1624,36 @@ mod tests {
     }
 
     #[test]
+    fn simulated_cache_config_reads_generic_provider_config() {
+        let config = simulated_cache_config_from_provider_config(Some(&serde_json::json!({
+            "simulated_cache": {
+                "enabled": true,
+                "min_percent": 90,
+                "max_percent": 100
+            }
+        })))
+        .expect("generic simulated cache config should parse");
+
+        assert_eq!(config.min_percent, 90.0);
+        assert_eq!(config.max_percent, 100.0);
+        assert!(kiro_simulated_cache_enabled_from_provider_config(Some(
+            &serde_json::json!({
+                "simulated_cache": {"enabled": true, "min_percent": 90, "max_percent": 100}
+            })
+        )));
+    }
+
+    #[test]
+    fn simulated_cache_config_rejects_invalid_range() {
+        assert!(
+            simulated_cache_config_from_provider_config(Some(&serde_json::json!({
+                "simulated_cache": {"enabled": true, "min_percent": 100, "max_percent": 90}
+            })))
+            .is_none()
+        );
+    }
+
+    #[test]
     fn kiro_simulated_cache_enabled_reads_report_context_flag() {
         assert!(!kiro_simulated_cache_enabled_from_report_context(None));
         assert!(!kiro_simulated_cache_enabled_from_report_context(Some(
@@ -1553,6 +1661,13 @@ mod tests {
         )));
         assert!(kiro_simulated_cache_enabled_from_report_context(Some(
             &serde_json::json!({"kiro_simulated_cache_enabled": true})
+        )));
+        assert!(kiro_simulated_cache_enabled_from_report_context(Some(
+            &serde_json::json!({
+                "simulated_cache_enabled": true,
+                "simulated_cache_min_percent": 90,
+                "simulated_cache_max_percent": 100
+            })
         )));
     }
 }

--- a/apps/aether-gateway/src/execution_runtime/mod.rs
+++ b/apps/aether-gateway/src/execution_runtime/mod.rs
@@ -15,6 +15,7 @@ mod oauth_retry;
 pub(crate) mod remote_compat;
 mod response_header_rules;
 mod server;
+mod simulated_cache;
 pub(crate) mod stream;
 mod stream_pump;
 pub(crate) mod submission;

--- a/apps/aether-gateway/src/execution_runtime/simulated_cache.rs
+++ b/apps/aether-gateway/src/execution_runtime/simulated_cache.rs
@@ -1,0 +1,442 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Map, Value};
+
+use crate::execution_runtime::kiro_cache::{
+    simulated_cache_config_from_report_context, SimulatedCacheConfig,
+};
+
+static SIMULATED_CACHE_RESPONSE_RANDOM_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) const SIMULATED_CACHE_HIT_PERCENT_CONTEXT_FIELD: &str = "simulated_cache_hit_percent";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SimulatedCacheUsageShape {
+    OpenAiChat,
+    OpenAiResponses,
+}
+
+pub(crate) fn maybe_apply_simulated_cache_to_response_body(
+    body: &mut Value,
+    report_context: &mut Option<Value>,
+    client_api_format: &str,
+) -> bool {
+    if !client_format_supports_simulated_cache_usage(client_api_format) {
+        return false;
+    }
+    let Some(config) = simulated_cache_config_from_report_context(report_context.as_ref()) else {
+        return false;
+    };
+    let Some(usage) = body.get_mut("usage") else {
+        return false;
+    };
+    let Some(shape) = simulated_cache_usage_shape(usage) else {
+        return false;
+    };
+    apply_simulated_cache_to_usage_value(usage, report_context, config, shape)
+}
+
+pub(crate) fn maybe_apply_simulated_cache_to_stream_chunk(
+    chunk: Vec<u8>,
+    report_context: &mut Option<Value>,
+    client_api_format: &str,
+) -> Vec<u8> {
+    if chunk.is_empty()
+        || simulated_cache_config_from_report_context(report_context.as_ref()).is_none()
+        || !client_format_supports_simulated_cache_usage(client_api_format)
+    {
+        return chunk;
+    }
+    rewrite_sse_usage_chunks(chunk, report_context, client_api_format)
+}
+
+fn apply_simulated_cache_to_usage_value(
+    usage: &mut Value,
+    report_context: &mut Option<Value>,
+    config: SimulatedCacheConfig,
+    shape: SimulatedCacheUsageShape,
+) -> bool {
+    let Some(object) = usage.as_object_mut() else {
+        return false;
+    };
+    let total_input_tokens = match shape {
+        SimulatedCacheUsageShape::OpenAiChat => number_u64(object.get("prompt_tokens")),
+        SimulatedCacheUsageShape::OpenAiResponses => number_u64(object.get("input_tokens")),
+    }
+    .unwrap_or(0);
+    let Some((_, cache_read_tokens)) =
+        simulated_cache_hit(report_context, config, total_input_tokens)
+    else {
+        return false;
+    };
+
+    match shape {
+        SimulatedCacheUsageShape::OpenAiChat => {
+            object.insert("prompt_tokens".to_string(), Value::from(total_input_tokens));
+            let output_tokens = number_u64(object.get("completion_tokens")).unwrap_or(0);
+            object.insert(
+                "total_tokens".to_string(),
+                Value::from(total_input_tokens.saturating_add(output_tokens)),
+            );
+            let details = object
+                .entry("prompt_tokens_details")
+                .or_insert_with(|| json!({}));
+            if !details.is_object() {
+                *details = json!({});
+            }
+            if let Some(details) = details.as_object_mut() {
+                details.insert("cached_tokens".to_string(), Value::from(cache_read_tokens));
+            }
+        }
+        SimulatedCacheUsageShape::OpenAiResponses => {
+            object.insert("input_tokens".to_string(), Value::from(total_input_tokens));
+            let output_tokens = number_u64(object.get("output_tokens")).unwrap_or(0);
+            object.insert(
+                "total_tokens".to_string(),
+                Value::from(total_input_tokens.saturating_add(output_tokens)),
+            );
+            let details = object
+                .entry("input_tokens_details")
+                .or_insert_with(|| json!({}));
+            if !details.is_object() {
+                *details = json!({});
+            }
+            if let Some(details) = details.as_object_mut() {
+                details.insert("cached_tokens".to_string(), Value::from(cache_read_tokens));
+            }
+        }
+    }
+    object.insert(
+        "cache_read_input_tokens".to_string(),
+        Value::from(cache_read_tokens),
+    );
+    true
+}
+
+fn rewrite_sse_usage_chunks(
+    mut chunk: Vec<u8>,
+    report_context: &mut Option<Value>,
+    client_api_format: &str,
+) -> Vec<u8> {
+    let mut cursor = 0usize;
+    let mut output = Vec::with_capacity(chunk.len());
+    while let Some((block_end, separator_len)) = find_sse_block_boundary(&chunk[cursor..]) {
+        let absolute_end = cursor + block_end;
+        let separator_end = absolute_end + separator_len;
+        output.extend(rewrite_sse_block(
+            &chunk[cursor..absolute_end],
+            &chunk[absolute_end..separator_end],
+            report_context,
+            client_api_format,
+        ));
+        cursor = separator_end;
+    }
+    output.extend_from_slice(&chunk[cursor..]);
+    chunk.clear();
+    output
+}
+
+fn rewrite_sse_block(
+    block: &[u8],
+    separator: &[u8],
+    report_context: &mut Option<Value>,
+    client_api_format: &str,
+) -> Vec<u8> {
+    let Ok(text) = std::str::from_utf8(block) else {
+        let mut output = block.to_vec();
+        output.extend_from_slice(separator);
+        return output;
+    };
+
+    let mut data_lines = Vec::new();
+    for line in text.lines() {
+        if let Some(data) = line.trim_start().strip_prefix("data:") {
+            data_lines.push(data.trim_start());
+        }
+    }
+    if data_lines.is_empty() {
+        let mut output = block.to_vec();
+        output.extend_from_slice(separator);
+        return output;
+    }
+    let data = data_lines.join("\n");
+    if data.trim() == "[DONE]" {
+        let mut output = block.to_vec();
+        output.extend_from_slice(separator);
+        return output;
+    }
+    let Ok(mut payload) = serde_json::from_str::<Value>(&data) else {
+        let mut output = block.to_vec();
+        output.extend_from_slice(separator);
+        return output;
+    };
+    if !rewrite_stream_payload_usage(&mut payload, report_context, client_api_format) {
+        let mut output = block.to_vec();
+        output.extend_from_slice(separator);
+        return output;
+    }
+
+    let line_ending = if text.contains("\r\n") { "\r\n" } else { "\n" };
+    let mut output = Vec::new();
+    for line in text.lines() {
+        if line.trim_start().starts_with("data:") {
+            output.extend_from_slice(b"data: ");
+            output.extend_from_slice(payload.to_string().as_bytes());
+            output.extend_from_slice(line_ending.as_bytes());
+        } else {
+            output.extend_from_slice(line.as_bytes());
+            output.extend_from_slice(line_ending.as_bytes());
+        }
+    }
+    output.extend_from_slice(separator);
+    output
+}
+
+fn rewrite_stream_payload_usage(
+    payload: &mut Value,
+    report_context: &mut Option<Value>,
+    client_api_format: &str,
+) -> bool {
+    if payload.get("usage").is_some() {
+        return maybe_apply_simulated_cache_to_response_body(
+            payload,
+            report_context,
+            client_api_format,
+        );
+    }
+    let Some(response) = payload.get_mut("response") else {
+        return false;
+    };
+    if response.get("usage").is_none() {
+        return false;
+    }
+    maybe_apply_simulated_cache_to_response_body(response, report_context, client_api_format)
+}
+
+fn find_sse_block_boundary(buffer: &[u8]) -> Option<(usize, usize)> {
+    let lf = buffer
+        .windows(2)
+        .position(|window| window == b"\n\n")
+        .map(|index| (index, 2));
+    let crlf = buffer
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|index| (index, 4));
+    match (lf, crlf) {
+        (Some(lf), Some(crlf)) => Some(if lf.0 <= crlf.0 { lf } else { crlf }),
+        (Some(lf), None) => Some(lf),
+        (None, Some(crlf)) => Some(crlf),
+        (None, None) => None,
+    }
+}
+
+fn simulated_cache_usage_shape(usage: &Value) -> Option<SimulatedCacheUsageShape> {
+    let object = usage.as_object()?;
+    if object.get("prompt_tokens").is_some() {
+        return Some(SimulatedCacheUsageShape::OpenAiChat);
+    }
+    if object.get("input_tokens").is_some() {
+        return Some(SimulatedCacheUsageShape::OpenAiResponses);
+    }
+    None
+}
+
+fn client_format_supports_simulated_cache_usage(client_api_format: &str) -> bool {
+    matches!(
+        aether_ai_formats::normalize_api_format_alias(client_api_format).as_str(),
+        "openai:chat" | "openai:responses" | "openai:responses:compact"
+    )
+}
+
+fn simulated_cache_hit(
+    report_context: &mut Option<Value>,
+    config: SimulatedCacheConfig,
+    total_input_tokens: u64,
+) -> Option<(f64, u64)> {
+    if total_input_tokens == 0 {
+        return None;
+    }
+    let hit_percent = existing_simulated_cache_hit_percent(report_context.as_ref())
+        .unwrap_or_else(|| random_simulated_cache_percent(config.min_percent, config.max_percent));
+    store_simulated_cache_hit_percent(report_context, hit_percent);
+    let cache_read_tokens = ((total_input_tokens as f64) * hit_percent / 100.0).round() as u64;
+    Some((hit_percent, cache_read_tokens.min(total_input_tokens)))
+}
+
+fn existing_simulated_cache_hit_percent(report_context: Option<&Value>) -> Option<f64> {
+    report_context
+        .and_then(Value::as_object)
+        .and_then(|context| context.get(SIMULATED_CACHE_HIT_PERCENT_CONTEXT_FIELD))
+        .and_then(value_as_f64)
+        .filter(|value| value.is_finite())
+}
+
+fn store_simulated_cache_hit_percent(report_context: &mut Option<Value>, hit_percent: f64) {
+    let value = json!(rounded_percent(hit_percent));
+    match report_context {
+        Some(Value::Object(context)) => {
+            context.insert(SIMULATED_CACHE_HIT_PERCENT_CONTEXT_FIELD.to_string(), value);
+        }
+        _ => {
+            let mut context = Map::new();
+            context.insert(SIMULATED_CACHE_HIT_PERCENT_CONTEXT_FIELD.to_string(), value);
+            *report_context = Some(Value::Object(context));
+        }
+    }
+}
+
+fn rounded_percent(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
+}
+
+fn number_u64(value: Option<&Value>) -> Option<u64> {
+    value.and_then(|value| match value {
+        Value::Number(number) => number
+            .as_u64()
+            .or_else(|| number.as_i64().map(|v| v.max(0) as u64)),
+        Value::String(text) => text.trim().parse::<u64>().ok(),
+        _ => None,
+    })
+}
+
+fn value_as_f64(value: &Value) -> Option<f64> {
+    match value {
+        Value::Number(number) => number.as_f64(),
+        Value::String(text) => text.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+fn random_simulated_cache_percent(min_percent: f64, max_percent: f64) -> f64 {
+    if (max_percent - min_percent).abs() <= f64::EPSILON {
+        return min_percent;
+    }
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_nanos() as u64)
+        .unwrap_or(0);
+    let counter = SIMULATED_CACHE_RESPONSE_RANDOM_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let seed = splitmix64(nanos ^ counter.rotate_left(17));
+    let unit = (seed as f64) / (u64::MAX as f64);
+    min_percent + (max_percent - min_percent) * unit
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    value ^ (value >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{
+        maybe_apply_simulated_cache_to_response_body, maybe_apply_simulated_cache_to_stream_chunk,
+    };
+
+    #[test]
+    fn simulated_cache_rewrites_openai_chat_usage_for_client() {
+        let mut context = Some(json!({
+            "simulated_cache_enabled": true,
+            "simulated_cache_min_percent": 90,
+            "simulated_cache_max_percent": 90
+        }));
+        let mut body = json!({
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 7,
+                "total_tokens": 107
+            }
+        });
+
+        assert!(maybe_apply_simulated_cache_to_response_body(
+            &mut body,
+            &mut context,
+            "openai:chat"
+        ));
+
+        assert_eq!(body["usage"]["prompt_tokens"], 100);
+        assert_eq!(body["usage"]["completion_tokens"], 7);
+        assert_eq!(body["usage"]["total_tokens"], 107);
+        assert_eq!(body["usage"]["prompt_tokens_details"]["cached_tokens"], 90);
+        assert_eq!(body["usage"]["cache_read_input_tokens"], 90);
+        assert_eq!(context.unwrap()["simulated_cache_hit_percent"], 90.0);
+    }
+
+    #[test]
+    fn simulated_cache_rewrites_openai_responses_usage_for_client() {
+        let mut context = Some(json!({
+            "simulated_cache_enabled": true,
+            "simulated_cache_min_percent": 50,
+            "simulated_cache_max_percent": 50
+        }));
+        let mut body = json!({
+            "usage": {
+                "input_tokens": 80,
+                "output_tokens": 3,
+                "total_tokens": 83
+            }
+        });
+
+        assert!(maybe_apply_simulated_cache_to_response_body(
+            &mut body,
+            &mut context,
+            "openai:responses"
+        ));
+
+        assert_eq!(body["usage"]["input_tokens"], 80);
+        assert_eq!(body["usage"]["output_tokens"], 3);
+        assert_eq!(body["usage"]["total_tokens"], 83);
+        assert_eq!(body["usage"]["input_tokens_details"]["cached_tokens"], 40);
+        assert_eq!(body["usage"]["cache_read_input_tokens"], 40);
+    }
+
+    #[test]
+    fn simulated_cache_rewrites_terminal_sse_usage_chunk() {
+        let mut context = Some(json!({
+            "simulated_cache_enabled": true,
+            "simulated_cache_min_percent": 25,
+            "simulated_cache_max_percent": 25
+        }));
+        let chunk = br#"data: {"id":"chatcmpl_1","object":"chat.completion.chunk","usage":{"prompt_tokens":20,"completion_tokens":4,"total_tokens":24}}
+
+data: [DONE]
+
+"#
+        .to_vec();
+
+        let rewritten =
+            maybe_apply_simulated_cache_to_stream_chunk(chunk, &mut context, "openai:chat");
+        let text = String::from_utf8(rewritten).expect("sse should remain utf8");
+
+        assert!(text.contains(r#""prompt_tokens_details":{"cached_tokens":5}"#));
+        assert!(text.contains(r#""cache_read_input_tokens":5"#));
+        assert!(text.contains("data: [DONE]"));
+    }
+
+    #[test]
+    fn simulated_cache_does_not_rewrite_non_openai_client_usage() {
+        let mut context = Some(json!({
+            "simulated_cache_enabled": true,
+            "simulated_cache_min_percent": 90,
+            "simulated_cache_max_percent": 90
+        }));
+        let mut body = json!({
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 7
+            }
+        });
+
+        assert!(!maybe_apply_simulated_cache_to_response_body(
+            &mut body,
+            &mut context,
+            "claude:messages"
+        ));
+        assert!(body["usage"].get("input_tokens_details").is_none());
+    }
+}

--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -67,8 +67,10 @@ use crate::execution_runtime::kiro_cache::{
     billed_input_tokens as kiro_billed_input_tokens, build_kiro_prompt_cache_profile,
     compute_kiro_prompt_cache_usage, estimate_kiro_prompt_input_tokens,
     kiro_simulated_cache_enabled_from_provider_config,
-    kiro_simulated_cache_enabled_from_report_context, KiroPromptCacheUsage,
-    KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD,
+    kiro_simulated_cache_enabled_from_report_context, simulated_cache_config_from_provider_config,
+    KiroPromptCacheUsage, KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD,
+    SIMULATED_CACHE_ENABLED_CONTEXT_FIELD, SIMULATED_CACHE_MAX_PERCENT_CONTEXT_FIELD,
+    SIMULATED_CACHE_MIN_PERCENT_CONTEXT_FIELD,
 };
 use crate::execution_runtime::kiro_web_search::maybe_execute_kiro_web_search_stream;
 use crate::execution_runtime::oauth_retry::refresh_oauth_plan_auth_for_retry;
@@ -357,47 +359,69 @@ async fn seed_kiro_simulated_cache_enabled(
     plan: &ExecutionPlan,
     report_context: &mut Option<Value>,
 ) {
-    if !plan
-        .provider_name
-        .as_deref()
-        .is_some_and(|provider_name| provider_name.eq_ignore_ascii_case("Kiro"))
-    {
-        return;
-    }
-
-    let enabled = match state
+    let (config, legacy_kiro_enabled) = match state
         .read_provider_catalog_providers_by_ids(std::slice::from_ref(&plan.provider_id))
         .await
     {
-        Ok(providers) => providers
-            .iter()
-            .find(|provider| provider.id == plan.provider_id)
-            .filter(|provider| provider.provider_type.eq_ignore_ascii_case("kiro"))
-            .is_some_and(|provider| {
-                kiro_simulated_cache_enabled_from_provider_config(provider.config.as_ref())
-            }),
+        Ok(providers) => {
+            let provider = providers
+                .iter()
+                .find(|provider| provider.id == plan.provider_id);
+            let config = provider.and_then(|provider| {
+                simulated_cache_config_from_provider_config(provider.config.as_ref())
+            });
+            let legacy_kiro_enabled = provider
+                .filter(|provider| provider.provider_type.eq_ignore_ascii_case("kiro"))
+                .is_some_and(|provider| {
+                    config.is_none()
+                        && kiro_simulated_cache_enabled_from_provider_config(
+                            provider.config.as_ref(),
+                        )
+                });
+            (config, legacy_kiro_enabled)
+        }
         Err(err) => {
             warn!(
-                event_name = "kiro_simulated_cache_config_read_failed",
+                event_name = "simulated_cache_config_read_failed",
                 log_type = "event",
                 request_id = %plan.request_id,
                 provider_id = %plan.provider_id,
                 error = ?err,
-                "failed to read Kiro simulated cache provider config; defaulting disabled"
+                "failed to read simulated cache provider config; defaulting disabled"
             );
-            false
+            (None, false)
         }
     };
 
     let Some(context) = report_context.as_mut().and_then(Value::as_object_mut) else {
         return;
     };
-    if enabled {
+    if let Some(config) = config {
+        context.insert(
+            SIMULATED_CACHE_ENABLED_CONTEXT_FIELD.to_string(),
+            Value::Bool(true),
+        );
+        context.insert(
+            SIMULATED_CACHE_MIN_PERCENT_CONTEXT_FIELD.to_string(),
+            Value::from(config.min_percent),
+        );
+        context.insert(
+            SIMULATED_CACHE_MAX_PERCENT_CONTEXT_FIELD.to_string(),
+            Value::from(config.max_percent),
+        );
+        context.remove(KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD);
+    } else if legacy_kiro_enabled {
+        context.remove(SIMULATED_CACHE_ENABLED_CONTEXT_FIELD);
+        context.remove(SIMULATED_CACHE_MIN_PERCENT_CONTEXT_FIELD);
+        context.remove(SIMULATED_CACHE_MAX_PERCENT_CONTEXT_FIELD);
         context.insert(
             KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD.to_string(),
             Value::Bool(true),
         );
     } else {
+        context.remove(SIMULATED_CACHE_ENABLED_CONTEXT_FIELD);
+        context.remove(SIMULATED_CACHE_MIN_PERCENT_CONTEXT_FIELD);
+        context.remove(SIMULATED_CACHE_MAX_PERCENT_CONTEXT_FIELD);
         context.remove(KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD);
     }
 }

--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -76,6 +76,9 @@ use crate::execution_runtime::kiro_web_search::maybe_execute_kiro_web_search_str
 use crate::execution_runtime::oauth_retry::refresh_oauth_plan_auth_for_retry;
 #[cfg(test)]
 use crate::execution_runtime::remote_compat::post_stream_plan_to_remote_execution_runtime;
+use crate::execution_runtime::simulated_cache::{
+    maybe_apply_simulated_cache_to_response_body, maybe_apply_simulated_cache_to_stream_chunk,
+};
 use crate::execution_runtime::submission::{
     resolve_core_error_background_report_kind, resolve_local_sync_error_status_code,
     strip_utf8_bom_and_ws, submit_local_core_error_or_sync_finalize,
@@ -2388,10 +2391,12 @@ async fn execute_stream_from_frame_stream(
     let normalized_stream_report_context =
         normalize_provider_private_report_context(report_context.as_ref());
     let upstream_headers = headers.clone();
+    let normalizer_report_context = report_context.clone();
+    let rewriter_report_context = normalized_stream_report_context.clone();
     let mut private_stream_normalizer =
-        maybe_build_provider_private_stream_normalizer(report_context.as_ref());
+        maybe_build_provider_private_stream_normalizer(normalizer_report_context.as_ref());
     let mut local_stream_rewriter =
-        maybe_build_stream_response_rewriter(normalized_stream_report_context.as_ref());
+        maybe_build_stream_response_rewriter(rewriter_report_context.as_ref());
     if private_stream_normalizer.is_some() || local_stream_rewriter.is_some() {
         headers.remove("content-encoding");
         headers.remove("content-length");
@@ -2625,9 +2630,14 @@ async fn execute_stream_from_frame_stream(
                     if !response_headers_indicate_sse(&upstream_headers)
                         && (200..300).contains(&status_code)
                     {
-                        if let Some(body_json) =
+                        if let Some(mut body_json) =
                             parse_prefetched_sync_json_body(&prefetched_inspection_body)
                         {
+                            maybe_apply_simulated_cache_to_response_body(
+                                &mut body_json,
+                                &mut report_context,
+                                plan.client_api_format.as_str(),
+                            );
                             match maybe_bridge_standard_sync_json_to_stream(
                                 &body_json,
                                 plan.provider_api_format.as_str(),
@@ -2740,6 +2750,11 @@ async fn execute_stream_from_frame_stream(
                     } else {
                         normalized_chunk
                     };
+                    let rewritten_chunk = maybe_apply_simulated_cache_to_stream_chunk(
+                        rewritten_chunk,
+                        &mut report_context,
+                        plan.client_api_format.as_str(),
+                    );
                     if !rewritten_chunk.is_empty() {
                         prefetched_body.extend_from_slice(&rewritten_chunk);
                         prefetched_chunks.push(Bytes::from(rewritten_chunk));
@@ -2837,7 +2852,7 @@ async fn execute_stream_from_frame_stream(
     let trace_id_owned = trace_id.to_string();
     let headers_for_report = headers.clone();
     let report_kind_owned = report_kind;
-    let report_context_owned = report_context;
+    let mut report_context_owned = report_context;
     let normalized_stream_report_context_owned = normalized_stream_report_context;
     let lifecycle_seed_for_report = lifecycle_seed;
     let provider_prefetched_body_for_report = provider_prefetched_body;
@@ -2897,15 +2912,17 @@ async fn execute_stream_from_frame_stream(
         let mut buffered_body = Vec::new();
         let mut provider_body_truncated = false;
         let mut client_body_truncated = false;
+        let normalizer_report_context = report_context_owned.clone();
+        let rewriter_report_context = normalized_stream_report_context_owned.clone();
         let mut private_stream_normalizer = if sync_json_stream_bridge_active_for_report {
             None
         } else {
-            maybe_build_provider_private_stream_normalizer(report_context_owned.as_ref())
+            maybe_build_provider_private_stream_normalizer(normalizer_report_context.as_ref())
         };
         let mut local_stream_rewriter = if sync_json_stream_bridge_active_for_report {
             None
         } else {
-            maybe_build_stream_response_rewriter(normalized_stream_report_context_owned.as_ref())
+            maybe_build_stream_response_rewriter(rewriter_report_context.as_ref())
         };
         let stream_usage_report_context =
             normalized_stream_report_context_owned.clone().or_else(|| {
@@ -3274,6 +3291,11 @@ async fn execute_stream_from_frame_stream(
                         } else {
                             normalized_chunk
                         };
+                        let rewritten_chunk = maybe_apply_simulated_cache_to_stream_chunk(
+                            rewritten_chunk,
+                            &mut report_context_owned,
+                            plan_for_report.client_api_format.as_str(),
+                        );
 
                         if rewritten_chunk.is_empty() {
                             if let Some(error_body_json) = provider_private_error_body_json {

--- a/apps/aether-gateway/src/execution_runtime/sync/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/sync/execution.rs
@@ -52,6 +52,7 @@ use crate::execution_runtime::kiro_cache::{
 use crate::execution_runtime::oauth_retry::refresh_oauth_plan_auth_for_retry;
 #[cfg(test)]
 use crate::execution_runtime::remote_compat::post_sync_plan_to_remote_execution_runtime;
+use crate::execution_runtime::simulated_cache::maybe_apply_simulated_cache_to_response_body;
 use crate::execution_runtime::submission::{
     resolve_local_sync_error_status_code, submit_local_core_error_or_sync_finalize,
 };
@@ -2153,7 +2154,32 @@ async fn execute_execution_runtime_sync_impl(
         }
         seed_kiro_sync_report_context_prompt_cache_usage(state, &plan, &mut report_context).await;
     }
+    let mut body_bytes = body_bytes;
+    let mut body_base64 = body_base64;
+    let mut body_json = body_json;
+    let mut response_body_rewritten = false;
+    if (200..300).contains(&status_code) {
+        if let Some(body_json) = body_json.as_mut() {
+            if maybe_apply_simulated_cache_to_response_body(
+                body_json,
+                &mut report_context,
+                plan.client_api_format.as_str(),
+            ) {
+                body_bytes = serde_json::to_vec(body_json)
+                    .map_err(|err| GatewayError::Internal(err.to_string()))?;
+                body_base64 = None;
+                response_body_rewritten = true;
+            }
+        }
+    }
     let mut client_headers = headers.clone();
+    if response_body_rewritten {
+        client_headers.remove("content-encoding");
+        client_headers.insert("content-length".to_string(), body_bytes.len().to_string());
+        client_headers
+            .entry("content-type".to_string())
+            .or_insert_with(|| "application/json".to_string());
+    }
     apply_endpoint_response_header_rules(state, &plan, &mut client_headers, body_json.as_ref())
         .await?;
     let explicit_finalize = should_finalize_sync_response(report_kind.as_deref());

--- a/apps/aether-gateway/src/execution_runtime/sync/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/sync/execution.rs
@@ -44,8 +44,10 @@ use crate::execution_runtime::grok::maybe_execute_grok_sync;
 use crate::execution_runtime::kiro_cache::{
     build_kiro_prompt_cache_profile, compute_kiro_prompt_cache_usage,
     estimate_kiro_prompt_input_tokens, kiro_simulated_cache_enabled_from_provider_config,
-    kiro_simulated_cache_enabled_from_report_context, KiroPromptCacheUsage,
-    KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD,
+    kiro_simulated_cache_enabled_from_report_context, simulated_cache_config_from_provider_config,
+    KiroPromptCacheUsage, KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD,
+    SIMULATED_CACHE_ENABLED_CONTEXT_FIELD, SIMULATED_CACHE_MAX_PERCENT_CONTEXT_FIELD,
+    SIMULATED_CACHE_MIN_PERCENT_CONTEXT_FIELD,
 };
 use crate::execution_runtime::oauth_retry::refresh_oauth_plan_auth_for_retry;
 #[cfg(test)]
@@ -399,47 +401,69 @@ async fn seed_kiro_sync_simulated_cache_enabled(
     plan: &ExecutionPlan,
     report_context: &mut Option<Value>,
 ) {
-    if !plan
-        .provider_name
-        .as_deref()
-        .is_some_and(|provider_name| provider_name.eq_ignore_ascii_case("Kiro"))
-    {
-        return;
-    }
-
-    let enabled = match state
+    let (config, legacy_kiro_enabled) = match state
         .read_provider_catalog_providers_by_ids(std::slice::from_ref(&plan.provider_id))
         .await
     {
-        Ok(providers) => providers
-            .iter()
-            .find(|provider| provider.id == plan.provider_id)
-            .filter(|provider| provider.provider_type.eq_ignore_ascii_case("kiro"))
-            .is_some_and(|provider| {
-                kiro_simulated_cache_enabled_from_provider_config(provider.config.as_ref())
-            }),
+        Ok(providers) => {
+            let provider = providers
+                .iter()
+                .find(|provider| provider.id == plan.provider_id);
+            let config = provider.and_then(|provider| {
+                simulated_cache_config_from_provider_config(provider.config.as_ref())
+            });
+            let legacy_kiro_enabled = provider
+                .filter(|provider| provider.provider_type.eq_ignore_ascii_case("kiro"))
+                .is_some_and(|provider| {
+                    config.is_none()
+                        && kiro_simulated_cache_enabled_from_provider_config(
+                            provider.config.as_ref(),
+                        )
+                });
+            (config, legacy_kiro_enabled)
+        }
         Err(err) => {
             warn!(
-                event_name = "kiro_simulated_cache_config_read_failed",
+                event_name = "simulated_cache_config_read_failed",
                 log_type = "event",
                 request_id = %plan.request_id,
                 provider_id = %plan.provider_id,
                 error = ?err,
-                "failed to read Kiro simulated cache provider config; defaulting disabled"
+                "failed to read simulated cache provider config; defaulting disabled"
             );
-            false
+            (None, false)
         }
     };
 
     let Some(context) = report_context.as_mut().and_then(Value::as_object_mut) else {
         return;
     };
-    if enabled {
+    if let Some(config) = config {
+        context.insert(
+            SIMULATED_CACHE_ENABLED_CONTEXT_FIELD.to_string(),
+            Value::Bool(true),
+        );
+        context.insert(
+            SIMULATED_CACHE_MIN_PERCENT_CONTEXT_FIELD.to_string(),
+            Value::from(config.min_percent),
+        );
+        context.insert(
+            SIMULATED_CACHE_MAX_PERCENT_CONTEXT_FIELD.to_string(),
+            Value::from(config.max_percent),
+        );
+        context.remove(KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD);
+    } else if legacy_kiro_enabled {
+        context.remove(SIMULATED_CACHE_ENABLED_CONTEXT_FIELD);
+        context.remove(SIMULATED_CACHE_MIN_PERCENT_CONTEXT_FIELD);
+        context.remove(SIMULATED_CACHE_MAX_PERCENT_CONTEXT_FIELD);
         context.insert(
             KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD.to_string(),
             Value::Bool(true),
         );
     } else {
+        context.remove(SIMULATED_CACHE_ENABLED_CONTEXT_FIELD);
+        context.remove(SIMULATED_CACHE_MIN_PERCENT_CONTEXT_FIELD);
+        context.remove(SIMULATED_CACHE_MAX_PERCENT_CONTEXT_FIELD);
         context.remove(KIRO_SIMULATED_CACHE_ENABLED_CONTEXT_FIELD);
     }
 }

--- a/apps/aether-gateway/src/handlers/admin/provider/summary/value.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/summary/value.rs
@@ -8,7 +8,7 @@ use aether_data_contracts::repository::candidates::{
 use aether_data_contracts::repository::provider_catalog::{
     StoredProviderCatalogEndpoint, StoredProviderCatalogKey, StoredProviderCatalogProvider,
 };
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::BTreeMap;
 
 fn json_truthy(value: &serde_json::Value) -> bool {
@@ -26,6 +26,34 @@ fn endpoint_timestamp_or_now(value: Option<u64>, now_unix_secs: u64) -> serde_js
     unix_secs_to_rfc3339(value.unwrap_or(now_unix_secs))
         .map(serde_json::Value::String)
         .unwrap_or(serde_json::Value::Null)
+}
+
+fn json_number_as_f64(value: Option<&Value>) -> Option<f64> {
+    value.and_then(|value| match value {
+        Value::Number(number) => number.as_f64(),
+        Value::String(text) => text.trim().parse::<f64>().ok(),
+        _ => None,
+    })
+}
+
+fn simulated_cache_summary(config: Option<&serde_json::Map<String, Value>>) -> (bool, f64, f64) {
+    let simulated_cache = config
+        .and_then(|cfg| cfg.get("simulated_cache"))
+        .and_then(Value::as_object);
+    let enabled = simulated_cache
+        .and_then(|cfg| cfg.get("enabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let min_percent = simulated_cache
+        .and_then(|cfg| json_number_as_f64(cfg.get("min_percent")))
+        .unwrap_or(90.0)
+        .clamp(0.0, 100.0);
+    let max_percent = simulated_cache
+        .and_then(|cfg| json_number_as_f64(cfg.get("max_percent")))
+        .unwrap_or(100.0)
+        .clamp(0.0, 100.0);
+
+    (enabled, min_percent, max_percent)
 }
 
 pub(crate) fn build_admin_provider_summary_value(
@@ -133,12 +161,15 @@ pub(crate) fn build_admin_provider_summary_value(
         .and_then(|cfg| cfg.get("architecture_id"))
         .and_then(serde_json::Value::as_str)
         .map(ToOwned::to_owned);
-    let kiro_simulated_cache_enabled = config
-        .and_then(|cfg| cfg.get("kiro"))
-        .and_then(serde_json::Value::as_object)
-        .and_then(|cfg| cfg.get("simulated_cache_enabled"))
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
+    let (simulated_cache_enabled, simulated_cache_min_percent, simulated_cache_max_percent) =
+        simulated_cache_summary(config);
+    let kiro_simulated_cache_enabled = simulated_cache_enabled
+        || config
+            .and_then(|cfg| cfg.get("kiro"))
+            .and_then(serde_json::Value::as_object)
+            .and_then(|cfg| cfg.get("simulated_cache_enabled"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
     let ops_quota_alert_enabled = provider_ops_config
         .and_then(serde_json::Value::as_object)
         .and_then(|cfg| cfg.get("quota_alert"))
@@ -167,47 +198,137 @@ pub(crate) fn build_admin_provider_summary_value(
         .or(provider.quota_expires_at_unix_secs)
         .and_then(unix_secs_to_rfc3339);
 
-    json!({
-        "id": provider.id.clone(),
-        "name": provider.name.clone(),
-        "provider_type": provider.provider_type.clone(),
-        "description": provider.description.clone(),
-        "website": provider.website.clone(),
-        "provider_priority": provider.provider_priority,
-        "keep_priority_on_conversion": provider.keep_priority_on_conversion,
-        "enable_format_conversion": provider.enable_format_conversion,
-        "is_active": provider.is_active,
-        "billing_type": billing_type,
-        "monthly_quota_usd": monthly_quota_usd,
-        "monthly_used_usd": monthly_used_usd,
-        "quota_reset_day": quota_reset_day,
-        "quota_last_reset_at": quota_last_reset_at,
-        "quota_expires_at": quota_expires_at,
-        "max_retries": provider.max_retries,
-        "proxy": provider.proxy.clone(),
-        "stream_first_byte_timeout": provider.stream_first_byte_timeout_secs,
-        "request_timeout": provider.request_timeout_secs,
-        "claude_code_advanced": config.and_then(|cfg| cfg.get("claude_code_advanced")).cloned(),
-        "pool_advanced": config.and_then(|cfg| cfg.get("pool_advanced")).cloned(),
-        "failover_rules": config.and_then(|cfg| cfg.get("failover_rules")).cloned(),
-        "chat_pii_redaction": config.and_then(|cfg| cfg.get("chat_pii_redaction")).cloned(),
-        "total_endpoints": total_endpoints,
-        "active_endpoints": active_endpoints,
-        "total_keys": total_keys,
-        "active_keys": active_keys,
-        "total_models": total_models,
-        "active_models": active_models,
-        "global_model_ids": active_global_model_ids,
-        "avg_health_score": avg_health_score,
-        "unhealthy_endpoints": unhealthy_endpoints,
-        "api_formats": api_formats,
-        "endpoint_health_details": endpoint_health_details,
-        "ops_configured": ops_configured,
-        "ops_architecture_id": ops_architecture_id,
-        "kiro_simulated_cache_enabled": kiro_simulated_cache_enabled,
-        "codex_cyber_flag_passthrough_enabled": codex_cyber_flag_passthrough_enabled(&provider.provider_type, provider.config.as_ref()),
-        "ops_quota_alert_enabled": ops_quota_alert_enabled,
-        "created_at": endpoint_timestamp_or_now(provider.created_at_unix_ms, now_unix_secs),
-        "updated_at": endpoint_timestamp_or_now(provider.updated_at_unix_secs, now_unix_secs),
-    })
+    let mut value = serde_json::Map::new();
+    value.insert("id".to_string(), json!(provider.id.clone()));
+    value.insert("name".to_string(), json!(provider.name.clone()));
+    value.insert(
+        "provider_type".to_string(),
+        json!(provider.provider_type.clone()),
+    );
+    value.insert(
+        "description".to_string(),
+        json!(provider.description.clone()),
+    );
+    value.insert("website".to_string(), json!(provider.website.clone()));
+    value.insert(
+        "provider_priority".to_string(),
+        json!(provider.provider_priority),
+    );
+    value.insert(
+        "keep_priority_on_conversion".to_string(),
+        json!(provider.keep_priority_on_conversion),
+    );
+    value.insert(
+        "enable_format_conversion".to_string(),
+        json!(provider.enable_format_conversion),
+    );
+    value.insert("is_active".to_string(), json!(provider.is_active));
+    value.insert("billing_type".to_string(), json!(billing_type));
+    value.insert("monthly_quota_usd".to_string(), json!(monthly_quota_usd));
+    value.insert("monthly_used_usd".to_string(), json!(monthly_used_usd));
+    value.insert("quota_reset_day".to_string(), json!(quota_reset_day));
+    value.insert(
+        "quota_last_reset_at".to_string(),
+        json!(quota_last_reset_at),
+    );
+    value.insert("quota_expires_at".to_string(), json!(quota_expires_at));
+    value.insert("max_retries".to_string(), json!(provider.max_retries));
+    value.insert("proxy".to_string(), json!(provider.proxy.clone()));
+    value.insert(
+        "stream_first_byte_timeout".to_string(),
+        json!(provider.stream_first_byte_timeout_secs),
+    );
+    value.insert(
+        "request_timeout".to_string(),
+        json!(provider.request_timeout_secs),
+    );
+    value.insert(
+        "claude_code_advanced".to_string(),
+        config
+            .and_then(|cfg| cfg.get("claude_code_advanced"))
+            .cloned()
+            .unwrap_or(Value::Null),
+    );
+    value.insert(
+        "pool_advanced".to_string(),
+        config
+            .and_then(|cfg| cfg.get("pool_advanced"))
+            .cloned()
+            .unwrap_or(Value::Null),
+    );
+    value.insert(
+        "failover_rules".to_string(),
+        config
+            .and_then(|cfg| cfg.get("failover_rules"))
+            .cloned()
+            .unwrap_or(Value::Null),
+    );
+    value.insert(
+        "chat_pii_redaction".to_string(),
+        config
+            .and_then(|cfg| cfg.get("chat_pii_redaction"))
+            .cloned()
+            .unwrap_or(Value::Null),
+    );
+    value.insert("total_endpoints".to_string(), json!(total_endpoints));
+    value.insert("active_endpoints".to_string(), json!(active_endpoints));
+    value.insert("total_keys".to_string(), json!(total_keys));
+    value.insert("active_keys".to_string(), json!(active_keys));
+    value.insert("total_models".to_string(), json!(total_models));
+    value.insert("active_models".to_string(), json!(active_models));
+    value.insert(
+        "global_model_ids".to_string(),
+        json!(active_global_model_ids),
+    );
+    value.insert("avg_health_score".to_string(), json!(avg_health_score));
+    value.insert(
+        "unhealthy_endpoints".to_string(),
+        json!(unhealthy_endpoints),
+    );
+    value.insert("api_formats".to_string(), json!(api_formats));
+    value.insert(
+        "endpoint_health_details".to_string(),
+        json!(endpoint_health_details),
+    );
+    value.insert("ops_configured".to_string(), json!(ops_configured));
+    value.insert(
+        "ops_architecture_id".to_string(),
+        json!(ops_architecture_id),
+    );
+    value.insert(
+        "kiro_simulated_cache_enabled".to_string(),
+        json!(kiro_simulated_cache_enabled),
+    );
+    value.insert(
+        "simulated_cache_enabled".to_string(),
+        json!(simulated_cache_enabled),
+    );
+    value.insert(
+        "simulated_cache_min_percent".to_string(),
+        json!(simulated_cache_min_percent),
+    );
+    value.insert(
+        "simulated_cache_max_percent".to_string(),
+        json!(simulated_cache_max_percent),
+    );
+    value.insert(
+        "codex_cyber_flag_passthrough_enabled".to_string(),
+        json!(codex_cyber_flag_passthrough_enabled(
+            &provider.provider_type,
+            provider.config.as_ref()
+        )),
+    );
+    value.insert(
+        "ops_quota_alert_enabled".to_string(),
+        json!(ops_quota_alert_enabled),
+    );
+    value.insert(
+        "created_at".to_string(),
+        endpoint_timestamp_or_now(provider.created_at_unix_ms, now_unix_secs),
+    );
+    value.insert(
+        "updated_at".to_string(),
+        endpoint_timestamp_or_now(provider.updated_at_unix_secs, now_unix_secs),
+    );
+    Value::Object(value)
 }

--- a/apps/aether-gateway/src/handlers/admin/provider/write/normalize.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/write/normalize.rs
@@ -159,6 +159,63 @@ pub(crate) fn normalize_chat_pii_redaction_config(
     }
 }
 
+pub(crate) fn normalize_simulated_cache_config(
+    value: Option<serde_json::Value>,
+) -> Result<Option<serde_json::Value>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    match value {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::Object(mut map) => {
+            let enabled = map
+                .remove("enabled")
+                .and_then(|value| value.as_bool())
+                .ok_or_else(|| "simulated_cache.enabled must be a boolean".to_string())?;
+            let min_percent =
+                simulated_cache_percent(map.remove("min_percent"), 90.0, "min_percent")?;
+            let max_percent =
+                simulated_cache_percent(map.remove("max_percent"), 100.0, "max_percent")?;
+            if min_percent > max_percent {
+                return Err(
+                    "simulated_cache.min_percent must not be greater than max_percent".to_string(),
+                );
+            }
+            Ok(Some(serde_json::json!({
+                "enabled": enabled,
+                "min_percent": min_percent,
+                "max_percent": max_percent
+            })))
+        }
+        _ => Err("simulated_cache must be a JSON object".to_string()),
+    }
+}
+
+fn simulated_cache_percent(
+    value: Option<serde_json::Value>,
+    default_value: f64,
+    field_name: &str,
+) -> Result<f64, String> {
+    let percent = match value {
+        Some(serde_json::Value::Number(number)) => number
+            .as_f64()
+            .ok_or_else(|| format!("simulated_cache.{field_name} must be a number"))?,
+        Some(serde_json::Value::String(text)) => text
+            .trim()
+            .parse::<f64>()
+            .map_err(|_| format!("simulated_cache.{field_name} must be a number"))?,
+        Some(_) => return Err(format!("simulated_cache.{field_name} must be a number")),
+        None => default_value,
+    };
+    if percent.is_finite() && (0.0..=100.0).contains(&percent) {
+        Ok(percent)
+    } else {
+        Err(format!(
+            "simulated_cache.{field_name} must be between 0 and 100"
+        ))
+    }
+}
+
 pub(crate) fn validate_vertex_api_formats(
     provider_type: &str,
     auth_type: &str,
@@ -212,7 +269,8 @@ mod tests {
         normalize_allow_auth_channel_mismatch_formats, normalize_api_format_json_object_keys,
         normalize_api_format_list, normalize_auth_type, normalize_auth_type_by_format,
         normalize_chat_pii_redaction_config, normalize_pool_advanced_config,
-        normalize_provider_type_input, validate_vertex_api_formats,
+        normalize_provider_type_input, normalize_simulated_cache_config,
+        validate_vertex_api_formats,
     };
     use serde_json::json;
 
@@ -254,6 +312,41 @@ mod tests {
             normalize_chat_pii_redaction_config(Some(json!({ "enabled": "yes" }))).unwrap_err(),
             "chat_pii_redaction.enabled 必须是布尔值"
         );
+    }
+
+    #[test]
+    fn normalize_simulated_cache_requires_valid_percent_range() {
+        assert_eq!(
+            normalize_simulated_cache_config(Some(json!({
+                "enabled": true,
+                "min_percent": 90,
+                "max_percent": 95
+            })))
+            .expect("simulated cache should normalize"),
+            Some(json!({
+                "enabled": true,
+                "min_percent": 90.0,
+                "max_percent": 95.0
+            }))
+        );
+        assert!(normalize_simulated_cache_config(Some(json!({
+            "enabled": true,
+            "min_percent": -1,
+            "max_percent": 95
+        })))
+        .is_err());
+        assert!(normalize_simulated_cache_config(Some(json!({
+            "enabled": true,
+            "min_percent": 95,
+            "max_percent": 90
+        })))
+        .is_err());
+        assert!(normalize_simulated_cache_config(Some(json!({
+            "enabled": "yes",
+            "min_percent": 90,
+            "max_percent": 95
+        })))
+        .is_err());
     }
 
     #[test]

--- a/apps/aether-gateway/src/handlers/admin/provider/write/provider/create.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/write/provider/create.rs
@@ -5,6 +5,7 @@ use crate::handlers::admin::provider::shared::support::{
 use crate::handlers::admin::provider::write::normalize::normalize_chat_pii_redaction_config;
 use crate::handlers::admin::provider::write::normalize::normalize_pool_advanced_config;
 use crate::handlers::admin::provider::write::normalize::normalize_provider_type_input;
+use crate::handlers::admin::provider::write::normalize::normalize_simulated_cache_config;
 use crate::handlers::admin::request::AdminAppState;
 use crate::handlers::admin::shared::normalize_json_object;
 use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogProvider;
@@ -139,6 +140,12 @@ pub(crate) async fn build_admin_create_provider_record(
         let value = normalize_chat_pii_redaction_config(config_map.remove("chat_pii_redaction"))?;
         if let Some(value) = value {
             config_map.insert("chat_pii_redaction".to_string(), value);
+        }
+    }
+    if config_map.contains_key("simulated_cache") {
+        let value = normalize_simulated_cache_config(config_map.remove("simulated_cache"))?;
+        if let Some(value) = value {
+            config_map.insert("simulated_cache".to_string(), value);
         }
     }
     let config = (!config_map.is_empty()).then_some(serde_json::Value::Object(config_map));

--- a/apps/aether-gateway/src/handlers/admin/provider/write/provider/update.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/write/provider/update.rs
@@ -5,6 +5,7 @@ use crate::handlers::admin::provider::shared::support::{
 use crate::handlers::admin::provider::write::normalize::normalize_chat_pii_redaction_config;
 use crate::handlers::admin::provider::write::normalize::normalize_pool_advanced_config;
 use crate::handlers::admin::provider::write::normalize::normalize_provider_type_input;
+use crate::handlers::admin::provider::write::normalize::normalize_simulated_cache_config;
 use crate::handlers::admin::request::AdminAppState;
 use crate::handlers::admin::shared::normalize_json_object;
 use aether_data_contracts::repository::provider_catalog::StoredProviderCatalogProvider;
@@ -290,6 +291,12 @@ pub(crate) async fn build_admin_update_provider_record(
         let value = normalize_chat_pii_redaction_config(config_map.remove("chat_pii_redaction"))?;
         if let Some(value) = value {
             config_map.insert("chat_pii_redaction".to_string(), value);
+        }
+    }
+    if config_map.contains_key("simulated_cache") {
+        let value = normalize_simulated_cache_config(config_map.remove("simulated_cache"))?;
+        if let Some(value) = value {
+            config_map.insert("simulated_cache".to_string(), value);
         }
     }
 

--- a/apps/aether-gateway/src/handlers/public/support/user_me_usage.rs
+++ b/apps/aether-gateway/src/handlers/public/support/user_me_usage.rs
@@ -110,6 +110,17 @@ fn users_me_usage_cache_creation_tokens(item: &StoredRequestUsageAudit) -> u64 {
     }
 }
 
+fn users_me_usage_simulated_cache_enabled(item: &StoredRequestUsageAudit) -> bool {
+    item.request_metadata
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+        .and_then(|metadata| metadata.get("dimensions"))
+        .and_then(serde_json::Value::as_object)
+        .and_then(|dimensions| dimensions.get("simulated_cache_enabled"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
 fn users_me_usage_total_input_context(item: &StoredRequestUsageAudit) -> u64 {
     let api_format = item
         .endpoint_api_format
@@ -119,6 +130,9 @@ fn users_me_usage_total_input_context(item: &StoredRequestUsageAudit) -> u64 {
     let cache_creation_tokens =
         i64::try_from(users_me_usage_cache_creation_tokens(item)).unwrap_or(i64::MAX);
     let cache_read_tokens = i64::try_from(item.cache_read_input_tokens).unwrap_or(i64::MAX);
+    if users_me_usage_simulated_cache_enabled(item) {
+        return input_tokens.max(0).saturating_add(cache_read_tokens.max(0)) as u64;
+    }
     normalize_total_input_context_for_cache_hit_rate(
         api_format,
         input_tokens,
@@ -134,6 +148,9 @@ fn users_me_usage_effective_input_tokens(item: &StoredRequestUsageAudit) -> u64 
         .or(item.api_format.as_deref());
     let input_tokens = i64::try_from(item.input_tokens).unwrap_or(i64::MAX);
     let cache_read_tokens = i64::try_from(item.cache_read_input_tokens).unwrap_or(i64::MAX);
+    if users_me_usage_simulated_cache_enabled(item) {
+        return input_tokens.max(0) as u64;
+    }
     normalize_input_tokens_for_billing(api_format, input_tokens, cache_read_tokens) as u64
 }
 
@@ -486,6 +503,7 @@ fn build_users_me_usage_record_payload(
         "cache_creation_ephemeral_5m_input_tokens": item.cache_creation_ephemeral_5m_input_tokens,
         "cache_creation_ephemeral_1h_input_tokens": item.cache_creation_ephemeral_1h_input_tokens,
         "cache_read_input_tokens": item.cache_read_input_tokens,
+        "simulated_cache_enabled": users_me_usage_simulated_cache_enabled(item),
         "status_code": item.status_code,
         "error_message": item.error_message,
         "input_price_per_1m": input_price_per_1m,
@@ -529,6 +547,7 @@ fn build_users_me_usage_active_payload(item: &StoredRequestUsageAudit) -> serde_
         "cache_creation_ephemeral_5m_input_tokens": item.cache_creation_ephemeral_5m_input_tokens,
         "cache_creation_ephemeral_1h_input_tokens": item.cache_creation_ephemeral_1h_input_tokens,
         "cache_read_input_tokens": item.cache_read_input_tokens,
+        "simulated_cache_enabled": users_me_usage_simulated_cache_enabled(item),
         "cost": round_to(item.total_cost_usd, 6),
         "actual_cost": round_to(item.actual_total_cost_usd, 6),
         "rate_multiplier": item.settlement_rate_multiplier(),
@@ -1696,6 +1715,27 @@ mod tests {
         assert_eq!(payload["effective_input_tokens"], 4941);
         assert_eq!(payload["cache_creation_input_tokens"], 687);
         assert_eq!(payload["cache_read_input_tokens"], 52873);
+    }
+
+    #[test]
+    fn user_usage_record_keeps_simulated_cache_input_as_effective_input() {
+        let mut item = sample_usage("completed");
+        item.input_tokens = 2103;
+        item.cache_read_input_tokens = 21439;
+        item.request_metadata = Some(json!({
+            "dimensions": {
+                "simulated_cache_enabled": true,
+                "simulated_cache_hit_percent": 91.07,
+                "simulated_cache_min_percent": 90,
+                "simulated_cache_max_percent": 95
+            }
+        }));
+
+        let payload = build_users_me_usage_record_payload(&item, false, &BTreeMap::new(), false);
+
+        assert_eq!(payload["effective_input_tokens"], 2103);
+        assert_eq!(payload["cache_read_input_tokens"], 21439);
+        assert_eq!(payload["simulated_cache_enabled"], true);
     }
 
     #[test]

--- a/apps/aether-gateway/src/tests/control/admin/providers.rs
+++ b/apps/aether-gateway/src/tests/control/admin/providers.rs
@@ -241,6 +241,7 @@ async fn gateway_handles_admin_provider_summary_locally_with_trusted_admin_princ
                 "pool_advanced": {"enabled": true},
                 "failover_rules": {"strategy": "ordered"},
                 "chat_pii_redaction": {"enabled": true},
+                "simulated_cache": {"enabled": true, "min_percent": 90, "max_percent": 100},
                 "kiro": {"simulated_cache_enabled": true},
                 "provider_ops": {"architecture_id": "anyrouter"}
             })),
@@ -355,6 +356,9 @@ async fn gateway_handles_admin_provider_summary_locally_with_trusted_admin_princ
     assert_eq!(payload["ops_architecture_id"], "anyrouter");
     assert_eq!(payload["chat_pii_redaction"], json!({"enabled": true}));
     assert_eq!(payload["kiro_simulated_cache_enabled"], true);
+    assert_eq!(payload["simulated_cache_enabled"], true);
+    assert_eq!(payload["simulated_cache_min_percent"], 90.0);
+    assert_eq!(payload["simulated_cache_max_percent"], 100.0);
     assert_eq!(payload["created_at"], "2024-03-21T05:46:40Z");
     assert_eq!(payload["updated_at"], "2024-03-21T05:48:20Z");
     assert_eq!(
@@ -870,6 +874,57 @@ async fn gateway_updates_admin_provider_locally_with_trusted_admin_principal() {
     assert_eq!(payload["ops_configured"], true);
     assert_eq!(payload["ops_architecture_id"], "cubence");
 
+    let simulated_cache_enable_response = reqwest::Client::new()
+        .patch(format!("{gateway_url}/api/admin/providers/provider-openai"))
+        .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
+            "config": {
+                "simulated_cache": {
+                    "enabled": true,
+                    "min_percent": 90,
+                    "max_percent": 100
+                }
+            }
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
+    let simulated_cache_enable_status = simulated_cache_enable_response.status();
+    let simulated_cache_enable_body = simulated_cache_enable_response
+        .text()
+        .await
+        .expect("body should read");
+    assert_eq!(
+        simulated_cache_enable_status,
+        StatusCode::OK,
+        "body={simulated_cache_enable_body}"
+    );
+    let simulated_cache_enable_payload: serde_json::Value =
+        serde_json::from_str(&simulated_cache_enable_body).expect("json body should parse");
+    assert_eq!(
+        simulated_cache_enable_payload["simulated_cache_enabled"],
+        true
+    );
+    assert_eq!(
+        simulated_cache_enable_payload["simulated_cache_min_percent"],
+        90.0
+    );
+    assert_eq!(
+        simulated_cache_enable_payload["simulated_cache_max_percent"],
+        100.0
+    );
+    assert_eq!(
+        simulated_cache_enable_payload["chat_pii_redaction"],
+        json!({"enabled": true})
+    );
+    assert_eq!(
+        simulated_cache_enable_payload["failover_rules"],
+        json!({"strategy": "ordered"})
+    );
+
     let disable_response = reqwest::Client::new()
         .patch(format!("{gateway_url}/api/admin/providers/provider-openai"))
         .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
@@ -878,7 +933,8 @@ async fn gateway_updates_admin_provider_locally_with_trusted_admin_principal() {
         .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
         .json(&json!({
             "config": {
-                "chat_pii_redaction": {"enabled": false}
+                "chat_pii_redaction": {"enabled": false},
+                "simulated_cache": null
             }
         }))
         .send()
@@ -899,6 +955,7 @@ async fn gateway_updates_admin_provider_locally_with_trusted_admin_principal() {
         json!({"strategy": "ordered"})
     );
     assert_eq!(disable_payload["ops_architecture_id"], "cubence");
+    assert_eq!(disable_payload["simulated_cache_enabled"], false);
 
     let invalid_response = reqwest::Client::new()
         .patch(format!("{gateway_url}/api/admin/providers/provider-openai"))
@@ -947,6 +1004,14 @@ async fn gateway_updates_admin_provider_locally_with_trusted_admin_principal() {
             .and_then(|value| value.get("failover_rules"))
             .cloned(),
         Some(json!({"strategy": "ordered"}))
+    );
+    assert_eq!(
+        updated_provider
+            .config
+            .as_ref()
+            .and_then(|value| value.get("simulated_cache"))
+            .cloned(),
+        None
     );
     assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
 

--- a/crates/aether-admin/src/observability/usage.rs
+++ b/crates/aether-admin/src/observability/usage.rs
@@ -1202,6 +1202,7 @@ fn admin_usage_active_request_json(
         "cache_creation_ephemeral_5m_input_tokens": item.cache_creation_ephemeral_5m_input_tokens,
         "cache_creation_ephemeral_1h_input_tokens": item.cache_creation_ephemeral_1h_input_tokens,
         "cache_read_input_tokens": item.cache_read_input_tokens,
+        "simulated_cache_enabled": admin_usage_simulated_cache_enabled(item),
         "cost": round_to(item.total_cost_usd, 6),
         "actual_cost": round_to(item.actual_total_cost_usd, 6),
         "response_time_ms": item.response_time_ms,
@@ -1294,6 +1295,7 @@ pub fn admin_usage_record_json(
         "cache_creation_ephemeral_5m_input_tokens": item.cache_creation_ephemeral_5m_input_tokens,
         "cache_creation_ephemeral_1h_input_tokens": item.cache_creation_ephemeral_1h_input_tokens,
         "cache_read_input_tokens": item.cache_read_input_tokens,
+        "simulated_cache_enabled": admin_usage_simulated_cache_enabled(item),
         "total_tokens": admin_usage_total_tokens(item),
         "cost": round_to(item.total_cost_usd, 6),
         "actual_cost": round_to(item.actual_total_cost_usd, 6),
@@ -1380,6 +1382,17 @@ pub fn admin_usage_cache_creation_tokens(item: &StoredRequestUsageAudit) -> u64 
     }
 }
 
+fn admin_usage_simulated_cache_enabled(item: &StoredRequestUsageAudit) -> bool {
+    item.request_metadata
+        .as_ref()
+        .and_then(Value::as_object)
+        .and_then(|metadata| metadata.get("dimensions"))
+        .and_then(Value::as_object)
+        .and_then(|dimensions| dimensions.get("simulated_cache_enabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
 pub fn admin_usage_total_input_context(item: &StoredRequestUsageAudit) -> u64 {
     let api_format = item
         .endpoint_api_format
@@ -1389,6 +1402,9 @@ pub fn admin_usage_total_input_context(item: &StoredRequestUsageAudit) -> u64 {
     let cache_creation_tokens =
         i64::try_from(admin_usage_cache_creation_tokens(item)).unwrap_or(i64::MAX);
     let cache_read_tokens = i64::try_from(item.cache_read_input_tokens).unwrap_or(i64::MAX);
+    if admin_usage_simulated_cache_enabled(item) {
+        return input_tokens.max(0).saturating_add(cache_read_tokens.max(0)) as u64;
+    }
     normalize_total_input_context_for_cache_hit_rate(
         api_format,
         input_tokens,
@@ -1404,6 +1420,9 @@ pub fn admin_usage_effective_input_tokens(item: &StoredRequestUsageAudit) -> u64
         .or(item.api_format.as_deref());
     let input_tokens = i64::try_from(item.input_tokens).unwrap_or(i64::MAX);
     let cache_read_tokens = i64::try_from(item.cache_read_input_tokens).unwrap_or(i64::MAX);
+    if admin_usage_simulated_cache_enabled(item) {
+        return input_tokens.max(0) as u64;
+    }
     normalize_input_tokens_for_billing(api_format, input_tokens, cache_read_tokens) as u64
 }
 
@@ -3429,6 +3448,36 @@ mod tests {
         assert_eq!(payload["cache_creation_ephemeral_5m_input_tokens"], 12);
         assert_eq!(payload["cache_creation_ephemeral_1h_input_tokens"], 8);
         assert_eq!(payload["total_tokens"], 50);
+    }
+
+    #[test]
+    fn admin_usage_record_keeps_simulated_cache_input_as_effective_input() {
+        let item = StoredRequestUsageAudit {
+            input_tokens: 2103,
+            cache_read_input_tokens: 21439,
+            request_metadata: Some(json!({
+                "dimensions": {
+                    "simulated_cache_enabled": true,
+                    "simulated_cache_hit_percent": 91.07,
+                    "simulated_cache_min_percent": 90,
+                    "simulated_cache_max_percent": 95
+                }
+            })),
+            ..sample_usage("completed", Some(200), None)
+        };
+
+        let payload = admin_usage_record_json(
+            &item,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            false,
+            false,
+            Some("primary"),
+        );
+
+        assert_eq!(payload["effective_input_tokens"], 2103);
+        assert_eq!(payload["cache_read_input_tokens"], 21439);
+        assert_eq!(payload["simulated_cache_enabled"], true);
     }
 
     #[test]

--- a/crates/aether-data/src/repository/usage/memory.rs
+++ b/crates/aether-data/src/repository/usage/memory.rs
@@ -922,9 +922,13 @@ fn normalize_usage_input_tokens(
     api_format: Option<&str>,
     input_tokens: i64,
     cache_read_tokens: i64,
+    simulated_cache_enabled: bool,
 ) -> i64 {
     if input_tokens <= 0 {
         return input_tokens.max(0);
+    }
+    if simulated_cache_enabled {
+        return input_tokens;
     }
     if cache_read_tokens <= 0 {
         return input_tokens;
@@ -943,10 +947,15 @@ fn normalize_usage_total_input_context(
     input_tokens: i64,
     cache_creation_tokens: i64,
     cache_read_tokens: i64,
+    simulated_cache_enabled: bool,
 ) -> i64 {
     let normalized_input_tokens = input_tokens.max(0);
     let normalized_cache_creation_tokens = cache_creation_tokens.max(0);
     let normalized_cache_read_tokens = cache_read_tokens.max(0);
+
+    if simulated_cache_enabled {
+        return normalized_input_tokens.saturating_add(normalized_cache_read_tokens);
+    }
 
     let fresh_input_tokens = match usage_api_family(api_format) {
         UsageApiFamily::Claude => {
@@ -956,6 +965,7 @@ fn normalize_usage_total_input_context(
             api_format,
             normalized_input_tokens,
             normalized_cache_read_tokens,
+            false,
         ),
         UsageApiFamily::Unknown => {
             if normalized_cache_creation_tokens > 0 {
@@ -983,6 +993,7 @@ fn usage_total_input_context(item: &StoredRequestUsageAudit) -> u64 {
         input_tokens,
         cache_creation_tokens,
         cache_read_tokens,
+        usage_simulated_cache_enabled(item),
     ) as u64
 }
 
@@ -993,7 +1004,23 @@ fn usage_effective_input_tokens(item: &StoredRequestUsageAudit) -> u64 {
         .or(item.api_format.as_deref());
     let input_tokens = i64::try_from(item.input_tokens).unwrap_or(i64::MAX);
     let cache_read_tokens = i64::try_from(item.cache_read_input_tokens).unwrap_or(i64::MAX);
-    normalize_usage_input_tokens(api_format, input_tokens, cache_read_tokens) as u64
+    normalize_usage_input_tokens(
+        api_format,
+        input_tokens,
+        cache_read_tokens,
+        usage_simulated_cache_enabled(item),
+    ) as u64
+}
+
+fn usage_simulated_cache_enabled(item: &StoredRequestUsageAudit) -> bool {
+    item.request_metadata
+        .as_ref()
+        .and_then(Value::as_object)
+        .and_then(|metadata| metadata.get("dimensions"))
+        .and_then(Value::as_object)
+        .and_then(|dimensions| dimensions.get("simulated_cache_enabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn usage_total_tokens(item: &StoredRequestUsageAudit) -> u64 {

--- a/crates/aether-data/src/repository/usage/postgres/mod.rs
+++ b/crates/aether-data/src/repository/usage/postgres/mod.rs
@@ -2102,39 +2102,41 @@ ORDER BY date ASC
             r#"
 SELECT
   COUNT(*)::BIGINT AS total_requests,
-  COALESCE(SUM(GREATEST(COALESCE("usage".input_tokens, 0), 0)), 0)::BIGINT AS input_tokens,
   COALESCE(SUM(
     CASE
-      WHEN GREATEST(COALESCE("usage".input_tokens, 0), 0) <= 0 THEN 0
-      WHEN GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0) <= 0
-      THEN GREATEST(COALESCE("usage".input_tokens, 0), 0)
-      WHEN split_part(lower(COALESCE(COALESCE("usage".endpoint_api_format, "usage".api_format), '')), ':', 1)
-           IN ('openai', 'gemini', 'google')
-      THEN GREATEST(
-        GREATEST(COALESCE("usage".input_tokens, 0), 0)
-          - GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0),
-        0
-      )
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.input_tokens, "usage".input_tokens, 0), 0)
       ELSE GREATEST(COALESCE("usage".input_tokens, 0), 0)
+    END
+  ), 0)::BIGINT AS input_tokens,
+  COALESCE(SUM(
+    CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.input_tokens, "usage".input_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".effective_input_tokens, "usage".input_tokens, 0), 0)
     END
   ), 0)::BIGINT AS effective_input_tokens,
-  COALESCE(SUM(GREATEST(COALESCE("usage".output_tokens, 0), 0)), 0)::BIGINT AS output_tokens,
   COALESCE(SUM(
     CASE
-      WHEN GREATEST(COALESCE("usage".input_tokens, 0), 0) <= 0 THEN 0
-      WHEN GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0) <= 0
-      THEN GREATEST(COALESCE("usage".input_tokens, 0), 0)
-      WHEN split_part(lower(COALESCE(COALESCE("usage".endpoint_api_format, "usage".api_format), '')), ':', 1)
-           IN ('openai', 'gemini', 'google')
-      THEN GREATEST(
-        GREATEST(COALESCE("usage".input_tokens, 0), 0)
-          - GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0),
-        0
-      )
-      ELSE GREATEST(COALESCE("usage".input_tokens, 0), 0)
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.output_tokens, "usage".output_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".output_tokens, 0), 0)
     END
-    + GREATEST(COALESCE("usage".output_tokens, 0), 0)
+  ), 0)::BIGINT AS output_tokens,
+  COALESCE(SUM(
+    CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.input_tokens, "usage".input_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".effective_input_tokens, "usage".input_tokens, 0), 0)
+    END
     + CASE
+        WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+        THEN GREATEST(COALESCE(usage_raw.output_tokens, "usage".output_tokens, 0), 0)
+        ELSE GREATEST(COALESCE("usage".output_tokens, 0), 0)
+      END
+    + CASE
+        WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+        THEN GREATEST(COALESCE(usage_raw.cache_creation_input_tokens, 0), 0)
         WHEN COALESCE("usage".cache_creation_input_tokens, 0) = 0
              AND (
                COALESCE("usage".cache_creation_input_tokens_5m, 0)
@@ -2144,10 +2146,16 @@ SELECT
            + COALESCE("usage".cache_creation_input_tokens_1h, 0)
         ELSE COALESCE("usage".cache_creation_input_tokens, 0)
       END
-    + GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0)
+    + CASE
+        WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+        THEN GREATEST(COALESCE(usage_raw.cache_read_input_tokens, "usage".cache_read_input_tokens, 0), 0)
+        ELSE GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0)
+      END
   ), 0)::BIGINT AS total_tokens,
   COALESCE(SUM(
     CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.cache_creation_input_tokens, 0), 0)
       WHEN COALESCE("usage".cache_creation_input_tokens, 0) = 0
            AND (
              COALESCE("usage".cache_creation_input_tokens_5m, 0)
@@ -2158,68 +2166,20 @@ SELECT
       ELSE COALESCE("usage".cache_creation_input_tokens, 0)
     END
   ), 0)::BIGINT AS cache_creation_tokens,
-  COALESCE(SUM(GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0)), 0)::BIGINT
+  COALESCE(SUM(
+    CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.cache_read_input_tokens, "usage".cache_read_input_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0)
+    END
+  ), 0)::BIGINT
     AS cache_read_tokens,
   COALESCE(SUM(
     CASE
-      WHEN split_part(lower(COALESCE(COALESCE("usage".endpoint_api_format, "usage".api_format), '')), ':', 1)
-           IN ('claude', 'anthropic')
-      THEN GREATEST(COALESCE("usage".input_tokens, 0), 0)
-         + CASE
-             WHEN COALESCE("usage".cache_creation_input_tokens, 0) = 0
-                  AND (
-                    COALESCE("usage".cache_creation_input_tokens_5m, 0)
-                    + COALESCE("usage".cache_creation_input_tokens_1h, 0)
-                  ) > 0
-             THEN COALESCE("usage".cache_creation_input_tokens_5m, 0)
-                + COALESCE("usage".cache_creation_input_tokens_1h, 0)
-             ELSE COALESCE("usage".cache_creation_input_tokens, 0)
-           END
-         + GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0)
-      WHEN split_part(lower(COALESCE(COALESCE("usage".endpoint_api_format, "usage".api_format), '')), ':', 1)
-           IN ('openai', 'gemini', 'google')
-      THEN (
-        CASE
-          WHEN GREATEST(COALESCE("usage".input_tokens, 0), 0) <= 0 THEN 0
-          WHEN GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0) <= 0
-          THEN GREATEST(COALESCE("usage".input_tokens, 0), 0)
-          ELSE GREATEST(
-            GREATEST(COALESCE("usage".input_tokens, 0), 0)
-              - GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0),
-            0
-          )
-        END
-      ) + GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0)
-      ELSE CASE
-        WHEN (
-          CASE
-            WHEN COALESCE("usage".cache_creation_input_tokens, 0) = 0
-                 AND (
-                   COALESCE("usage".cache_creation_input_tokens_5m, 0)
-                   + COALESCE("usage".cache_creation_input_tokens_1h, 0)
-                 ) > 0
-            THEN COALESCE("usage".cache_creation_input_tokens_5m, 0)
-               + COALESCE("usage".cache_creation_input_tokens_1h, 0)
-            ELSE COALESCE("usage".cache_creation_input_tokens, 0)
-          END
-        ) > 0
-        THEN GREATEST(COALESCE("usage".input_tokens, 0), 0)
-           + (
-             CASE
-               WHEN COALESCE("usage".cache_creation_input_tokens, 0) = 0
-                    AND (
-                      COALESCE("usage".cache_creation_input_tokens_5m, 0)
-                      + COALESCE("usage".cache_creation_input_tokens_1h, 0)
-                    ) > 0
-               THEN COALESCE("usage".cache_creation_input_tokens_5m, 0)
-                  + COALESCE("usage".cache_creation_input_tokens_1h, 0)
-               ELSE COALESCE("usage".cache_creation_input_tokens, 0)
-             END
-           )
-           + GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0)
-        ELSE GREATEST(COALESCE("usage".input_tokens, 0), 0)
-           + GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0)
-      END
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.input_tokens, "usage".input_tokens, 0), 0)
+         + GREATEST(COALESCE(usage_raw.cache_read_input_tokens, "usage".cache_read_input_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".total_input_context, "usage".input_tokens, 0), 0)
     END
   ), 0)::BIGINT AS total_input_context,
   COALESCE(SUM(COALESCE(CAST("usage".cache_creation_cost_usd AS DOUBLE PRECISION), 0)), 0)
@@ -2252,6 +2212,8 @@ SELECT
     END
   ), 0)::BIGINT AS response_time_samples
 FROM usage_billing_facts AS "usage"
+LEFT JOIN public."usage" AS usage_raw
+  ON usage_raw.request_id = "usage".request_id
 "#,
         );
         let mut has_where = false;
@@ -4811,10 +4773,27 @@ ORDER BY request_count DESC, group_key ASC
 WITH filtered_usage AS (
   SELECT
     {group_key_expr} AS group_key,
-    GREATEST(COALESCE("usage".input_tokens, 0), 0) AS input_tokens,
-    GREATEST(COALESCE("usage".output_tokens, 0), 0) AS output_tokens,
-    GREATEST(COALESCE("usage".total_tokens, 0), 0) AS total_tokens,
     CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.input_tokens, "usage".input_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".input_tokens, 0), 0)
+    END AS input_tokens,
+    CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.output_tokens, "usage".output_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".output_tokens, 0), 0)
+    END AS output_tokens,
+    CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.input_tokens, 0), 0)
+         + GREATEST(COALESCE(usage_raw.output_tokens, 0), 0)
+         + GREATEST(COALESCE(usage_raw.cache_creation_input_tokens, 0), 0)
+         + GREATEST(COALESCE(usage_raw.cache_read_input_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".total_tokens, 0), 0)
+    END AS total_tokens,
+    CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.cache_creation_input_tokens, 0), 0)
       WHEN COALESCE("usage".cache_creation_input_tokens, 0) = 0
            AND (
              COALESCE("usage".cache_creation_input_tokens_5m, 0)
@@ -4828,7 +4807,11 @@ WITH filtered_usage AS (
       AS cache_creation_ephemeral_5m_tokens,
     GREATEST(COALESCE("usage".cache_creation_input_tokens_1h, 0), 0)
       AS cache_creation_ephemeral_1h_tokens,
-    GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0) AS cache_read_tokens,
+    CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.cache_read_input_tokens, "usage".cache_read_input_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0)
+    END AS cache_read_tokens,
     COALESCE(CAST("usage".total_cost_usd AS DOUBLE PRECISION), 0) AS total_cost_usd,
     COALESCE(CAST("usage".actual_total_cost_usd AS DOUBLE PRECISION), 0) AS actual_total_cost_usd,
     CASE
@@ -4865,7 +4848,11 @@ WITH filtered_usage AS (
       ELSE 0
     END AS successful_response_time_samples,
     COALESCE(COALESCE("usage".endpoint_api_format, "usage".api_format), '') AS normalized_api_format
+    , (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      AS simulated_cache_enabled
   FROM usage_billing_facts AS "usage"
+  LEFT JOIN public."usage" AS usage_raw
+    ON usage_raw.request_id = "usage".request_id
 "#,
         ));
         let mut has_where = false;
@@ -4918,8 +4905,10 @@ normalized_usage AS (
     response_time_samples,
     successful_response_time_ms,
     successful_response_time_samples,
+    simulated_cache_enabled,
     CASE
       WHEN input_tokens <= 0 THEN 0
+      WHEN simulated_cache_enabled THEN input_tokens
       WHEN cache_read_tokens <= 0 THEN input_tokens
       WHEN split_part(lower(COALESCE(normalized_api_format, '')), ':', 1)
            IN ('openai', 'gemini', 'google')
@@ -4927,6 +4916,7 @@ normalized_usage AS (
       ELSE input_tokens
     END AS effective_input_tokens,
     CASE
+      WHEN simulated_cache_enabled THEN input_tokens + cache_read_tokens
       WHEN split_part(lower(COALESCE(normalized_api_format, '')), ':', 1)
            IN ('claude', 'anthropic')
       THEN input_tokens + cache_creation_tokens + cache_read_tokens
@@ -7074,10 +7064,27 @@ WITH filtered_usage AS (
     {provider_display_name_expr} AS provider_display_name,
     {provider_identity_source_expr} AS provider_identity_source,
     COALESCE("usage".api_format, 'unknown') AS api_format_group_key,
-    GREATEST(COALESCE("usage".input_tokens, 0), 0) AS input_tokens,
-    GREATEST(COALESCE("usage".output_tokens, 0), 0) AS output_tokens,
-    GREATEST(COALESCE("usage".total_tokens, 0), 0) AS total_tokens,
     CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.input_tokens, "usage".input_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".input_tokens, 0), 0)
+    END AS input_tokens,
+    CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.output_tokens, "usage".output_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".output_tokens, 0), 0)
+    END AS output_tokens,
+    CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.input_tokens, 0), 0)
+         + GREATEST(COALESCE(usage_raw.output_tokens, 0), 0)
+         + GREATEST(COALESCE(usage_raw.cache_creation_input_tokens, 0), 0)
+         + GREATEST(COALESCE(usage_raw.cache_read_input_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".total_tokens, 0), 0)
+    END AS total_tokens,
+    CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.cache_creation_input_tokens, 0), 0)
       WHEN COALESCE("usage".cache_creation_input_tokens, 0) = 0
            AND (
              COALESCE("usage".cache_creation_input_tokens_5m, 0)
@@ -7091,8 +7098,14 @@ WITH filtered_usage AS (
       AS cache_creation_ephemeral_5m_tokens,
     GREATEST(COALESCE("usage".cache_creation_input_tokens_1h, 0), 0)
       AS cache_creation_ephemeral_1h_tokens,
-    GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0) AS cache_read_tokens,
+    CASE
+      WHEN (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      THEN GREATEST(COALESCE(usage_raw.cache_read_input_tokens, "usage".cache_read_input_tokens, 0), 0)
+      ELSE GREATEST(COALESCE("usage".cache_read_input_tokens, 0), 0)
+    END AS cache_read_tokens,
     COALESCE("usage".endpoint_api_format, "usage".api_format) AS normalized_api_format,
+    (usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled') = 'true'
+      AS simulated_cache_enabled,
     COALESCE(CAST("usage".total_cost_usd AS DOUBLE PRECISION), 0) AS total_cost_usd,
     COALESCE(CAST("usage".actual_total_cost_usd AS DOUBLE PRECISION), 0) AS actual_total_cost_usd,
     GREATEST(COALESCE("usage".response_time_ms, 0), 0) AS response_time_ms,
@@ -7103,6 +7116,8 @@ WITH filtered_usage AS (
       ELSE 0
     END AS success_flag
   FROM usage_billing_facts AS "usage"
+  LEFT JOIN public."usage" AS usage_raw
+    ON usage_raw.request_id = "usage".request_id
 {provider_identity_join}
   WHERE "usage".created_at >= TO_TIMESTAMP($1::double precision)
     AND "usage".created_at < TO_TIMESTAMP($2::double precision)
@@ -7125,8 +7140,10 @@ normalized_usage AS (
     actual_total_cost_usd,
     response_time_ms,
     success_flag,
+    simulated_cache_enabled,
     CASE
       WHEN input_tokens <= 0 THEN 0
+      WHEN simulated_cache_enabled THEN input_tokens
       WHEN cache_read_tokens <= 0 THEN input_tokens
       WHEN split_part(lower(COALESCE(normalized_api_format, '')), ':', 1)
            IN ('openai', 'gemini', 'google')
@@ -7134,6 +7151,7 @@ normalized_usage AS (
       ELSE input_tokens
     END AS effective_input_tokens,
     CASE
+      WHEN simulated_cache_enabled THEN input_tokens + cache_read_tokens
       WHEN split_part(lower(COALESCE(normalized_api_format, '')), ':', 1)
            IN ('claude', 'anthropic')
       THEN input_tokens + cache_creation_tokens + cache_read_tokens
@@ -10659,6 +10677,15 @@ fn metadata_or_snapshot_dimensions(
         })
 }
 
+fn metadata_simulated_cache_enabled(metadata: Option<&serde_json::Map<String, Value>>) -> bool {
+    metadata
+        .and_then(|object| object.get("dimensions"))
+        .and_then(Value::as_object)
+        .and_then(|dimensions| dimensions.get("simulated_cache_enabled"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
 fn json_i64_value(value: &Value) -> Option<i64> {
     value
         .as_i64()
@@ -10866,8 +10893,12 @@ fn usage_effective_input_tokens(
     input_tokens: Option<i64>,
     cache_read_tokens: Option<i64>,
     api_family: &str,
+    simulated_cache_enabled: bool,
 ) -> Option<i64> {
     let input_tokens = input_tokens?;
+    if simulated_cache_enabled {
+        return Some(input_tokens);
+    }
     let cache_read_tokens = cache_read_tokens.unwrap_or_default();
     if matches!(api_family, "openai" | "gemini" | "google")
         && input_tokens > 0
@@ -10884,6 +10915,7 @@ fn usage_total_input_context(
     cache_creation_tokens: Option<i64>,
     cache_read_tokens: Option<i64>,
     api_family: &str,
+    simulated_cache_enabled: bool,
 ) -> Option<i64> {
     if input_tokens.is_none()
         && effective_input_tokens.is_none()
@@ -10897,6 +10929,9 @@ fn usage_total_input_context(
     let effective_input_tokens = effective_input_tokens.unwrap_or(input_tokens);
     let cache_creation_tokens = cache_creation_tokens.unwrap_or_default();
     let cache_read_tokens = cache_read_tokens.unwrap_or_default();
+    if simulated_cache_enabled {
+        return Some(input_tokens.saturating_add(cache_read_tokens));
+    }
     match api_family {
         "claude" | "anthropic" => Some(
             input_tokens
@@ -10963,6 +10998,7 @@ fn usage_settlement_pricing_snapshot_from_usage(
     let billing_cache_read_tokens =
         billing_dimension_i64(object, "cache_read_tokens").or(usage_cache_read_tokens);
     let api_family = usage_normalized_api_family(usage);
+    let simulated_cache_enabled = metadata_simulated_cache_enabled(object);
     let billing_effective_input_tokens = billing_dimension_i64(object, "effective_input_tokens")
         .or_else(|| {
             has_billing_dimensions
@@ -10974,6 +11010,7 @@ fn usage_settlement_pricing_snapshot_from_usage(
                 billing_input_tokens,
                 billing_cache_read_tokens,
                 api_family.as_str(),
+                simulated_cache_enabled,
             )
         });
     let billing_total_input_context =
@@ -10984,6 +11021,7 @@ fn usage_settlement_pricing_snapshot_from_usage(
                 billing_cache_creation_tokens,
                 billing_cache_read_tokens,
                 api_family.as_str(),
+                simulated_cache_enabled,
             )
         });
     let snapshot = UsageSettlementPricingSnapshot {

--- a/crates/aether-data/src/repository/usage/postgres/queries/list_recent_usage_audits_prefix.sql
+++ b/crates/aether-data/src/repository/usage/postgres/queries/list_recent_usage_audits_prefix.sql
@@ -118,6 +118,7 @@ SELECT
       OR NULLIF(BTRIM("usage".request_metadata->>'provider_service_tier'), '') IS NOT NULL
       OR ("usage".request_metadata->>'client_requested_stream') IN ('true', 'false')
       OR ("usage".request_metadata->>'upstream_is_stream') IN ('true', 'false')
+      OR ("usage".request_metadata->'dimensions'->>'simulated_cache_enabled') IN ('true', 'false')
       THEN jsonb_strip_nulls(jsonb_build_object(
         'client_ip',
         NULLIF(BTRIM("usage".request_metadata->>'client_ip'), ''),
@@ -141,6 +142,36 @@ SELECT
         CASE
           WHEN ("usage".request_metadata->>'upstream_is_stream') IN ('true', 'false')
             THEN ("usage".request_metadata->>'upstream_is_stream')::boolean
+          ELSE NULL
+        END,
+        'dimensions',
+        CASE
+          WHEN ("usage".request_metadata->'dimensions'->>'simulated_cache_enabled') IN ('true', 'false')
+          THEN jsonb_strip_nulls(jsonb_build_object(
+            'simulated_cache_enabled',
+            ("usage".request_metadata->'dimensions'->>'simulated_cache_enabled')::boolean,
+            'simulated_cache_hit_percent',
+            CASE
+              WHEN ("usage".request_metadata->'dimensions'->>'simulated_cache_hit_percent')
+                   ~ '^-?[0-9]+(\.[0-9]+)?$'
+              THEN ("usage".request_metadata->'dimensions'->>'simulated_cache_hit_percent')::double precision
+              ELSE NULL
+            END,
+            'simulated_cache_min_percent',
+            CASE
+              WHEN ("usage".request_metadata->'dimensions'->>'simulated_cache_min_percent')
+                   ~ '^-?[0-9]+(\.[0-9]+)?$'
+              THEN ("usage".request_metadata->'dimensions'->>'simulated_cache_min_percent')::double precision
+              ELSE NULL
+            END,
+            'simulated_cache_max_percent',
+            CASE
+              WHEN ("usage".request_metadata->'dimensions'->>'simulated_cache_max_percent')
+                   ~ '^-?[0-9]+(\.[0-9]+)?$'
+              THEN ("usage".request_metadata->'dimensions'->>'simulated_cache_max_percent')::double precision
+              ELSE NULL
+            END
+          ))
           ELSE NULL
         END
       ))::json

--- a/crates/aether-data/src/repository/usage/postgres/queries/list_usage_audits_prefix.sql
+++ b/crates/aether-data/src/repository/usage/postgres/queries/list_usage_audits_prefix.sql
@@ -118,6 +118,7 @@ SELECT
       OR NULLIF(BTRIM("usage".request_metadata->>'provider_service_tier'), '') IS NOT NULL
       OR ("usage".request_metadata->>'client_requested_stream') IN ('true', 'false')
       OR ("usage".request_metadata->>'upstream_is_stream') IN ('true', 'false')
+      OR ("usage".request_metadata->'dimensions'->>'simulated_cache_enabled') IN ('true', 'false')
       THEN jsonb_strip_nulls(jsonb_build_object(
         'client_ip',
         NULLIF(BTRIM("usage".request_metadata->>'client_ip'), ''),
@@ -141,6 +142,36 @@ SELECT
         CASE
           WHEN ("usage".request_metadata->>'upstream_is_stream') IN ('true', 'false')
             THEN ("usage".request_metadata->>'upstream_is_stream')::boolean
+          ELSE NULL
+        END,
+        'dimensions',
+        CASE
+          WHEN ("usage".request_metadata->'dimensions'->>'simulated_cache_enabled') IN ('true', 'false')
+          THEN jsonb_strip_nulls(jsonb_build_object(
+            'simulated_cache_enabled',
+            ("usage".request_metadata->'dimensions'->>'simulated_cache_enabled')::boolean,
+            'simulated_cache_hit_percent',
+            CASE
+              WHEN ("usage".request_metadata->'dimensions'->>'simulated_cache_hit_percent')
+                   ~ '^-?[0-9]+(\.[0-9]+)?$'
+              THEN ("usage".request_metadata->'dimensions'->>'simulated_cache_hit_percent')::double precision
+              ELSE NULL
+            END,
+            'simulated_cache_min_percent',
+            CASE
+              WHEN ("usage".request_metadata->'dimensions'->>'simulated_cache_min_percent')
+                   ~ '^-?[0-9]+(\.[0-9]+)?$'
+              THEN ("usage".request_metadata->'dimensions'->>'simulated_cache_min_percent')::double precision
+              ELSE NULL
+            END,
+            'simulated_cache_max_percent',
+            CASE
+              WHEN ("usage".request_metadata->'dimensions'->>'simulated_cache_max_percent')
+                   ~ '^-?[0-9]+(\.[0-9]+)?$'
+              THEN ("usage".request_metadata->'dimensions'->>'simulated_cache_max_percent')::double precision
+              ELSE NULL
+            END
+          ))
           ELSE NULL
         END
       ))::json

--- a/crates/aether-data/src/repository/usage/postgres/tests.rs
+++ b/crates/aether-data/src/repository/usage/postgres/tests.rs
@@ -613,6 +613,22 @@ fn usage_sql_provider_performance_reads_upstream_stream_from_billing_facts() {
 }
 
 #[test]
+fn usage_sql_raw_analytics_preserve_simulated_cache_effective_input() {
+    let source = include_str!("mod.rs");
+
+    assert!(source.contains("usage_raw.request_metadata->'dimensions'->>'simulated_cache_enabled'"));
+    assert!(source.contains("WHEN simulated_cache_enabled THEN input_tokens"));
+    assert!(source.contains("WHEN simulated_cache_enabled THEN input_tokens + cache_read_tokens"));
+}
+
+#[test]
+fn usage_sqlite_simulated_cache_boolean_accepts_json_true() {
+    let source = include_str!("../sqlite.rs");
+
+    assert!(source.contains("json_extract(request_metadata, '$.dimensions.simulated_cache_enabled') AS TEXT) IN ('true', '1')"));
+}
+
+#[test]
 fn usage_billing_facts_projects_upstream_stream_mode() {
     let migration = include_str!(
         "../../../../migrations/postgres/20260505130000_project_upstream_stream_in_usage_billing_facts.sql"
@@ -1725,6 +1741,91 @@ fn usage_settlement_pricing_snapshot_from_usage_extracts_typed_billing_fields() 
             ..UsageSettlementPricingSnapshot::default()
         }
     );
+}
+
+#[test]
+fn usage_settlement_pricing_snapshot_preserves_simulated_cache_input() {
+    let snapshot = usage_settlement_pricing_snapshot_from_usage(
+        &UpsertUsageRecord {
+            request_id: "req-simulated-cache".to_string(),
+            user_id: None,
+            api_key_id: None,
+            username: None,
+            api_key_name: None,
+            provider_name: "openai".to_string(),
+            model: "gpt-5".to_string(),
+            target_model: None,
+            provider_id: Some("provider-1".to_string()),
+            provider_endpoint_id: Some("endpoint-1".to_string()),
+            provider_api_key_id: Some("provider-key-1".to_string()),
+            request_type: Some("chat".to_string()),
+            api_format: Some("openai:chat".to_string()),
+            api_family: Some("openai".to_string()),
+            endpoint_kind: Some("chat".to_string()),
+            endpoint_api_format: Some("openai:chat".to_string()),
+            provider_api_family: Some("openai".to_string()),
+            provider_endpoint_kind: Some("chat".to_string()),
+            has_format_conversion: Some(false),
+            is_stream: Some(false),
+            input_tokens: Some(10),
+            output_tokens: Some(2),
+            total_tokens: Some(102),
+            cache_creation_input_tokens: Some(0),
+            cache_creation_ephemeral_5m_input_tokens: None,
+            cache_creation_ephemeral_1h_input_tokens: None,
+            cache_read_input_tokens: Some(90),
+            cache_creation_cost_usd: None,
+            cache_read_cost_usd: None,
+            output_price_per_1m: None,
+            total_cost_usd: None,
+            actual_total_cost_usd: None,
+            status_code: Some(200),
+            error_message: None,
+            error_category: None,
+            response_time_ms: Some(100),
+            first_byte_time_ms: None,
+            status: "completed".to_string(),
+            billing_status: "pending".to_string(),
+            request_headers: None,
+            request_body: None,
+            request_body_ref: None,
+            provider_request_headers: None,
+            provider_request_body: None,
+            provider_request_body_ref: None,
+            response_headers: None,
+            response_body: None,
+            response_body_ref: None,
+            client_response_headers: None,
+            client_response_body: None,
+            client_response_body_ref: None,
+            request_body_state: None,
+            provider_request_body_state: None,
+            response_body_state: None,
+            client_response_body_state: None,
+            candidate_id: None,
+            candidate_index: None,
+            key_name: None,
+            planner_kind: None,
+            route_family: None,
+            route_kind: None,
+            execution_path: None,
+            local_execution_runtime_miss_reason: None,
+            request_metadata: None,
+            finalized_at_unix_secs: None,
+            created_at_unix_ms: Some(100),
+            updated_at_unix_secs: 100,
+        },
+        Some(&json!({
+            "dimensions": {
+                "simulated_cache_enabled": true,
+                "simulated_cache_hit_percent": 90.0
+            }
+        })),
+    )
+    .expect("snapshot should build");
+
+    assert_eq!(snapshot.billing_effective_input_tokens, Some(10));
+    assert_eq!(snapshot.billing_total_input_context, Some(100));
 }
 
 #[test]

--- a/crates/aether-data/src/repository/usage/sqlite.rs
+++ b/crates/aether-data/src/repository/usage/sqlite.rs
@@ -279,6 +279,8 @@ END
 
 const SQLITE_USAGE_EFFECTIVE_INPUT_TOKENS_EXPR: &str = r#"
 CASE
+  WHEN CAST(json_extract(request_metadata, '$.dimensions.simulated_cache_enabled') AS TEXT) IN ('true', '1')
+  THEN MAX(COALESCE(input_tokens, 0), 0)
   WHEN (
     LOWER(COALESCE(endpoint_api_format, api_format, '')) = 'openai'
     OR LOWER(COALESCE(endpoint_api_format, api_format, '')) LIKE 'openai:%'
@@ -296,6 +298,8 @@ END
 
 const SQLITE_USAGE_TOTAL_INPUT_CONTEXT_EXPR: &str = r#"
 CASE
+  WHEN CAST(json_extract(request_metadata, '$.dimensions.simulated_cache_enabled') AS TEXT) IN ('true', '1')
+  THEN MAX(COALESCE(input_tokens, 0), 0) + MAX(COALESCE(cache_read_input_tokens, 0), 0)
   WHEN (
     LOWER(COALESCE(endpoint_api_format, api_format, '')) = 'openai'
     OR LOWER(COALESCE(endpoint_api_format, api_format, '')) LIKE 'openai:%'
@@ -331,6 +335,8 @@ END
 const SQLITE_USAGE_CANONICAL_TOTAL_TOKENS_EXPR: &str = r#"
 (
   CASE
+    WHEN CAST(json_extract(request_metadata, '$.dimensions.simulated_cache_enabled') AS TEXT) IN ('true', '1')
+    THEN MAX(COALESCE(input_tokens, 0), 0)
     WHEN (
       LOWER(COALESCE(endpoint_api_format, api_format, '')) = 'openai'
       OR LOWER(COALESCE(endpoint_api_format, api_format, '')) LIKE 'openai:%'

--- a/crates/aether-usage-runtime/src/request_metadata.rs
+++ b/crates/aether-usage-runtime/src/request_metadata.rs
@@ -47,6 +47,12 @@ fn copy_simulated_cache_dimensions(source: &Map<String, Value>, target: &mut Map
     {
         dimensions.insert("simulated_cache_max_percent".to_string(), value.clone());
     }
+    if let Some(value) = source
+        .get("simulated_cache_hit_percent")
+        .filter(|value| value.is_number())
+    {
+        dimensions.insert("simulated_cache_hit_percent".to_string(), value.clone());
+    }
     target.insert("dimensions".to_string(), Value::Object(dimensions));
 }
 

--- a/crates/aether-usage-runtime/src/request_metadata.rs
+++ b/crates/aether-usage-runtime/src/request_metadata.rs
@@ -21,8 +21,33 @@ pub(crate) fn build_usage_request_metadata_seed(
     let mut metadata = Map::new();
     if let Some(context) = context {
         copy_allowed_metadata_fields(context, &mut metadata);
+        copy_simulated_cache_dimensions(context, &mut metadata);
     }
     (!metadata.is_empty()).then_some(Value::Object(metadata))
+}
+
+fn copy_simulated_cache_dimensions(source: &Map<String, Value>, target: &mut Map<String, Value>) {
+    let Some(Value::Bool(enabled)) = source.get("simulated_cache_enabled") else {
+        return;
+    };
+    let mut dimensions = match target.remove("dimensions") {
+        Some(Value::Object(object)) => object,
+        _ => Map::new(),
+    };
+    dimensions.insert("simulated_cache_enabled".to_string(), Value::Bool(*enabled));
+    if let Some(value) = source
+        .get("simulated_cache_min_percent")
+        .filter(|value| value.is_number())
+    {
+        dimensions.insert("simulated_cache_min_percent".to_string(), value.clone());
+    }
+    if let Some(value) = source
+        .get("simulated_cache_max_percent")
+        .filter(|value| value.is_number())
+    {
+        dimensions.insert("simulated_cache_max_percent".to_string(), value.clone());
+    }
+    target.insert("dimensions".to_string(), Value::Object(dimensions));
 }
 
 pub(crate) fn merge_usage_request_metadata(

--- a/crates/aether-usage-runtime/src/write.rs
+++ b/crates/aether-usage-runtime/src/write.rs
@@ -990,7 +990,11 @@ fn apply_simulated_cache_to_usage(
         return usage.has_token_signal().then_some(usage);
     }
 
-    let hit_percent = random_simulated_cache_percent(config.min_percent, config.max_percent);
+    let hit_percent =
+        simulated_cache_hit_percent_from_metadata(context_seed.request_metadata.as_ref())
+            .unwrap_or_else(|| {
+                random_simulated_cache_percent(config.min_percent, config.max_percent)
+            });
     let cache_read_tokens = ((total_input_tokens as f64) * hit_percent / 100.0).round() as u64;
     let cache_read_tokens = cache_read_tokens.min(total_input_tokens);
     let billed_input_tokens = total_input_tokens.saturating_sub(cache_read_tokens);
@@ -1042,6 +1046,17 @@ fn simulated_cache_config_from_metadata(
         min_percent,
         max_percent,
     })
+}
+
+fn simulated_cache_hit_percent_from_metadata(metadata: Option<&Value>) -> Option<f64> {
+    let object = metadata.and_then(Value::as_object)?;
+    let dimensions = object
+        .get("dimensions")
+        .and_then(Value::as_object)
+        .unwrap_or(object);
+    json_f64(dimensions.get("simulated_cache_hit_percent"))
+        .filter(|value| value.is_finite())
+        .map(|value| value.clamp(0.0, 100.0))
 }
 
 fn json_f64(value: Option<&Value>) -> Option<f64> {

--- a/crates/aether-usage-runtime/src/write.rs
+++ b/crates/aether-usage-runtime/src/write.rs
@@ -1,4 +1,6 @@
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use aether_ai_formats::UPSTREAM_IS_STREAM_KEY;
 use aether_contracts::{ExecutionPlan, ExecutionTelemetry};
@@ -24,6 +26,8 @@ use crate::{
     STREAM_MISSING_TERMINAL_EVENT_MESSAGE, STREAM_TERMINAL_ERROR_CATEGORY,
     STREAM_TERMINAL_ERROR_MESSAGE,
 };
+
+static SIMULATED_CACHE_RANDOM_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum UsageLifecycleState {
@@ -562,6 +566,35 @@ fn build_terminal_usage_event_from_seed_impl(
     };
     let request_metadata =
         attach_provider_request_body_metadata(request_metadata, provider_request.as_ref());
+    let usage_context = TerminalUsageContextSeed {
+        client_contract: client_contract.clone(),
+        provider_contract: provider_contract.clone(),
+        request_id: request_id.clone(),
+        user_id: user_id.clone(),
+        api_key_id: api_key_id.clone(),
+        username: username.clone(),
+        api_key_name: api_key_name.clone(),
+        provider_name: provider_name.clone(),
+        model: model.clone(),
+        target_model: target_model.clone(),
+        model_id: model_id.clone(),
+        global_model_id: global_model_id.clone(),
+        provider_id: provider_id.clone(),
+        provider_endpoint_id: provider_endpoint_id.clone(),
+        provider_api_key_id: provider_api_key_id.clone(),
+        request_type: request_type.clone(),
+        has_format_conversion,
+        is_stream,
+        request_headers: None,
+        request_body: None,
+        provider_request_headers: None,
+        provider_request: None,
+        body_refs: UsageBodyRefsSeed::default(),
+        body_states: UsageBodyStatesSeed::default(),
+        routing: UsageRoutingSeed::default(),
+        request_metadata: request_metadata.clone(),
+    };
+    let standardized_usage = apply_simulated_cache_to_usage(standardized_usage, &usage_context);
 
     let mut data = UsageEventData {
         user_id,
@@ -625,7 +658,6 @@ fn build_terminal_usage_event_from_seed_impl(
     if let Some(usage) = standardized_usage.as_ref() {
         apply_standardized_usage_seed(usage, &mut data);
     }
-
     if data.total_tokens.is_none() {
         if let Some(tokens) = data
             .response_body
@@ -940,6 +972,132 @@ fn merge_standardized_usage_with_context_cache(
         usage.cache_read_tokens = context_usage.cache_read_tokens;
     }
     Some(usage)
+}
+
+fn apply_simulated_cache_to_usage(
+    usage: Option<StandardizedUsage>,
+    context_seed: &TerminalUsageContextSeed,
+) -> Option<StandardizedUsage> {
+    let Some(config) = simulated_cache_config_from_metadata(context_seed.request_metadata.as_ref())
+    else {
+        return usage;
+    };
+
+    let mut usage = usage.unwrap_or_else(StandardizedUsage::new);
+    let total_input_tokens =
+        usage_total_input_tokens(&usage, context_seed.provider_contract.as_str());
+    if total_input_tokens == 0 {
+        return usage.has_token_signal().then_some(usage);
+    }
+
+    let hit_percent = random_simulated_cache_percent(config.min_percent, config.max_percent);
+    let cache_read_tokens = ((total_input_tokens as f64) * hit_percent / 100.0).round() as u64;
+    let cache_read_tokens = cache_read_tokens.min(total_input_tokens);
+    let billed_input_tokens = total_input_tokens.saturating_sub(cache_read_tokens);
+
+    usage.input_tokens = billed_input_tokens as i64;
+    usage.cache_creation_tokens = 0;
+    usage.cache_creation_ephemeral_5m_tokens = 0;
+    usage.cache_creation_ephemeral_1h_tokens = 0;
+    usage.cache_read_tokens = cache_read_tokens as i64;
+    usage
+        .dimensions
+        .insert("simulated_cache_enabled".to_string(), json!(true));
+    usage.dimensions.insert(
+        "simulated_cache_hit_percent".to_string(),
+        json!((hit_percent * 100.0).round() / 100.0),
+    );
+    Some(usage)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SimulatedCacheRuntimeConfig {
+    min_percent: f64,
+    max_percent: f64,
+}
+
+fn simulated_cache_config_from_metadata(
+    metadata: Option<&Value>,
+) -> Option<SimulatedCacheRuntimeConfig> {
+    let object = metadata.and_then(Value::as_object)?;
+    let dimensions = object
+        .get("dimensions")
+        .and_then(Value::as_object)
+        .unwrap_or(object);
+    if !dimensions
+        .get("simulated_cache_enabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    let min_percent = json_f64(dimensions.get("simulated_cache_min_percent")).unwrap_or(90.0);
+    let max_percent = json_f64(dimensions.get("simulated_cache_max_percent")).unwrap_or(100.0);
+    if !min_percent.is_finite() || !max_percent.is_finite() {
+        return None;
+    }
+    let min_percent = min_percent.clamp(0.0, 100.0);
+    let max_percent = max_percent.clamp(0.0, 100.0);
+    (min_percent <= max_percent).then_some(SimulatedCacheRuntimeConfig {
+        min_percent,
+        max_percent,
+    })
+}
+
+fn json_f64(value: Option<&Value>) -> Option<f64> {
+    value.and_then(|value| match value {
+        Value::Number(number) => number.as_f64(),
+        Value::String(text) => text.trim().parse::<f64>().ok(),
+        _ => None,
+    })
+}
+
+fn usage_total_input_tokens(usage: &StandardizedUsage, api_format: &str) -> u64 {
+    let input_tokens = usage.input_tokens.max(0) as u64;
+    let api_family = api_format
+        .split(':')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase();
+    if matches!(api_family.as_str(), "openai" | "gemini" | "google") {
+        return input_tokens;
+    }
+
+    let cache_creation_tokens = usage
+        .cache_creation_tokens
+        .max(0)
+        .saturating_add(usage.cache_creation_ephemeral_5m_tokens.max(0))
+        .saturating_add(usage.cache_creation_ephemeral_1h_tokens.max(0))
+        as u64;
+    let cache_read_tokens = usage.cache_read_tokens.max(0) as u64;
+    input_tokens
+        .saturating_add(cache_creation_tokens)
+        .saturating_add(cache_read_tokens)
+}
+
+fn random_simulated_cache_percent(min_percent: f64, max_percent: f64) -> f64 {
+    if (max_percent - min_percent).abs() <= f64::EPSILON {
+        return min_percent;
+    }
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_nanos() as u64)
+        .unwrap_or(0);
+    let counter = SIMULATED_CACHE_RANDOM_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let seed = splitmix64(nanos ^ counter.rotate_left(17));
+    let unit = seed as f64 / u64::MAX as f64;
+    min_percent + (max_percent - min_percent) * unit
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9E3779B97F4A7C15);
+    let mut mixed = value;
+    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94D049BB133111EB);
+    mixed ^ (mixed >> 31)
 }
 
 pub fn build_stream_terminal_usage_seed(
@@ -3235,9 +3393,10 @@ mod tests {
         build_terminal_usage_event_from_seed, build_usage_event_data_seed, decode_body_for_storage,
         extract_token_counts_from_json, extract_token_counts_from_value, headers_to_json,
         mask_header_value, mask_sensitive_body_fields, mask_sensitive_headers_in_json_value,
-        parse_sse_body_for_storage, resolve_error_message, trim_owned_non_empty_string,
-        LifecycleUsageSeed, TerminalUsageSeed, UsageBodyRefsSeed, UsageBodyStatesSeed,
-        UsageRoutingSeed, UsageTerminalState, MAX_USAGE_CAPTURE_BYTES, MAX_USAGE_CAPTURE_DEPTH,
+        parse_sse_body_for_storage, random_simulated_cache_percent, resolve_error_message,
+        trim_owned_non_empty_string, LifecycleUsageSeed, TerminalUsageSeed, UsageBodyRefsSeed,
+        UsageBodyStatesSeed, UsageRoutingSeed, UsageTerminalState, MAX_USAGE_CAPTURE_BYTES,
+        MAX_USAGE_CAPTURE_DEPTH,
     };
     use crate::{
         build_upsert_usage_record_from_event, GatewayStreamReportRequest, GatewaySyncReportRequest,
@@ -6008,6 +6167,113 @@ mod tests {
         assert_eq!(event.data.cache_creation_input_tokens, Some(1200));
         assert_eq!(event.data.cache_read_input_tokens, Some(300));
         assert_eq!(event.data.total_tokens, Some(300));
+    }
+
+    #[test]
+    fn sync_terminal_usage_applies_generic_simulated_cache_override() {
+        let plan = ExecutionPlan {
+            request_id: "req-sync-generic-cache-context-1".to_string(),
+            candidate_id: Some("cand-sync-generic-cache-context-1".to_string()),
+            provider_name: Some("Custom".to_string()),
+            provider_id: "provider-custom-1".to_string(),
+            endpoint_id: "endpoint-custom-1".to_string(),
+            key_id: "key-custom-1".to_string(),
+            method: "POST".to_string(),
+            url: "https://custom.example/v1/chat/completions".to_string(),
+            headers: BTreeMap::new(),
+            content_type: Some("application/json".to_string()),
+            content_encoding: None,
+            body: RequestBody::from_json(json!({"model": "custom-model"})),
+            stream: false,
+            client_api_format: "openai:chat".to_string(),
+            provider_api_format: "openai:chat".to_string(),
+            model_name: Some("custom-model".to_string()),
+            proxy: None,
+            transport_profile: None,
+            timeouts: None,
+        };
+        let payload = GatewaySyncReportRequest {
+            trace_id: "trace-sync-generic-cache-context-1".to_string(),
+            report_kind: "openai_chat_sync_success".to_string(),
+            report_context: Some(json!({
+                "client_api_format": "openai:chat",
+                "provider_api_format": "openai:chat",
+                "provider_name": "Custom",
+                "model": "custom-model",
+                "simulated_cache_enabled": true,
+                "simulated_cache_min_percent": 90,
+                "simulated_cache_max_percent": 95
+            })),
+            status_code: 200,
+            headers: BTreeMap::new(),
+            body_json: Some(json!({
+                "id": "chatcmpl-generic-cache-1",
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 7,
+                    "total_tokens": 127,
+                    "prompt_tokens_details": {
+                        "cached_tokens": 20
+                    }
+                }
+            })),
+            client_body_json: None,
+            body_base64: None,
+            telemetry: None,
+        };
+
+        let event =
+            build_sync_terminal_usage_event(&plan, payload.report_context.as_ref(), &payload)
+                .expect("usage event should build");
+
+        let input_tokens = event
+            .data
+            .input_tokens
+            .expect("simulated cache below 100% should leave uncached input tokens");
+        assert_eq!(event.data.output_tokens, Some(7));
+        assert_eq!(event.data.cache_creation_input_tokens, None);
+        let cache_read_tokens = event
+            .data
+            .cache_read_input_tokens
+            .expect("simulated cache should write cache read tokens");
+        assert!((5..=10).contains(&input_tokens));
+        assert!((90..=95).contains(&cache_read_tokens));
+        assert_eq!(input_tokens + cache_read_tokens, 100);
+        assert_eq!(event.data.total_tokens, Some(127));
+        let dimensions = event
+            .data
+            .request_metadata
+            .as_ref()
+            .and_then(Value::as_object)
+            .and_then(|metadata| metadata.get("dimensions"))
+            .and_then(Value::as_object)
+            .expect("dimensions should exist");
+        assert_eq!(
+            dimensions.get("simulated_cache_enabled"),
+            Some(&json!(true))
+        );
+        assert_eq!(
+            dimensions
+                .get("simulated_cache_min_percent")
+                .and_then(Value::as_f64)
+                .unwrap_or_default(),
+            90.0
+        );
+        assert_eq!(
+            dimensions
+                .get("simulated_cache_max_percent")
+                .and_then(Value::as_f64)
+                .unwrap_or_default(),
+            95.0
+        );
+    }
+
+    #[test]
+    fn random_simulated_cache_percent_stays_in_range() {
+        let percent = random_simulated_cache_percent(90.0, 95.0);
+
+        assert!((90.0..=95.0).contains(&percent));
+        assert_eq!(random_simulated_cache_percent(92.0, 92.0), 92.0);
     }
 
     #[test]

--- a/frontend/src/api/endpoints/providers.ts
+++ b/frontend/src/api/endpoints/providers.ts
@@ -50,6 +50,9 @@ function normalizeProviderSummary(
     chat_pii_redaction: normalizeChatPiiRedactionProvider(provider.chat_pii_redaction),
     pool_advanced: normalizePoolAdvanced(provider.pool_advanced),
     kiro_simulated_cache_enabled: provider.kiro_simulated_cache_enabled ?? false,
+    simulated_cache_enabled: provider.simulated_cache_enabled ?? false,
+    simulated_cache_min_percent: provider.simulated_cache_min_percent ?? 90,
+    simulated_cache_max_percent: provider.simulated_cache_max_percent ?? 100,
   }
 }
 

--- a/frontend/src/api/endpoints/types/provider.ts
+++ b/frontend/src/api/endpoints/types/provider.ts
@@ -180,8 +180,15 @@ export interface ChatPiiRedactionProviderConfig {
   enabled: boolean
 }
 
+export interface SimulatedCacheProviderConfig {
+  enabled: boolean
+  min_percent?: number
+  max_percent?: number
+}
+
 export interface ProviderConfig {
   chat_pii_redaction?: ChatPiiRedactionProviderConfig
+  simulated_cache?: SimulatedCacheProviderConfig | null
   pool_advanced?: PoolAdvancedConfig
   failover_rules?: FailoverRulesConfig
   claude_code_advanced?: ClaudeCodeAdvancedConfig
@@ -827,6 +834,9 @@ export interface ProviderWithEndpointsSummary {
   ops_configured: boolean  // 是否配置了扩展操作（余额监控等）
   ops_architecture_id?: string  // 扩展操作使用的架构 ID（如 cubence, anyrouter）
   kiro_simulated_cache_enabled?: boolean
+  simulated_cache_enabled?: boolean
+  simulated_cache_min_percent?: number
+  simulated_cache_max_percent?: number
   ops_quota_alert_enabled?: boolean
   created_at: string
   updated_at: string

--- a/frontend/src/api/me.ts
+++ b/frontend/src/api/me.ts
@@ -81,6 +81,7 @@ export interface UsageRecordDetail {
   cache_creation_ephemeral_5m_input_tokens?: number
   cache_creation_ephemeral_1h_input_tokens?: number
   cache_read_input_tokens?: number
+  simulated_cache_enabled?: boolean
   status_code: number
   error_message?: string
   input_price_per_1m: number

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -23,6 +23,7 @@ export interface UsageRecord {
   cache_creation_ephemeral_5m_input_tokens?: number
   cache_creation_ephemeral_1h_input_tokens?: number
   cache_read_input_tokens?: number
+  simulated_cache_enabled?: boolean
   total_tokens: number
   cost?: number
   response_time?: number

--- a/frontend/src/features/providers/components/ProviderFormDialog.vue
+++ b/frontend/src/features/providers/components/ProviderFormDialog.vue
@@ -281,20 +281,50 @@
           />
         </div>
 
-        <div
-          v-if="form.provider_type === 'kiro'"
-          class="flex items-center justify-between p-3 border rounded-lg bg-muted/50"
-        >
-          <div class="space-y-0.5">
-            <span class="text-sm font-medium">模拟缓存模式</span>
-            <p class="text-xs text-muted-foreground leading-relaxed">
-              启用后仅对 Kiro 请求模拟 prompt cache 读写计量。
-            </p>
+        <div class="space-y-3 p-3 border rounded-lg bg-muted/50">
+          <div class="flex items-center justify-between gap-4">
+            <div class="space-y-0.5">
+              <span class="text-sm font-medium">模拟缓存</span>
+              <p class="text-xs text-muted-foreground leading-relaxed">
+                按请求输入 token 的随机百分比强制覆盖缓存命中统计。
+              </p>
+            </div>
+            <Switch
+              :model-value="form.simulated_cache_enabled"
+              @update:model-value="(v: boolean) => form.simulated_cache_enabled = v"
+            />
           </div>
-          <Switch
-            :model-value="form.kiro_simulated_cache_enabled"
-            @update:model-value="(v: boolean) => form.kiro_simulated_cache_enabled = v"
-          />
+          <div
+            v-if="form.simulated_cache_enabled"
+            class="grid grid-cols-2 gap-3"
+          >
+            <div class="space-y-1.5">
+              <Label for="simulated_cache_min_percent">最小命中百分比</Label>
+              <Input
+                id="simulated_cache_min_percent"
+                :model-value="form.simulated_cache_min_percent ?? ''"
+                type="number"
+                min="0"
+                max="100"
+                step="0.01"
+                placeholder="90"
+                @update:model-value="(v) => form.simulated_cache_min_percent = parseNumberInput(v, { allowFloat: true, min: 0, max: 100 }) ?? 90"
+              />
+            </div>
+            <div class="space-y-1.5">
+              <Label for="simulated_cache_max_percent">最大命中百分比</Label>
+              <Input
+                id="simulated_cache_max_percent"
+                :model-value="form.simulated_cache_max_percent ?? ''"
+                type="number"
+                min="0"
+                max="100"
+                step="0.01"
+                placeholder="100"
+                @update:model-value="(v) => form.simulated_cache_max_percent = parseNumberInput(v, { allowFloat: true, min: 0, max: 100 }) ?? 100"
+              />
+            </div>
+          </div>
         </div>
 
         <div class="flex items-center justify-between gap-4 p-3 border rounded-lg bg-muted/50">
@@ -406,8 +436,9 @@ const form = ref({
   request_timeout: undefined as number | undefined,
   // 号池模式
   pool_mode_enabled: false,
-  // Kiro 专属配置
-  kiro_simulated_cache_enabled: false,
+  simulated_cache_enabled: false,
+  simulated_cache_min_percent: 90 as number | undefined,
+  simulated_cache_max_percent: 100 as number | undefined,
 })
 
 // 重置表单
@@ -434,8 +465,9 @@ function resetForm() {
     request_timeout: undefined,
     // 号池模式
     pool_mode_enabled: false,
-    // Kiro 专属配置
-    kiro_simulated_cache_enabled: false,
+    simulated_cache_enabled: false,
+    simulated_cache_min_percent: 90,
+    simulated_cache_max_percent: 100,
   }
 }
 
@@ -466,8 +498,9 @@ function loadProviderData() {
     request_timeout: props.provider.request_timeout ?? undefined,
     // 号池模式
     pool_mode_enabled: poolAdvanced !== null,
-    // Kiro 专属配置
-    kiro_simulated_cache_enabled: props.provider.kiro_simulated_cache_enabled ?? false,
+    simulated_cache_enabled: props.provider.simulated_cache_enabled ?? props.provider.kiro_simulated_cache_enabled ?? false,
+    simulated_cache_min_percent: props.provider.simulated_cache_min_percent ?? 90,
+    simulated_cache_max_percent: props.provider.simulated_cache_max_percent ?? 100,
   }
 }
 
@@ -485,9 +518,6 @@ const { isEditMode, handleDialogUpdate, handleCancel } = useFormDialog({
 watch(() => form.value.provider_type, () => {
   if (!isEditMode.value) {
     form.value.pool_mode_enabled = false
-  }
-  if (form.value.provider_type !== 'kiro') {
-    form.value.kiro_simulated_cache_enabled = false
   }
 })
 
@@ -514,6 +544,14 @@ const handleSubmit = async () => {
     showError('过期时间必须是合法时间', '验证失败')
     return
   }
+  if (form.value.simulated_cache_enabled) {
+    const minPercent = form.value.simulated_cache_min_percent ?? 90
+    const maxPercent = form.value.simulated_cache_max_percent ?? 100
+    if (minPercent < 0 || minPercent > 100 || maxPercent < 0 || maxPercent > 100 || minPercent > maxPercent) {
+      showError('模拟缓存百分比必须在 0-100 之间，且最小值不能大于最大值', '验证失败')
+      return
+    }
+  }
 
   loading.value = true
   try {
@@ -538,15 +576,22 @@ const handleSubmit = async () => {
       pool_advanced: form.value.pool_mode_enabled
         ? (currentPoolAdvanced ?? {})
         : null,
-      ...(form.value.provider_type === 'kiro'
-        ? {
-            config: {
+      config: {
+        simulated_cache: form.value.simulated_cache_enabled
+          ? {
+              enabled: true,
+              min_percent: form.value.simulated_cache_min_percent ?? 90,
+              max_percent: form.value.simulated_cache_max_percent ?? 100,
+            }
+          : null,
+        ...(form.value.provider_type === 'kiro'
+          ? {
               kiro: {
-                simulated_cache_enabled: form.value.kiro_simulated_cache_enabled,
+                simulated_cache_enabled: false,
               },
-            },
-          }
-        : {}),
+            }
+          : {}),
+      },
     }
 
     if (isEditMode.value && props.provider) {

--- a/frontend/src/features/usage/__tests__/token-normalization.spec.ts
+++ b/frontend/src/features/usage/__tests__/token-normalization.spec.ts
@@ -41,6 +41,16 @@ describe('usage token normalization', () => {
     })).toBe(80)
   })
 
+  it('does not subtract simulated cache reads from already-split input tokens', () => {
+    expect(getEffectiveInputTokens({
+      input_tokens: 2103,
+      effective_input_tokens: 0,
+      cache_read_input_tokens: 21439,
+      api_format: 'openai:chat',
+      simulated_cache_enabled: true,
+    })).toBe(2103)
+  })
+
   it('does not subtract cache read tokens for Claude usage', () => {
     expect(getEffectiveInputTokens({
       input_tokens: 4941,

--- a/frontend/src/features/usage/token-normalization.ts
+++ b/frontend/src/features/usage/token-normalization.ts
@@ -7,6 +7,7 @@ type UsageTokenLike = {
   cache_read_input_tokens?: number | null
   api_format?: string | null
   endpoint_api_format?: string | null
+  simulated_cache_enabled?: boolean | null
 }
 
 function toNonNegativeNumber(value: number | null | undefined): number {
@@ -42,7 +43,7 @@ export function getEffectiveInputTokens(usage: UsageTokenLike): number {
 
   const inputTokens = toNonNegativeNumber(usage.input_tokens)
   const cacheReadTokens = toNonNegativeNumber(usage.cache_read_input_tokens)
-  if (inputTokens === 0 || cacheReadTokens === 0) {
+  if (inputTokens === 0 || cacheReadTokens === 0 || usage.simulated_cache_enabled === true) {
     return inputTokens
   }
 

--- a/frontend/src/features/usage/types.ts
+++ b/frontend/src/features/usage/types.ts
@@ -108,6 +108,7 @@ export interface UsageRecord {
   cache_creation_ephemeral_5m_input_tokens?: number
   cache_creation_ephemeral_1h_input_tokens?: number
   cache_read_input_tokens?: number
+  simulated_cache_enabled?: boolean
   total_tokens: number
   cost: number
   actual_cost?: number


### PR DESCRIPTION
This PR addresses two related issues we hit while running Aether in production:

1. **Unlimited wallet balance was still rejected after the wallet state was updated**
   When a key's wallet was initially cached as `BalanceDenied` and then changed to `unlimited` balance mode, the gateway kept returning the stale cached rejection. This change makes the refresh logic re-check wallet rejections so that `unlimited` wallets are allowed through instead of being blocked by a stale `BalanceDenied` state.

2. **Simulated cache was not applied consistently and was invisible to proxy clients**
   The existing `kiro` simulated cache only covered a subset of providers. We added a provider-level `simulated_cache` configuration that applies to all providers and overrides any native cache reporting when enabled. We also wired the simulated cache hit/miss counts through to proxy clients via response metadata.

### What's changed

- `apps/aether-gateway/src/control/auth/resolution.rs`
  - Re-validate wallet rejections during auth context refresh so `unlimited` wallets can recover from a previous `BalanceDenied` state.
  - Add test coverage for the unlimited-wallet recovery path.

- `apps/aether-gateway/src/execution_runtime/kiro_cache.rs`
  - Add `SimulatedCacheConfig` and provider-level `simulated_cache_enabled` / `simulated_cache_min_percent` / `simulated_cache_max_percent` context fields.

- `apps/aether-gateway/src/execution_runtime/simulated_cache.rs` (new)
  - Centralized simulated cache implementation that forces cache overrides for providers regardless of native cache support.

- `apps/aether-gateway/src/execution_runtime/stream/execution.rs` & `sync/execution.rs`
  - Use simulated cache uniformly and expose cache usage back to proxy clients.

- `crates/aether-usage-runtime/src/request_metadata.rs` & `write.rs`
  - Carry simulated cache usage through usage tracking so clients can see it.

- Admin provider write/normalize paths and frontend provider form
  - Allow configuring simulated cache parameters on each provider.

- Usage repositories (memory / postgres / sqlite)
  - Store simulated cache read/write tokens and add test coverage.

### Notes for reviewers

- This PR intentionally combines the unlimited-wallet fix and the simulated-cache unification because the second commit builds on the usage-tracking changes introduced in the first one.
- We have been running this internally for a few days and it resolves both the "insufficient balance" false positives for unlimited wallets and the inconsistent cache reporting across providers.