### PR TITLE
修复管理端额度显示、节点表格与移动端滚动问题

### DIFF
--- a/frontend/src/components/ui/dialog/Dialog.vue
+++ b/frontend/src/components/ui/dialog/Dialog.vue
@@ -2,7 +2,7 @@
   <Teleport to="body">
     <div
       v-if="isOpen"
-      class="fixed inset-0 overflow-y-auto pointer-events-none"
+      class="fixed inset-0 overflow-hidden pointer-events-none"
       :style="{ zIndex: containerZIndex }"
     >
       <!-- 背景遮罩 -->
@@ -22,7 +22,7 @@
         />
       </Transition>
 
-      <div class="relative flex min-h-full items-end justify-center px-3 py-4 text-center sm:items-center sm:p-0 pointer-events-none">
+      <div class="relative flex h-full items-end justify-center overflow-hidden px-3 py-4 text-center sm:items-center sm:p-0 pointer-events-none">
         <!-- 对话框内容 -->
         <Transition
           enter-active-class="duration-300 ease-out"
@@ -34,7 +34,7 @@
         >
           <div
             v-if="isOpen"
-            class="relative transform rounded-lg bg-background text-left shadow-2xl transition-all w-full sm:my-8 sm:w-full border border-border pointer-events-auto"
+            class="relative flex max-h-[calc(100dvh-2rem)] w-full transform flex-col overflow-hidden rounded-lg border border-border bg-background text-left shadow-2xl transition-all pointer-events-auto sm:my-8 sm:w-full sm:max-h-[calc(100dvh-4rem)]"
             :style="{ zIndex: contentZIndex }"
             :class="maxWidthClass"
             @click.stop
@@ -43,7 +43,7 @@
             <slot name="header">
               <div
                 v-if="title"
-                class="border-b border-border px-4 py-4 sm:px-6"
+                class="shrink-0 border-b border-border px-4 py-4 sm:px-6"
               >
                 <div class="flex items-center gap-3">
                   <div
@@ -73,14 +73,14 @@
             </slot>
 
             <!-- 内容区域：可选添加 padding -->
-            <div :class="noPadding ? '' : 'px-4 py-3 sm:px-6'">
+            <div :class="contentBodyClass">
               <slot />
             </div>
 
             <!-- Footer 区域：如果有 footer 插槽，自动添加样式 -->
             <div
               v-if="slots.footer"
-              class="border-t border-border bg-muted/10 px-4 py-4 sm:px-6 flex flex-row-reverse gap-3"
+              class="shrink-0 border-t border-border bg-muted/10 px-4 py-4 sm:px-6 flex flex-row-reverse gap-3"
             >
               <slot name="footer" />
             </div>
@@ -167,6 +167,11 @@ const maxWidthClass = computed(() => {
   }
   return sizes[sizeValue]
 })
+
+const contentBodyClass = computed(() => [
+  'min-h-0 overflow-y-auto overscroll-contain',
+  props.noPadding ? '' : 'px-4 py-3 sm:px-6',
+].filter(Boolean).join(' '))
 
 // Z-index computed values for nested dialogs support
 const containerZIndex = computed(() => props.zIndex || 60)

--- a/frontend/src/features/providers/components/ProviderDetailDrawer.vue
+++ b/frontend/src/features/providers/components/ProviderDetailDrawer.vue
@@ -181,6 +181,7 @@
                           v-if="getCodexQuotaDisplay(key)?.primary_used_percent !== undefined"
                           :label="legacyT('周限额')"
                           :used-percent="getCodexQuotaDisplay(key)?.primary_used_percent || 0"
+                          :remaining-percent="toCodexRemainingPercent(getCodexQuotaDisplay(key)?.primary_used_percent)"
                           :meter-class="getQuotaRemainingClass(getCodexQuotaDisplay(key)?.primary_used_percent || 0)"
                           :bar-class="getQuotaRemainingBarColor(getCodexQuotaDisplay(key)?.primary_used_percent || 0)"
                           :reset-text="(getCodexQuotaDisplay(key)?.primary_reset_at || getCodexQuotaDisplay(key)?.primary_reset_seconds) && shouldStartCodexResetCountdown(getCodexQuotaDisplay(key)?.primary_used_percent || 0)
@@ -203,6 +204,7 @@
                           v-if="isCodexTeamPlan(key) && getCodexQuotaDisplay(key)?.secondary_used_percent !== undefined"
                           :label="legacyT('5H限额')"
                           :used-percent="getCodexQuotaDisplay(key)?.secondary_used_percent || 0"
+                          :remaining-percent="toCodexRemainingPercent(getCodexQuotaDisplay(key)?.secondary_used_percent)"
                           :meter-class="getQuotaRemainingClass(getCodexQuotaDisplay(key)?.secondary_used_percent || 0)"
                           :bar-class="getQuotaRemainingBarColor(getCodexQuotaDisplay(key)?.secondary_used_percent || 0)"
                           :reset-text="shouldStartCodexResetCountdown(getCodexQuotaDisplay(key)?.secondary_used_percent || 0)
@@ -234,6 +236,7 @@
                             v-if="getCodexQuotaDisplay(key)?.spark_secondary_used_percent !== undefined"
                             :label="legacyT('Spark 周')"
                             :used-percent="getCodexQuotaDisplay(key)?.spark_secondary_used_percent || 0"
+                            :remaining-percent="toCodexRemainingPercent(getCodexQuotaDisplay(key)?.spark_secondary_used_percent)"
                             :meter-class="getQuotaRemainingClass(getCodexQuotaDisplay(key)?.spark_secondary_used_percent || 0)"
                             :bar-class="getQuotaRemainingBarColor(getCodexQuotaDisplay(key)?.spark_secondary_used_percent || 0)"
                             :reset-text="shouldStartCodexResetCountdown(getCodexQuotaDisplay(key)?.spark_secondary_used_percent || 0)
@@ -255,6 +258,7 @@
                             v-if="getCodexQuotaDisplay(key)?.spark_primary_used_percent !== undefined"
                             :label="legacyT('Spark 5H')"
                             :used-percent="getCodexQuotaDisplay(key)?.spark_primary_used_percent || 0"
+                            :remaining-percent="toCodexRemainingPercent(getCodexQuotaDisplay(key)?.spark_primary_used_percent)"
                             :meter-class="getQuotaRemainingClass(getCodexQuotaDisplay(key)?.spark_primary_used_percent || 0)"
                             :bar-class="getQuotaRemainingBarColor(getCodexQuotaDisplay(key)?.spark_primary_used_percent || 0)"
                             :reset-text="shouldStartCodexResetCountdown(getCodexQuotaDisplay(key)?.spark_primary_used_percent || 0)
@@ -1717,8 +1721,54 @@ function getQuotaWindowLiveResetSeconds(
   return null
 }
 
-function getCodexQuotaDisplay(key: EndpointAPIKey): CodexUpstreamMetadata | null {
-  const quota = getQuotaSnapshotForProvider(key, 'codex')
+function copyCodexNumberField(
+  target: CodexUpstreamMetadata,
+  source: CodexUpstreamMetadata,
+  field: keyof CodexUpstreamMetadata,
+) {
+  const value = source[field]
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    ;(target[field] as number | undefined) = value
+  }
+}
+
+function getCodexQuotaDisplayFromMetadata(metadata: CodexUpstreamMetadata | null | undefined): CodexUpstreamMetadata | null {
+  if (!metadata) return null
+
+  const display: CodexUpstreamMetadata = {}
+  if (metadata.plan_type) display.plan_type = metadata.plan_type
+
+  const numberFields: (keyof CodexUpstreamMetadata)[] = [
+    'updated_at',
+    'primary_used_percent',
+    'primary_reset_seconds',
+    'primary_reset_after_seconds',
+    'primary_reset_at',
+    'primary_window_minutes',
+    'secondary_used_percent',
+    'secondary_reset_seconds',
+    'secondary_reset_after_seconds',
+    'secondary_reset_at',
+    'secondary_window_minutes',
+    'spark_primary_used_percent',
+    'spark_primary_reset_seconds',
+    'spark_primary_reset_after_seconds',
+    'spark_primary_reset_at',
+    'spark_primary_window_minutes',
+    'spark_secondary_used_percent',
+    'spark_secondary_reset_seconds',
+    'spark_secondary_reset_after_seconds',
+    'spark_secondary_reset_at',
+    'spark_secondary_window_minutes',
+    'credits_balance',
+  ]
+  numberFields.forEach(field => copyCodexNumberField(display, metadata, field))
+  if (metadata.has_credits !== undefined) display.has_credits = metadata.has_credits
+
+  return Object.keys(display).length > 0 ? display : null
+}
+
+function getCodexQuotaDisplayFromSnapshot(quota: QuotaStatusSnapshot | null | undefined): CodexUpstreamMetadata | null {
   if (!quota) return null
 
   const display: CodexUpstreamMetadata = {}
@@ -1771,6 +1821,39 @@ function getCodexQuotaDisplay(key: EndpointAPIKey): CodexUpstreamMetadata | null
   }
 
   return Object.keys(display).length > 0 ? display : null
+}
+
+function getCodexQuotaDisplayUpdatedAt(display: CodexUpstreamMetadata | null | undefined): number | null {
+  const updatedAt = Number(display?.updated_at)
+  return Number.isFinite(updatedAt) ? updatedAt : null
+}
+
+function codexDisplayHasUsage(display: CodexUpstreamMetadata | null | undefined): boolean {
+  return !!display && (
+    display.primary_used_percent !== undefined
+    || display.secondary_used_percent !== undefined
+    || display.spark_primary_used_percent !== undefined
+    || display.spark_secondary_used_percent !== undefined
+  )
+}
+
+function getCodexQuotaDisplay(key: EndpointAPIKey): CodexUpstreamMetadata | null {
+  const snapshotDisplay = getCodexQuotaDisplayFromSnapshot(getQuotaSnapshotForProvider(key, 'codex'))
+  const metadataDisplay = getCodexQuotaDisplayFromMetadata(key.upstream_metadata?.codex)
+
+  if (!snapshotDisplay) return metadataDisplay
+  if (!metadataDisplay) return snapshotDisplay
+  if (!codexDisplayHasUsage(snapshotDisplay) && codexDisplayHasUsage(metadataDisplay)) {
+    return metadataDisplay
+  }
+
+  const snapshotUpdatedAt = getCodexQuotaDisplayUpdatedAt(snapshotDisplay)
+  const metadataUpdatedAt = getCodexQuotaDisplayUpdatedAt(metadataDisplay)
+  if (metadataUpdatedAt !== null && (snapshotUpdatedAt === null || metadataUpdatedAt > snapshotUpdatedAt)) {
+    return metadataDisplay
+  }
+
+  return snapshotDisplay
 }
 
 function hasCodexQuotaDisplayData(key: EndpointAPIKey): boolean {

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -160,14 +160,14 @@
         <Transition
           enter-active-class="transition-all duration-300 ease-out overflow-hidden"
           enter-from-class="opacity-0 max-h-0"
-          enter-to-class="opacity-100 max-h-[500px]"
+          enter-to-class="opacity-100 max-h-[calc(100dvh-5rem)]"
           leave-active-class="transition-all duration-200 ease-in overflow-hidden"
-          leave-from-class="opacity-100 max-h-[500px]"
+          leave-from-class="opacity-100 max-h-[calc(100dvh-5rem)]"
           leave-to-class="opacity-0 max-h-0"
         >
           <div
             v-if="mobileMenuOpen"
-            class="border-t border-[var(--shell-border)] bg-[var(--shell-glass)] backdrop-blur-xl"
+            class="max-h-[calc(100dvh-5rem)] overflow-y-auto overscroll-contain border-t border-[var(--shell-border)] bg-[var(--shell-glass)] backdrop-blur-xl"
           >
             <div class="mx-auto max-w-7xl px-6 py-4">
               <!-- Navigation Groups -->

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -158,18 +158,18 @@
 
         <!-- Mobile Dropdown Menu -->
         <Transition
-          enter-active-class="transition-all duration-300 ease-out overflow-hidden"
-          enter-from-class="opacity-0 max-h-0"
-          enter-to-class="opacity-100 max-h-[calc(100dvh-5rem)]"
-          leave-active-class="transition-all duration-200 ease-in overflow-hidden"
-          leave-from-class="opacity-100 max-h-[calc(100dvh-5rem)]"
-          leave-to-class="opacity-0 max-h-0"
+          enter-active-class="transition-all duration-300 ease-out"
+          enter-from-class="opacity-0 -translate-y-2"
+          enter-to-class="opacity-100 translate-y-0"
+          leave-active-class="transition-all duration-200 ease-in"
+          leave-from-class="opacity-100 translate-y-0"
+          leave-to-class="opacity-0 -translate-y-2"
         >
           <div
             v-if="mobileMenuOpen"
-            class="max-h-[calc(100dvh-5rem)] overflow-y-auto overscroll-contain border-t border-[var(--shell-border)] bg-[var(--shell-glass)] backdrop-blur-xl"
+            class="fixed inset-x-0 bottom-0 top-[73px] overflow-y-scroll overscroll-contain border-t border-[var(--shell-border)] bg-[var(--shell-glass)] backdrop-blur-xl [-webkit-overflow-scrolling:touch] touch-pan-y"
           >
-            <div class="mx-auto max-w-7xl px-6 py-4">
+            <div class="mx-auto max-w-7xl px-6 py-4 pb-28">
               <!-- Navigation Groups -->
               <div class="space-y-4">
                 <div

--- a/frontend/src/views/admin/components/ProxyNodeList.vue
+++ b/frontend/src/views/admin/components/ProxyNodeList.vue
@@ -53,21 +53,177 @@
         </TableRow>
       </TableHeader>
       <TableBody>
-        <ProxyNodeTableRow
+        <template
           v-for="node in nodes"
           :key="node.id"
-          :node="node"
-          :expanded="expandedNodeIds.has(node.id)"
-          :testing="testingNodeIds.has(node.id)"
-          :detail-state="nodeDetails[node.id]"
-          @toggle-details="$emit('toggle-details', node)"
-          @refresh-details="$emit('refresh-details', node)"
-          @test="$emit('test', node)"
-          @edit="$emit('edit', node)"
-          @config="$emit('config', node)"
-          @view-events="$emit('view-events', node)"
-          @delete="$emit('delete', node)"
-        />
+        >
+          <TableRow
+            class="border-b border-border/40 hover:bg-muted/30 transition-colors"
+            :class="expandedNodeIds.has(node.id) ? 'bg-muted/20' : ''"
+          >
+            <TableCell class="w-[28px] min-w-[28px] max-w-[28px] p-0 pl-2 text-center">
+              <button
+                type="button"
+                class="inline-flex h-5 w-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                :title="expandedNodeIds.has(node.id) ? legacyT('收起数据') : legacyT('展开数据')"
+                @click="$emit('toggle-details', node)"
+              >
+                <ChevronDown
+                  v-if="expandedNodeIds.has(node.id)"
+                  class="h-3.5 w-3.5"
+                />
+                <ChevronRight
+                  v-else
+                  class="h-3.5 w-3.5"
+                />
+              </button>
+            </TableCell>
+            <TableCell class="py-4 min-w-0">
+              <div class="flex items-center gap-1.5 min-w-0">
+                <span
+                  class="min-w-0 truncate text-sm font-semibold"
+                  :title="node.name"
+                >{{ node.name }}</span>
+                <Badge
+                  v-if="node.is_manual"
+                  variant="outline"
+                  class="text-[10px] px-1.5 py-0"
+                >
+                  {{ legacyT('手动') }}
+                </Badge>
+                <Badge
+                  v-if="node.tunnel_mode"
+                  variant="outline"
+                  class="text-[10px] px-1.5 py-0"
+                >
+                  Tunnel
+                </Badge>
+                <Badge
+                  v-if="proxyNodeSchedulingBadge(node)"
+                  :variant="proxyNodeSchedulingBadge(node)?.variant"
+                  class="text-[10px] px-1.5 py-0"
+                >
+                  {{ legacyT(proxyNodeSchedulingBadge(node)?.label || '') }}
+                </Badge>
+                <HardwareTooltip :node="node" />
+              </div>
+            </TableCell>
+            <TableCell class="py-4 min-w-0">
+              <code
+                class="block min-w-0 truncate text-xs text-muted-foreground"
+                :title="proxyNodeAddress(node)"
+              >{{ proxyNodeAddress(node) }}</code>
+            </TableCell>
+            <TableCell class="py-4 min-w-0">
+              <span
+                class="block min-w-0 truncate text-sm text-muted-foreground"
+                :title="legacyT(formatProxyNodeRegion(node.region))"
+              >{{ legacyT(formatProxyNodeRegion(node.region)) }}</span>
+            </TableCell>
+            <TableCell class="py-4 text-center">
+              <Badge
+                :variant="proxyNodeStatusVariant(node.status)"
+                :title="legacyT(proxyNodeStatusTitle(node))"
+                class="font-medium px-2.5 py-0.5 text-xs"
+              >
+                {{ legacyT(proxyNodeStatusLabel(node)) }}
+              </Badge>
+            </TableCell>
+            <TableCell class="py-4 text-center">
+              <span class="text-sm tabular-nums">{{ formatProxyNodeNumber(node.total_requests) }}</span>
+            </TableCell>
+            <TableCell class="py-4 text-center">
+              <span
+                class="text-sm tabular-nums"
+                :class="proxyNodeFailureRate(node) > 5 ? 'text-destructive font-medium' : ''"
+              >{{ formatProxyNodeFailureRate(node) }}</span>
+            </TableCell>
+            <TableCell class="py-4 text-center">
+              <span class="text-sm tabular-nums">{{ node.avg_latency_ms != null ? `${node.avg_latency_ms.toFixed(0)}ms` : '-' }}</span>
+            </TableCell>
+            <TableCell class="py-4 text-center">
+              <span class="text-sm tabular-nums">{{ node.is_manual ? '-' : proxyNodeVersion(node) }}</span>
+            </TableCell>
+            <TableCell class="py-4 min-w-0">
+              <span class="block min-w-0 truncate text-xs text-muted-foreground">{{ formatProxyNodeTime(node.last_heartbeat_at, locale) }}</span>
+            </TableCell>
+            <TableCell class="py-4 text-center">
+              <div class="flex items-center justify-center gap-0.5">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  class="h-8 w-8"
+                  :title="testingNodeIds.has(node.id) ? legacyT('测试中...') : legacyT('测试连通性')"
+                  :disabled="testingNodeIds.has(node.id)"
+                  @click="$emit('test', node)"
+                >
+                  <Loader2
+                    v-if="testingNodeIds.has(node.id)"
+                    class="h-4 w-4 animate-spin"
+                  />
+                  <Activity
+                    v-else
+                    class="h-4 w-4"
+                  />
+                </Button>
+                <Button
+                  v-if="node.is_manual"
+                  variant="ghost"
+                  size="icon"
+                  class="h-8 w-8"
+                  :title="legacyT('编辑')"
+                  @click="$emit('edit', node)"
+                >
+                  <SquarePen class="h-4 w-4" />
+                </Button>
+                <Button
+                  v-if="!node.is_manual"
+                  variant="ghost"
+                  size="icon"
+                  class="h-8 w-8"
+                  :title="legacyT('远程配置')"
+                  @click="$emit('config', node)"
+                >
+                  <Settings class="h-4 w-4" />
+                </Button>
+                <Button
+                  v-if="!node.is_manual"
+                  variant="ghost"
+                  size="icon"
+                  class="h-8 w-8"
+                  :title="legacyT('连接事件')"
+                  @click="$emit('view-events', node)"
+                >
+                  <History class="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  class="h-8 w-8"
+                  :title="legacyT('删除')"
+                  @click="$emit('delete', node)"
+                >
+                  <Trash2 class="h-4 w-4" />
+                </Button>
+              </div>
+            </TableCell>
+          </TableRow>
+          <TableRow
+            v-if="expandedNodeIds.has(node.id)"
+            class="border-b border-border/40 hover:bg-transparent"
+          >
+            <TableCell
+              colspan="11"
+              class="p-0"
+            >
+              <ProxyNodeDataPanel
+                :node="node"
+                :state="nodeDetails[node.id]"
+                @refresh="$emit('refresh-details', node)"
+              />
+            </TableCell>
+          </TableRow>
+        </template>
         <TableRow v-if="nodes.length === 0">
           <TableCell
             colspan="11"
@@ -114,11 +270,26 @@
 </template>
 
 <script setup lang="ts">
-import { Pagination, SortableTableHead, Table, TableBody, TableCell, TableFilterMenu, TableHead, TableHeader, TableRow } from '@/components/ui'
+import { Activity, ChevronDown, ChevronRight, History, Loader2, Settings, SquarePen, Trash2 } from 'lucide-vue-next'
+import { Badge, Button, Pagination, SortableTableHead, Table, TableBody, TableCell, TableFilterMenu, TableHead, TableHeader, TableRow } from '@/components/ui'
 import type { ProxyNode } from '@/api/proxy-nodes'
 import { useI18n } from '@/i18n'
+import HardwareTooltip from './HardwareTooltip.vue'
 import ProxyNodeMobileCard from './ProxyNodeMobileCard.vue'
-import ProxyNodeTableRow from './ProxyNodeTableRow.vue'
+import ProxyNodeDataPanel from './ProxyNodeDataPanel.vue'
+import {
+  formatProxyNodeFailureRate,
+  formatProxyNodeNumber,
+  formatProxyNodeRegion,
+  formatProxyNodeTime,
+  proxyNodeAddress,
+  proxyNodeFailureRate,
+  proxyNodeSchedulingBadge,
+  proxyNodeStatusLabel,
+  proxyNodeStatusTitle,
+  proxyNodeStatusVariant,
+  proxyNodeVersion,
+} from './proxy-node-display'
 import type { ProxyNodeDetailState, ProxyNodeStatusFilterOption } from './proxy-node-types'
 
 defineProps<{
@@ -147,5 +318,5 @@ defineEmits<{
   delete: [node: ProxyNode]
 }>()
 
-const { legacyT } = useI18n()
+const { legacyT, locale } = useI18n()
 </script>

--- a/frontend/src/views/admin/components/ProxyNodeList.vue
+++ b/frontend/src/views/admin/components/ProxyNodeList.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="hidden xl:block overflow-x-auto">
-    <Table>
+    <Table class="min-w-[1040px] table-fixed">
       <TableHeader>
         <TableRow class="border-b border-border/60 hover:bg-transparent">
           <TableHead class="w-[28px] min-w-[28px] max-w-[28px] h-12 p-0 pl-2" />
-          <TableHead class="w-[160px] h-12 font-semibold">
+          <TableHead class="w-[150px] h-12 font-semibold">
             {{ legacyT('名称') }}
           </TableHead>
-          <TableHead class="w-[180px] h-12 font-semibold">
+          <TableHead class="w-[190px] h-12 font-semibold">
             {{ legacyT('地址') }}
           </TableHead>
-          <TableHead class="w-[100px] h-12 font-semibold">
+          <TableHead class="w-[90px] h-12 font-semibold">
             {{ legacyT('区域') }}
           </TableHead>
           <SortableTableHead
@@ -32,22 +32,22 @@
               />
             </template>
           </SortableTableHead>
-          <TableHead class="w-[100px] h-12 font-semibold text-center">
+          <TableHead class="w-[86px] h-12 font-semibold text-center">
             {{ legacyT('总请求') }}
           </TableHead>
-          <TableHead class="w-[100px] h-12 font-semibold text-center">
+          <TableHead class="w-[86px] h-12 font-semibold text-center">
             {{ legacyT('失败率') }}
           </TableHead>
-          <TableHead class="w-[100px] h-12 font-semibold text-center">
+          <TableHead class="w-[86px] h-12 font-semibold text-center">
             {{ legacyT('延迟') }}
           </TableHead>
-          <TableHead class="w-[120px] h-12 font-semibold text-center">
+          <TableHead class="w-[90px] h-12 font-semibold text-center">
             {{ legacyT('版本') }}
           </TableHead>
-          <TableHead class="w-[160px] h-12 font-semibold">
+          <TableHead class="w-[130px] h-12 font-semibold">
             {{ legacyT('最后心跳') }}
           </TableHead>
-          <TableHead class="w-[140px] h-12 font-semibold text-center">
+          <TableHead class="w-[120px] h-12 font-semibold text-center">
             {{ legacyT('操作') }}
           </TableHead>
         </TableRow>

--- a/frontend/src/views/admin/components/ProxyNodeTableRow.vue
+++ b/frontend/src/views/admin/components/ProxyNodeTableRow.vue
@@ -21,9 +21,12 @@
           />
         </button>
       </TableCell>
-      <TableCell class="py-4">
-        <div class="flex items-center gap-1.5">
-          <span class="text-sm font-semibold">{{ node.name }}</span>
+      <TableCell class="py-4 min-w-0">
+        <div class="flex items-center gap-1.5 min-w-0">
+          <span
+            class="min-w-0 truncate text-sm font-semibold"
+            :title="node.name"
+          >{{ node.name }}</span>
           <Badge
             v-if="node.is_manual"
             variant="outline"
@@ -48,11 +51,17 @@
           <HardwareTooltip :node="node" />
         </div>
       </TableCell>
-      <TableCell class="py-4">
-        <code class="text-xs text-muted-foreground">{{ proxyNodeAddress(node) }}</code>
+      <TableCell class="py-4 min-w-0">
+        <code
+          class="block min-w-0 truncate text-xs text-muted-foreground"
+          :title="proxyNodeAddress(node)"
+        >{{ proxyNodeAddress(node) }}</code>
       </TableCell>
-      <TableCell class="py-4">
-        <span class="text-sm text-muted-foreground">{{ legacyT(formatProxyNodeRegion(node.region)) }}</span>
+      <TableCell class="py-4 min-w-0">
+        <span
+          class="block min-w-0 truncate text-sm text-muted-foreground"
+          :title="legacyT(formatProxyNodeRegion(node.region))"
+        >{{ legacyT(formatProxyNodeRegion(node.region)) }}</span>
       </TableCell>
       <TableCell class="py-4 text-center">
         <Badge
@@ -78,8 +87,8 @@
       <TableCell class="py-4 text-center">
         <span class="text-sm tabular-nums">{{ node.is_manual ? '-' : proxyNodeVersion(node) }}</span>
       </TableCell>
-      <TableCell class="py-4">
-        <span class="text-xs text-muted-foreground">{{ formatProxyNodeTime(node.last_heartbeat_at, locale) }}</span>
+      <TableCell class="py-4 min-w-0">
+        <span class="block min-w-0 truncate text-xs text-muted-foreground">{{ formatProxyNodeTime(node.last_heartbeat_at, locale) }}</span>
       </TableCell>
       <TableCell class="py-4 text-center">
         <div class="flex items-center justify-center gap-0.5">

--- a/frontend/src/views/public/guide/GuideLayout.vue
+++ b/frontend/src/views/public/guide/GuideLayout.vue
@@ -158,18 +158,18 @@
 
         <!-- Mobile Dropdown Menu -->
         <Transition
-          enter-active-class="transition-all duration-300 ease-out overflow-hidden"
-          enter-from-class="opacity-0 max-h-0"
-          enter-to-class="opacity-100 max-h-[calc(100dvh-5rem)]"
-          leave-active-class="transition-all duration-200 ease-in overflow-hidden"
-          leave-from-class="opacity-100 max-h-[calc(100dvh-5rem)]"
-          leave-to-class="opacity-0 max-h-0"
+          enter-active-class="transition-all duration-300 ease-out"
+          enter-from-class="opacity-0 -translate-y-2"
+          enter-to-class="opacity-100 translate-y-0"
+          leave-active-class="transition-all duration-200 ease-in"
+          leave-from-class="opacity-100 translate-y-0"
+          leave-to-class="opacity-0 -translate-y-2"
         >
           <div
             v-if="mobileMenuOpen"
-            class="max-h-[calc(100dvh-5rem)] overflow-y-auto overscroll-contain border-t border-[var(--shell-border)] bg-[var(--shell-glass)] backdrop-blur-xl"
+            class="fixed inset-x-0 bottom-0 top-[73px] overflow-y-scroll overscroll-contain border-t border-[var(--shell-border)] bg-[var(--shell-glass)] backdrop-blur-xl [-webkit-overflow-scrolling:touch] touch-pan-y"
           >
-            <div class="mx-auto max-w-7xl px-6 py-4">
+            <div class="mx-auto max-w-7xl px-6 py-4 pb-28">
               <div class="space-y-4">
                 <div
                   v-for="group in navigation"

--- a/frontend/src/views/public/guide/GuideLayout.vue
+++ b/frontend/src/views/public/guide/GuideLayout.vue
@@ -160,14 +160,14 @@
         <Transition
           enter-active-class="transition-all duration-300 ease-out overflow-hidden"
           enter-from-class="opacity-0 max-h-0"
-          enter-to-class="opacity-100 max-h-[500px]"
+          enter-to-class="opacity-100 max-h-[calc(100dvh-5rem)]"
           leave-active-class="transition-all duration-200 ease-in overflow-hidden"
-          leave-from-class="opacity-100 max-h-[500px]"
+          leave-from-class="opacity-100 max-h-[calc(100dvh-5rem)]"
           leave-to-class="opacity-0 max-h-0"
         >
           <div
             v-if="mobileMenuOpen"
-            class="border-t border-[var(--shell-border)] bg-[var(--shell-glass)] backdrop-blur-xl"
+            class="max-h-[calc(100dvh-5rem)] overflow-y-auto overscroll-contain border-t border-[var(--shell-border)] bg-[var(--shell-glass)] backdrop-blur-xl"
           >
             <div class="mx-auto max-w-7xl px-6 py-4">
               <div class="space-y-4">


### PR DESCRIPTION
## 变更说明

- 修复 Codex 账号额度显示异常：当 `status_snapshot` 过期时，优先使用更新的 `upstream_metadata.codex`，避免额度一直显示为 0。
- 修复代理节点 PC 端表格内容不可见：调整表格固定布局、列宽和文本截断策略，恢复节点名称、地址、区域等内容显示。
- 修复移动端长菜单无法滚动：后台主菜单和指南页菜单现在按视口高度限制，并支持触摸滚动。
- 修复移动端长弹窗无法操作底部按钮：共享 Dialog 改为视口内弹性布局，内容区独立滚动，底部操作区保持可见。

## 验证

- `npm run type-check`
- `npx vitest run src/features/providers/components/__tests__/provider-quota-display.spec.ts`
- `npx vitest run src/layouts/main-layout/__tests__/navigation.spec.ts`
- VS Code 相关文件诊断无错误