### PR TITLE
修复钱包余额变更后的鉴权缓存延迟

### DIFF
--- a/apps/aether-gateway/src/state/runtime/payments.rs
+++ b/apps/aether-gateway/src/state/runtime/payments.rs
@@ -196,7 +196,11 @@ impl AppState {
             order.credited_at_unix_secs = Some(now_unix_secs);
             order.refundable_amount_usd = order.amount_usd;
             order.gateway_response = Some(serde_json::Value::Object(gateway_response));
-            return Ok(AdminWalletMutationOutcome::Applied((order.clone(), true)));
+            let updated_order = order.clone();
+            drop(wallets);
+            drop(orders);
+            self.invalidate_auth_context_cache();
+            return Ok(AdminWalletMutationOutcome::Applied((updated_order, true)));
         }
 
         match self
@@ -344,10 +348,18 @@ impl AppState {
         input: aether_data::repository::wallet::RedeemWalletCodeInput,
     ) -> Result<Option<aether_data::repository::wallet::RedeemWalletCodeOutcome>, GatewayError>
     {
-        self.data
+        let outcome = self
+            .data
             .redeem_wallet_code(input)
             .await
-            .map_err(|err| GatewayError::Internal(err.to_string()))
+            .map_err(|err| GatewayError::Internal(err.to_string()))?;
+        if matches!(
+            outcome,
+            Some(aether_data::repository::wallet::RedeemWalletCodeOutcome::Redeemed { .. })
+        ) {
+            self.invalidate_auth_context_cache();
+        }
+        Ok(outcome)
     }
 }
 

--- a/apps/aether-gateway/src/state/runtime/wallet/balance_mutations.rs
+++ b/apps/aether-gateway/src/state/runtime/wallet/balance_mutations.rs
@@ -87,7 +87,10 @@ impl AppState {
                 ),
                 created_at_unix_ms: chrono::Utc::now().timestamp().max(0) as u64,
             };
-            return Ok(Some((wallet.clone(), transaction)));
+            let updated_wallet = wallet.clone();
+            drop(guard);
+            self.invalidate_auth_context_cache();
+            return Ok(Some((updated_wallet, transaction)));
         }
 
         Ok(self
@@ -153,7 +156,10 @@ impl AppState {
                 credited_at_unix_secs: Some(created_at),
                 expires_at_unix_secs: None,
             };
-            return Ok(Some((wallet.clone(), order)));
+            let updated_wallet = wallet.clone();
+            drop(guard);
+            self.invalidate_auth_context_cache();
+            return Ok(Some((updated_wallet, order)));
         }
 
         let now = chrono::Utc::now();

--- a/apps/aether-gateway/src/state/runtime/wallet/mutations.rs
+++ b/apps/aether-gateway/src/state/runtime/wallet/mutations.rs
@@ -44,10 +44,15 @@ impl AppState {
         &self,
         input: ProcessPaymentCallbackInput,
     ) -> Result<Option<ProcessPaymentCallbackOutcome>, GatewayError> {
-        self.data
+        let outcome = self
+            .data
             .process_payment_callback(input)
             .await
-            .map_err(|err| GatewayError::Internal(err.to_string()))
+            .map_err(|err| GatewayError::Internal(err.to_string()))?;
+        if matches!(outcome, Some(ProcessPaymentCallbackOutcome::Applied { .. })) {
+            self.invalidate_auth_context_cache();
+        }
+        Ok(outcome)
     }
 
     pub(crate) async fn adjust_wallet_balance(
@@ -60,10 +65,15 @@ impl AppState {
         )>,
         GatewayError,
     > {
-        self.data
+        let result = self
+            .data
             .adjust_wallet_balance(input)
             .await
-            .map_err(|err| GatewayError::Internal(err.to_string()))
+            .map_err(|err| GatewayError::Internal(err.to_string()))?;
+        if result.is_some() {
+            self.invalidate_auth_context_cache();
+        }
+        Ok(result)
     }
 
     pub(crate) async fn create_manual_wallet_recharge(
@@ -76,10 +86,15 @@ impl AppState {
         )>,
         GatewayError,
     > {
-        self.data
+        let result = self
+            .data
             .create_manual_wallet_recharge(input)
             .await
-            .map_err(|err| GatewayError::Internal(err.to_string()))
+            .map_err(|err| GatewayError::Internal(err.to_string()))?;
+        if result.is_some() {
+            self.invalidate_auth_context_cache();
+        }
+        Ok(result)
     }
 
     pub(crate) async fn process_admin_wallet_refund(
@@ -95,10 +110,15 @@ impl AppState {
         >,
         GatewayError,
     > {
-        self.data
+        let outcome = self
+            .data
             .process_admin_wallet_refund(input)
             .await
-            .map_err(|err| GatewayError::Internal(err.to_string()))
+            .map_err(|err| GatewayError::Internal(err.to_string()))?;
+        if matches!(outcome, Some(WalletMutationOutcome::Applied(_))) {
+            self.invalidate_auth_context_cache();
+        }
+        Ok(outcome)
     }
 
     pub(crate) async fn complete_admin_wallet_refund(
@@ -127,10 +147,18 @@ impl AppState {
         >,
         GatewayError,
     > {
-        self.data
+        let outcome = self
+            .data
             .fail_admin_wallet_refund(input)
             .await
-            .map_err(|err| GatewayError::Internal(err.to_string()))
+            .map_err(|err| GatewayError::Internal(err.to_string()))?;
+        if matches!(
+            outcome,
+            Some(WalletMutationOutcome::Applied((_, _, Some(_))))
+        ) {
+            self.invalidate_auth_context_cache();
+        }
+        Ok(outcome)
     }
 
     pub(crate) async fn expire_admin_payment_order(
@@ -176,9 +204,14 @@ impl AppState {
         >,
         GatewayError,
     > {
-        self.data
+        let outcome = self
+            .data
             .credit_admin_payment_order(input)
             .await
-            .map_err(|err| GatewayError::Internal(err.to_string()))
+            .map_err(|err| GatewayError::Internal(err.to_string()))?;
+        if matches!(outcome, Some(WalletMutationOutcome::Applied((_, true)))) {
+            self.invalidate_auth_context_cache();
+        }
+        Ok(outcome)
     }
 }

--- a/apps/aether-gateway/src/state/runtime/wallet/refund_lifecycle.rs
+++ b/apps/aether-gateway/src/state/runtime/wallet/refund_lifecycle.rs
@@ -131,6 +131,7 @@ impl AppState {
                     .insert(updated_order.id.clone(), updated_order);
             }
 
+            self.invalidate_auth_context_cache();
             return Ok(AdminWalletMutationOutcome::Applied((
                 updated_wallet,
                 updated_refund,
@@ -354,6 +355,7 @@ impl AppState {
                 .expect("admin wallet refund store should lock")
                 .insert(updated_refund.id.clone(), updated_refund.clone());
 
+            self.invalidate_auth_context_cache();
             return Ok(AdminWalletMutationOutcome::Applied((
                 updated_wallet,
                 updated_refund,

--- a/apps/aether-gateway/src/wallet_runtime/access.rs
+++ b/apps/aether-gateway/src/wallet_runtime/access.rs
@@ -257,6 +257,44 @@ mod tests {
         assert_eq!(decision.remaining, Some(4.0));
     }
 
+    #[tokio::test]
+    async fn admin_wallet_recharge_invalidates_cached_auth_capacity_state() {
+        let wallet = empty_user_wallet();
+        let state =
+            state_with_wallet_and_quota(wallet.clone(), None).with_auth_wallets_for_tests([wallet]);
+        let auth_snapshot = ordinary_user_api_key_snapshot();
+
+        let denied = resolve_wallet_auth_gate(&state, &auth_snapshot)
+            .await
+            .expect("wallet gate should resolve")
+            .expect("wallet gate should return a decision");
+
+        assert!(!denied.allowed);
+        assert_eq!(denied.failure, Some(WalletAccessFailure::BalanceDenied));
+
+        let recharge = state
+            .admin_create_manual_wallet_recharge(
+                "wallet-user-1",
+                10.0,
+                "admin_manual",
+                Some("admin-1"),
+                Some("manual recharge"),
+            )
+            .await
+            .expect("wallet recharge should complete");
+
+        assert!(recharge.is_some());
+
+        let refreshed = resolve_wallet_auth_gate(&state, &auth_snapshot)
+            .await
+            .expect("wallet gate should resolve after recharge")
+            .expect("wallet gate should return a decision after recharge");
+
+        assert!(refreshed.allowed);
+        assert_eq!(refreshed.failure, None);
+        assert_eq!(refreshed.remaining, Some(10.0));
+    }
+
     fn state_with_wallet_and_quota(
         wallet: StoredWalletSnapshot,
         quota: Option<UserDailyQuotaAvailabilityRecord>,


### PR DESCRIPTION
## 背景

用户钱包余额发生充值、调账、支付入账、兑换码兑换或退款回补后，本地鉴权链路可能继续命中旧的鉴权缓存，导致界面余额已经更新，但请求仍短时间返回 `balance_exceeded`。

## 修改

- 在钱包可用额度实际发生变化后，主动清理鉴权相关缓存，避免旧的 `BalanceDenied` 结果继续生效。
- 覆盖管理员手动充值、余额调账、支付回调入账、管理员订单入账、兑换码、退款占用与失败回补等会影响钱包可用额度的路径。
- 新增回归测试，证明管理员充值后下一次鉴权立即读取新余额，不再等待缓存 TTL。

## 验证

- `cargo test -p aether-gateway wallet_runtime::access::tests::admin_wallet_recharge_invalidates_cached_auth_capacity_state -- --exact`
- `cargo test -p aether-gateway wallet_runtime::access::tests --lib`
- `cargo test -p aether-gateway gateway_handles_admin_wallets --lib`
- `cargo test -p aether-gateway gateway_handles_admin_payments_credit_order_locally_with_trusted_admin_principal --lib`
- `cargo test -p aether-gateway gateway_redeems_wallet_code_locally --lib`
- `cargo test -p aether-gateway gateway_handles_payment_callback_route_locally_without_proxying_upstream --lib`
- `cargo clippy -p aether-gateway --lib -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
