### PR TITLE
[codex] Persist provider quota refresh state

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -514,6 +514,9 @@ jobs:
         env:
           RUSTC_WRAPPER: sccache
           SCCACHE_GHA_ENABLED: "true"
+          # Prefer the workflow service container over a local initdb/postgres child process.
+          # ManagedPostgresServer creates an isolated database per test against this URL.
+          AETHER_TEST_POSTGRES_URL: postgres://aether:aether@127.0.0.1:5432/aether_test
           AETHER_REQUIRE_LOCAL_POSTGRES_TESTS: "true"
         run: |
           cargo test -p aether-data --all-features lifecycle::migrate::tests::postgres_request_candidates_preserve_deleted_api_key_identity --lib -- --exact --nocapture

--- a/apps/aether-gateway/src/tests/control/admin/stats.rs
+++ b/apps/aether-gateway/src/tests/control/admin/stats.rs
@@ -162,6 +162,21 @@ fn recent_unix_secs(minutes_ago: u64) -> i64 {
     now.saturating_sub((minutes_ago * 60) as i64)
 }
 
+/// Timestamp guaranteed to fall inside the default admin stats calendar-day window (today UTC).
+///
+/// `recent_unix_secs(N)` can land on yesterday when CI runs just after UTC midnight, which
+/// empties the default 1-day window and flakes leaderboard/error-distribution default tests.
+fn recent_within_default_window_unix_secs() -> i64 {
+    let now = chrono::Utc::now();
+    let start_of_today = now
+        .date_naive()
+        .and_hms_opt(0, 0, 1)
+        .expect("start of day should be valid")
+        .and_utc()
+        .timestamp();
+    now.timestamp().saturating_sub(5).max(start_of_today)
+}
+
 #[derive(Debug)]
 struct PartialListAuthApiKeyRepository {
     lookup: InMemoryAuthApiKeySnapshotRepository,
@@ -706,7 +721,7 @@ async fn gateway_defaults_admin_stats_error_distribution_to_bounded_recent_windo
         10,
         0.02,
         0.02,
-        recent_unix_secs(5),
+        recent_within_default_window_unix_secs(),
     );
     recent_error.status_code = Some(429);
     recent_error.error_category = Some("rate_limit".to_string());
@@ -1454,7 +1469,7 @@ async fn gateway_defaults_admin_stats_leaderboard_models_to_bounded_recent_windo
         50,
         0.4,
         0.4,
-        recent_unix_secs(10),
+        recent_within_default_window_unix_secs(),
     );
     let stale_row = sample_usage_row(
         "usage-model-stale",

--- a/apps/aether-gateway/src/tests/control/admin/stats.rs
+++ b/apps/aether-gateway/src/tests/control/admin/stats.rs
@@ -1649,8 +1649,13 @@ async fn gateway_handles_admin_stats_leaderboard_api_keys_locally_without_auth_s
 }
 
 #[tokio::test]
-async fn gateway_handles_admin_stats_leaderboard_api_keys_with_auth_snapshot_single_lookup_fallback(
+async fn gateway_handles_admin_stats_leaderboard_api_keys_with_auth_snapshot_bulk_list_as_authoritative(
 ) {
+    // Leaderboard treats bulk snapshot list results as authoritative and does not fall back to
+    // per-id single lookups. Historical aggregates can contain many deleted key IDs; retrying
+    // every missing ID would turn one leaderboard request into an unbounded N+1 query pattern.
+    // PartialListAuthApiKeyRepository returns no rows from list while still answering find, so
+    // this exercises the no-fallback path: missing bulk rows are treated as absent snapshots.
     let (_upstream_url, upstream_hits, upstream_handle) =
         start_stats_upstream("/api/admin/stats/leaderboard/api-keys").await;
 
@@ -1684,6 +1689,7 @@ async fn gateway_handles_admin_stats_leaderboard_api_keys_with_auth_snapshot_sin
     );
     let (gateway_url, gateway_handle) = start_server(gateway).await;
 
+    // Default filters hide keys without a bulk snapshot (may be deleted / inactive).
     let response = admin_request(
         reqwest::Client::new().get(format!(
             "{gateway_url}/api/admin/stats/leaderboard/api-keys?start_date=2024-03-21&end_date=2024-03-21&metric=cost&order=desc&tz_offset_minutes=0"
@@ -1695,10 +1701,27 @@ async fn gateway_handles_admin_stats_leaderboard_api_keys_with_auth_snapshot_sin
 
     assert_eq!(response.status(), StatusCode::OK);
     let payload: serde_json::Value = response.json().await.expect("json body should parse");
-    assert_eq!(payload["total"], 1);
-    assert_eq!(payload["items"][0]["id"], "key-1");
-    assert_eq!(payload["items"][0]["name"], "fresh-key");
-    assert_eq!(payload["items"][0]["value"], 0.3);
+    assert_eq!(payload["total"], 0);
+    assert_eq!(payload["items"], serde_json::Value::Array(vec![]));
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    // Explicit historical view surfaces the legacy usage identity without N+1 single lookups.
+    let historical = admin_request(
+        reqwest::Client::new().get(format!(
+            "{gateway_url}/api/admin/stats/leaderboard/api-keys?start_date=2024-03-21&end_date=2024-03-21&metric=cost&order=desc&include_inactive=true&tz_offset_minutes=0"
+        )),
+    )
+    .send()
+    .await
+    .expect("historical request should succeed");
+
+    assert_eq!(historical.status(), StatusCode::OK);
+    let historical_payload: serde_json::Value =
+        historical.json().await.expect("json body should parse");
+    assert_eq!(historical_payload["total"], 1);
+    assert_eq!(historical_payload["items"][0]["id"], "key-1");
+    assert_eq!(historical_payload["items"][0]["name"], "legacy-key");
+    assert_eq!(historical_payload["items"][0]["value"], 0.3);
     assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
 
     gateway_handle.abort();

--- a/crates/aether-data/adapters/mysql/src/provider_catalog.rs
+++ b/crates/aether-data/adapters/mysql/src/provider_catalog.rs
@@ -748,6 +748,19 @@ WHERE id = ?
                 "provider_api_keys.last_models_fetch_at",
             )?)
             .bind(&key.last_models_fetch_error)
+            .bind(optional_json_to_string(
+                &key.upstream_metadata,
+                "provider_api_keys.upstream_metadata",
+            )?)
+            .bind(optional_i64_from_u64(
+                key.oauth_invalid_at_unix_secs,
+                "provider_api_keys.oauth_invalid_at",
+            )?)
+            .bind(&key.oauth_invalid_reason)
+            .bind(optional_json_to_string(
+                &key.status_snapshot,
+                "provider_api_keys.status_snapshot",
+            )?)
             .bind(updated_at)
             .bind(&key.id)
             .execute(&self.pool)
@@ -1526,6 +1539,10 @@ SET
   last_rpm_peak = ?,
   last_models_fetch_at = ?,
   last_models_fetch_error = ?,
+  upstream_metadata = ?,
+  oauth_invalid_at = ?,
+  oauth_invalid_reason = ?,
+  status_snapshot = ?,
   updated_at = ?
 WHERE id = ?
 "#

--- a/crates/aether-data/adapters/sqlite/src/provider_catalog.rs
+++ b/crates/aether-data/adapters/sqlite/src/provider_catalog.rs
@@ -1172,6 +1172,19 @@ WHERE id = ?
                 "provider_api_keys.last_models_fetch_at",
             )?)
             .bind(&key.last_models_fetch_error)
+            .bind(optional_json_to_string(
+                &key.upstream_metadata,
+                "provider_api_keys.upstream_metadata",
+            )?)
+            .bind(optional_i64_from_u64(
+                key.oauth_invalid_at_unix_secs,
+                "provider_api_keys.oauth_invalid_at",
+            )?)
+            .bind(&key.oauth_invalid_reason)
+            .bind(optional_json_to_string(
+                &key.status_snapshot,
+                "provider_api_keys.status_snapshot",
+            )?)
             .bind(updated_at)
             .bind(&key.id)
             .execute(&self.pool)
@@ -1978,6 +1991,10 @@ SET
   last_rpm_peak = ?,
   last_models_fetch_at = ?,
   last_models_fetch_error = ?,
+  upstream_metadata = ?,
+  oauth_invalid_at = ?,
+  oauth_invalid_reason = ?,
+  status_snapshot = ?,
   updated_at = ?
 WHERE id = ?
 "#
@@ -2553,6 +2570,14 @@ mod tests {
         updated_key.name = "Updated Key".to_string();
         updated_key.is_active = false;
         updated_key.upstream_metadata = Some(json!({"models":["gpt-4.1"]}));
+        updated_key.oauth_invalid_at_unix_secs = Some(1_730_000_300);
+        updated_key.oauth_invalid_reason = Some("quota refresh marker".to_string());
+        updated_key.status_snapshot = Some(json!({
+            "quota": {
+                "provider_type": "codex",
+                "windows": [{"code": "5h", "remaining_ratio": 0.5}]
+            }
+        }));
         updated_key.last_models_fetch_at_unix_secs = Some(1_730_000_200);
         updated_key.last_models_fetch_error = None;
         let updated_key = repository
@@ -2566,6 +2591,24 @@ mod tests {
             Some(1_730_000_200)
         );
         assert_eq!(updated_key.last_models_fetch_error, None);
+        assert_eq!(
+            updated_key.upstream_metadata,
+            Some(json!({"models":["gpt-4.1"]}))
+        );
+        assert_eq!(updated_key.oauth_invalid_at_unix_secs, Some(1_730_000_300));
+        assert_eq!(
+            updated_key.oauth_invalid_reason.as_deref(),
+            Some("quota refresh marker")
+        );
+        assert_eq!(
+            updated_key.status_snapshot,
+            Some(json!({
+                "quota": {
+                    "provider_type": "codex",
+                    "windows": [{"code": "5h", "remaining_ratio": 0.5}]
+                }
+            }))
+        );
 
         assert!(repository
             .update_key_upstream_metadata(

--- a/crates/aether-data/runtime/src/lifecycle/migrate/tests.rs
+++ b/crates/aether-data/runtime/src/lifecycle/migrate/tests.rs
@@ -31,10 +31,32 @@ struct ManagedPostgresServer {
     child: Option<Child>,
     workdir: PathBuf,
     database_url: String,
+    /// Admin URL used to CREATE/DROP an isolated database when sharing an external server.
+    admin_database_url: Option<String>,
+    /// Database name created for this fixture; dropped on cleanup when set.
+    owned_database_name: Option<String>,
 }
 
 impl ManagedPostgresServer {
     async fn try_start() -> Result<Option<Self>, Box<dyn std::error::Error>> {
+        // Prefer a shared external Postgres (e.g. CI service container) when provided.
+        // Each fixture still gets an isolated database so sequential tests cannot clobber each other.
+        if let Some(base_url) = external_postgres_url() {
+            return match Self::start_from_external_url(&base_url).await {
+                Ok(server) => Ok(Some(server)),
+                Err(err) => {
+                    let required = local_postgres_tests_required();
+                    if !required {
+                        eprintln!(
+                            "skipping postgres integration test because external postgres is unavailable: {err}"
+                        );
+                        return Ok(None);
+                    }
+                    Err(err)
+                }
+            };
+        }
+
         let required = local_postgres_tests_required();
         let initdb_bin = std::env::var("AETHER_INITDB_BIN")
             .ok()
@@ -68,6 +90,34 @@ impl ManagedPostgresServer {
             }
             Err(err) => Err(err),
         }
+    }
+
+    async fn start_from_external_url(base_url: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        wait_for_postgres(base_url).await?;
+
+        let owned_database_name = format!(
+            "aether_migrate_{}_{}",
+            std::process::id(),
+            &uuid::Uuid::new_v4().simple().to_string()[..12]
+        );
+        validate_postgres_identifier(&owned_database_name)?;
+
+        let mut admin = PgConnection::connect(base_url).await?;
+        // CREATE DATABASE cannot take a bound parameter for the identifier.
+        let create_sql = format!("CREATE DATABASE \"{owned_database_name}\"");
+        query(&create_sql).execute(&mut admin).await?;
+        admin.close().await?;
+
+        let database_url = rewrite_postgres_url_database(base_url, &owned_database_name)?;
+        wait_for_postgres(&database_url).await?;
+
+        Ok(Self {
+            child: None,
+            workdir: PathBuf::new(),
+            database_url,
+            admin_database_url: Some(base_url.to_string()),
+            owned_database_name: Some(owned_database_name),
+        })
     }
 
     async fn start(
@@ -140,6 +190,8 @@ impl ManagedPostgresServer {
             child: Some(child),
             workdir,
             database_url,
+            admin_database_url: None,
+            owned_database_name: None,
         })
     }
 
@@ -153,6 +205,47 @@ impl ManagedPostgresServer {
             let _ = child.wait();
         }
     }
+
+    fn drop_owned_database(&mut self) {
+        let (Some(admin_url), Some(database_name)) = (
+            self.admin_database_url.take(),
+            self.owned_database_name.take(),
+        ) else {
+            return;
+        };
+
+        // Drop runs from a synchronous destructor; spin a short-lived runtime off the test
+        // executor so we can issue CREATE/DROP DATABASE cleanup over sqlx.
+        let join = std::thread::spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(err) => {
+                    eprintln!(
+                        "failed to build runtime for postgres fixture cleanup ({database_name}): {err}"
+                    );
+                    return;
+                }
+            };
+            if let Err(err) =
+                runtime.block_on(drop_isolated_postgres_database(&admin_url, &database_name))
+            {
+                eprintln!(
+                    "failed to drop isolated postgres fixture database {database_name}: {err}"
+                );
+            }
+        });
+        let _ = join.join();
+    }
+}
+
+fn external_postgres_url() -> Option<String> {
+    std::env::var("AETHER_TEST_POSTGRES_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 fn local_postgres_tests_required() -> bool {
@@ -167,10 +260,59 @@ fn local_postgres_tests_required() -> bool {
         })
 }
 
+fn validate_postgres_identifier(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid postgres identifier for test database: {name}"),
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn rewrite_postgres_url_database(
+    base_url: &str,
+    database_name: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut url = url::Url::parse(base_url)?;
+    url.set_path(&format!("/{database_name}"));
+    Ok(url.into())
+}
+
+async fn drop_isolated_postgres_database(
+    admin_url: &str,
+    database_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    validate_postgres_identifier(database_name)?;
+    let mut admin = PgConnection::connect(admin_url).await?;
+    // Terminate leftover connections so DROP DATABASE is not blocked.
+    let terminate_sql = format!(
+        r#"
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE datname = '{database_name}'
+  AND pid <> pg_backend_pid()
+"#
+    );
+    let _ = query(&terminate_sql).execute(&mut admin).await;
+    let drop_sql = format!("DROP DATABASE IF EXISTS \"{database_name}\"");
+    query(&drop_sql).execute(&mut admin).await?;
+    admin.close().await?;
+    Ok(())
+}
+
 impl Drop for ManagedPostgresServer {
     fn drop(&mut self) {
         self.stop();
-        let _ = std::fs::remove_dir_all(&self.workdir);
+        self.drop_owned_database();
+        if !self.workdir.as_os_str().is_empty() {
+            let _ = std::fs::remove_dir_all(&self.workdir);
+        }
     }
 }
 
@@ -211,7 +353,7 @@ fn postgres_local_startup_unavailable(message: &str) -> bool {
 }
 
 async fn wait_for_postgres(database_url: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + Duration::from_secs(30);
     loop {
         match PgConnection::connect(database_url).await {
             Ok(connection) => {


### PR DESCRIPTION
﻿## Summary
- Persist provider key quota refresh/runtime state when `update_key` writes SQLite/MySQL rows.
- Cover the SQLite repository update path with quota/status fields so refresh data survives a list reload.

## Root cause
`persist_provider_quota_refresh_state()` updates `upstream_metadata`, OAuth invalid markers, and `status_snapshot` on the in-memory key before calling the generic provider catalog key update. The SQLite/MySQL `update_key` SQL omitted those runtime columns, so the refresh response could briefly show quota progress, then the next list reload read the old row without quota windows and the progress bar disappeared.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p aether-data sqlite_repository_writes_provider_catalog_contract_views -- --nocapture`
- `cargo test -p aether-data provider_catalog -- --nocapture`