### PR TITLE
修复 Antigravity v1internal 查询参数透传

### DIFF
--- a/crates/aether-provider-transport/src/antigravity/url.rs
+++ b/crates/aether-provider-transport/src/antigravity/url.rs
@@ -41,7 +41,11 @@ pub fn build_antigravity_v1internal_url(
         for (key, value) in query {
             let key = key.trim();
             let value = value.trim();
-            if key.is_empty() || value.is_empty() || key.eq_ignore_ascii_case("beta") {
+            if key.is_empty()
+                || value.is_empty()
+                || key.eq_ignore_ascii_case("beta")
+                || key.eq_ignore_ascii_case("key")
+            {
                 continue;
             }
             params.insert(key.to_string(), value.to_string());

--- a/crates/aether-provider-transport/src/request_url/mod.rs
+++ b/crates/aether-provider-transport/src/request_url/mod.rs
@@ -1197,6 +1197,33 @@ mod tests {
     }
 
     #[test]
+    fn antigravity_generate_content_drops_client_api_key_query() {
+        let transport = sample_transport(
+            "antigravity",
+            "gemini:generate_content",
+            "https://daily-cloudcode-pa.googleapis.com",
+            None,
+        );
+
+        assert_eq!(
+            build_transport_request_url(
+                &transport,
+                TransportRequestUrlParams {
+                    provider_api_format: "gemini:generate_content",
+                    mapped_model: Some("gemini-3-flash-agent"),
+                    upstream_is_stream: true,
+                    request_query: Some("key=client-aether-key&trace=1&beta=true"),
+                    kiro_api_region: None,
+                },
+            )
+            .as_deref(),
+            Some(
+                "https://daily-cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse&trace=1"
+            )
+        );
+    }
+
+    #[test]
     fn embedding_request_url_preserves_google_openai_compat_roots() {
         let developer_api_openai = sample_transport(
             "custom",


### PR DESCRIPTION
## 内容
- Antigravity v1internal URL 构造过滤客户端 `key` 查询参数，避免 Aether API key 透传到 Google Cloud Code 上游。
- 保留 `alt=sse` 与普通查询参数透传，模型映射、可用性检测与请求转换继续走通用 transport 链路。
- 增加 transport 层单测覆盖 generateContent URL 构造。

## 验证
- `cargo fmt --all --check`
- `cargo test -p aether-provider-transport antigravity_generate_content_drops_client_api_key_query -- --nocapture`
- `cargo test -p aether-provider-transport antigravity -- --nocapture`