### PR TITLE
修复 Gemini 空输出按候选重试处理

### DIFF
--- a/apps/aether-gateway/src/ai_serving/finalize/tests_sync.rs
+++ b/apps/aether-gateway/src/ai_serving/finalize/tests_sync.rs
@@ -1440,6 +1440,57 @@ fn local_finalize_handles_openai_responses_cross_format_stream_response_from_gem
 }
 
 #[test]
+fn local_finalize_rejects_antigravity_usage_only_gemini_wrapper() {
+    let payload = GatewaySyncReportRequest {
+        trace_id: "trace-antigravity-empty-gemini-wrapper".to_string(),
+        report_kind: "gemini_chat_sync_finalize".to_string(),
+        report_context: Some(json!({
+            "client_api_format": "gemini:generate_content",
+            "provider_api_format": "gemini:generate_content",
+            "model": "gemini-3.5-flash",
+            "mapped_model": "gemini-3-flash-agent",
+            "needs_conversion": false,
+            "has_envelope": true,
+            "envelope_name": "antigravity:v1internal",
+            "upstream_is_stream": true,
+        })),
+        status_code: 200,
+        headers: BTreeMap::from([("content-type".to_string(), "application/json".to_string())]),
+        body_json: Some(json!({
+            "chunks": [{
+                "response": {
+                    "responseId": "resp-usage-only",
+                    "modelVersion": "gemini-3-flash-agent",
+                    "usageMetadata": {
+                        "promptTokenCount": 5528,
+                        "totalTokenCount": 5528
+                    }
+                },
+                "metadata": {},
+                "traceId": "trace-antigravity-empty-gemini-wrapper"
+            }],
+            "metadata": {
+                "stream": true,
+                "stored_chunks": 1,
+                "total_chunks": 1
+            }
+        })),
+        client_body_json: None,
+        body_base64: None,
+        telemetry: None,
+    };
+
+    let outcome = maybe_build_local_core_sync_finalize_response(
+        "trace-antigravity-empty-gemini-wrapper",
+        &test_decision(),
+        &payload,
+    )
+    .expect("local finalize should evaluate payload");
+
+    assert!(outcome.is_none());
+}
+
+#[test]
 fn local_finalize_handles_openai_responses_compact_openai_family_stream_response_even_when_conversion_flagged(
 ) {
     let body = concat!(

--- a/apps/aether-gateway/src/execution_runtime/sync/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/sync/execution.rs
@@ -105,6 +105,7 @@ const SYNC_EXECUTION_IDLE_LOG_INTERVAL: Duration = Duration::from_secs(60);
 const OPENAI_IMAGE_SYNC_JSON_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
 const OPENAI_IMAGE_SYNC_JSON_HEARTBEAT_BYTES: &[u8] = b"\n";
 const OPENAI_IMAGE_SYNC_PROGRESS_WRITE_INTERVAL: Duration = Duration::from_secs(5);
+const INVALID_GEMINI_PROVIDER_SUCCESS_MESSAGE: &str = "Provider returned HTTP 200 but the Gemini response did not contain visible model output; refusing to finalize it as a successful response.";
 
 #[derive(Debug)]
 struct SyncExecutionFailure {
@@ -628,13 +629,7 @@ fn invalid_gemini_provider_success_message(
     if status_code >= 400 {
         return None;
     }
-    let provider_api_format = report_context
-        .and_then(|value| value.get("provider_api_format"))
-        .and_then(Value::as_str)
-        .unwrap_or(plan.provider_api_format.as_str());
-    if crate::ai_serving::normalize_api_format_alias(provider_api_format)
-        != "gemini:generate_content"
-    {
+    if !provider_api_format_is_gemini_generate_content(plan, report_context) {
         return None;
     }
     let body_json = body_json?;
@@ -658,7 +653,53 @@ fn invalid_gemini_provider_success_message(
     if crate::ai_serving::gemini_generate_content_response_has_visible_output(body_json) {
         return None;
     }
-    Some("Provider returned HTTP 200 but the Gemini response did not contain visible model output; refusing to finalize it as a successful response.")
+    Some(INVALID_GEMINI_PROVIDER_SUCCESS_MESSAGE)
+}
+
+fn invalid_gemini_provider_stream_success_message(
+    plan: &ExecutionPlan,
+    report_context: Option<&Value>,
+    status_code: u16,
+    body_json: Option<&Value>,
+    body_bytes: &[u8],
+    has_body_bytes: bool,
+) -> Option<&'static str> {
+    if status_code >= 400 || body_json.is_some() || !has_body_bytes {
+        return None;
+    }
+    if !provider_api_format_is_gemini_generate_content(plan, report_context) {
+        return None;
+    }
+    let Some(body_json) = crate::ai_serving::aggregate_gemini_stream_sync_response(body_bytes)
+    else {
+        return Some(INVALID_GEMINI_PROVIDER_SUCCESS_MESSAGE);
+    };
+    if crate::ai_serving::gemini_generate_content_response_has_visible_output(&body_json) {
+        return None;
+    }
+    Some(INVALID_GEMINI_PROVIDER_SUCCESS_MESSAGE)
+}
+
+fn provider_api_format_is_gemini_generate_content(
+    plan: &ExecutionPlan,
+    report_context: Option<&Value>,
+) -> bool {
+    let provider_api_format = report_context
+        .and_then(|value| value.get("provider_api_format"))
+        .and_then(Value::as_str)
+        .unwrap_or(plan.provider_api_format.as_str());
+    crate::ai_serving::normalize_api_format_alias(provider_api_format) == "gemini:generate_content"
+}
+
+fn invalid_gemini_provider_success_execution_error(message: &str) -> ExecutionError {
+    ExecutionError {
+        kind: ExecutionErrorKind::Upstream5xx,
+        phase: ExecutionPhase::Finalize,
+        message: message.to_string(),
+        upstream_status: Some(StatusCode::OK.as_u16()),
+        retryable: true,
+        failover_recommended: true,
+    }
 }
 
 fn build_invalid_provider_success_body(
@@ -2031,16 +2072,19 @@ async fn execute_execution_runtime_sync_impl(
             report_context.as_ref(),
             result.status_code,
             body_json.as_ref(),
-        ) {
+        )
+        .or_else(|| {
+            invalid_gemini_provider_stream_success_message(
+                &plan,
+                report_context.as_ref(),
+                result.status_code,
+                body_json.as_ref(),
+                &body_bytes,
+                body_base64.is_some(),
+            )
+        }) {
             result.status_code = StatusCode::BAD_GATEWAY.as_u16();
-            result.error = Some(ExecutionError {
-                kind: ExecutionErrorKind::Upstream5xx,
-                phase: ExecutionPhase::Finalize,
-                message: message.to_string(),
-                upstream_status: Some(StatusCode::OK.as_u16()),
-                retryable: false,
-                failover_recommended: false,
-            });
+            result.error = Some(invalid_gemini_provider_success_execution_error(message));
             if let Some(error_body) =
                 build_invalid_provider_success_body(&plan, report_context.as_ref(), message)
             {
@@ -2911,6 +2955,65 @@ mod tests {
         .expect("empty Gemini 200 response should be rejected from plan format");
 
         assert!(message.contains("visible model output"));
+    }
+
+    #[test]
+    fn invalid_gemini_provider_success_error_is_retryable_candidate_failure() {
+        let error = invalid_gemini_provider_success_execution_error(
+            INVALID_GEMINI_PROVIDER_SUCCESS_MESSAGE,
+        );
+
+        assert_eq!(error.kind, ExecutionErrorKind::Upstream5xx);
+        assert_eq!(error.phase, ExecutionPhase::Finalize);
+        assert_eq!(error.upstream_status, Some(StatusCode::OK.as_u16()));
+        assert!(error.retryable);
+        assert!(error.failover_recommended);
+    }
+
+    #[test]
+    fn invalid_gemini_provider_success_accepts_antigravity_chunks_with_visible_output() {
+        let plan = test_gemini_chat_plan();
+        let report_context = json!({
+            "has_envelope": true,
+            "envelope_name": "antigravity:v1internal",
+            "provider_api_format": "gemini:generate_content",
+        });
+        let body = json!({
+            "chunks": [{
+                "response": {
+                    "responseId": "resp_antigravity_chunks_123",
+                    "candidates": [{
+                        "content": {
+                            "parts": [{"text": "Hello Gemini"}],
+                            "role": "model"
+                        },
+                        "finishReason": "STOP",
+                        "index": 0
+                    }],
+                    "modelVersion": "gemini-3-flash-agent",
+                    "usageMetadata": {
+                        "promptTokenCount": 2,
+                        "candidatesTokenCount": 2,
+                        "totalTokenCount": 4
+                    }
+                },
+                "traceId": "trace-antigravity-chunks"
+            }],
+            "metadata": {
+                "stream": true,
+                "stored_chunks": 1,
+                "total_chunks": 1
+            }
+        });
+
+        let message = invalid_gemini_provider_success_message(
+            &plan,
+            Some(&report_context),
+            StatusCode::OK.as_u16(),
+            Some(&body),
+        );
+
+        assert!(message.is_none());
     }
 
     #[test]

--- a/apps/aether-gateway/src/handlers/admin/observability/usage/replay.rs
+++ b/apps/aether-gateway/src/handlers/admin/observability/usage/replay.rs
@@ -58,7 +58,9 @@ pub(super) async fn admin_usage_resolve_body_value(
         | Some(UsageBodyCaptureState::Unavailable)
         | Some(UsageBodyCaptureState::None) => return Ok(None),
         Some(UsageBodyCaptureState::Inline) | Some(UsageBodyCaptureState::Truncated) => {
-            return Ok(inline_body.cloned());
+            if inline_body.is_some() {
+                return Ok(inline_body.cloned());
+            }
         }
         Some(UsageBodyCaptureState::Reference) | None => {}
     }

--- a/apps/aether-gateway/src/handlers/admin/observability/usage/summary_routes.rs
+++ b/apps/aether-gateway/src/handlers/admin/observability/usage/summary_routes.rs
@@ -305,6 +305,9 @@ pub(super) fn admin_usage_terminal_candidate_state_override(
     candidates: &[StoredRequestCandidate],
 ) -> Option<serde_json::Value> {
     let candidate = admin_usage_current_candidate(candidates)?;
+    if admin_usage_candidate_failure_is_retryable_transition(candidate) {
+        return None;
+    }
 
     let status = match candidate.status {
         RequestCandidateStatus::Success => "completed",
@@ -341,6 +344,30 @@ pub(super) fn admin_usage_terminal_candidate_state_override(
         payload["error_message"] = json!(error_message);
     }
     Some(payload)
+}
+
+fn admin_usage_candidate_failure_is_retryable_transition(
+    candidate: &StoredRequestCandidate,
+) -> bool {
+    if candidate.status != RequestCandidateStatus::Failed {
+        return false;
+    }
+    let Some(error_flow) = candidate
+        .extra_data
+        .as_ref()
+        .and_then(|value| value.get("error_flow"))
+    else {
+        return false;
+    };
+    let retryable = error_flow
+        .get("retryable")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let retry_next_candidate = error_flow
+        .get("decision")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|value| value == "retry_next_candidate");
+    retryable && retry_next_candidate
 }
 
 pub(super) fn apply_admin_usage_state_override(
@@ -998,6 +1025,7 @@ mod tests {
     use aether_data_contracts::repository::candidates::{
         RequestCandidateStatus, StoredRequestCandidate,
     };
+    use serde_json::json;
 
     use super::admin_usage_terminal_candidate_state_override;
 
@@ -1073,6 +1101,29 @@ mod tests {
         streaming.finished_at_unix_ms = None;
 
         let payload = admin_usage_terminal_candidate_state_override(&[failed, streaming]);
+
+        assert!(payload.is_none());
+    }
+
+    #[test]
+    fn admin_usage_active_override_ignores_retryable_candidate_failure() {
+        let mut failed = sample_candidate(
+            0,
+            RequestCandidateStatus::Failed,
+            Some(502),
+            Some(1_000),
+            Some("provider returned HTTP 200 without visible model output"),
+        );
+        failed.extra_data = Some(json!({
+            "error_flow": {
+                "decision": "retry_next_candidate",
+                "retryable": true,
+                "propagation": "suppressed",
+                "classification": "retry_upstream_failure"
+            }
+        }));
+
+        let payload = admin_usage_terminal_candidate_state_override(&[failed]);
 
         assert!(payload.is_none());
     }

--- a/apps/aether-gateway/src/tests/control/admin/usage.rs
+++ b/apps/aether-gateway/src/tests/control/admin/usage.rs
@@ -12,7 +12,7 @@ use aether_data::repository::users::{
 use aether_data_contracts::repository::candidates::{
     RequestCandidateStatus, StoredRequestCandidate,
 };
-use aether_data_contracts::repository::usage::StoredRequestUsageAudit;
+use aether_data_contracts::repository::usage::{StoredRequestUsageAudit, UsageBodyCaptureState};
 use axum::body::{Body, Bytes};
 use axum::routing::{any, get, post};
 use axum::{extract::Request, Router};
@@ -2282,6 +2282,84 @@ async fn gateway_handles_admin_usage_detail_with_ref_backed_bodies() {
         payload["client_response_body"]["output_text"],
         "hello from ref"
     );
+    assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
+
+    gateway_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_resolves_admin_usage_detail_when_inline_state_has_body_ref() {
+    let (_upstream_url, upstream_hits, upstream_handle) =
+        start_usage_upstream("/api/admin/usage/usage-inline-state-ref-detail").await;
+
+    let mut usage = sample_usage_row(
+        "usage-inline-state-ref-detail",
+        "req-inline-state-ref-detail",
+        Some("user-1"),
+        Some("key-1"),
+        Some("primary"),
+        "Gemini",
+        "gemini-3.5-flash",
+        "completed",
+        120,
+        30,
+        0.3,
+        0.36,
+        DAY_1_UNIX_SECS,
+    );
+    usage.request_body = Some(json!({
+        "contents": [{"role": "user", "parts": [{"text": "hello"}]}],
+    }));
+    usage.provider_request_body = Some(json!({
+        "model": "gemini-3-flash-agent",
+        "request": {"contents": [{"role": "user", "parts": [{"text": "hello"}]}]},
+    }));
+    usage.response_body = Some(json!({
+        "chunks": [{"candidates": [{"content": {"parts": [{"text": "hello back"}]}}]}],
+    }));
+    usage.client_response_body = Some(json!({
+        "candidates": [{"content": {"parts": [{"text": "hello back"}]}}],
+    }));
+    usage.request_body_state = Some(UsageBodyCaptureState::Inline);
+    usage.provider_request_body_state = Some(UsageBodyCaptureState::Inline);
+    usage.response_body_state = Some(UsageBodyCaptureState::Inline);
+    usage.client_response_body_state = Some(UsageBodyCaptureState::Inline);
+
+    let usage_repository = Arc::new(InMemoryUsageReadRepository::seed_with_detached_bodies(
+        vec![usage],
+    ));
+    let data_state = GatewayDataState::with_usage_reader_for_tests(usage_repository);
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(data_state),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+
+    let response = admin_request(reqwest::Client::new().get(format!(
+        "{gateway_url}/api/admin/usage/usage-inline-state-ref-detail"
+    )))
+    .send()
+    .await
+    .expect("request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
+    assert_eq!(payload["request_body"]["contents"][0]["role"], "user");
+    assert_eq!(
+        payload["provider_request_body"]["model"],
+        "gemini-3-flash-agent"
+    );
+    assert_eq!(
+        payload["response_body"]["chunks"][0]["candidates"][0]["content"]["parts"][0]["text"],
+        "hello back"
+    );
+    assert_eq!(
+        payload["client_response_body"]["candidates"][0]["content"]["parts"][0]["text"],
+        "hello back"
+    );
+    assert!(payload["body_load_errors"].is_null());
     assert_eq!(*upstream_hits.lock().expect("mutex should lock"), 0);
 
     gateway_handle.abort();

--- a/crates/aether-ai-formats/src/formats/shared/sync_products.rs
+++ b/crates/aether-ai-formats/src/formats/shared/sync_products.rs
@@ -510,6 +510,11 @@ fn maybe_build_standard_same_format_sync_body(
     if is_error_like_sync_body(body_json) {
         return None;
     }
+    if api_format_is_gemini_generate_content(expected_api_format)
+        && !gemini_generate_content_body_has_visible_output(body_json)
+    {
+        return None;
+    }
 
     let mut body_json = body_json.clone();
     if expected_api_format == "claude:messages" {
@@ -578,6 +583,11 @@ fn maybe_build_standard_same_format_stream_sync_body(
     else {
         return Ok(None);
     };
+    if api_format_is_gemini_generate_content(&provider_stream_event_api_format)
+        && !gemini_generate_content_body_has_visible_output(&body)
+    {
+        return Ok(None);
+    }
     let Some(client_body) = convert_aggregated_stream_body_to_client_sync_response(
         report_kind,
         body,
@@ -750,6 +760,14 @@ fn is_error_like_sync_body(value: &Value) -> bool {
                     })
                 })
             })
+}
+
+fn gemini_generate_content_body_has_visible_output(value: &Value) -> bool {
+    crate::formats::gemini::generate_content::response::from_raw(value).is_some()
+}
+
+fn api_format_is_gemini_generate_content(api_format: &str) -> bool {
+    aether_ai_formats::normalize_api_format_alias(api_format) == "gemini:generate_content"
 }
 
 pub fn maybe_build_standard_cross_format_sync_product(
@@ -5413,6 +5431,34 @@ mod tests {
         };
         assert_eq!(body_json["object"], "chat.completion");
         assert_eq!(body_json["choices"][0]["message"]["content"], "pong");
+    }
+
+    #[test]
+    fn standard_same_format_gemini_finalize_rejects_usage_only_body() {
+        let report_context = json!({
+            "provider_api_format": "gemini:generate_content",
+            "client_api_format": "gemini:generate_content",
+            "needs_conversion": false,
+        });
+        let provider_body_json = json!({
+            "responseId": "resp-empty-visible-output",
+            "modelVersion": "gemini-3-flash-preview",
+            "usageMetadata": {
+                "promptTokenCount": 8,
+                "totalTokenCount": 8
+            }
+        });
+
+        let product = maybe_build_standard_sync_finalize_product_from_normalized_payload(
+            "gemini_chat_sync_finalize",
+            200,
+            Some(&report_context),
+            Some(&provider_body_json),
+            None,
+        )
+        .expect("dispatch should succeed");
+
+        assert_eq!(product, None);
     }
 
     #[test]

--- a/crates/aether-ai-formats/src/provider_compat/private_envelope.rs
+++ b/crates/aether-ai-formats/src/provider_compat/private_envelope.rs
@@ -101,25 +101,66 @@ pub fn normalize_provider_private_response_value(
             }
         }
         Some(ANTIGRAVITY_V1INTERNAL_ENVELOPE_NAME) => {
-            if let Some(response) = data
-                .get("response")
-                .and_then(Value::as_object)
-                .filter(|response| !response.contains_key("response"))
-            {
-                let mut unwrapped = response.clone();
-                if let Some(response_id) = data.get("responseId").cloned() {
-                    unwrapped.insert("_v1internal_response_id".to_string(), response_id);
-                }
-                Value::Object(unwrapped)
-            } else {
-                data
-            }
+            normalize_antigravity_sync_response_value(data, provider_api_format)
         }
         Some(WINDSURF_ENVELOPE_NAME) => normalize_windsurf_sync_response_value(data)?,
         _ => return None,
     };
     postprocess_private_response_value(&mut unwrapped, report_context);
     Some(unwrapped)
+}
+
+fn normalize_antigravity_sync_response_value(data: Value, provider_api_format: &str) -> Value {
+    if crate::normalize_api_format_alias(provider_api_format) == "gemini:generate_content" {
+        if let Some(aggregated) = aggregate_antigravity_gemini_chunks(&data) {
+            return aggregated;
+        }
+    }
+    if let Some(response) = data
+        .get("response")
+        .and_then(Value::as_object)
+        .filter(|response| !response.contains_key("response"))
+    {
+        let mut unwrapped = response.clone();
+        if let Some(response_id) = data.get("responseId").cloned() {
+            unwrapped.insert("_v1internal_response_id".to_string(), response_id);
+        }
+        Value::Object(unwrapped)
+    } else {
+        data
+    }
+}
+
+fn aggregate_antigravity_gemini_chunks(data: &Value) -> Option<Value> {
+    let chunks = data.get("chunks").and_then(Value::as_array)?;
+    if chunks.is_empty() {
+        return None;
+    }
+    let body = serde_json::to_vec(chunks).ok()?;
+    let mut aggregated =
+        crate::formats::shared::sync_products::aggregate_gemini_stream_sync_response(&body)?;
+    if let Some(response_id) = antigravity_chunks_response_id(chunks) {
+        if let Some(object) = aggregated.as_object_mut() {
+            if object.get("responseId").is_none_or(|value| value.is_null()) {
+                object.insert("responseId".to_string(), response_id);
+            }
+        }
+    }
+    Some(aggregated)
+}
+
+fn antigravity_chunks_response_id(chunks: &[Value]) -> Option<Value> {
+    chunks.iter().find_map(|chunk| {
+        chunk
+            .get("responseId")
+            .or_else(|| {
+                chunk
+                    .get("response")
+                    .and_then(|response| response.get("responseId"))
+            })
+            .cloned()
+            .filter(|value| !value.is_null())
+    })
 }
 
 pub fn transform_provider_private_stream_line(
@@ -912,6 +953,69 @@ mod tests {
             normalized["candidates"][0]["content"]["parts"][0]["functionCall"]["id"],
             json!("call_get_weather_0")
         );
+    }
+
+    #[test]
+    fn unwraps_antigravity_chunks_sync_response() {
+        let report_context = json!({
+            "has_envelope": true,
+            "provider_api_format": "gemini:generate_content",
+            "envelope_name": "antigravity:v1internal",
+            "mapped_model": "gemini-3-flash-agent",
+        });
+        let body = json!({
+            "chunks": [{
+                "response": {
+                    "responseId": "resp_antigravity_chunks_123",
+                    "candidates": [{
+                        "content": {
+                            "parts": [{"text": "Hello "}],
+                            "role": "model"
+                        },
+                        "index": 0
+                    }],
+                    "modelVersion": "gemini-3-flash-agent"
+                },
+                "traceId": "trace-antigravity-chunks"
+            }, {
+                "response": {
+                    "responseId": "resp_antigravity_chunks_123",
+                    "candidates": [{
+                        "content": {
+                            "parts": [{"text": "Gemini"}],
+                            "role": "model"
+                        },
+                        "finishReason": "STOP",
+                        "index": 0
+                    }],
+                    "modelVersion": "gemini-3-flash-agent",
+                    "usageMetadata": {
+                        "promptTokenCount": 2,
+                        "candidatesTokenCount": 2,
+                        "totalTokenCount": 4
+                    }
+                },
+                "traceId": "trace-antigravity-chunks"
+            }],
+            "metadata": {
+                "stream": true,
+                "stored_chunks": 2,
+                "total_chunks": 2
+            }
+        });
+
+        let normalized = normalize_provider_private_response_value(body, &report_context)
+            .expect("chunks should normalize");
+
+        assert_eq!(
+            normalized["candidates"][0]["content"]["parts"][0]["text"],
+            json!("Hello Gemini")
+        );
+        assert_eq!(
+            normalized["_v1internal_response_id"],
+            json!("resp_antigravity_chunks_123")
+        );
+        assert_eq!(normalized["usageMetadata"]["totalTokenCount"], json!(4));
     }
 
     #[test]

--- a/crates/aether-data/src/repository/usage/postgres/mod.rs
+++ b/crates/aether-data/src/repository/usage/postgres/mod.rs
@@ -10461,6 +10461,27 @@ fn prepare_usage_body_storage(value: Option<&Value>) -> Result<UsageBodyStorage,
     })
 }
 
+fn usage_body_capture_state_for_storage(
+    incoming_state: Option<UsageBodyCaptureState>,
+    storage: &UsageBodyStorage,
+    body_ref: Option<&str>,
+) -> Option<UsageBodyCaptureState> {
+    if matches!(
+        incoming_state,
+        Some(
+            UsageBodyCaptureState::Disabled
+                | UsageBodyCaptureState::Unavailable
+                | UsageBodyCaptureState::None
+        )
+    ) {
+        return incoming_state;
+    }
+    if storage.has_detached_blob() || body_ref.is_some() {
+        return Some(UsageBodyCaptureState::Reference);
+    }
+    incoming_state
+}
+
 fn json_bind_text(value: Option<&Value>) -> Result<Option<String>, DataLayerError> {
     value
         .map(|value| {
@@ -10515,10 +10536,26 @@ fn prepare_usage_upsert_context(
         ),
     };
     let http_audit_states = UsageHttpAuditStates {
-        request_body_state: usage.request_body_state,
-        provider_request_body_state: usage.provider_request_body_state,
-        response_body_state: usage.response_body_state,
-        client_response_body_state: usage.client_response_body_state,
+        request_body_state: usage_body_capture_state_for_storage(
+            usage.request_body_state,
+            &request_body_storage,
+            http_audit_refs.request_body_ref.as_deref(),
+        ),
+        provider_request_body_state: usage_body_capture_state_for_storage(
+            usage.provider_request_body_state,
+            &provider_request_body_storage,
+            http_audit_refs.provider_request_body_ref.as_deref(),
+        ),
+        response_body_state: usage_body_capture_state_for_storage(
+            usage.response_body_state,
+            &response_body_storage,
+            http_audit_refs.response_body_ref.as_deref(),
+        ),
+        client_response_body_state: usage_body_capture_state_for_storage(
+            usage.client_response_body_state,
+            &client_response_body_storage,
+            http_audit_refs.client_response_body_ref.as_deref(),
+        ),
     };
     let request_metadata_value = prepare_request_metadata_for_body_storage(
         usage.request_metadata.clone(),

--- a/crates/aether-data/src/repository/usage/postgres/tests.rs
+++ b/crates/aether-data/src/repository/usage/postgres/tests.rs
@@ -6,15 +6,16 @@ use super::{
     attach_usage_routing_snapshot_metadata, attach_usage_settlement_pricing_snapshot_metadata,
     inflate_usage_json_value, prepare_request_metadata_for_body_storage,
     prepare_usage_body_storage, resolved_read_usage_body_ref, resolved_write_usage_body_ref,
-    split_dashboard_daily_aggregate_range, split_dashboard_hourly_aggregate_range, usage_body_ref,
-    usage_http_audit_body_refs, usage_http_audit_capture_mode, usage_routing_snapshot_from_usage,
+    split_dashboard_daily_aggregate_range, split_dashboard_hourly_aggregate_range,
+    usage_body_capture_state_for_storage, usage_body_ref, usage_http_audit_body_refs,
+    usage_http_audit_capture_mode, usage_routing_snapshot_from_usage,
     usage_settlement_pricing_snapshot_from_usage, AggregateRangeSplit, SqlxUsageReadRepository,
     UsageHttpAuditRefs, UsageRoutingSnapshot, UsageSettlementPricingSnapshot,
     MAX_INLINE_USAGE_BODY_BYTES,
 };
 use crate::driver::postgres::{PostgresPoolConfig, PostgresPoolFactory};
 use crate::repository::usage::UpsertUsageRecord;
-use aether_data_contracts::repository::usage::UsageBodyField;
+use aether_data_contracts::repository::usage::{UsageBodyCaptureState, UsageBodyField};
 
 #[tokio::test]
 async fn repository_constructs_from_lazy_pool() {
@@ -1036,6 +1037,45 @@ fn prepare_usage_body_storage_compresses_large_payloads() {
     assert_eq!(
         inflate_usage_json_value(compressed).expect("payload should inflate"),
         payload
+    );
+}
+
+#[test]
+fn usage_body_capture_state_for_storage_marks_detached_bodies_as_reference() {
+    let payload = json!({"message": "hello"});
+    let storage = prepare_usage_body_storage(Some(&payload)).expect("storage should serialize");
+
+    assert!(storage.has_detached_blob());
+    assert_eq!(
+        usage_body_capture_state_for_storage(Some(UsageBodyCaptureState::Inline), &storage, None,),
+        Some(UsageBodyCaptureState::Reference)
+    );
+    assert_eq!(
+        usage_body_capture_state_for_storage(None, &storage, None),
+        Some(UsageBodyCaptureState::Reference)
+    );
+}
+
+#[test]
+fn usage_body_capture_state_for_storage_preserves_unavailable_states() {
+    let payload = json!({"message": "hello"});
+    let storage = prepare_usage_body_storage(Some(&payload)).expect("storage should serialize");
+
+    assert_eq!(
+        usage_body_capture_state_for_storage(
+            Some(UsageBodyCaptureState::Disabled),
+            &storage,
+            Some("usage://request/req-1/request_body"),
+        ),
+        Some(UsageBodyCaptureState::Disabled)
+    );
+    assert_eq!(
+        usage_body_capture_state_for_storage(
+            Some(UsageBodyCaptureState::Unavailable),
+            &storage,
+            Some("usage://request/req-1/request_body"),
+        ),
+        Some(UsageBodyCaptureState::Unavailable)
     );
 }
 


### PR DESCRIPTION
## 变更内容
- 将 Gemini generateContent 的 HTTP 200 空输出判定为可重试候选失败，进入既有候选重试/故障转移链路，不新增独立重试循环。
- 在格式层复用 Antigravity 私有 envelope 归一化和 Gemini stream 聚合能力，保留有可见输出的 chunks，拒绝仅包含 usageMetadata 的空结果。
- 调整用量观测的活跃请求状态推导，避免可重试候选失败在重试窗口内过早显示为终态失败。
- 修复 usage 详情 body 引用解包：detached blob 写入时将 body capture 状态归一为 reference，并允许历史 inline-state/ref-backed 记录在详情、cURL、replay 共用链路中按 body_ref 解包。

## 验证
- cargo fmt
- git diff --check
- cargo test -p aether-data usage_body_capture_state_for_storage -- --nocapture
- cargo test -p aether-gateway gateway_handles_admin_usage_detail_with_ref_backed_bodies -- --nocapture
- cargo test -p aether-gateway gateway_resolves_admin_usage_detail_when_inline_state_has_body_ref -- --nocapture
- cargo test -p aether-data repository::usage::postgres::tests -- --nocapture
- cargo test -p aether-gateway tests::control::admin::usage -- --nocapture
- cargo fmt --all --check
- git diff --check origin/main...HEAD
- cargo test -p aether-ai-formats --quiet
- RUST_MIN_STACK=16777216 cargo test -p aether-gateway
- cargo clippy -p aether-gateway --lib --bins --examples -- -D warnings
- cargo clippy -p aether-ai-formats --all-targets -- -D warnings