### PR TITLE
fix(proxy): dedupe tunnel heartbeat metrics by session

### DIFF
--- a/apps/aether-gateway/src/handlers/internal/gateway.rs
+++ b/apps/aether-gateway/src/handlers/internal/gateway.rs
@@ -806,6 +806,11 @@ pub(crate) async fn maybe_build_local_internal_proxy_response_impl(
                 Err(response) => return Ok(Some(response)),
             };
             let node_id = payload.node_id.trim().to_string();
+            let proxy_metadata = attach_heartbeat_cursor(
+                payload.proxy_metadata,
+                payload.heartbeat_session_id.as_deref(),
+                payload.heartbeat_id,
+            );
             let mutation = ProxyNodeHeartbeatMutation {
                 node_id: node_id.clone(),
                 heartbeat_interval: payload.heartbeat_interval,
@@ -815,7 +820,7 @@ pub(crate) async fn maybe_build_local_internal_proxy_response_impl(
                 failed_requests_delta: payload.window_failed_requests.or(payload.failed_requests),
                 dns_failures_delta: payload.window_dns_failures.or(payload.dns_failures),
                 stream_errors_delta: payload.window_stream_errors.or(payload.stream_errors),
-                proxy_metadata: payload.proxy_metadata,
+                proxy_metadata,
                 proxy_version: payload.proxy_version,
             };
 
@@ -870,4 +875,23 @@ pub(crate) async fn maybe_build_local_internal_proxy_response_impl(
     }
 
     Ok(None)
+}
+
+fn attach_heartbeat_cursor(
+    proxy_metadata: Option<serde_json::Value>,
+    heartbeat_session_id: Option<&str>,
+    heartbeat_id: u64,
+) -> Option<serde_json::Value> {
+    let Some(heartbeat_session_id) = heartbeat_session_id.map(str::trim) else {
+        return proxy_metadata;
+    };
+    let mut metadata = proxy_metadata
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    metadata.insert(
+        "heartbeat_session_id".to_string(),
+        serde_json::Value::String(heartbeat_session_id.to_string()),
+    );
+    metadata.insert("heartbeat_id".to_string(), heartbeat_id.into());
+    Some(serde_json::Value::Object(metadata))
 }

--- a/apps/aether-gateway/src/handlers/internal/gateway_helpers.rs
+++ b/apps/aether-gateway/src/handlers/internal/gateway_helpers.rs
@@ -391,7 +391,17 @@ pub(crate) fn parse_internal_tunnel_heartbeat_request(
         })?;
 
     let node_id = payload.node_id.trim();
-    if node_id.is_empty() || node_id.len() > 36 || payload.heartbeat_id == 0 {
+    let heartbeat_session_id = payload
+        .heartbeat_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if node_id.is_empty()
+        || node_id.len() > 36
+        || payload.heartbeat_id == 0
+        || payload.heartbeat_session_id.is_some() && heartbeat_session_id.is_none()
+        || heartbeat_session_id.is_some_and(|value| value.len() > 128)
+    {
         return Err(build_internal_control_error_response(
             http::StatusCode::BAD_REQUEST,
             "invalid heartbeat payload",

--- a/apps/aether-gateway/src/handlers/shared/payloads.rs
+++ b/apps/aether-gateway/src/handlers/shared/payloads.rs
@@ -4,6 +4,8 @@ use std::collections::BTreeMap;
 #[derive(Debug, Deserialize)]
 pub(crate) struct InternalTunnelHeartbeatRequest {
     pub(crate) node_id: String,
+    #[serde(default)]
+    pub(crate) heartbeat_session_id: Option<String>,
     pub(crate) heartbeat_id: u64,
     #[serde(default)]
     pub(crate) heartbeat_interval: Option<i32>,

--- a/apps/aether-gateway/src/tests/control/internal.rs
+++ b/apps/aether-gateway/src/tests/control/internal.rs
@@ -49,6 +49,7 @@ async fn gateway_handles_internal_tunnel_heartbeat_locally_with_loopback() {
         .post(format!("{gateway_url}/api/internal/tunnel/heartbeat"))
         .json(&json!({
             "node_id": "node-123",
+            "heartbeat_session_id": "process-123",
             "heartbeat_id": 77,
             "heartbeat_interval": 45,
             "active_connections": 5,
@@ -84,6 +85,24 @@ async fn gateway_handles_internal_tunnel_heartbeat_locally_with_loopback() {
     assert_eq!(node.failed_requests, 1);
     assert_eq!(node.dns_failures, 2);
     assert_eq!(node.stream_errors, 3);
+    assert_eq!(
+        node.proxy_metadata
+            .as_ref()
+            .and_then(|value| value.get("arch")),
+        Some(&json!("arm64"))
+    );
+    assert_eq!(
+        node.proxy_metadata
+            .as_ref()
+            .and_then(|value| value.get("heartbeat_session_id")),
+        Some(&json!("process-123"))
+    );
+    assert_eq!(
+        node.proxy_metadata
+            .as_ref()
+            .and_then(|value| value.get("heartbeat_id")),
+        Some(&json!(77))
+    );
 
     gateway_handle.abort();
     upstream_handle.abort();
@@ -116,6 +135,39 @@ async fn gateway_rejects_internal_tunnel_heartbeat_without_heartbeat_id() {
         .expect("request should succeed");
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    gateway_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_rejects_invalid_internal_tunnel_heartbeat_session_id() {
+    let repository = Arc::new(InMemoryProxyNodeRepository::seed(vec![sample_proxy_node(
+        "node-123",
+    )]));
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(GatewayDataState::with_proxy_node_repository_for_tests(
+                repository,
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+    let client = reqwest::Client::new();
+
+    for heartbeat_session_id in ["   ".to_string(), "x".repeat(129)] {
+        let response = client
+            .post(format!("{gateway_url}/api/internal/tunnel/heartbeat"))
+            .json(&json!({
+                "node_id": "node-123",
+                "heartbeat_session_id": heartbeat_session_id,
+                "heartbeat_id": 1
+            }))
+            .send()
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
 
     gateway_handle.abort();
 }

--- a/crates/aether-data/src/repository/proxy_nodes/types.rs
+++ b/crates/aether-data/src/repository/proxy_nodes/types.rs
@@ -361,6 +361,12 @@ pub struct TunnelMetricsSample {
     pub recent_error_events: Vec<TunnelErrorEventRecord>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HeartbeatCursor<'a> {
+    session_id: &'a str,
+    heartbeat_id: u64,
+}
+
 pub fn bucket_start_unix_secs(timestamp_unix_secs: u64, step: ProxyNodeMetricsStep) -> u64 {
     let size = step.bucket_size_secs();
     timestamp_unix_secs / size * size
@@ -375,21 +381,38 @@ pub fn build_tunnel_metrics_sample(
     let current = extract_tunnel_metrics_counters(current_proxy_metadata)?;
     let previous = extract_tunnel_metrics_counters(previous_proxy_metadata);
     let current_recent_errors = extract_recent_tunnel_errors(current_proxy_metadata);
+    let previous_cursor = extract_heartbeat_cursor(previous_proxy_metadata);
+    let current_cursor = extract_heartbeat_cursor(current_proxy_metadata);
+    // Cursorless samples come from older tunnels; keep their existing delta behavior only
+    // while both sides are legacy metadata.
+    let counters_are_comparable = match (previous_cursor, current_cursor) {
+        (None, None) => true,
+        (Some(previous), Some(current)) => {
+            previous.session_id == current.session_id
+                && current.heartbeat_id > previous.heartbeat_id
+        }
+        _ => false,
+    };
 
+    let counter_delta = |previous: Option<u64>, current: u64| {
+        if counters_are_comparable {
+            counter_delta_u64(previous, current)
+        } else {
+            0
+        }
+    };
     let connect_errors_delta =
-        counter_delta_u64(previous.map(|v| v.connect_errors), current.connect_errors);
-    let disconnects_delta = counter_delta_u64(previous.map(|v| v.disconnects), current.disconnects);
-    let error_events_delta = counter_delta_u64(
+        counter_delta(previous.map(|v| v.connect_errors), current.connect_errors);
+    let disconnects_delta = counter_delta(previous.map(|v| v.disconnects), current.disconnects);
+    let error_events_delta = counter_delta(
         previous.map(|v| v.error_events_total),
         current.error_events_total,
     );
-    let ws_in_bytes_delta = counter_delta_u64(previous.map(|v| v.ws_in_bytes), current.ws_in_bytes);
-    let ws_out_bytes_delta =
-        counter_delta_u64(previous.map(|v| v.ws_out_bytes), current.ws_out_bytes);
-    let ws_in_frames_delta =
-        counter_delta_u64(previous.map(|v| v.ws_in_frames), current.ws_in_frames);
+    let ws_in_bytes_delta = counter_delta(previous.map(|v| v.ws_in_bytes), current.ws_in_bytes);
+    let ws_out_bytes_delta = counter_delta(previous.map(|v| v.ws_out_bytes), current.ws_out_bytes);
+    let ws_in_frames_delta = counter_delta(previous.map(|v| v.ws_in_frames), current.ws_in_frames);
     let ws_out_frames_delta =
-        counter_delta_u64(previous.map(|v| v.ws_out_frames), current.ws_out_frames);
+        counter_delta(previous.map(|v| v.ws_out_frames), current.ws_out_frames);
 
     let take_recent = usize::try_from(error_events_delta).unwrap_or(usize::MAX);
     let recent_error_events = if take_recent == 0 {
@@ -530,6 +553,18 @@ fn extract_tunnel_metrics_counters(
         ws_in_frames: json_u64(tunnel_metrics.get("ws_in_frames")).unwrap_or(0),
         ws_out_frames: json_u64(tunnel_metrics.get("ws_out_frames")).unwrap_or(0),
         heartbeat_rtt_last_ms: json_u64(tunnel_metrics.get("heartbeat_rtt_last_ms")).unwrap_or(0),
+    })
+}
+
+fn extract_heartbeat_cursor(proxy_metadata: Option<&Value>) -> Option<HeartbeatCursor<'_>> {
+    let metadata = proxy_metadata.and_then(Value::as_object)?;
+    let session_id = metadata
+        .get("heartbeat_session_id")
+        .and_then(Value::as_str)?;
+    let heartbeat_id = json_u64(metadata.get("heartbeat_id"))?;
+    Some(HeartbeatCursor {
+        session_id,
+        heartbeat_id,
     })
 }
 
@@ -893,6 +928,8 @@ mod tests {
     #[test]
     fn builds_tunnel_metrics_sample_with_reset_safe_counter_deltas() {
         let previous = json!({
+            "heartbeat_session_id": "process-a",
+            "heartbeat_id": 40,
             "tunnel_metrics": {
                 "connect_errors": 10,
                 "disconnects": 5,
@@ -905,6 +942,8 @@ mod tests {
             }
         });
         let current = json!({
+            "heartbeat_session_id": "process-a",
+            "heartbeat_id": 41,
             "tunnel_metrics": {
                 "connect_errors": 12,
                 "disconnects": 2,
@@ -961,6 +1000,144 @@ mod tests {
             build_tunnel_error_event_detail(&sample.recent_error_events[1]),
             "[newer] WebSocket write failed because the peer closed or reset the connection"
         );
+    }
+
+    #[test]
+    fn builds_tunnel_metrics_sample_treats_changed_or_non_advancing_cursors_as_baselines() {
+        let previous = json!({
+            "heartbeat_session_id": "process-a",
+            "heartbeat_id": 40,
+            "tunnel_metrics": {
+                "connect_errors": 10,
+                "disconnects": 5,
+                "error_events_total": 7,
+                "ws_in_bytes": 1_000,
+                "ws_out_bytes": 2_000,
+                "ws_in_frames": 10,
+                "ws_out_frames": 20,
+                "heartbeat_rtt_last_ms": 30
+            }
+        });
+
+        for (session_id, heartbeat_id) in [("process-b", 1), ("process-a", 40), ("process-a", 39)] {
+            let current = json!({
+                "heartbeat_session_id": session_id,
+                "heartbeat_id": heartbeat_id,
+                "tunnel_metrics": {
+                    "connect_errors": 12,
+                    "disconnects": 8,
+                    "error_events_total": 9,
+                    "ws_in_bytes": 1_500,
+                    "ws_out_bytes": 2_500,
+                    "ws_in_frames": 15,
+                    "ws_out_frames": 25,
+                    "heartbeat_rtt_last_ms": 44
+                },
+                "recent_tunnel_errors": [
+                    {"timestamp_unix_secs": 101, "category": "newer", "message": "new"}
+                ]
+            });
+
+            let sample = build_tunnel_metrics_sample(Some(&previous), Some(&current), 4, true)
+                .expect("sample should build");
+            assert_eq!(sample.samples, 1);
+            assert_eq!(sample.heartbeat_rtt_ms_sum, 44);
+            assert_eq!(sample.connect_errors_delta, 0);
+            assert_eq!(sample.disconnects_delta, 0);
+            assert_eq!(sample.error_events_delta, 0);
+            assert_eq!(sample.ws_in_bytes_delta, 0);
+            assert_eq!(sample.ws_out_bytes_delta, 0);
+            assert_eq!(sample.ws_in_frames_delta, 0);
+            assert_eq!(sample.ws_out_frames_delta, 0);
+            assert!(sample.recent_error_events.is_empty());
+        }
+    }
+
+    #[test]
+    fn builds_tunnel_metrics_sample_treats_cursor_adoption_as_a_baseline() {
+        let previous = json!({
+            "tunnel_metrics": {
+                "connect_errors": 10,
+                "disconnects": 5,
+                "error_events_total": 7,
+                "ws_in_bytes": 1_000,
+                "ws_out_bytes": 2_000,
+                "ws_in_frames": 10,
+                "ws_out_frames": 20,
+                "heartbeat_rtt_last_ms": 30
+            }
+        });
+        let current = json!({
+            "heartbeat_session_id": "process-a",
+            "heartbeat_id": 1,
+            "tunnel_metrics": {
+                "connect_errors": 12,
+                "disconnects": 8,
+                "error_events_total": 9,
+                "ws_in_bytes": 1_500,
+                "ws_out_bytes": 2_500,
+                "ws_in_frames": 15,
+                "ws_out_frames": 25,
+                "heartbeat_rtt_last_ms": 44
+            },
+            "recent_tunnel_errors": [
+                {"timestamp_unix_secs": 101, "category": "newer", "message": "new"}
+            ]
+        });
+
+        let sample = build_tunnel_metrics_sample(Some(&previous), Some(&current), 4, true)
+            .expect("sample should build");
+        assert_eq!(sample.connect_errors_delta, 0);
+        assert_eq!(sample.disconnects_delta, 0);
+        assert_eq!(sample.error_events_delta, 0);
+        assert_eq!(sample.ws_in_bytes_delta, 0);
+        assert_eq!(sample.ws_out_bytes_delta, 0);
+        assert_eq!(sample.ws_in_frames_delta, 0);
+        assert_eq!(sample.ws_out_frames_delta, 0);
+        assert!(sample.recent_error_events.is_empty());
+    }
+
+    #[test]
+    fn builds_tunnel_metrics_sample_preserves_legacy_counter_behavior_without_cursors() {
+        let previous = json!({
+            "tunnel_metrics": {
+                "connect_errors": 10,
+                "disconnects": 5,
+                "error_events_total": 7,
+                "ws_in_bytes": 1_000,
+                "ws_out_bytes": 2_000,
+                "ws_in_frames": 10,
+                "ws_out_frames": 20,
+                "heartbeat_rtt_last_ms": 30
+            }
+        });
+        let current = json!({
+            "tunnel_metrics": {
+                "connect_errors": 12,
+                "disconnects": 2,
+                "error_events_total": 9,
+                "ws_in_bytes": 1_500,
+                "ws_out_bytes": 100,
+                "ws_in_frames": 11,
+                "ws_out_frames": 3,
+                "heartbeat_rtt_last_ms": 44
+            },
+            "recent_tunnel_errors": [
+                {"timestamp_unix_secs": 100, "category": "older", "message": "old"},
+                {"timestamp_unix_secs": 101, "category": "newer", "message": "new"}
+            ]
+        });
+
+        let sample = build_tunnel_metrics_sample(Some(&previous), Some(&current), 4, true)
+            .expect("sample should build");
+        assert_eq!(sample.connect_errors_delta, 2);
+        assert_eq!(sample.disconnects_delta, 2);
+        assert_eq!(sample.error_events_delta, 2);
+        assert_eq!(sample.ws_in_bytes_delta, 500);
+        assert_eq!(sample.ws_out_bytes_delta, 100);
+        assert_eq!(sample.ws_in_frames_delta, 1);
+        assert_eq!(sample.ws_out_frames_delta, 3);
+        assert_eq!(sample.recent_error_events.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- persist the tunnel's existing `heartbeat_session_id` and `heartbeat_id` in proxy metadata
- only derive cumulative tunnel metric deltas when two heartbeats belong to the same session and the heartbeat ID advances
- treat session switches, retries, out-of-order heartbeats, and initial cursor adoption as counter baselines
- preserve the existing behavior for older tunnel clients that do not send heartbeat cursors

## Problem

The tunnel already sends a process-scoped `heartbeat_session_id` and a monotonically increasing `heartbeat_id`, but the gateway discarded the session ID. When two tunnel processes shared one node ID, their independent cumulative counters alternated. A counter decrease was interpreted as a reset, so the current total was counted as a fresh delta and the same `recent_tunnel_errors` were inserted repeatedly.

The observed heartbeat rate matched two 5-second tunnel loops (24 samples/minute), while persisted error-event deltas were orders of magnitude larger than the node's actual cumulative error counter.

## Implementation

The gateway now validates the optional session ID and attaches both cursor fields to the metadata passed to the repository. `build_tunnel_metrics_sample` compares those cursors before calculating deltas. Samples still contribute availability and heartbeat RTT data when counters are not comparable, but all cumulative deltas and recent raw error events are zeroed for that heartbeat.

No schema migration is required.

## Tests

- `cargo fmt --all --check`
- `cargo clippy -p aether-data --all-targets -- -D warnings`
- `cargo test -p aether-data builds_tunnel_metrics_sample --lib` (5 passed)
- `cargo test -p aether-data repository::proxy_nodes --lib` (19 passed)

Added gateway HTTP coverage for cursor persistence and invalid session IDs. The local Windows gateway build stops in the third-party `boring-sys2` native build because CMake is unavailable; the repository's Linux CI is expected to exercise those tests.

A full local `cargo test -p aether-data --lib` run completed 475 tests and had 6 unrelated failures in existing provider-catalog/usage assertions (including LF-sensitive source-string checks on a CRLF checkout). All proxy-node tests passed.