### PR TITLE
修复：避免多 tunnel 实例心跳导致代理节点事件重复入库

### DIFF
--- a/apps/aether-gateway/src/handlers/internal/gateway.rs
+++ b/apps/aether-gateway/src/handlers/internal/gateway.rs
@@ -806,6 +806,11 @@ pub(crate) async fn maybe_build_local_internal_proxy_response_impl(
                 Err(response) => return Ok(Some(response)),
             };
             let node_id = payload.node_id.trim().to_string();
+            let proxy_metadata = attach_heartbeat_cursor(
+                payload.proxy_metadata,
+                payload.heartbeat_session_id.as_deref(),
+                payload.heartbeat_id,
+            );
             let mutation = ProxyNodeHeartbeatMutation {
                 node_id: node_id.clone(),
                 heartbeat_interval: payload.heartbeat_interval,
@@ -815,7 +820,7 @@ pub(crate) async fn maybe_build_local_internal_proxy_response_impl(
                 failed_requests_delta: payload.window_failed_requests.or(payload.failed_requests),
                 dns_failures_delta: payload.window_dns_failures.or(payload.dns_failures),
                 stream_errors_delta: payload.window_stream_errors.or(payload.stream_errors),
-                proxy_metadata: payload.proxy_metadata,
+                proxy_metadata,
                 proxy_version: payload.proxy_version,
             };
 
@@ -870,4 +875,23 @@ pub(crate) async fn maybe_build_local_internal_proxy_response_impl(
     }
 
     Ok(None)
+}
+
+fn attach_heartbeat_cursor(
+    proxy_metadata: Option<serde_json::Value>,
+    heartbeat_session_id: Option<&str>,
+    heartbeat_id: u64,
+) -> Option<serde_json::Value> {
+    let Some(heartbeat_session_id) = heartbeat_session_id.map(str::trim) else {
+        return proxy_metadata;
+    };
+    let mut metadata = proxy_metadata
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    metadata.insert(
+        "heartbeat_session_id".to_string(),
+        serde_json::Value::String(heartbeat_session_id.to_string()),
+    );
+    metadata.insert("heartbeat_id".to_string(), heartbeat_id.into());
+    Some(serde_json::Value::Object(metadata))
 }

--- a/apps/aether-gateway/src/handlers/internal/gateway_helpers.rs
+++ b/apps/aether-gateway/src/handlers/internal/gateway_helpers.rs
@@ -391,7 +391,17 @@ pub(crate) fn parse_internal_tunnel_heartbeat_request(
         })?;
 
     let node_id = payload.node_id.trim();
-    if node_id.is_empty() || node_id.len() > 36 || payload.heartbeat_id == 0 {
+    let heartbeat_session_id = payload
+        .heartbeat_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if node_id.is_empty()
+        || node_id.len() > 36
+        || payload.heartbeat_id == 0
+        || payload.heartbeat_session_id.is_some() && heartbeat_session_id.is_none()
+        || heartbeat_session_id.is_some_and(|value| value.len() > 128)
+    {
         return Err(build_internal_control_error_response(
             http::StatusCode::BAD_REQUEST,
             "invalid heartbeat payload",

--- a/apps/aether-gateway/src/handlers/shared/payloads.rs
+++ b/apps/aether-gateway/src/handlers/shared/payloads.rs
@@ -4,6 +4,8 @@ use std::collections::BTreeMap;
 #[derive(Debug, Deserialize)]
 pub(crate) struct InternalTunnelHeartbeatRequest {
     pub(crate) node_id: String,
+    #[serde(default)]
+    pub(crate) heartbeat_session_id: Option<String>,
     pub(crate) heartbeat_id: u64,
     #[serde(default)]
     pub(crate) heartbeat_interval: Option<i32>,

--- a/apps/aether-gateway/src/tests/control/internal.rs
+++ b/apps/aether-gateway/src/tests/control/internal.rs
@@ -49,6 +49,7 @@ async fn gateway_handles_internal_tunnel_heartbeat_locally_with_loopback() {
         .post(format!("{gateway_url}/api/internal/tunnel/heartbeat"))
         .json(&json!({
             "node_id": "node-123",
+            "heartbeat_session_id": "process-123",
             "heartbeat_id": 77,
             "heartbeat_interval": 45,
             "active_connections": 5,
@@ -84,6 +85,24 @@ async fn gateway_handles_internal_tunnel_heartbeat_locally_with_loopback() {
     assert_eq!(node.failed_requests, 1);
     assert_eq!(node.dns_failures, 2);
     assert_eq!(node.stream_errors, 3);
+    assert_eq!(
+        node.proxy_metadata
+            .as_ref()
+            .and_then(|value| value.get("arch")),
+        Some(&json!("arm64"))
+    );
+    assert_eq!(
+        node.proxy_metadata
+            .as_ref()
+            .and_then(|value| value.get("heartbeat_session_id")),
+        Some(&json!("process-123"))
+    );
+    assert_eq!(
+        node.proxy_metadata
+            .as_ref()
+            .and_then(|value| value.get("heartbeat_id")),
+        Some(&json!(77))
+    );
 
     gateway_handle.abort();
     upstream_handle.abort();
@@ -116,6 +135,39 @@ async fn gateway_rejects_internal_tunnel_heartbeat_without_heartbeat_id() {
         .expect("request should succeed");
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    gateway_handle.abort();
+}
+
+#[tokio::test]
+async fn gateway_rejects_invalid_internal_tunnel_heartbeat_session_id() {
+    let repository = Arc::new(InMemoryProxyNodeRepository::seed(vec![sample_proxy_node(
+        "node-123",
+    )]));
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(GatewayDataState::with_proxy_node_repository_for_tests(
+                repository,
+            )),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
+    let client = reqwest::Client::new();
+
+    for heartbeat_session_id in ["   ".to_string(), "x".repeat(129)] {
+        let response = client
+            .post(format!("{gateway_url}/api/internal/tunnel/heartbeat"))
+            .json(&json!({
+                "node_id": "node-123",
+                "heartbeat_session_id": heartbeat_session_id,
+                "heartbeat_id": 1
+            }))
+            .send()
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
 
     gateway_handle.abort();
 }

--- a/crates/aether-data/src/repository/proxy_nodes/types.rs
+++ b/crates/aether-data/src/repository/proxy_nodes/types.rs
@@ -361,6 +361,12 @@ pub struct TunnelMetricsSample {
     pub recent_error_events: Vec<TunnelErrorEventRecord>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HeartbeatCursor<'a> {
+    session_id: &'a str,
+    heartbeat_id: u64,
+}
+
 pub fn bucket_start_unix_secs(timestamp_unix_secs: u64, step: ProxyNodeMetricsStep) -> u64 {
     let size = step.bucket_size_secs();
     timestamp_unix_secs / size * size
@@ -375,21 +381,38 @@ pub fn build_tunnel_metrics_sample(
     let current = extract_tunnel_metrics_counters(current_proxy_metadata)?;
     let previous = extract_tunnel_metrics_counters(previous_proxy_metadata);
     let current_recent_errors = extract_recent_tunnel_errors(current_proxy_metadata);
+    let previous_cursor = extract_heartbeat_cursor(previous_proxy_metadata);
+    let current_cursor = extract_heartbeat_cursor(current_proxy_metadata);
+    // Cursorless samples come from older tunnels; keep their existing delta behavior only
+    // while both sides are legacy metadata.
+    let counters_are_comparable = match (previous_cursor, current_cursor) {
+        (None, None) => true,
+        (Some(previous), Some(current)) => {
+            previous.session_id == current.session_id
+                && current.heartbeat_id > previous.heartbeat_id
+        }
+        _ => false,
+    };
 
+    let counter_delta = |previous: Option<u64>, current: u64| {
+        if counters_are_comparable {
+            counter_delta_u64(previous, current)
+        } else {
+            0
+        }
+    };
     let connect_errors_delta =
-        counter_delta_u64(previous.map(|v| v.connect_errors), current.connect_errors);
-    let disconnects_delta = counter_delta_u64(previous.map(|v| v.disconnects), current.disconnects);
-    let error_events_delta = counter_delta_u64(
+        counter_delta(previous.map(|v| v.connect_errors), current.connect_errors);
+    let disconnects_delta = counter_delta(previous.map(|v| v.disconnects), current.disconnects);
+    let error_events_delta = counter_delta(
         previous.map(|v| v.error_events_total),
         current.error_events_total,
     );
-    let ws_in_bytes_delta = counter_delta_u64(previous.map(|v| v.ws_in_bytes), current.ws_in_bytes);
-    let ws_out_bytes_delta =
-        counter_delta_u64(previous.map(|v| v.ws_out_bytes), current.ws_out_bytes);
-    let ws_in_frames_delta =
-        counter_delta_u64(previous.map(|v| v.ws_in_frames), current.ws_in_frames);
+    let ws_in_bytes_delta = counter_delta(previous.map(|v| v.ws_in_bytes), current.ws_in_bytes);
+    let ws_out_bytes_delta = counter_delta(previous.map(|v| v.ws_out_bytes), current.ws_out_bytes);
+    let ws_in_frames_delta = counter_delta(previous.map(|v| v.ws_in_frames), current.ws_in_frames);
     let ws_out_frames_delta =
-        counter_delta_u64(previous.map(|v| v.ws_out_frames), current.ws_out_frames);
+        counter_delta(previous.map(|v| v.ws_out_frames), current.ws_out_frames);
 
     let take_recent = usize::try_from(error_events_delta).unwrap_or(usize::MAX);
     let recent_error_events = if take_recent == 0 {
@@ -530,6 +553,18 @@ fn extract_tunnel_metrics_counters(
         ws_in_frames: json_u64(tunnel_metrics.get("ws_in_frames")).unwrap_or(0),
         ws_out_frames: json_u64(tunnel_metrics.get("ws_out_frames")).unwrap_or(0),
         heartbeat_rtt_last_ms: json_u64(tunnel_metrics.get("heartbeat_rtt_last_ms")).unwrap_or(0),
+    })
+}
+
+fn extract_heartbeat_cursor(proxy_metadata: Option<&Value>) -> Option<HeartbeatCursor<'_>> {
+    let metadata = proxy_metadata.and_then(Value::as_object)?;
+    let session_id = metadata
+        .get("heartbeat_session_id")
+        .and_then(Value::as_str)?;
+    let heartbeat_id = json_u64(metadata.get("heartbeat_id"))?;
+    Some(HeartbeatCursor {
+        session_id,
+        heartbeat_id,
     })
 }
 
@@ -893,6 +928,8 @@ mod tests {
     #[test]
     fn builds_tunnel_metrics_sample_with_reset_safe_counter_deltas() {
         let previous = json!({
+            "heartbeat_session_id": "process-a",
+            "heartbeat_id": 40,
             "tunnel_metrics": {
                 "connect_errors": 10,
                 "disconnects": 5,
@@ -905,6 +942,8 @@ mod tests {
             }
         });
         let current = json!({
+            "heartbeat_session_id": "process-a",
+            "heartbeat_id": 41,
             "tunnel_metrics": {
                 "connect_errors": 12,
                 "disconnects": 2,
@@ -961,6 +1000,144 @@ mod tests {
             build_tunnel_error_event_detail(&sample.recent_error_events[1]),
             "[newer] WebSocket write failed because the peer closed or reset the connection"
         );
+    }
+
+    #[test]
+    fn builds_tunnel_metrics_sample_treats_changed_or_non_advancing_cursors_as_baselines() {
+        let previous = json!({
+            "heartbeat_session_id": "process-a",
+            "heartbeat_id": 40,
+            "tunnel_metrics": {
+                "connect_errors": 10,
+                "disconnects": 5,
+                "error_events_total": 7,
+                "ws_in_bytes": 1_000,
+                "ws_out_bytes": 2_000,
+                "ws_in_frames": 10,
+                "ws_out_frames": 20,
+                "heartbeat_rtt_last_ms": 30
+            }
+        });
+
+        for (session_id, heartbeat_id) in [("process-b", 1), ("process-a", 40), ("process-a", 39)] {
+            let current = json!({
+                "heartbeat_session_id": session_id,
+                "heartbeat_id": heartbeat_id,
+                "tunnel_metrics": {
+                    "connect_errors": 12,
+                    "disconnects": 8,
+                    "error_events_total": 9,
+                    "ws_in_bytes": 1_500,
+                    "ws_out_bytes": 2_500,
+                    "ws_in_frames": 15,
+                    "ws_out_frames": 25,
+                    "heartbeat_rtt_last_ms": 44
+                },
+                "recent_tunnel_errors": [
+                    {"timestamp_unix_secs": 101, "category": "newer", "message": "new"}
+                ]
+            });
+
+            let sample = build_tunnel_metrics_sample(Some(&previous), Some(&current), 4, true)
+                .expect("sample should build");
+            assert_eq!(sample.samples, 1);
+            assert_eq!(sample.heartbeat_rtt_ms_sum, 44);
+            assert_eq!(sample.connect_errors_delta, 0);
+            assert_eq!(sample.disconnects_delta, 0);
+            assert_eq!(sample.error_events_delta, 0);
+            assert_eq!(sample.ws_in_bytes_delta, 0);
+            assert_eq!(sample.ws_out_bytes_delta, 0);
+            assert_eq!(sample.ws_in_frames_delta, 0);
+            assert_eq!(sample.ws_out_frames_delta, 0);
+            assert!(sample.recent_error_events.is_empty());
+        }
+    }
+
+    #[test]
+    fn builds_tunnel_metrics_sample_treats_cursor_adoption_as_a_baseline() {
+        let previous = json!({
+            "tunnel_metrics": {
+                "connect_errors": 10,
+                "disconnects": 5,
+                "error_events_total": 7,
+                "ws_in_bytes": 1_000,
+                "ws_out_bytes": 2_000,
+                "ws_in_frames": 10,
+                "ws_out_frames": 20,
+                "heartbeat_rtt_last_ms": 30
+            }
+        });
+        let current = json!({
+            "heartbeat_session_id": "process-a",
+            "heartbeat_id": 1,
+            "tunnel_metrics": {
+                "connect_errors": 12,
+                "disconnects": 8,
+                "error_events_total": 9,
+                "ws_in_bytes": 1_500,
+                "ws_out_bytes": 2_500,
+                "ws_in_frames": 15,
+                "ws_out_frames": 25,
+                "heartbeat_rtt_last_ms": 44
+            },
+            "recent_tunnel_errors": [
+                {"timestamp_unix_secs": 101, "category": "newer", "message": "new"}
+            ]
+        });
+
+        let sample = build_tunnel_metrics_sample(Some(&previous), Some(&current), 4, true)
+            .expect("sample should build");
+        assert_eq!(sample.connect_errors_delta, 0);
+        assert_eq!(sample.disconnects_delta, 0);
+        assert_eq!(sample.error_events_delta, 0);
+        assert_eq!(sample.ws_in_bytes_delta, 0);
+        assert_eq!(sample.ws_out_bytes_delta, 0);
+        assert_eq!(sample.ws_in_frames_delta, 0);
+        assert_eq!(sample.ws_out_frames_delta, 0);
+        assert!(sample.recent_error_events.is_empty());
+    }
+
+    #[test]
+    fn builds_tunnel_metrics_sample_preserves_legacy_counter_behavior_without_cursors() {
+        let previous = json!({
+            "tunnel_metrics": {
+                "connect_errors": 10,
+                "disconnects": 5,
+                "error_events_total": 7,
+                "ws_in_bytes": 1_000,
+                "ws_out_bytes": 2_000,
+                "ws_in_frames": 10,
+                "ws_out_frames": 20,
+                "heartbeat_rtt_last_ms": 30
+            }
+        });
+        let current = json!({
+            "tunnel_metrics": {
+                "connect_errors": 12,
+                "disconnects": 2,
+                "error_events_total": 9,
+                "ws_in_bytes": 1_500,
+                "ws_out_bytes": 100,
+                "ws_in_frames": 11,
+                "ws_out_frames": 3,
+                "heartbeat_rtt_last_ms": 44
+            },
+            "recent_tunnel_errors": [
+                {"timestamp_unix_secs": 100, "category": "older", "message": "old"},
+                {"timestamp_unix_secs": 101, "category": "newer", "message": "new"}
+            ]
+        });
+
+        let sample = build_tunnel_metrics_sample(Some(&previous), Some(&current), 4, true)
+            .expect("sample should build");
+        assert_eq!(sample.connect_errors_delta, 2);
+        assert_eq!(sample.disconnects_delta, 2);
+        assert_eq!(sample.error_events_delta, 2);
+        assert_eq!(sample.ws_in_bytes_delta, 500);
+        assert_eq!(sample.ws_out_bytes_delta, 100);
+        assert_eq!(sample.ws_in_frames_delta, 1);
+        assert_eq!(sample.ws_out_frames_delta, 3);
+        assert_eq!(sample.recent_error_events.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## 现象

`proxy_node_events` 会在短时间内写入大量重复的 `tunnel_err` 记录，事件表持续膨胀。

实际数据中，同一个时间点可以出现十几万条记录，但 `detail` 和 `event_metadata` 只有少量不同值；同时，节点上报的累计 `error_events_total` 远小于数据库中的事件行数。这说明同一批近期 tunnel 错误被心跳重复持久化，并不是真实发生了数百万次独立错误。

代理节点仍然可以显示在线，因为问题发生在心跳指标和错误事件的累计逻辑，不代表 tunnel 连接一定离线。

## 触发条件

核心触发条件是：**多个 `aether-tunnel` 进程共用同一个代理节点 ID**。

例如同一台机器同时通过 systemd 和 Docker 启动 tunnel：

1. 两个进程各自维护独立的累计计数器。
2. 两个进程使用同一个 `node_id` 交替发送心跳。
3. 服务端看到累计计数器下降时，将其视为计数器重置，并把当前累计值当作本次新增值。
4. 下一个高计数器实例再次上报时，又会产生一笔较大的 delta。
5. `recent_tunnel_errors` 根据这个错误的 delta 被重复写入 `proxy_node_events`。

相同 heartbeat 重试、heartbeat ID 回退或乱序，也可能造成相同事件被重复处理。

## 根因

新版 tunnel 客户端已经在心跳顶层发送：

- `heartbeat_session_id`：标识当前 tunnel 进程/心跳任务会话。
- `heartbeat_id`：同一 session 内严格递增，重试时复用原 ID。

但 gateway 的 `InternalTunnelHeartbeatRequest` 没有读取 `heartbeat_session_id`，Serde 会把该字段当作未知字段丢弃。数据层因此只能看到累计计数器，无法判断两次心跳是否来自同一个 tunnel 进程，也无法可靠识别 session 切换、重放和乱序。

## 修复方案

本 PR 直接复用 tunnel 已经发送的 heartbeat cursor，不新增数据库字段，也不需要数据库迁移：

1. gateway 读取并校验可选的 `heartbeat_session_id`。
2. 将 `heartbeat_session_id` 和 `heartbeat_id` 写入代理节点 metadata。
3. 只有 previous/current 属于同一 session，且当前 `heartbeat_id` 严格大于上一次时，才计算累计指标 delta。
4. 以下情况作为新的计数基线，累计 delta 设为 0，并且不写入 `recent_tunnel_errors`：
   - heartbeat session 切换；
   - 相同 heartbeat ID 重放；
   - heartbeat ID 回退或乱序；
   - 首次从无 cursor 的旧 metadata 切换到有 cursor 的新 metadata。
5. 基线心跳仍会正常记录在线状态、活跃连接数和心跳 RTT。
6. previous/current 都没有 cursor 时继续使用原有逻辑，兼容旧版 tunnel 客户端。

这样即使两个 tunnel 实例使用同一个节点 ID 交替上报，也不会再把各自的累计计数器反复计算成新增事件。

## 验证

已覆盖以下场景：

- 同一 session、heartbeat ID 递增时正常计算 delta。
- session A/B 切换时所有累计 delta 为 0。
- 相同 heartbeat ID 重放时不重复写事件。
- heartbeat ID 回退/乱序时不重复写事件。
- 首次采用 cursor 时作为基线。
- 旧客户端无 cursor 时保持原有行为。
- gateway 能保存 cursor，并拒绝空白或过长的 session ID。

本地验证结果：

```text
cargo fmt --all --check
通过

cargo clippy -p aether-data --all-targets -- -D warnings
通过

cargo test -p aether-data builds_tunnel_metrics_sample --lib
5 passed, 0 failed

cargo test -p aether-data repository::proxy_nodes --lib
19 passed, 0 failed
```

gateway 的 HTTP 回归测试已随 PR 提交，由仓库 Linux CI 继续执行。