### PR TITLE
fix(codex): 统一通用缓存键与原生会话身份

### DIFF
--- a/apps/aether-gateway/src/ai_serving/planner/decision_input.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/decision_input.rs
@@ -133,6 +133,17 @@ pub(crate) fn apply_provider_request_routing_policy_to_decision(
     );
 
     let Some(context) = input.routing_context.as_ref() else {
+        // Cache identity headers are projected only at the terminal boundary. Any non-empty
+        // session headers already present here are explicit client or header-rule inputs and stay
+        // authoritative.
+        if let Some(provider_request_body) = decision.provider_request_body.as_ref() {
+            crate::ai_serving::apply_codex_openai_responses_identity_headers(
+                &mut decision.provider_request_headers,
+                provider_request_body,
+                provider_type.as_str(),
+                provider_api_format.as_str(),
+            );
+        }
         return Ok(());
     };
     let provider_body_rules = decision
@@ -182,6 +193,14 @@ pub(crate) fn apply_provider_request_routing_policy_to_decision(
     })?;
     ensure_report_context_routing_trace(input, decision, &policy);
     if policy.mutation_plan.is_empty() {
+        if let Some(provider_request_body) = decision.provider_request_body.as_ref() {
+            crate::ai_serving::apply_codex_openai_responses_identity_headers(
+                &mut decision.provider_request_headers,
+                provider_request_body,
+                provider_type.as_str(),
+                provider_api_format.as_str(),
+            );
+        }
         return Ok(());
     }
     if original_provider_request_body.is_none() && !policy.mutation_plan.body_patch.is_empty() {
@@ -255,6 +274,12 @@ pub(crate) fn apply_provider_request_routing_policy_to_decision(
             input.requested_model.as_str(),
         )
     });
+    crate::ai_serving::apply_codex_openai_responses_identity_headers(
+        &mut provider_request_headers,
+        &provider_request_body,
+        provider_type.as_str(),
+        provider_api_format.as_str(),
+    );
     crate::ai_serving::apply_codex_openai_responses_lite_header_for_request_body_with_capabilities(
         &mut provider_request_headers,
         Some(&provider_request_body),
@@ -1277,6 +1302,107 @@ mod tests {
             report_context["routing_trace"]["global_candidates"][0]["provider_id"],
             json!("provider-1")
         );
+    }
+
+    #[test]
+    fn codex_prompt_cache_identity_headers_are_terminal_after_routing_mutations() {
+        let mut input = sample_decision_input();
+        input
+            .routing_context
+            .as_mut()
+            .expect("routing context")
+            .client_api_format = "openai:responses".to_string();
+        set_provider_request_rules(
+            &mut input,
+            &["gpt-5"],
+            json!([{
+                "type": "patch_headers",
+                "patch": [
+                    {"op": "remove", "name": "session-id"},
+                    {"op": "remove", "name": "thread-id"}
+                ]
+            }]),
+        );
+        let identity = "172c39e6-c0a0-5a70-8b63-e0f8e0d185a3";
+        let mut decision = sample_decision();
+        decision.provider_type = Some("codex".to_string());
+        decision.provider_api_format = Some("openai:responses".to_string());
+        decision.client_api_format = Some("openai:responses".to_string());
+        decision.provider_request_body = Some(json!({
+            "model": "gpt-5",
+            "input": [],
+            "prompt_cache_key": identity,
+            "client_metadata": {
+                "session_id": identity,
+                "thread_id": identity
+            }
+        }));
+        assert!(!decision.provider_request_headers.contains_key("session-id"));
+        assert!(!decision.provider_request_headers.contains_key("thread-id"));
+
+        apply_provider_request_routing_policy_to_decision(&input, &mut decision, None)
+            .expect("terminal Codex identity contract should be restored");
+
+        assert_eq!(
+            decision
+                .provider_request_headers
+                .get("session-id")
+                .map(String::as_str),
+            Some(identity)
+        );
+        assert_eq!(
+            decision
+                .provider_request_headers
+                .get("thread-id")
+                .map(String::as_str),
+            Some(identity)
+        );
+    }
+
+    #[test]
+    fn codex_prompt_cache_identity_headers_fail_closed_after_body_identity_removal() {
+        let mut input = sample_decision_input();
+        input
+            .routing_context
+            .as_mut()
+            .expect("routing context")
+            .client_api_format = "openai:responses".to_string();
+        set_provider_request_rules(
+            &mut input,
+            &["gpt-5"],
+            json!([{
+                "type": "json_patch_body",
+                "patch": [
+                    {"op": "remove", "path": "/prompt_cache_key"},
+                    {"op": "remove", "path": "/client_metadata"}
+                ]
+            }]),
+        );
+        let identity = "172c39e6-c0a0-5a70-8b63-e0f8e0d185a3";
+        let mut decision = sample_decision();
+        decision.provider_type = Some("codex".to_string());
+        decision.provider_api_format = Some("openai:responses".to_string());
+        decision.client_api_format = Some("openai:responses".to_string());
+        decision.provider_request_body = Some(json!({
+            "model": "gpt-5",
+            "input": [],
+            "prompt_cache_key": identity,
+            "client_metadata": {
+                "session_id": identity,
+                "thread_id": identity
+            }
+        }));
+        assert!(!decision.provider_request_headers.contains_key("session-id"));
+        assert!(!decision.provider_request_headers.contains_key("thread-id"));
+
+        apply_provider_request_routing_policy_to_decision(&input, &mut decision, None)
+            .expect("terminal Codex identity contract should fail closed");
+
+        let body = decision.provider_request_body.as_ref().expect("body");
+        assert!(body.get("prompt_cache_key").is_none());
+        assert!(body.get("client_metadata").is_none());
+        assert!(!decision.provider_request_headers.contains_key("session-id"));
+        assert!(!decision.provider_request_headers.contains_key("thread-id"));
     }
 
     #[test]

--- a/apps/aether-gateway/src/ai_serving/planner/standard/codex.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/codex.rs
@@ -3,7 +3,8 @@
 mod tests;
 
 pub(crate) use crate::ai_serving::{
-    apply_codex_openai_responses_special_body_edits, apply_codex_openai_special_headers,
+    apply_codex_openai_responses_identity_headers, apply_codex_openai_responses_special_body_edits,
+    apply_codex_openai_special_headers,
 };
 
 pub(crate) fn codex_model_capabilities_for_transport(

--- a/apps/aether-gateway/src/ai_serving/planner/standard/codex/tests.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/codex/tests.rs
@@ -4,7 +4,9 @@ use super::{
     apply_codex_openai_responses_special_body_edits, apply_codex_openai_special_headers,
     codex_model_capabilities,
 };
-use crate::ai_serving::planner::standard::build_local_openai_responses_request_body;
+use crate::ai_serving::planner::standard::{
+    build_cross_format_openai_responses_request_body, build_local_openai_responses_request_body,
+};
 use http::{HeaderMap, HeaderValue};
 use serde_json::json;
 
@@ -180,11 +182,11 @@ fn does_not_synthesize_prompt_cache_key_from_api_key_identity() {
 }
 
 #[test]
-fn keeps_existing_prompt_cache_key_for_codex_requests() {
+fn adapts_generic_prompt_cache_key_to_codex_native_identity() {
     let mut body = json!({
         "model": "gpt-5",
         "input": "hello",
-        "prompt_cache_key": "existing-key",
+        "prompt_cache_key": "ltm-pc-v2-5557e02f5c9b447a97673ba330dbe77a",
     });
 
     apply_codex_openai_responses_special_body_edits(
@@ -195,7 +197,222 @@ fn keeps_existing_prompt_cache_key_for_codex_requests() {
         Some("key-123"),
     );
 
-    assert_eq!(body["prompt_cache_key"], "existing-key");
+    let expected_identity = "d9c5d122-7c1c-5fb1-ba9d-656062eda44e";
+    assert_eq!(body["prompt_cache_key"], expected_identity);
+    assert_eq!(body["client_metadata"]["session_id"], expected_identity);
+    assert_eq!(body["client_metadata"]["thread_id"], expected_identity);
+}
+
+#[test]
+fn preserves_native_codex_cache_identity_and_metadata() {
+    let mut body = json!({
+        "model": "gpt-5",
+        "input": "hello",
+        "prompt_cache_key": "guardian:parent-thread",
+        "client_metadata": {
+            "session_id": "native-session",
+            "thread_id": "native-thread",
+            "turn_id": "native-turn"
+        }
+    });
+    let expected = body.clone();
+
+    apply_codex_openai_responses_special_body_edits(
+        &mut body,
+        "codex",
+        "openai:responses",
+        None,
+        Some("key-123"),
+    );
+
+    assert_eq!(body["prompt_cache_key"], expected["prompt_cache_key"]);
+    assert_eq!(body["client_metadata"], expected["client_metadata"]);
+}
+
+#[test]
+fn preserves_uuid_prompt_cache_key_while_completing_codex_identity() {
+    let identity = "172c39e6-c0a0-5a70-8b63-e0f8e0d185a3";
+    let mut body = json!({
+        "model": "gpt-5.6-luna",
+        "input": "hello",
+        "prompt_cache_key": identity
+    });
+
+    apply_codex_openai_responses_special_body_edits(
+        &mut body,
+        "codex",
+        "openai:responses",
+        None,
+        None,
+    );
+
+    assert_eq!(body["prompt_cache_key"], identity);
+    assert_eq!(body["client_metadata"]["session_id"], identity);
+    assert_eq!(body["client_metadata"]["thread_id"], identity);
+}
+
+#[test]
+fn keeps_codex_prompt_cache_domains_distinct() {
+    let mut first = json!({
+        "model": "gpt-5.6-luna",
+        "input": "hello",
+        "prompt_cache_key": "tenant-a"
+    });
+    let mut second = json!({
+        "model": "gpt-5.6-luna",
+        "input": "hello",
+        "prompt_cache_key": "tenant-b"
+    });
+
+    for body in [&mut first, &mut second] {
+        apply_codex_openai_responses_special_body_edits(
+            body,
+            "codex",
+            "openai:responses",
+            None,
+            None,
+        );
+    }
+
+    assert_ne!(first["prompt_cache_key"], second["prompt_cache_key"]);
+    assert_eq!(
+        first["prompt_cache_key"],
+        first["client_metadata"]["session_id"]
+    );
+    assert_eq!(
+        second["prompt_cache_key"],
+        second["client_metadata"]["session_id"]
+    );
+}
+
+#[test]
+fn completes_partial_and_null_codex_client_metadata() {
+    let mut partial = json!({
+        "model": "gpt-5.6-luna",
+        "input": "hello",
+        "prompt_cache_key": "generic-affinity",
+        "client_metadata": {
+            "thread_id": "native-thread",
+            "caller": "sdk"
+        }
+    });
+    let mut null_metadata = json!({
+        "model": "gpt-5.6-luna",
+        "input": "hello",
+        "prompt_cache_key": "generic-affinity",
+        "client_metadata": null
+    });
+
+    for body in [&mut partial, &mut null_metadata] {
+        apply_codex_openai_responses_special_body_edits(
+            body,
+            "codex",
+            "openai:responses",
+            None,
+            None,
+        );
+    }
+
+    assert_eq!(partial["client_metadata"]["thread_id"], "native-thread");
+    assert_eq!(partial["client_metadata"]["caller"], "sdk");
+    assert_eq!(
+        partial["client_metadata"]["session_id"],
+        partial["prompt_cache_key"]
+    );
+    assert_eq!(
+        null_metadata["client_metadata"]["session_id"],
+        null_metadata["prompt_cache_key"]
+    );
+    assert_eq!(
+        null_metadata["client_metadata"]["thread_id"],
+        null_metadata["prompt_cache_key"]
+    );
+}
+
+#[test]
+fn leaves_malformed_codex_client_metadata_unchanged() {
+    let mut body = json!({
+        "model": "gpt-5.6-luna",
+        "input": "hello",
+        "prompt_cache_key": "generic-affinity",
+        "client_metadata": "invalid"
+    });
+
+    apply_codex_openai_responses_special_body_edits(
+        &mut body,
+        "codex",
+        "openai:responses",
+        None,
+        None,
+    );
+
+    assert_eq!(body["prompt_cache_key"], "generic-affinity");
+    assert_eq!(body["client_metadata"], "invalid");
+}
+
+#[test]
+fn limits_prompt_cache_identity_adaptation_to_codex_responses_family() {
+    let original = json!({
+        "model": "gpt-5.6-luna",
+        "input": "hello",
+        "prompt_cache_key": "generic-affinity"
+    });
+    let mut standard_openai = original.clone();
+    let mut codex_compact = original.clone();
+
+    apply_codex_openai_responses_special_body_edits(
+        &mut standard_openai,
+        "openai",
+        "openai:responses",
+        None,
+        None,
+    );
+    apply_codex_openai_responses_special_body_edits(
+        &mut codex_compact,
+        "codex",
+        "openai:responses:compact",
+        None,
+        None,
+    );
+
+    assert_eq!(standard_openai, original);
+    assert_ne!(codex_compact["prompt_cache_key"], "generic-affinity");
+    assert!(codex_compact.get("client_metadata").is_none());
+}
+
+#[test]
+fn chat_to_codex_responses_adapts_prompt_cache_identity_end_to_end() {
+    let body = json!({
+        "model": "gpt-5.6-luna",
+        "messages": [{"role": "user", "content": "hello"}],
+        "prompt_cache_key": "ltm-pc-v2-5557e02f5c9b447a97673ba330dbe77a"
+    });
+
+    let provider_request_body = build_cross_format_openai_responses_request_body(
+        &body,
+        "gpt-5.6-luna",
+        "openai:chat",
+        "openai:responses",
+        true,
+        false,
+        "codex",
+        None,
+        None,
+        &HeaderMap::new(),
+        false,
+    )
+    .expect("chat to Codex Responses request should build");
+
+    let expected_identity = "d9c5d122-7c1c-5fb1-ba9d-656062eda44e";
+    assert_eq!(provider_request_body["prompt_cache_key"], expected_identity);
+    assert_eq!(
+        provider_request_body["client_metadata"]["session_id"],
+        expected_identity
+    );
+    assert_eq!(
+        provider_request_body["client_metadata"]["thread_id"],
+        expected_identity
+    );
 }
 
 #[test]

--- a/apps/aether-gateway/src/ai_serving/planner/standard/codex/tests.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/codex/tests.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use super::{
-    apply_codex_openai_responses_special_body_edits, apply_codex_openai_special_headers,
-    codex_model_capabilities,
+    apply_codex_openai_responses_identity_headers, apply_codex_openai_responses_special_body_edits,
+    apply_codex_openai_special_headers, codex_model_capabilities,
 };
 use crate::ai_serving::planner::standard::{
     build_cross_format_openai_responses_request_body, build_local_openai_responses_request_body,
@@ -302,8 +302,18 @@ fn completes_partial_and_null_codex_client_metadata() {
         "prompt_cache_key": "generic-affinity",
         "client_metadata": null
     });
+    let mut null_session = json!({
+        "model": "gpt-5.6-luna",
+        "input": "hello",
+        "prompt_cache_key": "generic-affinity",
+        "client_metadata": {
+            "session_id": null,
+            "thread_id": null,
+            "caller": "sdk"
+        }
+    });
 
-    for body in [&mut partial, &mut null_metadata] {
+    for body in [&mut partial, &mut null_metadata, &mut null_session] {
         apply_codex_openai_responses_special_body_edits(
             body,
             "codex",
@@ -327,6 +337,15 @@ fn completes_partial_and_null_codex_client_metadata() {
         null_metadata["client_metadata"]["thread_id"],
         null_metadata["prompt_cache_key"]
     );
+    assert_eq!(
+        null_session["client_metadata"]["session_id"],
+        null_session["prompt_cache_key"]
+    );
+    assert_eq!(
+        null_session["client_metadata"]["thread_id"],
+        null_session["prompt_cache_key"]
+    );
+    assert_eq!(null_session["client_metadata"]["caller"], "sdk");
 }
 
 #[test]
@@ -337,17 +356,34 @@ fn leaves_malformed_codex_client_metadata_unchanged() {
         "prompt_cache_key": "generic-affinity",
         "client_metadata": "invalid"
     });
+    let mut malformed_fields = json!({
+        "model": "gpt-5.6-luna",
+        "input": "hello",
+        "prompt_cache_key": "generic-affinity",
+        "client_metadata": {
+            "session_id": 42,
+            "thread_id": ""
+        }
+    });
+    let expected_malformed_metadata = malformed_fields["client_metadata"].clone();
 
-    apply_codex_openai_responses_special_body_edits(
-        &mut body,
-        "codex",
-        "openai:responses",
-        None,
-        None,
-    );
+    for candidate in [&mut body, &mut malformed_fields] {
+        apply_codex_openai_responses_special_body_edits(
+            candidate,
+            "codex",
+            "openai:responses",
+            None,
+            None,
+        );
+    }
 
     assert_eq!(body["prompt_cache_key"], "generic-affinity");
     assert_eq!(body["client_metadata"], "invalid");
+    assert_eq!(malformed_fields["prompt_cache_key"], "generic-affinity");
+    assert_eq!(
+        malformed_fields["client_metadata"],
+        expected_malformed_metadata
+    );
 }
 
 #[test]
@@ -413,10 +449,39 @@ fn chat_to_codex_responses_adapts_prompt_cache_identity_end_to_end() {
         provider_request_body["client_metadata"]["thread_id"],
         expected_identity
     );
+
+    let mut provider_request_headers = BTreeMap::new();
+    apply_codex_openai_special_headers(
+        &mut provider_request_headers,
+        &provider_request_body,
+        &HeaderMap::new(),
+        "codex",
+        "openai:responses",
+        Some("trace-codex-cache-identity"),
+        None,
+    );
+    apply_codex_openai_responses_identity_headers(
+        &mut provider_request_headers,
+        &provider_request_body,
+        "codex",
+        "openai:responses",
+    );
+    assert_eq!(
+        provider_request_headers
+            .get("session-id")
+            .map(String::as_str),
+        Some(expected_identity)
+    );
+    assert_eq!(
+        provider_request_headers
+            .get("thread-id")
+            .map(String::as_str),
+        Some(expected_identity)
+    );
 }
 
 #[test]
-fn injects_identity_headers_without_deriving_session_headers_from_body() {
+fn projects_uuid_prompt_cache_identity_into_missing_session_headers() {
     let mut headers = BTreeMap::new();
     let body = json!({
         "model": "gpt-5",
@@ -432,7 +497,7 @@ fn injects_identity_headers_without_deriving_session_headers_from_body() {
         Some("trace-codex-123"),
         Some(r#"{"account_id":"acc-123","is_fedramp":true}"#),
     );
-
+    apply_codex_openai_responses_identity_headers(&mut headers, &body, "codex", "openai:responses");
     assert_eq!(
         headers.get("chatgpt-account-id"),
         Some(&"acc-123".to_string())
@@ -445,8 +510,88 @@ fn injects_identity_headers_without_deriving_session_headers_from_body() {
     assert_eq!(headers.get("originator"), Some(&"codex_cli_rs".to_string()));
     assert!(!headers.contains_key("version"));
     assert_eq!(headers.get("x-openai-fedramp"), Some(&"true".to_string()));
-    assert_eq!(headers.get("session-id"), None);
-    assert_eq!(headers.get("thread-id"), None);
+    assert_eq!(
+        headers.get("session-id").map(String::as_str),
+        Some("172c39e6-c0a0-5a70-8b63-e0f8e0d185a3")
+    );
+    assert_eq!(
+        headers.get("thread-id").map(String::as_str),
+        Some("172c39e6-c0a0-5a70-8b63-e0f8e0d185a3")
+    );
+}
+
+#[test]
+fn projects_native_codex_metadata_for_non_uuid_cache_overrides() {
+    let mut headers = BTreeMap::new();
+    let body = json!({
+        "model": "gpt-5.6-luna",
+        "prompt_cache_key": "guardian:parent-thread",
+        "client_metadata": {
+            "session_id": "019f687b-8e92-7842-9631-d5bf0dba0a3b",
+            "thread_id": "019f6d20-1111-7222-8333-444455556666"
+        }
+    });
+
+    apply_codex_openai_special_headers(
+        &mut headers,
+        &body,
+        &HeaderMap::new(),
+        "codex",
+        "openai:responses",
+        None,
+        None,
+    );
+    apply_codex_openai_responses_identity_headers(&mut headers, &body, "codex", "openai:responses");
+
+    assert_eq!(
+        headers.get("session-id").map(String::as_str),
+        Some("019f687b-8e92-7842-9631-d5bf0dba0a3b")
+    );
+    assert_eq!(
+        headers.get("thread-id").map(String::as_str),
+        Some("019f6d20-1111-7222-8333-444455556666")
+    );
+}
+
+#[test]
+fn leaves_non_native_cache_keys_out_of_identity_headers() {
+    let mut headers = BTreeMap::new();
+    let body = json!({
+        "model": "gpt-5.6-luna",
+        "prompt_cache_key": "generic-cache-key"
+    });
+
+    apply_codex_openai_special_headers(
+        &mut headers,
+        &body,
+        &HeaderMap::new(),
+        "codex",
+        "openai:responses",
+        None,
+        None,
+    );
+    apply_codex_openai_responses_identity_headers(&mut headers, &body, "codex", "openai:responses");
+
+    assert!(!headers.contains_key("session-id"));
+    assert!(!headers.contains_key("thread-id"));
+}
+
+#[test]
+fn leaves_malformed_native_metadata_out_of_identity_headers() {
+    let mut headers = BTreeMap::new();
+    let body = json!({
+        "model": "gpt-5.6-luna",
+        "prompt_cache_key": "172c39e6-c0a0-5a70-8b63-e0f8e0d185a3",
+        "client_metadata": {
+            "session_id": 42,
+            "thread_id": ""
+        }
+    });
+
+    apply_codex_openai_responses_identity_headers(&mut headers, &body, "codex", "openai:responses");
+
+    assert!(!headers.contains_key("session-id"));
+    assert!(!headers.contains_key("thread-id"));
 }
 
 #[test]
@@ -464,7 +609,6 @@ fn injects_only_codex_client_headers_for_images_requests() {
         Some("trace-codex-image-123"),
         Some(r#"{"account_id":"acc-123","is_fedramp":true}"#),
     );
-
     assert_eq!(
         headers.get("chatgpt-account-id"),
         Some(&"acc-123".to_string())
@@ -547,6 +691,7 @@ fn preserves_client_context_headers_and_enforces_codex_provider_identity() {
         Some("trace-codex-123"),
         Some(r#"{"account_id":"acc-123","is_fedramp":true}"#),
     );
+    apply_codex_openai_responses_identity_headers(&mut headers, &body, "codex", "openai:responses");
 
     assert_eq!(
         headers.get("x-client-request-id"),
@@ -588,7 +733,7 @@ fn preserves_client_context_headers_and_enforces_codex_provider_identity() {
 }
 
 #[test]
-fn compact_does_not_derive_session_headers_from_body() {
+fn compact_projects_uuid_prompt_cache_identity_into_session_headers() {
     let mut headers = BTreeMap::new();
     let body = json!({
         "model": "gpt-5",
@@ -604,6 +749,12 @@ fn compact_does_not_derive_session_headers_from_body() {
         Some("trace-codex-compact-123"),
         Some(r#"{"account_id":"acc-123","is_fedramp":true}"#),
     );
+    apply_codex_openai_responses_identity_headers(
+        &mut headers,
+        &body,
+        "codex",
+        "openai:responses:compact",
+    );
 
     assert_eq!(
         headers.get("chatgpt-account-id"),
@@ -617,6 +768,12 @@ fn compact_does_not_derive_session_headers_from_body() {
     assert_eq!(headers.get("originator"), Some(&"codex_cli_rs".to_string()));
     assert!(!headers.contains_key("version"));
     assert_eq!(headers.get("x-openai-fedramp"), Some(&"true".to_string()));
-    assert_eq!(headers.get("session-id"), None);
-    assert_eq!(headers.get("thread-id"), None);
+    assert_eq!(
+        headers.get("session-id").map(String::as_str),
+        Some("172c39e6-c0a0-5a70-8b63-e0f8e0d185a3")
+    );
+    assert_eq!(
+        headers.get("thread-id").map(String::as_str),
+        Some("172c39e6-c0a0-5a70-8b63-e0f8e0d185a3")
+    );
 }

--- a/apps/aether-gateway/src/ai_serving/pure/mod.rs
+++ b/apps/aether-gateway/src/ai_serving/pure/mod.rs
@@ -4,6 +4,7 @@ pub(crate) use aether_ai_formats::api::{
     aggregate_standard_chat_stream_sync_response, aggregate_standard_cli_stream_sync_response,
     api_format_alias_matches, api_format_storage_aliases,
     apply_codex_openai_compact_terminal_headers, apply_codex_openai_responses_chat_body_edits,
+    apply_codex_openai_responses_identity_headers,
     apply_codex_openai_responses_lite_header_for_request_body_with_capabilities,
     apply_codex_openai_responses_lite_header_with_capabilities,
     apply_codex_openai_responses_special_body_edits,

--- a/apps/aether-gateway/src/tests/ai_execute/stream_cli/compact.rs
+++ b/apps/aether-gateway/src/tests/ai_execute/stream_cli/compact.rs
@@ -657,7 +657,8 @@ async fn gateway_executes_openai_responses_compact_as_unary_request_impl() {
     );
     assert_eq!(
         seen_execution_runtime_request.body["prompt_cache_key"],
-        json!("session:compact-e2e")
+        // Compact omits client_metadata, but keeps the same deterministic Codex cache identity.
+        json!("f3eb8726-b7b2-56c5-90b5-8789d628c8cf")
     );
     assert_eq!(
         seen_execution_runtime_request.proxy_node_id,

--- a/crates/aether-ai/formats/src/api.rs
+++ b/crates/aether-ai/formats/src/api.rs
@@ -173,6 +173,7 @@ pub use crate::formats::{
             codex::{
                 apply_codex_openai_compact_terminal_headers,
                 apply_codex_openai_responses_chat_body_edits,
+                apply_codex_openai_responses_identity_headers,
                 apply_codex_openai_responses_lite_header_for_request_body_with_capabilities,
                 apply_codex_openai_responses_lite_header_with_capabilities,
                 apply_codex_openai_responses_special_body_edits,

--- a/crates/aether-ai/formats/src/formats/openai/responses/codex.rs
+++ b/crates/aether-ai/formats/src/formats/openai/responses/codex.rs
@@ -7,6 +7,8 @@ use serde_json::{json, Value};
 
 const CODEX_DEFAULT_REASONING_EFFORT: &str = "medium";
 const CODEX_REASONING_ENCRYPTED_CONTENT_INCLUDE: &str = "reasoning.encrypted_content";
+const CODEX_PROMPT_CACHE_IDENTITY_NAMESPACE: &str =
+    "https://github.com/fawney19/Aether/codex/prompt-cache-identity/v1/";
 pub const CODEX_RESPONSES_LITE_HEADER: &str = "x-openai-internal-codex-responses-lite";
 pub const CODEX_MODEL_CATALOG_METADATA_FIELD: &str = "codex_models";
 const CODEX_OPENAI_RESPONSES_UNSUPPORTED_BODY_FIELDS: &[&str] = &[
@@ -1466,6 +1468,58 @@ fn wrap_codex_responses_string_input_for_backend(
     );
 }
 
+fn adapt_codex_prompt_cache_identity_for_backend(body_object: &mut serde_json::Map<String, Value>) {
+    // The Codex backend scopes prompt caching through client_metadata.session_id, while the
+    // standard OpenAI contract permits arbitrary prompt_cache_key strings. Adapt only requests
+    // that carry a cache key but do not already carry a native Codex session identity.
+    let Some(prompt_cache_key) = body_object
+        .get("prompt_cache_key")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+    else {
+        return;
+    };
+
+    match body_object.get("client_metadata") {
+        Some(Value::Object(metadata)) if metadata.contains_key("session_id") => return,
+        Some(Value::Object(_) | Value::Null) | None => {}
+        Some(_) => return,
+    }
+
+    let cache_identity = uuid::Uuid::parse_str(&prompt_cache_key)
+        .unwrap_or_else(|_| {
+            uuid::Uuid::new_v5(
+                &uuid::Uuid::NAMESPACE_URL,
+                format!("{CODEX_PROMPT_CACHE_IDENTITY_NAMESPACE}{prompt_cache_key}").as_bytes(),
+            )
+        })
+        .to_string();
+
+    {
+        let metadata = body_object
+            .entry("client_metadata".to_string())
+            .or_insert_with(|| json!({}));
+        if metadata.is_null() {
+            *metadata = json!({});
+        }
+        let Some(metadata) = metadata.as_object_mut() else {
+            return;
+        };
+        metadata
+            .entry("session_id".to_string())
+            .or_insert_with(|| Value::String(cache_identity.clone()));
+        metadata
+            .entry("thread_id".to_string())
+            .or_insert_with(|| Value::String(cache_identity.clone()));
+    }
+
+    body_object.insert(
+        "prompt_cache_key".to_string(),
+        Value::String(cache_identity),
+    );
+}
+
 pub fn apply_codex_openai_responses_special_body_edits(
     provider_request_body: &mut Value,
     provider_type: &str,
@@ -1532,6 +1586,7 @@ pub fn apply_codex_openai_responses_special_body_edits_with_source_model_and_cap
             body_object.remove(*field);
         }
     }
+    adapt_codex_prompt_cache_identity_for_backend(body_object);
     if is_openai_responses_compact_request(provider_api_format) {
         body_object.remove("store");
     } else if !body_rules_handle_path(body_rules, "store") {

--- a/crates/aether-ai/formats/src/formats/openai/responses/codex.rs
+++ b/crates/aether-ai/formats/src/formats/openai/responses/codex.rs
@@ -1468,10 +1468,17 @@ fn wrap_codex_responses_string_input_for_backend(
     );
 }
 
+fn non_empty_json_string(value: Option<&Value>) -> Option<&str> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
 fn adapt_codex_prompt_cache_identity_for_backend(body_object: &mut serde_json::Map<String, Value>) {
-    // The Codex backend scopes prompt caching through client_metadata.session_id, while the
-    // standard OpenAI contract permits arbitrary prompt_cache_key strings. Adapt only requests
-    // that carry a cache key but do not already carry a native Codex session identity.
+    // The standard OpenAI contract permits arbitrary prompt_cache_key strings, while the Codex
+    // backend's native session identity is UUID-shaped. Adapt only requests that carry a cache key
+    // but do not already carry a native Codex session identity.
     let Some(prompt_cache_key) = body_object
         .get("prompt_cache_key")
         .and_then(Value::as_str)
@@ -1482,8 +1489,19 @@ fn adapt_codex_prompt_cache_identity_for_backend(body_object: &mut serde_json::M
     };
 
     match body_object.get("client_metadata") {
-        Some(Value::Object(metadata)) if metadata.contains_key("session_id") => return,
-        Some(Value::Object(_) | Value::Null) | None => {}
+        Some(Value::Object(metadata)) => {
+            match metadata.get("session_id") {
+                Some(Value::String(session_id)) if !session_id.trim().is_empty() => return,
+                None | Some(Value::Null) => {}
+                Some(_) => return,
+            }
+            match metadata.get("thread_id") {
+                None | Some(Value::Null) => {}
+                Some(Value::String(thread_id)) if !thread_id.trim().is_empty() => {}
+                Some(_) => return,
+            }
+        }
+        Some(Value::Null) | None => {}
         Some(_) => return,
     }
 
@@ -1506,18 +1524,90 @@ fn adapt_codex_prompt_cache_identity_for_backend(body_object: &mut serde_json::M
         let Some(metadata) = metadata.as_object_mut() else {
             return;
         };
-        metadata
-            .entry("session_id".to_string())
-            .or_insert_with(|| Value::String(cache_identity.clone()));
-        metadata
-            .entry("thread_id".to_string())
-            .or_insert_with(|| Value::String(cache_identity.clone()));
+        metadata.insert(
+            "session_id".to_string(),
+            Value::String(cache_identity.clone()),
+        );
+        if metadata.get("thread_id").is_none_or(Value::is_null) {
+            metadata.insert(
+                "thread_id".to_string(),
+                Value::String(cache_identity.clone()),
+            );
+        }
     }
 
     body_object.insert(
         "prompt_cache_key".to_string(),
         Value::String(cache_identity),
     );
+}
+
+fn valid_codex_identity_header(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() || value.parse::<http::HeaderValue>().is_err() {
+        return None;
+    }
+    Some(value.to_string())
+}
+
+fn codex_prompt_cache_header_identity(provider_request_body: &Value) -> Option<(String, String)> {
+    let prompt_cache_key = non_empty_json_string(provider_request_body.get("prompt_cache_key"))?;
+
+    match provider_request_body.get("client_metadata") {
+        Some(Value::Object(metadata)) => match metadata.get("session_id") {
+            Some(Value::String(session_id)) if !session_id.trim().is_empty() => {
+                let session_id = valid_codex_identity_header(session_id)?;
+                let thread_id = match metadata.get("thread_id") {
+                    None | Some(Value::Null) => session_id.clone(),
+                    Some(Value::String(thread_id)) if !thread_id.trim().is_empty() => {
+                        valid_codex_identity_header(thread_id)?
+                    }
+                    Some(_) => return None,
+                };
+                return Some((session_id, thread_id));
+            }
+            None | Some(Value::Null) => {}
+            Some(_) => return None,
+        },
+        Some(Value::Null) | None => {}
+        Some(_) => return None,
+    }
+
+    let cache_identity = uuid::Uuid::parse_str(prompt_cache_key).ok()?.to_string();
+    Some((cache_identity.clone(), cache_identity))
+}
+
+fn insert_btree_header_if_missing(
+    headers: &mut BTreeMap<String, String>,
+    header_name: &str,
+    header_value: String,
+) {
+    if headers.iter().any(|(name, value)| {
+        name.trim().eq_ignore_ascii_case(header_name) && !value.trim().is_empty()
+    }) {
+        return;
+    }
+    remove_btree_header(headers, header_name);
+    headers.insert(header_name.to_string(), header_value);
+}
+
+pub fn apply_codex_openai_responses_identity_headers(
+    provider_request_headers: &mut BTreeMap<String, String>,
+    provider_request_body: &Value,
+    provider_type: &str,
+    provider_api_format: &str,
+) {
+    // Codex projects its body session identity into compatibility HTTP headers. Existing explicit
+    // headers remain authoritative; only missing values are completed here.
+    if !is_codex_openai_responses_request(provider_type, provider_api_format) {
+        return;
+    }
+    let Some((session_id, thread_id)) = codex_prompt_cache_header_identity(provider_request_body)
+    else {
+        return;
+    };
+    insert_btree_header_if_missing(provider_request_headers, "session-id", session_id);
+    insert_btree_header_if_missing(provider_request_headers, "thread-id", thread_id);
 }
 
 pub fn apply_codex_openai_responses_special_body_edits(


### PR DESCRIPTION
## 问题

标准 OpenAI Responses 允许调用方使用任意稳定字符串作为 `prompt_cache_key`。Aether 的 Codex provider 原先只透传该字段；当请求没有完整的 Codex 原生会话身份时，上游会为每次请求生成新的 UUID，使相同请求落入不同缓存域。

现场中两次完全相同、间隔 8 秒的请求具有相同的模型、provider、endpoint、账号、输入 token、出站正文 SHA-256 和 `prompt_cache_key`，但上游分别返回不同 UUID，且两次 `cache_write_tokens/cached_tokens` 均为 0。

进一步在现有 live 上做受控变量实验：仅补充稳定且相同的 HTTP `session-id` / `thread-id` 后，上游连续两次保持同一 UUID；把超过缓存门槛的稳定共享前缀放入 `instructions` 后，第二次请求得到 `cached_tokens=3840`。因此问题不是普通前缀不一致，也不是 Aether 丢失 `prompt_cache_key`，而是 Codex provider 缺少完整的原生 wire identity 适配。

## 根因

OpenAI Codex 客户端默认以 `session_id` 作为 `prompt_cache_key`，同时在正文发送 `client_metadata.session_id/thread_id`，并在 HTTP 请求头发送 `session-id/thread-id`。Aether 已完成“通用缓存键透传”，但没有在 Codex provider 的最终出站请求上完成“通用缓存亲和身份 → Codex 原生正文与请求头身份”的统一投影。

只修正文会留下生命周期缺口：路由规则仍可能在随后改写 provider body。请求头必须从最终正文派生，并在所有终态返回路径统一执行，才能避免正文与请求头身份漂移。

## 修复

- 严格限定在 Codex OpenAI Responses family；标准 OpenAI、Gemini、Vertex 及通用 transport 行为不变。
- 请求已有 `prompt_cache_key`、但没有有效原生 `client_metadata.session_id` 时：
  - 合法 UUID 保持原值；
  - 其他非空字符串通过固定 namespace 的 UUID v5 确定性映射；
  - 统一写入最终 `prompt_cache_key`、`client_metadata.session_id`，并仅在缺失时补齐 `thread_id`。
- 已有有效的原生 `session_id/thread_id/turn_id` 完全保留，不覆盖 Guardian、子线程或调用方明确身份。
- 在 provider routing 完成并重新 finalize 最终正文后，统一把最终 Codex 身份投影到缺失的 HTTP `session-id/thread-id`；显式非空请求头保持最高优先级。
- 无 routing context、空 routing policy、routing mutation 三个终态路径使用同一 owner；预路由阶段不生成自动身份请求头，避免 stale header。
- Regular Responses 与 Compact 复用同一确定性缓存身份；Compact 继续遵守既有 wire schema 投影。
- malformed/空身份 fail closed，不猜测或修复其他契约错误；调用方未提供缓存键时行为不变。
- 不合成 `x-client-request-id`：受控实验已经证明缓存复用只需要稳定的 Codex session/thread identity，避免扩大最小必要变更。

## 官方契约依据

- OpenAI Prompt Caching 文档允许标准 API 使用任意字符串 key，缓存要求精确前缀匹配且输入不少于 1024 tokens；因此不能在标准 OpenAI 链路全局强制 UUID：<https://developers.openai.com/api/docs/guides/prompt-caching>
- Codex 当前实现把 session identity 同时投影到正文 metadata 和 HTTP session/thread headers：
  - <https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/core/src/client.rs#L462-L474>
  - <https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/core/src/client.rs#L889-L906>
  - <https://github.com/openai/codex/blob/315195492c80fdade38e917c18f9584efd599304/codex-rs/codex-api/src/endpoint/responses.rs#L70-L96>

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -q -p aether-ai-formats`：728/728
- `cargo test -q -p aether-gateway --lib ai_serving::planner::standard`：71/71
- `cargo test -q -p aether-gateway --lib ai_serving::planner::decision_input::tests`：10/10
- `cargo check -q -p aether-ai-formats --tests`
- `cargo check -q -p aether-gateway --tests`
- `cargo clippy -q -p aether-ai-formats -p aether-gateway --lib --tests -- -D warnings`：通过，0 warning

新增回归覆盖通用字符串稳定映射、UUID 原值保留、缓存域隔离、原生 metadata/header 优先级、partial/null/malformed metadata、Chat Completions → Codex Responses 完整转换、路由删除身份后的终态一致性、标准 OpenAI 零影响，以及 Regular/Compact 身份一致性。

本 PR 不顺带放开 `prompt_cache_options` / `prompt_cache_retention`。它们是独立的 Codex 上游能力与 wire schema 决策，不是本次身份逐次替换的根因；在没有相应上游契约证据前保持现状，避免把独立兼容议题混入根因修复。
