### PR TITLE
feat(models): add dedicated catalog proxy(为外部模型目录增加独立代理配置)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,11 @@ ADMIN_USERNAME=admin123456
 # Docker/Nginx 位于独立容器时，请按实际容器网络设置，例如：172.16.0.0/12。
 # AETHER_TRUSTED_PROXY_CIDRS=127.0.0.0/8,::1/128,172.16.0.0/12
 
+# 模型管理的外部模型目录，默认从 https://models.dev/api.json 拉取并缓存 15 分钟。
+# 可为该请求单独设置出站代理，不影响 Provider 或其他 Gateway 请求。
+# AETHER_GATEWAY_EXTERNAL_MODELS_URL=https://models.dev/api.json
+# AETHER_GATEWAY_EXTERNAL_MODELS_PROXY=http://proxy:7890
+
 # docker compose 下 app 启动前自动执行 pending migration/backfill（默认 true）
 # AETHER_GATEWAY_AUTO_PREPARE_DATABASE=true
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Aether Tunnel 是配套的正向代理节点，部署在海外 VPS 上，为墙�
 - `REDIS_URL`：Redis 连接串；仅 Postgres + Redis 的 Docker Compose 部署需要配置
 - `AETHER_RUNTIME_BACKEND=memory|redis`：运行时缓存/协调后端。SQLite 默认用 `memory`，不会连接 Redis
 - `AETHER_GATEWAY_AUTO_PREPARE_DATABASE`：常规启动前自动执行挂起的 schema migration 和 backfill；仓库自带的 `docker-compose.yml` 默认开启
+- `AETHER_GATEWAY_EXTERNAL_MODELS_URL`：模型管理使用的外部模型目录，默认 `https://models.dev/api.json`
+- `AETHER_GATEWAY_EXTERNAL_MODELS_PROXY`：仅用于拉取外部模型目录的出站代理，例如同一 Docker 网络中的 `http://proxy:7890`；不影响 Provider 或其他 Gateway 请求，也不复用 `AETHER_UPDATE_PROXY_URL`
 - `JWT_SECRET_KEY` / `ENCRYPTION_KEY`：认证和敏感数据加密所需密钥
 - `API_KEY_PREFIX`：用户和管理员新建 API Key 时使用的前缀，默认 `sk`
 - `ADMIN_USERNAME` / `ADMIN_PASSWORD` / `ADMIN_EMAIL`：首次启动时自举首个本地管理员；`install.sh` 会提示输入管理员密码

--- a/apps/aether-gateway/src/handlers/admin/model/external_cache.rs
+++ b/apps/aether-gateway/src/handlers/admin/model/external_cache.rs
@@ -8,6 +8,7 @@ const ADMIN_EXTERNAL_MODELS_CACHE_KEY: &str = "aether:external:models_dev";
 const ADMIN_EXTERNAL_MODELS_CACHE_TTL_SECS: u64 = 15 * 60;
 const ADMIN_EXTERNAL_MODELS_SOURCE_URL_ENV: &str = "AETHER_GATEWAY_EXTERNAL_MODELS_URL";
 const ADMIN_EXTERNAL_MODELS_SOURCE_URL_DEFAULT: &str = "https://models.dev/api.json";
+const ADMIN_EXTERNAL_MODELS_PROXY_ENV: &str = "AETHER_GATEWAY_EXTERNAL_MODELS_PROXY";
 
 fn admin_external_models_source_url() -> String {
     std::env::var(ADMIN_EXTERNAL_MODELS_SOURCE_URL_ENV)
@@ -15,6 +16,40 @@ fn admin_external_models_source_url() -> String {
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| ADMIN_EXTERNAL_MODELS_SOURCE_URL_DEFAULT.to_string())
+}
+
+fn admin_external_models_proxy_url() -> Option<String> {
+    std::env::var(ADMIN_EXTERNAL_MODELS_PROXY_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn build_admin_external_models_proxy_client(
+    proxy_url: Option<&str>,
+) -> Result<Option<reqwest::Client>, GatewayError> {
+    let Some(proxy_url) = proxy_url else {
+        return Ok(None);
+    };
+    let proxy = reqwest::Proxy::all(proxy_url).map_err(|_| {
+        GatewayError::Internal(format!(
+            "invalid {ADMIN_EXTERNAL_MODELS_PROXY_ENV} proxy URL"
+        ))
+    })?;
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(300))
+        .http2_adaptive_window(true)
+        .use_rustls_tls()
+        .no_proxy()
+        .proxy(proxy)
+        .build()
+        .map_err(|_| {
+            GatewayError::Internal(format!(
+                "failed to build {ADMIN_EXTERNAL_MODELS_PROXY_ENV} proxy client"
+            ))
+        })?;
+    Ok(Some(client))
 }
 
 fn normalize_admin_external_models_payload(payload: serde_json::Value) -> serde_json::Value {
@@ -42,12 +77,17 @@ async fn fetch_admin_external_models_from_source(
     state: &AdminAppState<'_>,
 ) -> Result<serde_json::Value, GatewayError> {
     let url = admin_external_models_source_url();
-    let response = state
-        .http_client()
-        .get(&url)
-        .send()
-        .await
-        .map_err(|err| GatewayError::Internal(err.to_string()))?;
+    let proxy_url = admin_external_models_proxy_url();
+    let proxy_client = build_admin_external_models_proxy_client(proxy_url.as_deref())?;
+    let using_proxy = proxy_client.is_some();
+    let client = proxy_client.as_ref().unwrap_or_else(|| state.http_client());
+    let response = client.get(&url).send().await.map_err(|err| {
+        if using_proxy {
+            GatewayError::Internal("external models proxy request failed".to_string())
+        } else {
+            GatewayError::Internal(err.to_string())
+        }
+    })?;
     let response = response
         .error_for_status()
         .map_err(|err| GatewayError::Internal(err.to_string()))?;
@@ -110,8 +150,9 @@ pub(crate) async fn clear_admin_external_models_cache(
 #[cfg(test)]
 mod tests {
     use super::{
-        admin_external_models_source_url, normalize_admin_external_models_payload,
-        read_admin_external_models_cache, ADMIN_EXTERNAL_MODELS_SOURCE_URL_ENV,
+        admin_external_models_source_url, build_admin_external_models_proxy_client,
+        normalize_admin_external_models_payload, read_admin_external_models_cache,
+        ADMIN_EXTERNAL_MODELS_SOURCE_URL_ENV,
     };
     use crate::handlers::admin::request::AdminAppState;
     use crate::tests::{start_server, AppState};
@@ -216,5 +257,34 @@ mod tests {
         assert_eq!(payload["openai"]["models"]["gpt-5"]["name"], json!("GPT-5"));
 
         upstream_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn external_models_proxy_client_routes_requests_through_configured_proxy() {
+        let proxy = Router::new().fallback(get(|| async {
+            Json(json!({
+                "openai": {
+                    "name": "Proxied OpenAI",
+                    "models": {}
+                }
+            }))
+        }));
+        let (proxy_url, proxy_handle) = start_server(proxy).await;
+        let client = build_admin_external_models_proxy_client(Some(&proxy_url))
+            .expect("proxy client should build")
+            .expect("proxy client should be configured");
+
+        let payload = client
+            .get("http://models.invalid/api.json")
+            .send()
+            .await
+            .expect("request should use the configured proxy")
+            .json::<serde_json::Value>()
+            .await
+            .expect("proxy response should be valid JSON");
+
+        assert_eq!(payload["openai"]["name"], json!("Proxied OpenAI"));
+
+        proxy_handle.abort();
     }
 }


### PR DESCRIPTION
## 背景
   Docker Compose 部署中，部分 Provider 位于同一 Docker 网络，需要保持直连；但服务器访问 `models.dev` 时可能需要代理。

   如果为整个 Gateway 设置全局代理，可能导致内部 Provider 请求也经过代理。因此，本 PR 为外部模型目录拉取增加独立代理配置。

## 改动内容

- 新增环境变量 `AETHER_GATEWAY_EXTERNAL_MODELS_PROXY`
- 仅让外部模型目录请求使用该代理
- 未配置时保持现有共享 HTTP Client 行为
- 不影响 Provider 及 Gateway 的其他请求
- 不复用 `AETHER_UPDATE_PROXY_URL`
- 避免在代理错误中暴露代理地址或认证信息
- 更新 `.env.example` 和 `README.md`
- 增加代理路由测试

## 配置方式

代理服务位于同一 Docker 网络时：

```env
AETHER_GATEWAY_EXTERNAL_MODELS_PROXY=http://proxy:7890
```

模型目录地址仍可独立配置：

```env
AETHER_GATEWAY_EXTERNAL_MODELS_URL=https://models.dev/api.json
```

 验证

```
 - cargo fmt --all --check
 - cargo test -p aether-gateway --lib handlers::admin::model::external_cache::tests
 - cargo test -p aether-gateway --lib gateway_handles_admin_external_models_locally_with_trusted_admin_principal
 ```
