### PR TITLE
fix(gateway): 修复管理员号池批量编辑请求体未缓冲

### DIFF
--- a/apps/aether-gateway/src/control/tests/admin_pool.rs
+++ b/apps/aether-gateway/src/control/tests/admin_pool.rs
@@ -1,6 +1,8 @@
 use http::Uri;
 
 use super::{classify_control_route, headers};
+use crate::control::GatewayPublicRequestContext;
+use crate::handlers::shared::local_proxy_route_requires_buffered_body;
 
 #[test]
 fn classifies_admin_pool_overview_as_admin_proxy_route() {
@@ -92,6 +94,16 @@ fn classifies_admin_pool_provider_key_routes_as_admin_proxy_route() {
         batch_update.route_kind.as_deref(),
         Some("batch_update_keys")
     );
+    let batch_update_context = GatewayPublicRequestContext::from_request_parts(
+        "trace-admin-pool-batch-update",
+        &http::Method::PATCH,
+        &batch_update_uri,
+        &headers,
+        Some(batch_update),
+    );
+    assert!(local_proxy_route_requires_buffered_body(
+        &batch_update_context
+    ));
 
     let resolve_selection_uri: Uri = "/api/admin/pool/provider-1/keys/resolve-selection"
         .parse()

--- a/apps/aether-gateway/src/execution_runtime/stream/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution.rs
@@ -13980,20 +13980,6 @@ mod tests {
     #[tokio::test]
     async fn execute_execution_runtime_stream_returns_client_error_with_local_tunnel_message_before_first_data(
     ) {
-        let state = AppState::new().expect("app state should build");
-        let tunnel_app = state.tunnel.app_state();
-        let (proxy_tx, mut proxy_rx) = aether_runtime::bounded_queue(8);
-        let (proxy_close_tx, _) = watch::channel(false);
-        tunnel_app.hub.register_proxy(Arc::new(TunnelProxyConn::new(
-            901,
-            "node-1".to_string(),
-            "Node 1".to_string(),
-            proxy_tx,
-            proxy_close_tx,
-            16,
-            2,
-        )));
-
         let plan = ExecutionPlan {
             request_id: "req-client-stream-error-1".into(),
             candidate_id: Some("cand-client-stream-error-1".into()),
@@ -14019,6 +14005,33 @@ mod tests {
                 ..ExecutionTimeouts::default()
             }),
         };
+        let provider_catalog = provider_catalog_for_plan(
+            &plan,
+            Some(json!({
+                "failover_rules": {
+                    "stop_on_transport_errors": true,
+                },
+            })),
+        );
+        let data_state = crate::data::GatewayDataState::with_provider_transport_reader_for_tests(
+            Arc::new(provider_catalog),
+            "development-key",
+        );
+        let state = AppState::new()
+            .expect("app state should build")
+            .with_data_state_for_tests(data_state);
+        let tunnel_app = state.tunnel.app_state();
+        let (proxy_tx, mut proxy_rx) = aether_runtime::bounded_queue(8);
+        let (proxy_close_tx, _) = watch::channel(false);
+        tunnel_app.hub.register_proxy(Arc::new(TunnelProxyConn::new(
+            901,
+            "node-1".to_string(),
+            "Node 1".to_string(),
+            proxy_tx,
+            proxy_close_tx,
+            16,
+            2,
+        )));
         let decision = test_decision();
 
         let state_for_task = state.clone();

--- a/apps/aether-gateway/src/execution_runtime/stream/execution_failures.rs
+++ b/apps/aether-gateway/src/execution_runtime/stream/execution_failures.rs
@@ -148,7 +148,7 @@ pub(super) fn build_stream_failure_from_execution_error(
     error: &ExecutionError,
 ) -> StreamFailureReport {
     let transport_error = execution_error_is_transport(error);
-    let status_code = error.upstream_status.unwrap_or_else(|| {
+    let status_code = error.upstream_status.unwrap_or({
         if matches!(
             error.kind,
             ExecutionErrorKind::ConnectTimeout

--- a/apps/aether-gateway/src/handlers/shared/request_utils.rs
+++ b/apps/aether-gateway/src/handlers/shared/request_utils.rs
@@ -377,6 +377,7 @@ pub(crate) fn admin_proxy_local_requires_buffered_body(
                 | (Some("users_manage"), http::Method::PATCH, Some("lock_user_api_key"))
                 | (Some("pool_manage"), http::Method::POST, Some("batch_import_keys"))
                 | (Some("pool_manage"), http::Method::POST, Some("batch_action_keys"))
+                | (Some("pool_manage"), http::Method::PATCH, Some("batch_update_keys"))
                 | (Some("pool_manage"), http::Method::POST, Some("resolve_selection"))
                 | (Some("usage_manage"), http::Method::POST, Some("replay"))
                 | (Some("wallets_manage"), http::Method::POST, Some("adjust_balance"))

--- a/apps/aether-gateway/src/tests/control/admin/pool.rs
+++ b/apps/aether-gateway/src/tests/control/admin/pool.rs
@@ -3615,19 +3615,26 @@ async fn gateway_batch_updates_shared_pool_key_configuration() {
         Vec::new(),
         vec![first_key, second_key],
     ));
-    let state = AppState::new()
-        .expect("gateway should build")
-        .with_data_state_for_tests(
-            GatewayDataState::with_provider_catalog_repository_for_tests(Arc::clone(
-                &provider_catalog_repository,
-            )),
-        );
+    let gateway = build_router_with_state(
+        AppState::new()
+            .expect("gateway should build")
+            .with_data_state_for_tests(
+                GatewayDataState::with_provider_catalog_repository_for_tests(Arc::clone(
+                    &provider_catalog_repository,
+                )),
+            ),
+    );
+    let (gateway_url, gateway_handle) = start_server(gateway).await;
 
-    let response = local_admin_pool_response(
-        &state,
-        http::Method::PATCH,
-        "/api/admin/pool/provider-openai/keys/batch-update",
-        Some(json!({
+    let response = reqwest::Client::new()
+        .patch(format!(
+            "{gateway_url}/api/admin/pool/provider-openai/keys/batch-update"
+        ))
+        .header(crate::constants::GATEWAY_HEADER, "rust-phase3b")
+        .header(TRUSTED_ADMIN_USER_ID_HEADER, "admin-user-123")
+        .header(TRUSTED_ADMIN_USER_ROLE_HEADER, "admin")
+        .header(TRUSTED_ADMIN_SESSION_ID_HEADER, "session-123")
+        .json(&json!({
             "key_ids": ["key-openai-b", "key-openai-a", "key-openai-a"],
             "patch": {
                 "api_formats": ["openai:responses"],
@@ -3638,17 +3645,13 @@ async fn gateway_batch_updates_shared_pool_key_configuration() {
                 "locked_models": [],
                 "note": null
             }
-        })),
-    )
-    .await;
+        }))
+        .send()
+        .await
+        .expect("request should succeed");
 
     assert_eq!(response.status(), StatusCode::OK);
-    let payload: serde_json::Value = serde_json::from_slice(
-        &to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("body should read"),
-    )
-    .expect("json body should parse");
+    let payload: serde_json::Value = response.json().await.expect("json body should parse");
     assert_eq!(payload["affected"], json!(2));
     assert_eq!(payload["model_sync"], serde_json::Value::Null);
 
@@ -3670,6 +3673,8 @@ async fn gateway_batch_updates_shared_pool_key_configuration() {
         assert_eq!(key.locked_models, None);
         assert_eq!(key.note, None);
     }
+
+    gateway_handle.abort();
 }
 
 #[tokio::test]

--- a/crates/aether-usage/runtime/src/runtime.rs
+++ b/crates/aether-usage/runtime/src/runtime.rs
@@ -12692,7 +12692,6 @@ mod tests {
         apply_usage_body_capture_policy_to_event(
             UsageBodyCapturePolicy {
                 record_level: UsageRequestRecordLevel::Basic,
-                ..UsageBodyCapturePolicy::default()
             },
             &mut event,
         );

--- a/crates/aether-usage/runtime/src/write.rs
+++ b/crates/aether-usage/runtime/src/write.rs
@@ -2093,6 +2093,11 @@ fn build_runtime_request_metadata_seed_from_parts(
     if let Some(user_agent) = context_string(context, "user_agent") {
         metadata.insert("user_agent".to_string(), Value::String(user_agent));
     }
+    for key in ["end_to_end_time_ms", "end_to_end_first_byte_time_ms"] {
+        if let Some(value) = context_u64(context, key) {
+            metadata.insert(key.to_string(), Value::from(value));
+        }
+    }
     if let Some(client_requested_stream) = context_bool(context, "client_requested_stream") {
         metadata.insert(
             "client_requested_stream".to_string(),
@@ -6710,7 +6715,9 @@ mod tests {
                 },
                 "original_request_body": {
                     "payload": "x".repeat(MAX_USAGE_CAPTURE_BYTES + 1)
-                }
+                },
+                "end_to_end_time_ms": 125,
+                "end_to_end_first_byte_time_ms": 47
             })),
         );
 
@@ -6726,6 +6733,18 @@ mod tests {
             Some(json!({
                 "payload": "x".repeat(MAX_USAGE_CAPTURE_BYTES + 1)
             }))
+        );
+        assert_eq!(
+            data.request_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("end_to_end_time_ms")),
+            Some(&json!(125))
+        );
+        assert_eq!(
+            data.request_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("end_to_end_first_byte_time_ms")),
+            Some(&json!(47))
         );
     }
 


### PR DESCRIPTION
## 背景与问题

管理员号池的批量编辑接口使用 `PATCH /api/admin/pool/{provider_id}/keys/batch-update`。当前 Rust frontdoor 已能把该接口识别为 `pool_manage / batch_update_keys`，本地 handler 也已经实现批量更新逻辑，但统一的管理员代理请求体缓冲策略没有覆盖这组路由语义。

这会造成同一条请求链路内部的契约不一致：路由分类认为请求应由 Rust 本地处理，handler 需要读取 JSON 请求体，frontdoor 却没有在进入本地处理前缓冲并解析 body。最终本地 handler 收到空 body，无法执行正常的批量编辑。

原有成功测试直接调用本地辅助函数并手工传入 `Some(json!(...))`，绕过了真实 Router 和 frontdoor 请求体生命周期，因此无法发现这类跨层缺口。

## 根因

请求链路中的三个事实没有在同一个策略中闭合：

1. `classify_control_route` 将该 PATCH 请求分类为 `pool_manage / batch_update_keys`；
2. 批量更新 handler 的输入契约要求存在结构化 JSON body；
3. `admin_proxy_local_requires_buffered_body` 只覆盖了同一模块中的批量导入、批量操作和选择解析等路由，遗漏了批量编辑路由。

请求体是否需要缓冲的唯一判断入口已经存在，因此修复应当落在这个统一 owner 中，而不是在 handler、Router 或代理层增加特殊分支。

## 改动内容

### 1. 补齐统一请求体缓冲策略

在 `admin_proxy_local_requires_buffered_body` 中加入：

```text
(pool_manage, PATCH, batch_update_keys)
```

这样请求会沿用现有管理员本地代理的通用链路：

```text
PATCH 请求
  -> control route 分类
  -> admin proxy body-buffer 策略
  -> 缓冲并解析 JSON body
  -> batch_update_keys 本地 handler
  -> 仓储原子更新
```

没有新增 fallback、兼容代理、第二套路由判断或 handler 特判。

### 2. 增加路由与请求体策略回归测试

扩展管理员号池路由分类测试，在构造完整 `GatewayPublicRequestContext` 后明确断言该路由需要本地请求体缓冲。该断言直接约束路由分类结果与 body-buffer 策略必须保持一致。

### 3. 将成功测试升级为真实 HTTP Router 测试

批量更新成功测试不再直接调用本地 helper，也不再手工注入解析后的 body，而是：

1. 使用 `build_router_with_state` 构建真实 gateway Router；
2. 启动本地测试服务器；
3. 使用 `reqwest` 发出真实 PATCH 请求；
4. 通过受信管理员请求头进入正式管理链路；
5. 验证响应中的受影响密钥数量；
6. 回读仓储，逐项验证 API 格式、内部优先级、RPM 限制、模型自动获取、允许模型、锁定模型和备注字段。

因此，如果删除本次 body-buffer 策略修复，测试会在真实 frontdoor 路径上失败，而不是继续被 helper 注入的 body 掩盖。

现有的原子性回归测试继续验证：当请求同时包含存在和不存在的密钥 ID 时，接口返回 400，任何密钥都不会被部分更新。

### 4. 修复当前 upstream 基线的两个 Clippy 阻断

当前 `main` 在 `build_stream_failure_from_execution_error` 中对一个无副作用的立即值使用 `unwrap_or_else`，会触发 `clippy::unnecessary_lazy_evaluations`。Rust CI 对整个 `aether-gateway` 执行 `-D warnings`，因此任何 gateway PR 都会被这条基线 lint 阻断。

此外，workspace-rest Clippy 覆盖的 usage runtime 测试在构造只有一个字段的 `UsageBodyCapturePolicy` 时仍使用 `..UsageBodyCapturePolicy::default()`。唯一字段已经被显式赋值，因此这个结构体更新没有任何效果，会触发 `clippy::needless_update`。

本 PR 以两个独立提交分别改为语义等价的 `unwrap_or`、删除无效的结构体更新行。状态码选择和 usage capture policy 的取值均保持不变，也没有放宽或屏蔽 lint。

### 5. 闭合当前 upstream 基线的执行生命周期测试合同

当前 `main` 已把提交首个响应数据之前的传输失败统一为“默认允许候选故障转移”，但原有本地 tunnel 错误测试仍在未配置终止策略时期待立即生成客户端响应。这与同模块已经明确覆盖的默认重试合同冲突。

测试夹具现通过正式 provider 配置入口显式设置 `failover_rules.stop_on_transport_errors = true`，继续验证“配置为立即终止时，客户端响应保留原始 tunnel 错误”这一行为。生产执行逻辑、默认故障转移策略和错误编码均未修改。

同一 upstream 提交还把请求诊断耗时写入 terminal guard 的 report context，并在 request metadata 白名单中声明了 `end_to_end_time_ms` 与 `end_to_end_first_byte_time_ms`，但统一的 runtime event seed builder 没有搬运这两个字段，导致诊断数据在进入 `UsageEventData` 前丢失。

本 PR 在统一 seed builder 中补齐两个数值字段的入口，并在 seed 边界测试中验证二者均被保留。没有在 guard、仓储或测试等待逻辑中增加旁路，也没有复制新的生命周期 owner。

## 架构边界与非目标

- 不修改前端、页面、样式或静态资源；
- 不改变 API 路径、请求结构或响应结构；
- 不改变鉴权、管理员身份解析或会话机制；
- 不增加 Python/旧网关代理回退；
- 不新增数据库表、迁移或数据兼容逻辑；
- 不复制请求体判断规则，继续由现有统一策略作为唯一真源。

## 验证结果

以下命令均在基于最新 `origin/main` 的纯后端分支上执行并通过：

```bash
cargo fmt --all -- --check
RUST_MIN_STACK=16777216 cargo test -p aether-gateway batch_update -- --nocapture
cargo test -p aether-usage-runtime usage_event_data_seed_masks_headers_before_outcome_paths_use_it -- --nocapture
RUST_MIN_STACK=16777216 cargo test -p aether-gateway sync_attempt_terminal_guard_marks_dropped_pending_attempt_cancelled -- --nocapture
RUST_MIN_STACK=16777216 cargo nextest run -p aether-gateway --lib --bin aether-gateway --no-fail-fast
cargo clippy -p aether-gateway --lib --bins --examples -- -D warnings
cargo clippy --workspace --exclude aether-gateway --exclude aether-data --exclude aether-integration-tests --all-targets -- -D warnings
git diff --check origin/main...HEAD
```

目标测试结果：

```text
2 passed; 0 failed; 3694 filtered out
3750 tests run: 3750 passed; 0 skipped
```

覆盖的关键行为包括：

- 批量编辑路由被判定为需要 body buffering；
- 真实 PATCH 请求能够穿过 Router 和 frontdoor；
- 两个有效密钥被一次性更新，重复 ID 不导致重复写入；
- 更新后的各配置字段与请求一致；
- 请求包含不存在的密钥时返回 400，已有密钥保持原值。
- 默认传输故障转移语义保持不变，显式终止策略下仍返回原始 tunnel 错误；
- terminal guard 生成的端到端诊断耗时能够进入并保留在 usage request metadata 中。

此外，运行态无写入冒烟验证确认：空 `key_ids` 的 PATCH 请求经过 `local_proxy` 缓冲完整 JSON body，进入 `pool_manage / batch_update_keys` 后返回业务校验错误 `key_ids 不能为空`，没有产生任何密钥更新。

## 兼容性与风险

核心修改只让一个已经由 Rust 本地 handler 正式拥有的写请求，遵循同类管理员写路由已经使用的请求体缓冲生命周期。内存预算、body 大小限制、超时和错误处理均复用现有通用机制。

附带的基线修正分别保持既有故障转移策略，以及补齐已声明但尚未接入 seed 的诊断字段；不改变 API、持久化 schema 或计费语义。

主要回归风险是路由三元组将来被重命名后策略未同步。新增的分类器测试和真实 Router 测试分别在策略层与端到端请求层约束这一关系，能够在 CI 中直接暴露漂移。
