### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ Aether Tunnel 是配套的正向代理节点，部署在海外 VPS 上，为墙�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=fawney19/Aether&type=date&legend=top-left)](https://www.star-history.com/?repos=fawney19%2FAether&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=fawney19/Aether&type=date&legend=top-left)](https://star-history.dera.page/#fawney19/Aether&type=date&legend=top-left)


### PR DESCRIPTION
The Star History chart in the README is currently broken and no longer renders. This switches it to a working mirror at star-history.dera.page so the project's stargazer history is visible again.