### PR TITLE
fix(admin): auto-switch to unified routing scope after removing last model policy

### DIFF
--- a/frontend/src/views/admin/RoutingProfiles.vue
+++ b/frontend/src/views/admin/RoutingProfiles.vue
@@ -1203,6 +1203,13 @@ function removePerModelPolicy(model: string): void {
   modelFilter.value = 'unconfigured'
   updateDraftConfig(next)
   resetEditingConfig()
+  // 移除最后一个模型特殊配置后，自动回到统一调度维度：
+  // 若仍停留在“区分模型”维度，canSaveDraft 会因
+  // perModelPolicies 为空而禁用保存按钮，且保存时会拦截
+  // “按模型排序时至少选择一个模型”，导致无法保存删除结果。
+  if (perModelPolicies.value.length === 0) {
+    setSortingScope('unified')
+  }
 }
 
 function selectGlobalModel(model: string): void {


### PR DESCRIPTION
## 问题

在路由策略（Routing Profiles）「区分模型」调度维度下删除唯一一个模型策略后，`perModelPolicies` 为空但 `sortingScope` 仍为 `per_model`，导致：
- `canSaveDraft` 恒为 false，保存按钮灰色不可点；
- `saveDraft` 拦截「按模型排序时至少选择一个模型」，删除结果无法保存。

## 修复

删除最后一个模型策略后自动调用 `setSortingScope('unified')`，恢复统一调度维度，保存按钮恢复可用。

## 测试

前端改动，逻辑简单；与上游 `a1d64e523`（preserve allowlist edits and save state）同一文件区域，已手动验证无冲突。
