### PR TITLE
feat: add OrcaRouter as a named provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## 简介
 
-Aether 是一个自托管的 AI API 网关，为团队和个人提供多租户管理、智能负载均衡、成本配额控制和健康监控能力。通过统一的 API 入口，可以无缝对接 Claude、OpenAI、Gemini 等主流 AI 服务及其 CLI 工具。
+Aether 是一个自托管的 AI API 网关，为团队和个人提供多租户管理、智能负载均衡、成本配额控制和健康监控能力。通过统一的 API 入口，可以无缝对接 Claude、OpenAI、Gemini、[OrcaRouter](https://www.orcarouter.ai) 等主流 AI 服务及其 CLI 工具。
 
 <p align="center">
   <picture>

--- a/apps/aether-gateway/src/handlers/admin/provider/write/normalize.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/write/normalize.rs
@@ -4,9 +4,9 @@ pub(crate) fn normalize_provider_type_input(value: &str) -> Result<String, Strin
     let normalized = value.trim().to_ascii_lowercase();
     match normalized.as_str() {
         "custom" | "claude_code" | "kiro" | "codex" | "chatgpt_web" | "gemini_cli"
-        | "antigravity" | "vertex_ai" | "grok" | "windsurf" => Ok(normalized),
+        | "antigravity" | "vertex_ai" | "grok" | "windsurf" | "orcarouter" => Ok(normalized),
         _ => Err(
-            "provider_type 仅支持 custom / claude_code / kiro / codex / chatgpt_web / gemini_cli / antigravity / vertex_ai / grok / windsurf"
+            "provider_type 仅支持 custom / claude_code / kiro / codex / chatgpt_web / gemini_cli / antigravity / vertex_ai / grok / windsurf / orcarouter"
                 .to_string(),
         ),
     }

--- a/crates/aether-provider/transport/src/provider_types.rs
+++ b/crates/aether-provider/transport/src/provider_types.rs
@@ -275,6 +275,12 @@ const WINDSURF_RUNTIME_POLICY: ProviderRuntimePolicy = ProviderRuntimePolicy {
     supports_local_same_format_transport: false,
     ..STANDARD_RUNTIME_POLICY
 };
+const ORCAROUTER_RUNTIME_POLICY: ProviderRuntimePolicy = ProviderRuntimePolicy {
+    fixed_provider: true,
+    enable_format_conversion_by_default: true,
+    supports_local_same_format_transport: false,
+    ..STANDARD_RUNTIME_POLICY
+};
 
 const CLAUDE_CODE_FIXED_PROVIDER_TEMPLATE: FixedProviderTemplate = FixedProviderTemplate {
     provider_type: "claude_code",
@@ -441,6 +447,27 @@ const WINDSURF_FIXED_PROVIDER_TEMPLATE: FixedProviderTemplate = FixedProviderTem
     runtime_policy: WINDSURF_RUNTIME_POLICY,
 };
 
+const ORCAROUTER_FIXED_PROVIDER_TEMPLATE: FixedProviderTemplate = FixedProviderTemplate {
+    provider_type: "orcarouter",
+    version: 1,
+    base_url: "https://api.orcarouter.ai/v1",
+    endpoints: &[
+        FixedProviderEndpointTemplate {
+            item_key: "openai:chat",
+            api_format: "openai:chat",
+            custom_path: None,
+            config_defaults: AUTO_STREAM_ENDPOINT_CONFIG_DEFAULTS,
+        },
+        FixedProviderEndpointTemplate {
+            item_key: "openai:responses",
+            api_format: "openai:responses",
+            custom_path: None,
+            config_defaults: AUTO_STREAM_ENDPOINT_CONFIG_DEFAULTS,
+        },
+    ],
+    runtime_policy: ORCAROUTER_RUNTIME_POLICY,
+};
+
 pub fn provider_type_is_fixed(provider_type: &str) -> bool {
     provider_runtime_policy(provider_type).fixed_provider
 }
@@ -493,6 +520,7 @@ pub fn fixed_provider_template(provider_type: &str) -> Option<&'static FixedProv
         "vertex_ai" => Some(&VERTEX_AI_FIXED_PROVIDER_TEMPLATE),
         "antigravity" => Some(&ANTIGRAVITY_FIXED_PROVIDER_TEMPLATE),
         "windsurf" => Some(&WINDSURF_FIXED_PROVIDER_TEMPLATE),
+        "orcarouter" => Some(&ORCAROUTER_FIXED_PROVIDER_TEMPLATE),
         _ => None,
     }
 }
@@ -632,8 +660,8 @@ mod tests {
     use super::{
         fixed_provider_endpoint_template_by_api_format, fixed_provider_key_inherits_api_formats,
         fixed_provider_template, provider_runtime_policy, provider_type_admin_oauth_template,
-        provider_type_allows_auth_channel_mismatch_by_default, provider_type_oauth_is_bearer_like,
-        provider_type_supports_local_embedding_transport,
+        provider_type_allows_auth_channel_mismatch_by_default, provider_type_is_fixed,
+        provider_type_oauth_is_bearer_like, provider_type_supports_local_embedding_transport,
         provider_type_supports_local_same_format_transport, FixedProviderEndpointConfigValue,
         ADMIN_PROVIDER_OAUTH_TEMPLATE_TYPES,
     };
@@ -802,6 +830,50 @@ mod tests {
         assert!(policy.oauth_is_bearer_like);
         assert!(!policy.supports_model_fetch);
         assert!(!policy.supports_local_same_format_transport);
+    }
+
+    #[test]
+    fn orcarouter_fixed_provider_template_exposes_openai_chat_and_responses() {
+        let template =
+            fixed_provider_template("orcarouter").expect("orcarouter template should exist");
+        assert_eq!(template.provider_type, "orcarouter");
+        assert_eq!(template.base_url, "https://api.orcarouter.ai/v1");
+        assert_eq!(template.version, 1);
+        assert_eq!(
+            template
+                .endpoints
+                .iter()
+                .map(|item| item.api_format)
+                .collect::<Vec<_>>(),
+            vec!["openai:chat", "openai:responses"]
+        );
+        assert!(
+            fixed_provider_endpoint_template_by_api_format("orcarouter", "openai:chat").is_some()
+        );
+        assert!(
+            fixed_provider_endpoint_template_by_api_format("orcarouter", "openai:responses")
+                .is_some()
+        );
+
+        let policy = provider_runtime_policy("orcarouter");
+        assert!(policy.fixed_provider);
+        assert!(policy.enable_format_conversion_by_default);
+        assert!(!policy.oauth_is_bearer_like);
+        assert!(policy.supports_model_fetch);
+        assert!(policy.supports_local_openai_chat_transport);
+        assert!(!policy.supports_local_same_format_transport);
+    }
+
+    #[test]
+    fn orcarouter_is_key_managed_and_has_no_oauth_template() {
+        assert!(provider_type_is_fixed("orcarouter"));
+        assert!(provider_type_admin_oauth_template("orcarouter").is_none());
+        assert!(!ADMIN_PROVIDER_OAUTH_TEMPLATE_TYPES.contains(&"orcarouter"));
+        assert!(!fixed_provider_key_inherits_api_formats(
+            "orcarouter",
+            "oauth",
+            None
+        ));
     }
 
     #[test]

--- a/frontend/src/api/endpoints/types/provider.ts
+++ b/frontend/src/api/endpoints/types/provider.ts
@@ -750,7 +750,7 @@ export interface HealthRelatedMonitorResponse {
   related_providers: HealthRelatedMonitor[]
 }
 
-export type ProviderType = 'custom' | 'claude_code' | 'codex' | 'chatgpt_web' | 'gemini_cli' | 'antigravity' | 'kiro' | 'grok' | 'windsurf' | 'vertex_ai'
+export type ProviderType = 'custom' | 'claude_code' | 'codex' | 'chatgpt_web' | 'gemini_cli' | 'antigravity' | 'kiro' | 'grok' | 'windsurf' | 'vertex_ai' | 'orcarouter'
 
 export interface ClaudeCodeAdvancedConfig {
   // 会话数量控制：null/undefined 表示不限制

--- a/frontend/src/features/providers/components/ProviderFormDialog.vue
+++ b/frontend/src/features/providers/components/ProviderFormDialog.vue
@@ -66,6 +66,9 @@
                   <SelectItem value="windsurf">
                     Windsurf
                   </SelectItem>
+                  <SelectItem value="orcarouter">
+                    OrcaRouter
+                  </SelectItem>
                   <SelectItem value="antigravity">
                     Antigravity
                   </SelectItem>
@@ -98,6 +101,9 @@
                   </SelectItem>
                   <SelectItem value="windsurf">
                     Windsurf
+                  </SelectItem>
+                  <SelectItem value="orcarouter">
+                    OrcaRouter
                   </SelectItem>
                   <SelectItem value="antigravity">
                     Antigravity


### PR DESCRIPTION
## Summary

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a named, first-class provider type in Aether, mirroring the existing fixed-provider wiring (Windsurf/Grok/Codex). Previously users had to create a generic `custom` OpenAI-compatible provider and manually type `https://api.orcarouter.ai/v1` — now they can pick **OrcaRouter** directly from the provider form.

OrcaRouter is a smart multi-model gateway with a single `sk-orca-` key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

- **Backend** (`crates/aether-provider/transport/src/provider_types.rs`)
  - New `orcarouter` fixed provider template with `base_url: https://api.orcarouter.ai/v1`
  - Exposes `openai:chat` and `openai:responses` endpoints (auto stream policy)
  - Key-managed provider (bearer API key, no OAuth template), with live model fetch enabled via `/v1/models`
- **Backend** (`apps/aether-gateway/src/handlers/admin/provider/write/normalize.rs`)
  - Allow `provider_type=orcarouter` in the admin provider write path
- **Frontend**
  - Add `orcarouter` to the `ProviderType` union and to the provider-form provider-type select
- **Docs**: mention OrcaRouter in the README intro

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy -p aether-provider-transport --all-targets -- -D warnings` — clean
- `cargo test -p aether-provider-transport` — 433 passed (incl. 2 new OrcaRouter tests)
- Frontend `vue-tsc --noEmit`, `npm run build`, and provider test suite (207 passed) — all green
- **Live L3 test** with a real `sk-orca-` key against the exact transport URLs the gateway will use:
  - `POST https://api.orcarouter.ai/v1/chat/completions` (model `orcarouter/auto`) → **200** `ORCA-LIVE-OK`
  - `POST https://api.orcarouter.ai/v1/responses` (model `orcarouter/auto`) → **200** `ORCA-LIVE-OK`
  - `GET https://api.orcarouter.ai/v1/models` → **200**, 205 models listed

Disclosure: I'm an engineer on the OrcaRouter team.
