### PR TITLE
fix(gateway): 非流式跨格式同步响应未做协议回转

### DIFF
--- a/apps/aether-gateway/src/ai_serving/finalize/tests_sync.rs
+++ b/apps/aether-gateway/src/ai_serving/finalize/tests_sync.rs
@@ -2640,3 +2640,66 @@ fn local_finalize_still_aggregates_a_real_cross_format_stream_capture() {
     assert_eq!(client_body["type"], "message");
     assert_eq!(client_body["content"][0]["text"], "connection ok");
 }
+
+#[test]
+fn local_finalize_keeps_an_unframed_stream_event_on_the_aggregation_path() {
+    // `parse_stream_json_events` accepts unframed JSON lines, so a capture holding a single
+    // terminal event is also a complete JSON object. It is still a stream, and the aggregator is
+    // the only thing that knows to unwrap the response the event carries.
+    let event = json!({
+        "type": "response.completed",
+        "response": {
+            "id": "resp_1",
+            "object": "response",
+            "status": "completed",
+            "model": "probe-model",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "connection ok"}]
+            }],
+            "usage": {"input_tokens": 9, "output_tokens": 3, "total_tokens": 12}
+        }
+    });
+    let body_base64 = base64::engine::general_purpose::STANDARD
+        .encode(serde_json::to_vec(&event).expect("serialize terminal event"));
+
+    let payload = GatewaySyncReportRequest {
+        trace_id: "trace-claude-from-unframed-event".to_string(),
+        report_kind: "claude_chat_sync_finalize".to_string(),
+        report_context: Some(json!({
+            "client_api_format": "claude:messages",
+            "provider_api_format": "openai:responses",
+            "model": "probe-model",
+            "needs_conversion": true,
+            "has_envelope": false,
+            "upstream_is_stream": true,
+        })),
+        status_code: 200,
+        headers: BTreeMap::from([("content-type".to_string(), "text/event-stream".to_string())]),
+        body_json: None,
+        client_body_json: None,
+        body_base64: Some(body_base64),
+        telemetry: None,
+    };
+
+    let outcome = maybe_build_local_core_sync_finalize_response(
+        "trace-claude-from-unframed-event",
+        &test_decision(),
+        &payload,
+    )
+    .expect("local finalize should succeed")
+    .expect("an unframed terminal event must still aggregate, not pass through");
+
+    let report = outcome
+        .background_report
+        .expect("cross-format finalize should carry a success report");
+    let client_body = report.client_body_json.expect("client body should exist");
+    assert_eq!(client_body["type"], "message");
+    assert_eq!(client_body["content"][0]["text"], "connection ok");
+    assert!(
+        client_body.get("response").is_none(),
+        "the event envelope must not reach the client: {client_body}"
+    );
+}

--- a/apps/aether-gateway/src/ai_serving/finalize/tests_sync.rs
+++ b/apps/aether-gateway/src/ai_serving/finalize/tests_sync.rs
@@ -2352,3 +2352,114 @@ async fn local_finalize_forces_gpt_image_stream_response_to_b64_json_even_when_u
     assert_eq!(response_json["data"][0]["b64_json"], "aGVsbG8=");
     assert!(response_json["data"][0].get("url").is_none());
 }
+
+#[test]
+fn local_finalize_converts_openai_responses_sync_response_from_claude_messages() {
+    // Mirrors a production trace: client spoke openai:responses, the attempt was routed to a
+    // claude:messages provider, and the provider answered non-streaming JSON.
+    let payload = GatewaySyncReportRequest {
+        trace_id: "trace-responses-from-claude".to_string(),
+        report_kind: "openai_responses_sync_finalize".to_string(),
+        report_context: Some(json!({
+            "client_api_format": "openai:responses",
+            "provider_api_format": "claude:messages",
+            "model": "deepseek-v4-flash",
+            "needs_conversion": true,
+            "has_envelope": false,
+        })),
+        status_code: 200,
+        headers: BTreeMap::from([("content-type".to_string(), "application/json".to_string())]),
+        body_json: Some(json!({
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "deepseek-v4-flash",
+            "content": [{"type": "text", "text": "connection ok"}],
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 12, "output_tokens": 3}
+        })),
+        client_body_json: None,
+        body_base64: None,
+        telemetry: None,
+    };
+
+    let outcome = maybe_build_local_core_sync_finalize_response(
+        "trace-responses-from-claude",
+        &test_decision(),
+        &payload,
+    )
+    .expect("local finalize should succeed")
+    .expect("cross-format sync response must be finalized, not passed through");
+
+    assert_eq!(outcome.response.status(), 200);
+    let report = outcome
+        .background_report
+        .expect("cross-format finalize should carry a success report");
+    let client_body = report.client_body_json.expect("client body should exist");
+    assert_eq!(client_body["object"], "response");
+    assert!(
+        client_body
+            .get("output")
+            .and_then(|v| v.as_array())
+            .is_some(),
+        "client body must be an openai:responses payload, got {client_body}"
+    );
+    assert!(
+        client_body.get("content").is_none(),
+        "client body must not keep the Anthropic Messages shape"
+    );
+}
+
+#[test]
+fn local_finalize_converts_openai_responses_sync_response_from_openai_chat() {
+    // Mirrors a production trace: client spoke openai:responses, the attempt was routed to an
+    // openai:chat provider, and the provider answered a non-streaming chat.completion.
+    let payload = GatewaySyncReportRequest {
+        trace_id: "trace-responses-from-chat".to_string(),
+        report_kind: "openai_responses_sync_finalize".to_string(),
+        report_context: Some(json!({
+            "client_api_format": "openai:responses",
+            "provider_api_format": "openai:chat",
+            "model": "stealth/ox-alpha",
+            "needs_conversion": true,
+            "has_envelope": false,
+        })),
+        status_code: 200,
+        headers: BTreeMap::from([("content-type".to_string(), "application/json".to_string())]),
+        body_json: Some(json!({
+            "id": "chatcmpl_1",
+            "object": "chat.completion",
+            "created": 1_787_379_436u64,
+            "model": "stealth/ox-alpha",
+            "choices": [{
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "connection ok"}
+            }],
+            "usage": {"prompt_tokens": 9, "completion_tokens": 3, "total_tokens": 12}
+        })),
+        client_body_json: None,
+        body_base64: None,
+        telemetry: None,
+    };
+
+    let outcome = maybe_build_local_core_sync_finalize_response(
+        "trace-responses-from-chat",
+        &test_decision(),
+        &payload,
+    )
+    .expect("local finalize should succeed")
+    .expect("cross-format sync response must be finalized, not passed through");
+
+    assert_eq!(outcome.response.status(), 200);
+    let report = outcome
+        .background_report
+        .expect("cross-format finalize should carry a success report");
+    let client_body = report.client_body_json.expect("client body should exist");
+    assert_eq!(client_body["object"], "response");
+    assert!(
+        client_body.get("choices").is_none(),
+        "client body must not keep the chat.completion shape"
+    );
+}

--- a/apps/aether-gateway/src/ai_serving/finalize/tests_sync.rs
+++ b/apps/aether-gateway/src/ai_serving/finalize/tests_sync.rs
@@ -2463,3 +2463,180 @@ fn local_finalize_converts_openai_responses_sync_response_from_openai_chat() {
         "client body must not keep the chat.completion shape"
     );
 }
+
+#[test]
+fn local_finalize_recovers_non_stream_json_capture_from_openai_responses_provider() {
+    // The plan forced upstream streaming (codex providers always do, and an endpoint config can
+    // too), so the response body reached the runtime as raw bytes with no parsed JSON. The
+    // provider answered with a plain Responses object instead of SSE, which the strict Responses
+    // aggregator used to reject as a stream missing its terminal event — turning a complete,
+    // already billed upstream answer into a 500.
+    let provider_body = json!({
+        "id": "resp_1",
+        "object": "response",
+        "status": "completed",
+        "error": null,
+        "model": "probe-model",
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "connection ok"}]
+        }],
+        "usage": {"input_tokens": 9, "output_tokens": 3, "total_tokens": 12}
+    });
+    let body_base64 = base64::engine::general_purpose::STANDARD
+        .encode(serde_json::to_vec(&provider_body).expect("serialize provider body"));
+
+    let payload = GatewaySyncReportRequest {
+        trace_id: "trace-claude-from-responses-json".to_string(),
+        report_kind: "claude_chat_sync_finalize".to_string(),
+        report_context: Some(json!({
+            "client_api_format": "claude:messages",
+            "provider_api_format": "openai:responses",
+            "model": "probe-model",
+            "needs_conversion": true,
+            "has_envelope": false,
+            "upstream_is_stream": true,
+        })),
+        status_code: 200,
+        headers: BTreeMap::from([("content-type".to_string(), "application/json".to_string())]),
+        body_json: None,
+        client_body_json: None,
+        body_base64: Some(body_base64),
+        telemetry: None,
+    };
+
+    let outcome = maybe_build_local_core_sync_finalize_response(
+        "trace-claude-from-responses-json",
+        &test_decision(),
+        &payload,
+    )
+    .expect("a non-streaming provider body must not fail the stream aggregator")
+    .expect("cross-format sync response must be finalized, not passed through");
+
+    assert_eq!(outcome.response.status(), 200);
+    let report = outcome
+        .background_report
+        .expect("cross-format finalize should carry a success report");
+    let client_body = report.client_body_json.expect("client body should exist");
+    assert_eq!(client_body["type"], "message");
+    assert!(
+        client_body
+            .get("content")
+            .and_then(|value| value.as_array())
+            .is_some(),
+        "client body must be an Anthropic Messages payload, got {client_body}"
+    );
+    assert!(
+        client_body.get("output").is_none(),
+        "client body must not keep the openai:responses shape"
+    );
+}
+
+#[test]
+fn local_finalize_prefers_the_parsed_json_body_over_its_own_encoding() {
+    // Both fields describe the same non-streaming provider response. The bytes are only that
+    // JSON's encoding, so they must not be handed to the stream aggregators.
+    let provider_body = json!({
+        "id": "resp_1",
+        "object": "response",
+        "status": "completed",
+        "error": null,
+        "model": "probe-model",
+        "output": [{
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "connection ok"}]
+        }],
+        "usage": {"input_tokens": 9, "output_tokens": 3, "total_tokens": 12}
+    });
+    let body_base64 = base64::engine::general_purpose::STANDARD
+        .encode(serde_json::to_vec(&provider_body).expect("serialize provider body"));
+
+    let payload = GatewaySyncReportRequest {
+        trace_id: "trace-gemini-from-responses-json".to_string(),
+        report_kind: "gemini_chat_sync_finalize".to_string(),
+        report_context: Some(json!({
+            "client_api_format": "gemini:generate_content",
+            "provider_api_format": "openai:responses",
+            "model": "probe-model",
+            "needs_conversion": true,
+            "has_envelope": false,
+        })),
+        status_code: 200,
+        headers: BTreeMap::from([("content-type".to_string(), "application/json".to_string())]),
+        body_json: Some(provider_body),
+        client_body_json: None,
+        body_base64: Some(body_base64),
+        telemetry: None,
+    };
+
+    let outcome = maybe_build_local_core_sync_finalize_response(
+        "trace-gemini-from-responses-json",
+        &test_decision(),
+        &payload,
+    )
+    .expect("a parsed JSON body must not be re-read as a stream capture")
+    .expect("cross-format sync response must be finalized, not passed through");
+
+    let report = outcome
+        .background_report
+        .expect("cross-format finalize should carry a success report");
+    let client_body = report.client_body_json.expect("client body should exist");
+    assert!(
+        client_body
+            .get("candidates")
+            .and_then(|value| value.as_array())
+            .is_some(),
+        "client body must be a gemini:generate_content payload, got {client_body}"
+    );
+}
+
+#[test]
+fn local_finalize_still_aggregates_a_real_cross_format_stream_capture() {
+    // Guards the recovery above: an actual SSE capture is not a complete JSON document, so it
+    // keeps going to the stream aggregator.
+    let sse = concat!(
+        "event: response.created\n",
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"in_progress\",\"model\":\"probe-model\",\"output\":[]}}\n\n",
+        "event: response.completed\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\",\"model\":\"probe-model\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"connection ok\"}]}],\"usage\":{\"input_tokens\":9,\"output_tokens\":3,\"total_tokens\":12}}}\n\n",
+    );
+    let body_base64 = base64::engine::general_purpose::STANDARD.encode(sse.as_bytes());
+
+    let payload = GatewaySyncReportRequest {
+        trace_id: "trace-claude-from-responses-sse".to_string(),
+        report_kind: "claude_chat_sync_finalize".to_string(),
+        report_context: Some(json!({
+            "client_api_format": "claude:messages",
+            "provider_api_format": "openai:responses",
+            "model": "probe-model",
+            "needs_conversion": true,
+            "has_envelope": false,
+            "upstream_is_stream": true,
+        })),
+        status_code: 200,
+        headers: BTreeMap::from([("content-type".to_string(), "text/event-stream".to_string())]),
+        body_json: None,
+        client_body_json: None,
+        body_base64: Some(body_base64),
+        telemetry: None,
+    };
+
+    let outcome = maybe_build_local_core_sync_finalize_response(
+        "trace-claude-from-responses-sse",
+        &test_decision(),
+        &payload,
+    )
+    .expect("local finalize should succeed")
+    .expect("cross-format sync response must be finalized, not passed through");
+
+    let report = outcome
+        .background_report
+        .expect("cross-format finalize should carry a success report");
+    let client_body = report.client_body_json.expect("client body should exist");
+    assert_eq!(client_body["type"], "message");
+    assert_eq!(client_body["content"][0]["text"], "connection ok");
+}

--- a/apps/aether-gateway/src/execution_runtime/fallback.rs
+++ b/apps/aether-gateway/src/execution_runtime/fallback.rs
@@ -159,13 +159,23 @@ pub(crate) fn should_fallback_to_control_sync(
     sync_body_has_embedded_error(Some(body_json))
 }
 
-/// A successful OpenAI Responses body always carries a top-level `"error": null`,
-/// so presence of the key alone must not be read as an embedded provider error.
-/// Mirrors the null-aware check used by the formats registry.
+/// Mirrors the top-level markers `is_error_like_sync_body` uses in the formats layer, so a
+/// body the conversion layer refuses as error-like is never forwarded as a success instead.
+///
+/// A successful OpenAI Responses body always carries a top-level `"error": null`, so the key
+/// alone must not be read as an embedded provider error — but `"status": "failed"` still is
+/// one even when `error` is null, as is a top-level `"type": "error"` envelope.
 pub(crate) fn sync_body_has_embedded_error(body_json: Option<&serde_json::Value>) -> bool {
-    body_json
-        .and_then(|value| value.get("error"))
-        .is_some_and(|error| !error.is_null())
+    let Some(object) = body_json.and_then(serde_json::Value::as_object) else {
+        return false;
+    };
+
+    object.get("error").is_some_and(|error| !error.is_null())
+        || object.get("status").and_then(serde_json::Value::as_str) == Some("failed")
+        || object
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| value == "error")
 }
 
 pub(crate) fn should_finalize_sync_response(report_kind: Option<&str>) -> bool {
@@ -1339,6 +1349,45 @@ mod tests {
         });
         assert!(sync_body_has_embedded_error(Some(&failure)));
         assert!(!sync_body_has_embedded_error(None));
+    }
+
+    #[test]
+    fn failed_responses_body_with_null_error_is_still_a_provider_error() {
+        // A failed Responses turn can arrive as HTTP 200 with `error` left null; ignoring the
+        // null must not let the failed provider body through as a successful response.
+        let failed = serde_json::json!({
+            "id": "resp_1",
+            "object": "response",
+            "status": "failed",
+            "error": null,
+            "output": [],
+        });
+        assert!(sync_body_has_embedded_error(Some(&failed)));
+
+        let error_envelope = serde_json::json!({
+            "type": "error",
+            "error": null,
+        });
+        assert!(sync_body_has_embedded_error(Some(&error_envelope)));
+
+        let result = ExecutionResult {
+            request_id: "req-1".to_string(),
+            candidate_id: None,
+            status_code: 200,
+            headers: Default::default(),
+            response_observation: None,
+            body: None,
+            telemetry: None,
+            error: None,
+        };
+        assert_eq!(
+            resolve_core_sync_error_finalize_report_kind(
+                "openai_chat_sync",
+                &result,
+                Some(&failed)
+            ),
+            Some("openai_chat_sync_finalize".to_string())
+        );
     }
 
     #[test]

--- a/apps/aether-gateway/src/execution_runtime/fallback.rs
+++ b/apps/aether-gateway/src/execution_runtime/fallback.rs
@@ -156,7 +156,16 @@ pub(crate) fn should_fallback_to_control_sync(
         return true;
     };
 
-    body_json.get("error").is_some()
+    sync_body_has_embedded_error(Some(body_json))
+}
+
+/// A successful OpenAI Responses body always carries a top-level `"error": null`,
+/// so presence of the key alone must not be read as an embedded provider error.
+/// Mirrors the null-aware check used by the formats registry.
+pub(crate) fn sync_body_has_embedded_error(body_json: Option<&serde_json::Value>) -> bool {
+    body_json
+        .and_then(|value| value.get("error"))
+        .is_some_and(|error| !error.is_null())
 }
 
 pub(crate) fn should_finalize_sync_response(report_kind: Option<&str>) -> bool {
@@ -168,7 +177,7 @@ pub(crate) fn resolve_core_sync_error_finalize_report_kind(
     result: &ExecutionResult,
     body_json: Option<&serde_json::Value>,
 ) -> Option<String> {
-    let has_embedded_error = body_json.is_some_and(|value| value.get("error").is_some());
+    let has_embedded_error = sync_body_has_embedded_error(body_json);
     if result.status_code < 400 && !has_embedded_error {
         return None;
     }
@@ -368,7 +377,7 @@ mod tests {
         resolve_core_sync_error_finalize_report_kind, should_fallback_to_control_stream,
         should_fallback_to_control_sync, should_retry_next_local_candidate_stream,
         should_retry_next_local_candidate_sync, should_stop_local_candidate_failover_stream,
-        should_stop_local_candidate_failover_sync,
+        should_stop_local_candidate_failover_sync, sync_body_has_embedded_error,
     };
     use crate::data::GatewayDataState;
     use crate::orchestration::{
@@ -1310,6 +1319,89 @@ mod tests {
                 Some("{\"error\":{\"code\":\"chatgpt_web_image_execution_unavailable\"}}"),
             )
             .await
+        );
+    }
+
+    #[test]
+    fn null_embedded_error_is_not_a_provider_error() {
+        // A successful OpenAI Responses body always carries `"error": null`.
+        let success = serde_json::json!({
+            "id": "resp_1",
+            "object": "response",
+            "status": "completed",
+            "error": null,
+            "output": [],
+        });
+        assert!(!sync_body_has_embedded_error(Some(&success)));
+
+        let failure = serde_json::json!({
+            "error": {"message": "boom", "type": "invalid_request_error"},
+        });
+        assert!(sync_body_has_embedded_error(Some(&failure)));
+        assert!(!sync_body_has_embedded_error(None));
+    }
+
+    #[test]
+    fn successful_responses_body_does_not_map_to_error_finalize() {
+        let result = ExecutionResult {
+            request_id: "req-1".to_string(),
+            candidate_id: None,
+            status_code: 200,
+            headers: Default::default(),
+            response_observation: None,
+            body: None,
+            telemetry: None,
+            error: None,
+        };
+        let body_json = serde_json::json!({
+            "id": "resp_1",
+            "object": "response",
+            "status": "completed",
+            "error": null,
+            "output": [],
+        });
+
+        assert_eq!(
+            resolve_core_sync_error_finalize_report_kind(
+                "openai_chat_sync",
+                &result,
+                Some(&body_json)
+            ),
+            None
+        );
+        assert!(!should_fallback_to_control_sync(
+            "openai_chat_sync",
+            &result,
+            Some(&body_json),
+            true,
+            false,
+            false,
+        ));
+    }
+
+    #[test]
+    fn non_null_embedded_error_still_maps_to_error_finalize() {
+        let result = ExecutionResult {
+            request_id: "req-1".to_string(),
+            candidate_id: None,
+            status_code: 200,
+            headers: Default::default(),
+            response_observation: None,
+            body: None,
+            telemetry: None,
+            error: None,
+        };
+        let body_json = serde_json::json!({
+            "error": {"message": "boom", "type": "invalid_request_error"},
+        });
+
+        assert_eq!(
+            resolve_core_sync_error_finalize_report_kind(
+                "openai_responses_sync",
+                &result,
+                Some(&body_json)
+            ),
+            Some("openai_responses_sync_finalize".to_string())
         );
     }
 }

--- a/apps/aether-gateway/src/execution_runtime/sync/execution.rs
+++ b/apps/aether-gateway/src/execution_runtime/sync/execution.rs
@@ -3279,7 +3279,17 @@ fn maybe_build_implicit_sync_finalize_outcome(
     body_base64: &Option<String>,
     telemetry: &Option<ExecutionTelemetry>,
 ) -> Result<Option<ImplicitSyncFinalizeOutcome>, GatewayError> {
-    if status_code >= 400 || body_json.is_some() || body_base64.is_none() {
+    if status_code >= 400 {
+        return Ok(None);
+    }
+    if body_json.is_none() && body_base64.is_none() {
+        return Ok(None);
+    }
+    // A parsed JSON provider body normally means the surface owns the response and the
+    // raw bytes are forwarded as-is. That is only correct when client and provider speak
+    // the same API format: a cross-format attempt still has to be converted back before it
+    // reaches the client, so it must reach finalize like the stream-captured path does.
+    if body_json.is_some() && !sync_report_context_needs_conversion(report_context.as_ref()) {
         return Ok(None);
     }
 
@@ -3287,6 +3297,15 @@ fn maybe_build_implicit_sync_finalize_outcome(
         return Ok(None);
     };
 
+    // Only the stream-captured path may hand raw bytes to finalize: there they are an SSE
+    // capture that has to be aggregated. When the provider body already parsed as JSON the
+    // bytes are just its own encoding, and feeding them to the stream aggregators would
+    // fail closed, so the JSON body is the single source of truth.
+    let body_base64 = if body_json.is_some() {
+        None
+    } else {
+        body_base64.clone()
+    };
     let payload = GatewaySyncReportRequest {
         trace_id: trace_id.to_string(),
         report_kind: report_kind.to_string(),
@@ -3295,7 +3314,7 @@ fn maybe_build_implicit_sync_finalize_outcome(
         headers: headers.clone(),
         body_json: body_json.clone(),
         client_body_json: None,
-        body_base64: body_base64.clone(),
+        body_base64,
         telemetry: telemetry.clone(),
     };
     let Some(outcome) = maybe_build_sync_finalize_outcome(trace_id, decision, &payload)? else {
@@ -3303,6 +3322,13 @@ fn maybe_build_implicit_sync_finalize_outcome(
     };
 
     Ok(Some(ImplicitSyncFinalizeOutcome { payload, outcome }))
+}
+
+fn sync_report_context_needs_conversion(report_context: Option<&serde_json::Value>) -> bool {
+    report_context
+        .and_then(|context| context.get("needs_conversion"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
 }
 
 #[allow(clippy::too_many_arguments)] // internal helper mirroring execute path context

--- a/crates/aether-ai/formats/src/formats/shared/sync_products.rs
+++ b/crates/aether-ai/formats/src/formats/shared/sync_products.rs
@@ -1047,6 +1047,40 @@ fn decode_non_stream_sync_capture_body(body_base64: &str) -> Option<Value> {
     serde_json::from_slice::<Value>(&body_bytes)
         .ok()
         .filter(Value::is_object)
+        .filter(|body_json| !is_stream_event_object(body_json))
+}
+
+/// Whether a complete JSON object is a single stream event rather than a provider response body.
+///
+/// `parse_stream_json_events` accepts unframed JSON lines on purpose, so a capture holding one
+/// event parses as a complete object just like a non-streaming body does. Those still belong to
+/// the aggregators, which know how to unwrap the response the event carries.
+///
+/// Provider response bodies never match: OpenAI Responses and Chat carry no top-level `type`,
+/// Gemini carries neither, and an Anthropic Messages body is `"type": "message"` with its payload
+/// under `content` rather than nested beside the event name.
+fn is_stream_event_object(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    if object
+        .get("object")
+        .and_then(Value::as_str)
+        .is_some_and(|object| object.ends_with(".chunk"))
+    {
+        return true;
+    }
+    object
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|event_type| {
+            // OpenAI Responses names its events `response.*`; the other formats nest the payload
+            // the event carries beside the event name.
+            event_type.contains('.')
+                || ["response", "message", "item", "delta", "content_block"]
+                    .iter()
+                    .any(|nested| object.contains_key(*nested))
+        })
 }
 
 fn is_error_like_sync_body(value: &Value) -> bool {
@@ -3986,7 +4020,8 @@ mod tests {
         aggregate_claude_stream_sync_response, aggregate_gemini_stream_sync_response,
         aggregate_openai_chat_stream_sync_response,
         aggregate_openai_responses_stream_sync_response, convert_standard_chat_response,
-        convert_standard_cli_response, materialize_openai_responses_reasoning_item,
+        convert_standard_cli_response, decode_non_stream_sync_capture_body,
+        materialize_openai_responses_reasoning_item,
         maybe_build_openai_chat_cross_format_sync_product_from_normalized_payload,
         maybe_build_openai_responses_cross_format_sync_product_from_normalized_payload,
         maybe_build_openai_responses_same_family_sync_body_from_normalized_payload,
@@ -4481,6 +4516,42 @@ mod tests {
             product.expect("product should exist").provider_body_json,
             provider_body_json
         );
+    }
+
+    #[test]
+    fn a_single_unframed_stream_event_is_not_mistaken_for_a_provider_body() {
+        for event in [
+            json!({"type": "response.completed", "response": {"status": "completed"}}),
+            json!({"type": "response.output_text.delta", "delta": "hi"}),
+            json!({"type": "message_start", "message": {"id": "msg_1"}}),
+            json!({"type": "content_block_delta", "index": 0, "delta": {"text": "hi"}}),
+            json!({"object": "chat.completion.chunk", "choices": []}),
+        ] {
+            let body_base64 = base64::engine::general_purpose::STANDARD
+                .encode(serde_json::to_vec(&event).expect("serialize event"));
+            assert!(
+                decode_non_stream_sync_capture_body(&body_base64).is_none(),
+                "stream events belong to the aggregators: {event}"
+            );
+        }
+    }
+
+    #[test]
+    fn provider_response_bodies_are_still_recovered_from_a_capture() {
+        for body in [
+            json!({"id": "resp_1", "object": "response", "status": "completed", "output": []}),
+            json!({"id": "chatcmpl_1", "object": "chat.completion", "choices": []}),
+            json!({"id": "msg_1", "type": "message", "role": "assistant", "content": []}),
+            json!({"candidates": [], "modelVersion": "probe-model"}),
+        ] {
+            let body_base64 = base64::engine::general_purpose::STANDARD
+                .encode(serde_json::to_vec(&body).expect("serialize body"));
+            assert_eq!(
+                decode_non_stream_sync_capture_body(&body_base64),
+                Some(body.clone()),
+                "a complete provider body is not a stream: {body}"
+            );
+        }
     }
 
     #[test]

--- a/crates/aether-ai/formats/src/formats/shared/sync_products.rs
+++ b/crates/aether-ai/formats/src/formats/shared/sync_products.rs
@@ -469,6 +469,29 @@ pub fn maybe_build_standard_sync_finalize_product_from_normalized_payload(
     };
     let body_base64 = body_base64.or(capture_stream_body_base64.as_deref());
 
+    // Raw bytes reach finalize as an SSE capture that still has to be aggregated, and they take
+    // precedence over a parsed body on purpose: that is how an explicit stream body stays
+    // authoritative over a capture envelope. A cross-format attempt can also arrive with bytes
+    // that are no stream at all — the plan forced upstream streaming and the provider answered
+    // with a plain JSON body anyway, or the body already parsed and the bytes are only its own
+    // encoding. Handing those to the stream aggregators fails closed on OpenAI Responses and
+    // yields no product at all on every other format, so the client gets a 500 or the provider's
+    // own shape instead of a converted response. A complete JSON object is never SSE framing, so
+    // parsing the capture is proof it never was a stream.
+    //
+    // Same-format attempts keep both fields verbatim: there the bytes already are the response the
+    // client asked for.
+    let non_stream_capture_body_json =
+        if capture_envelope_used || !sync_finalize_needs_conversion(report_context) {
+            None
+        } else {
+            body_base64.and_then(decode_non_stream_sync_capture_body)
+        };
+    let (body_json, body_base64) = match non_stream_capture_body_json.as_ref() {
+        Some(capture_body_json) => (body_json.or(Some(capture_body_json)), None),
+        None => (body_json, body_base64),
+    };
+
     if let Some(body_json) = maybe_build_standard_same_format_sync_body_from_normalized_payload(
         report_kind,
         status_code,
@@ -1007,6 +1030,23 @@ fn maybe_build_openai_cross_format_provider_body_from_normalized_payload(
             body_json,
             aggregated_from_stream,
         }))
+}
+
+fn sync_finalize_needs_conversion(report_context: Option<&Value>) -> bool {
+    report_context
+        .and_then(|report_context| report_context.get("needs_conversion"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// Decodes a capture that turns out to be a single complete JSON object rather than a stream.
+fn decode_non_stream_sync_capture_body(body_base64: &str) -> Option<Value> {
+    let body_bytes = base64::engine::general_purpose::STANDARD
+        .decode(body_base64)
+        .ok()?;
+    serde_json::from_slice::<Value>(&body_bytes)
+        .ok()
+        .filter(Value::is_object)
 }
 
 fn is_error_like_sync_body(value: &Value) -> bool {
@@ -4440,6 +4480,83 @@ mod tests {
         assert_eq!(
             product.expect("product should exist").provider_body_json,
             provider_body_json
+        );
+    }
+
+    #[test]
+    fn recovers_a_cross_format_capture_that_is_a_complete_json_body() {
+        let report_context = json!({
+            "provider_api_format": "openai:responses",
+            "client_api_format": "claude:messages",
+            "needs_conversion": true,
+            "upstream_is_stream": true,
+        });
+        let provider_body_json = json!({
+            "id": "resp_1",
+            "object": "response",
+            "status": "completed",
+            "error": null,
+            "model": "probe-model",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{ "type": "output_text", "text": "hello" }]
+            }],
+            "usage": { "input_tokens": 5, "output_tokens": 7, "total_tokens": 12 }
+        });
+        let body_base64 = base64::engine::general_purpose::STANDARD
+            .encode(serde_json::to_vec(&provider_body_json).expect("serialize provider body"));
+
+        let product = maybe_build_standard_sync_finalize_product_from_normalized_payload(
+            "claude_chat_sync_finalize",
+            200,
+            Some(&report_context),
+            None,
+            Some(&body_base64),
+        )
+        .expect("a non-streaming provider body must not fail the stream aggregator")
+        .expect("product should exist");
+
+        let StandardSyncFinalizeNormalizedProduct::CrossFormat(product) = product else {
+            panic!("cross-format attempt should produce a cross-format product");
+        };
+        assert_eq!(product.provider_body_json, provider_body_json);
+        assert_eq!(
+            product.client_body_json.get("type"),
+            Some(&json!("message"))
+        );
+    }
+
+    #[test]
+    fn keeps_a_cross_format_stream_capture_on_the_aggregation_path() {
+        let body = concat!(
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\",\"model\":\"probe-model\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":\"hello\"}]}],\"usage\":{\"input_tokens\":5,\"output_tokens\":7,\"total_tokens\":12}}}\n\n",
+        );
+        let report_context = json!({
+            "provider_api_format": "openai:responses",
+            "client_api_format": "claude:messages",
+            "needs_conversion": true,
+            "upstream_is_stream": true,
+        });
+
+        let product = maybe_build_standard_sync_finalize_product_from_normalized_payload(
+            "claude_chat_sync_finalize",
+            200,
+            Some(&report_context),
+            None,
+            Some(&base64::engine::general_purpose::STANDARD.encode(body)),
+        )
+        .expect("stream capture should aggregate")
+        .expect("product should exist");
+
+        let StandardSyncFinalizeNormalizedProduct::CrossFormat(product) = product else {
+            panic!("cross-format attempt should produce a cross-format product");
+        };
+        assert_eq!(
+            product.client_body_json.get("content"),
+            Some(&json!([{ "type": "text", "text": "hello" }]))
         );
     }
 


### PR DESCRIPTION
Fixes #744 · 同根因的 #711

## 问题

非流式跨格式的同步请求，**请求方向转换正常，响应方向完全没转**：网关把上游原始报文连同上游原始响应头一起透传给下游。客户端走 `openai:responses` 被路由到 `openai:chat` / `claude:messages` 上游时，拿到的是 HTTP 200 加一个 `chat.completion` 或 Anthropic Messages 对象。

判定依据：下游 `client_response_headers` 与上游 `response_headers` 逐字节相同，`content-length` 等于上游原始报文字节数。而 `prepare_local_success_response_parts_owned` 在任何 finalize 路径上都会无条件删掉再重算 `content-length`——下游值仍等于上游原值，说明 finalize 根本没被调用。完整证据在 #744。

同条件下流式跨格式转换是正常的（上游 `chat.completion.chunk` → 下游 `message_start` / `content_block_delta`），可作对照。

## 根因

本地同步路径对 openai 系客户端面缺少成功侧 finalize 入口，三处连锁：

1. openai 系 sync spec 的 `report_kind` 是 `*_sync_success`，而 `should_finalize_sync_response` 按 `_finalize` 后缀判定。claude / gemini / embedding / image 用的都是 `*_sync_finalize`，只有 openai 系不是，因此 `explicit_finalize` 恒为 false。
2. `maybe_build_implicit_sync_finalize_outcome` 在 `body_json.is_some()` 时直接返回 `None`，而非流式上游返回可解析 JSON 时 `body_json` 必为 `Some`。这条 guard 本意只服务于「同步请求但上游走 SSE」的 capture-envelope 场景（#676 修的那一支）。
3. `should_fallback_to_control_sync` 对 200 且无顶层 `error` 键的 JSON 返回 `false`，也不会兜底。

三者叠加，本地同步直接把上游原始字节和原始 header 交给客户端。

## 改动

### `execution_runtime/sync/execution.rs`

隐式 finalize 在 report context 标记 `needs_conversion` 时接受 JSON body。门槛就是「这次尝试需要跨格式转换」，同格式透传行为完全不变。

改动是严格增量的：原先能进入 finalize 的条件（`body_json` 为空且 `body_base64` 非空）行为逐字节不变，只是额外放行了跨格式且 body 已解析为 JSON 的情况。

另外只有流式捕获路径才把原始字节交给 finalize——那里它是待聚合的 SSE；body 已经解析成 JSON 时以 JSON 为唯一来源，否则把普通 JSON 字节喂给流聚合器会 fail closed。

### `execution_runtime/fallback.rs`

抽出 `sync_body_has_embedded_error`，不再把顶层 `"error": null` 当成上游错误。OpenAI Responses 成功响应固定携带这个键，null-blind 的判断会把成功响应误判为内嵌错误，路由进 error finalize 分支并吐出 HTTP 400 `"completed"`（#711）。formats registry 里本来就是 null-aware 的（`openai/responses/response.rs` 的 `is_some_and(|error| !error.is_null())`）。

判定复用 `is_error_like_sync_body` 的全部顶层标记：非 null `error`、`"status": "failed"`、顶层 `"type": "error"` 信封。**只判 `error` 非 null 是不够的**——上游可能以 HTTP 200 返回 `{"status":"failed","error":null}`，这种 body 会被 `is_error_like_sync_body` 从成功转换里过滤掉，跨格式尝试产不出 product，若此处又判定无错误，失败报文就会被当成功响应 200 原样返回。两侧用同一组标记可以保证：转换层拒绝为 error-like 的 body，绝不会从成功路径漏出去。

### `formats/shared/sync_products.rs`

同步 finalize 把 `body_base64` 当成待聚合的 SSE 捕获，并且刻意让它优先于 `body_json`——capture envelope 场景正是靠这个优先级保证显式流式 body 权威。但没有任何地方校验这串字节真的是流。

当计划强制上游流式（codex + `openai:responses` 恒定如此，endpoint config 也能开）而上游实际返回普通 JSON 时，`build_execution_response_body` 走 `stream` 分支，交给 finalize 的是 `body_json: None` 加原始 JSON 字节。跨格式尝试于是把这串字节直接喂给流聚合器：

- provider 是 `openai:responses` 时 fail closed，报 `OpenAI Responses stream is missing an authoritative terminal event`，一次已经产生计费的完整上游响应变成 HTTP 500；
- 其余 provider 格式聚合返回 `None`，产不出 product，上游原始形状被透传给说另一种协议的客户端。

完整 JSON 对象不可能是 SSE 分帧，所以「能解析成 JSON 对象」本身就是「它从来不是流」的证据。这种情况下取解析后的 body 并丢弃字节。同格式尝试原样不动；真正的流式捕获仍然走聚合器，capture envelope 的优先级不变。

跨格式同步矩阵实测（4 种 provider 格式 × 6 个 finalize 面）：修复前 5 个硬失败（HTTP 500）+ 9 个错误形状透传，修复后全部通过。

判定「不是流」只靠「能整体解析成一个 JSON 对象」还不够。`parse_stream_json_events` 有意接受无 `data:` 前缀的 JSON 行，所以只含单条终结事件的 capture 同样能解析成完整对象——那仍然是流，必须留给聚合器去拆出它携带的 response。因此恢复路径额外排除「本身就是流事件」的对象：`object` 以 `.chunk` 结尾，或存在顶层 `type` 且事件名含 `.`（Responses 的 `response.*`）或对象里同时挂着 `response` / `message` / `item` / `delta` / `content_block`。provider 响应体不会命中：Responses 与 Chat 顶层没有 `type`，Gemini 两个标记都没有，Anthropic Messages 虽是 `"type": "message"` 但负载在 `content` 下。

## 测试

`execution_runtime/fallback.rs` 新增 4 个用例：

- `null_embedded_error_is_not_a_provider_error`
- `successful_responses_body_does_not_map_to_error_finalize`
- `non_null_embedded_error_still_maps_to_error_finalize`
- `failed_responses_body_with_null_error_is_still_a_provider_error`

`ai_serving/finalize/tests_sync.rs` 新增 2 个用例，直接对应 #744 里的两个生产 trace：

- `local_finalize_converts_openai_responses_sync_response_from_claude_messages`
- `local_finalize_converts_openai_responses_sync_response_from_openai_chat`

断言下游 body 是 `object: "response"` 且不再保留上游形状（不含 `content` / `choices`）。

`formats/shared/sync_products.rs` 新增 2 个用例：

- `recovers_a_cross_format_capture_that_is_a_complete_json_body`
- `keeps_a_cross_format_stream_capture_on_the_aggregation_path`

`ai_serving/finalize/tests_sync.rs` 再新增 3 个用例：

- `local_finalize_recovers_non_stream_json_capture_from_openai_responses_provider`
- `local_finalize_prefers_the_parsed_json_body_over_its_own_encoding`
- `local_finalize_still_aggregates_a_real_cross_format_stream_capture`（回归护栏：真 SSE 仍走聚合）
- `local_finalize_keeps_an_unframed_stream_event_on_the_aggregation_path`（无分帧单事件仍走聚合）

`formats/shared/sync_products.rs` 另有 2 个用例覆盖恢复判据的两侧：

- `a_single_unframed_stream_event_is_not_mistaken_for_a_provider_body`（5 种事件形状）
- `provider_response_bodies_are_still_recovered_from_a_capture`（4 种 provider 响应体）

## 验证

```
cargo fmt --all --check
cargo clippy -p aether-gateway --lib --bins --examples -- -D warnings
cargo test -p aether-gateway --lib                      # 4174 passed, 0 failed
cargo test -p aether-ai-formats --lib                   # 800 passed, 0 failed
cargo test --workspace --exclude aether-gateway         # 0 failed
```

同一份改动在 fork 上跑过完整 CI，23 项检查全部通过（fmt / clippy ×3 / test ×多个 / Data 各驱动 smoke）。

## 兼容性

非流式跨格式请求会开始真正走 finalize，返回体形状变为客户端声明的格式——这正是修复目的，但依赖了当前「透传上游格式」行为的客户端会看到差异。同格式请求与流式请求行为不变。

第三个 commit 的门槛同样是 `needs_conversion`：同格式路径的 `body_json` / `body_base64` 逐字节不变，capture envelope 分支先于新逻辑求值，显式流式 body 优先于 capture envelope 的既有契约由 `standard_sync_finalize_prefers_explicit_stream_body_over_capture_envelope` 继续守住。