### PR TITLE
fix(admin): Codex 模型级限额报头污染账号额度槽位

### DIFF
--- a/crates/aether-admin/src/provider/quota.rs
+++ b/crates/aether-admin/src/provider/quota.rs
@@ -10,6 +10,9 @@ const OAUTH_REFRESH_FAILED_PREFIX: &str = "[REFRESH_FAILED] ";
 const OAUTH_EXPIRED_PREFIX: &str = "[OAUTH_EXPIRED] ";
 const OAUTH_REQUEST_FAILED_PREFIX: &str = "[REQUEST_FAILED] ";
 const CODEX_SPARK_LIMIT_NAME: &str = "GPT-5.3-Codex-Spark";
+const CODEX_ACTIVE_LIMIT_HEADER: &str = "x-codex-active-limit";
+const CODEX_HEADER_PREFIX: &str = "x-codex-";
+const CODEX_LIMIT_NAME_HEADER_SUFFIX: &str = "-limit-name";
 
 pub fn provider_auto_remove_banned_keys(config: Option<&serde_json::Value>) -> bool {
     config
@@ -2538,6 +2541,48 @@ pub fn parse_codex_backend_me_response(
     Some(serde_json::Value::Object(result))
 }
 
+/// Lists the named per-model limits the response headers announce, as `(feature, limit_name)`.
+///
+/// `feature` is the header segment that carries the limit's windows
+/// (`x-codex-bengalfox-primary-used-percent`), and matches the `metered_feature` reported by
+/// `wham/usage` minus its `codex_` prefix.
+fn codex_named_limit_headers(normalized: &BTreeMap<String, String>) -> Vec<(String, String)> {
+    normalized
+        .iter()
+        .filter_map(|(key, value)| {
+            let feature = key
+                .strip_prefix(CODEX_HEADER_PREFIX)?
+                .strip_suffix(CODEX_LIMIT_NAME_HEADER_SUFFIX)?;
+            let limit_name = value.trim();
+            (!feature.is_empty() && !limit_name.is_empty())
+                .then(|| (feature.to_string(), limit_name.to_string()))
+        })
+        .collect()
+}
+
+/// Whether one of the announced named limits owns the unprefixed `x-codex-primary/secondary-*`
+/// windows.
+///
+/// `x-codex-active-limit` names the metered feature this request was billed against, and reports
+/// the plan's own limit as `premium`, which matches no announced feature. The account therefore
+/// keeps the unprefixed windows unless the active limit is one of the named ones.
+fn codex_named_limit_owns_unprefixed_windows(
+    normalized: &BTreeMap<String, String>,
+    named_limits: &[(String, String)],
+) -> bool {
+    let Some(active_limit) = normalized
+        .get(CODEX_ACTIVE_LIMIT_HEADER)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    else {
+        return false;
+    };
+    named_limits.iter().any(|(feature, _)| {
+        active_limit.eq_ignore_ascii_case(feature)
+            || active_limit.eq_ignore_ascii_case(&format!("codex_{feature}"))
+    })
+}
+
 pub fn parse_codex_usage_headers(
     headers: &BTreeMap<String, String>,
     updated_at_unix_secs: u64,
@@ -2597,28 +2642,52 @@ pub fn parse_codex_usage_headers(
         object
     };
 
-    let primary_window = read_window("primary");
-    let secondary_window = read_window("secondary");
-    let use_paid_windows =
-        codex_window_has_active_limit(&secondary_window) && plan_type.as_deref() != Some("free");
-    if use_paid_windows {
-        codex_write_window(&mut result, &secondary_window, "primary");
-        codex_write_window(&mut result, &primary_window, "secondary");
-    } else {
-        codex_write_window(&mut result, &primary_window, "primary");
-        if codex_window_is_explicitly_disabled(&secondary_window) {
-            codex_write_disabled_window(&mut result, "secondary");
+    // Every named limit is announced by its own `x-codex-<feature>-limit-name` header and carries
+    // its windows under the same `<feature>` prefix, so the header set describes itself.
+    let named_limits = codex_named_limit_headers(&normalized);
+    for (feature, limit_name) in &named_limits {
+        if limit_name != CODEX_SPARK_LIMIT_NAME {
+            continue;
+        }
+        let spark_primary_window = read_window(&format!("{feature}-primary"));
+        if !spark_primary_window.is_empty() {
+            codex_write_window(&mut result, &spark_primary_window, "spark_primary");
+        }
+        let spark_secondary_window = read_window(&format!("{feature}-secondary"));
+        if !spark_secondary_window.is_empty() {
+            codex_write_window(&mut result, &spark_secondary_window, "spark_secondary");
         }
     }
 
-    if let Some(value) = normalized
-        .get("x-codex-primary-over-secondary-limit-percent")
-        .and_then(|value| value.parse::<f64>().ok())
-    {
-        result.insert(
-            "primary_over_secondary_limit_percent".to_string(),
-            json!(value),
-        );
+    // The unprefixed windows describe whichever limit governed this request, not the account:
+    // on a request metered against a named limit they repeat that limit's windows verbatim.
+    // `x-codex-active-limit` is the only thing that tells the two apart, so an account window is
+    // only claimed when no named limit owns the unprefixed set. Upstreams that do not send the
+    // header keep the previous behaviour.
+    if !codex_named_limit_owns_unprefixed_windows(&normalized, &named_limits) {
+        let primary_window = read_window("primary");
+        let secondary_window = read_window("secondary");
+        let use_paid_windows = codex_window_has_active_limit(&secondary_window)
+            && plan_type.as_deref() != Some("free");
+        if use_paid_windows {
+            codex_write_window(&mut result, &secondary_window, "primary");
+            codex_write_window(&mut result, &primary_window, "secondary");
+        } else {
+            codex_write_window(&mut result, &primary_window, "primary");
+            if codex_window_is_explicitly_disabled(&secondary_window) {
+                codex_write_disabled_window(&mut result, "secondary");
+            }
+        }
+
+        if let Some(value) = normalized
+            .get("x-codex-primary-over-secondary-limit-percent")
+            .and_then(|value| value.parse::<f64>().ok())
+        {
+            result.insert(
+                "primary_over_secondary_limit_percent".to_string(),
+                json!(value),
+            );
+        }
     }
     if let Some(value) = normalized
         .get("x-codex-credits-has-credits")
@@ -5356,6 +5425,223 @@ mod tests {
         assert!(!should_auto_remove_structured_reason(Some(
             "[REFRESH_FAILED] Token 续期失败 (401): refresh_token 已失效"
         )));
+    }
+
+    /// Header set captured from a `gpt-5.6-sol` response: the request was metered against the
+    /// plan's own limit, so the unprefixed windows are the account's and the Spark limit is
+    /// announced separately.
+    fn codex_premium_response_headers() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("x-codex-plan-type".to_string(), "pro".to_string()),
+            ("x-codex-active-limit".to_string(), "premium".to_string()),
+            ("x-codex-primary-used-percent".to_string(), "50".to_string()),
+            (
+                "x-codex-primary-window-minutes".to_string(),
+                "10080".to_string(),
+            ),
+            (
+                "x-codex-primary-reset-at".to_string(),
+                "1787801347".to_string(),
+            ),
+            (
+                "x-codex-secondary-used-percent".to_string(),
+                "0".to_string(),
+            ),
+            (
+                "x-codex-secondary-window-minutes".to_string(),
+                "0".to_string(),
+            ),
+            ("x-codex-secondary-reset-at".to_string(), "".to_string()),
+            (
+                "x-codex-secondary-reset-after-seconds".to_string(),
+                "0".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-limit-name".to_string(),
+                "GPT-5.3-Codex-Spark".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-used-percent".to_string(),
+                "17".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-window-minutes".to_string(),
+                "300".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-reset-at".to_string(),
+                "1787410252".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-used-percent".to_string(),
+                "8".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-window-minutes".to_string(),
+                "10080".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-reset-at".to_string(),
+                "1787833868".to_string(),
+            ),
+        ])
+    }
+
+    /// Header set captured from a `gpt-5.3-codex-spark` response three seconds later on the same
+    /// key: the unprefixed windows now repeat the Spark limit verbatim, and only
+    /// `x-codex-active-limit` says so.
+    fn codex_spark_response_headers() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("x-codex-plan-type".to_string(), "pro".to_string()),
+            (
+                "x-codex-active-limit".to_string(),
+                "codex_bengalfox".to_string(),
+            ),
+            ("x-codex-primary-used-percent".to_string(), "22".to_string()),
+            (
+                "x-codex-primary-window-minutes".to_string(),
+                "300".to_string(),
+            ),
+            (
+                "x-codex-primary-reset-at".to_string(),
+                "1787410252".to_string(),
+            ),
+            (
+                "x-codex-secondary-used-percent".to_string(),
+                "11".to_string(),
+            ),
+            (
+                "x-codex-secondary-window-minutes".to_string(),
+                "10080".to_string(),
+            ),
+            (
+                "x-codex-secondary-reset-at".to_string(),
+                "1787833868".to_string(),
+            ),
+            (
+                "x-codex-secondary-reset-after-seconds".to_string(),
+                "424336".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-limit-name".to_string(),
+                "GPT-5.3-Codex-Spark".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-used-percent".to_string(),
+                "22".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-window-minutes".to_string(),
+                "300".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-reset-at".to_string(),
+                "1787410252".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-used-percent".to_string(),
+                "11".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-window-minutes".to_string(),
+                "10080".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-reset-at".to_string(),
+                "1787833868".to_string(),
+            ),
+        ])
+    }
+
+    #[test]
+    fn codex_usage_headers_keep_the_account_window_when_the_plan_limit_is_active() {
+        let parsed = parse_codex_usage_headers(&codex_premium_response_headers(), 1_787_409_530)
+            .expect("Codex usage headers should parse");
+
+        assert_eq!(parsed.get("primary_used_percent"), Some(&json!(50.0)));
+        assert_eq!(
+            parsed.get("primary_window_minutes"),
+            Some(&json!(10_080u64))
+        );
+        assert_eq!(
+            parsed.get("primary_reset_at"),
+            Some(&json!(1_787_801_347u64))
+        );
+        assert_eq!(parsed.get("secondary_window_minutes"), Some(&json!(0u64)));
+    }
+
+    #[test]
+    fn codex_usage_headers_capture_named_limit_windows_alongside_the_account_window() {
+        let parsed = parse_codex_usage_headers(&codex_premium_response_headers(), 1_787_409_530)
+            .expect("Codex usage headers should parse");
+
+        assert_eq!(parsed.get("spark_primary_used_percent"), Some(&json!(17.0)));
+        assert_eq!(
+            parsed.get("spark_primary_window_minutes"),
+            Some(&json!(300u64))
+        );
+        assert_eq!(
+            parsed.get("spark_primary_reset_at"),
+            Some(&json!(1_787_410_252u64))
+        );
+        assert_eq!(
+            parsed.get("spark_secondary_used_percent"),
+            Some(&json!(8.0))
+        );
+        assert_eq!(
+            parsed.get("spark_secondary_window_minutes"),
+            Some(&json!(10_080u64))
+        );
+    }
+
+    #[test]
+    fn codex_usage_headers_keep_model_scoped_windows_out_of_the_account_family() {
+        let parsed = parse_codex_usage_headers(&codex_spark_response_headers(), 1_787_409_530)
+            .expect("Codex usage headers should parse");
+
+        // Without this the paid-window swap promotes the Spark weekly window into the account's
+        // own weekly slot, which is what the scheduler reads.
+        assert!(
+            parsed.get("primary_used_percent").is_none(),
+            "the Spark limit governed this request, so it must not claim the account window: {parsed}"
+        );
+        assert!(parsed.get("primary_window_minutes").is_none());
+        assert!(parsed.get("primary_reset_at").is_none());
+        assert!(parsed.get("secondary_used_percent").is_none());
+        assert!(parsed.get("primary_over_secondary_limit_percent").is_none());
+
+        assert_eq!(parsed.get("spark_primary_used_percent"), Some(&json!(22.0)));
+        assert_eq!(
+            parsed.get("spark_secondary_used_percent"),
+            Some(&json!(11.0))
+        );
+        assert_eq!(parsed.get("plan_type"), Some(&json!("pro")));
+    }
+
+    #[test]
+    fn codex_usage_headers_without_an_active_limit_still_fill_the_account_window() {
+        let mut headers = codex_premium_response_headers();
+        headers.remove("x-codex-active-limit");
+
+        let parsed = parse_codex_usage_headers(&headers, 1_787_409_530)
+            .expect("Codex usage headers should parse");
+
+        assert_eq!(parsed.get("primary_used_percent"), Some(&json!(50.0)));
+        assert_eq!(parsed.get("spark_primary_used_percent"), Some(&json!(17.0)));
+    }
+
+    #[test]
+    fn codex_usage_headers_ignore_an_active_limit_that_matches_no_announced_family() {
+        let mut headers = codex_premium_response_headers();
+        headers.insert(
+            "x-codex-active-limit".to_string(),
+            "codex_unknown_feature".to_string(),
+        );
+
+        let parsed = parse_codex_usage_headers(&headers, 1_787_409_530)
+            .expect("Codex usage headers should parse");
+
+        assert_eq!(parsed.get("primary_used_percent"), Some(&json!(50.0)));
     }
 
     #[test]

--- a/crates/aether-admin/src/provider/quota.rs
+++ b/crates/aether-admin/src/provider/quota.rs
@@ -2167,18 +2167,24 @@ fn parse_codex_websocket_usage_limit_error(
             result.insert("plan_type".to_string(), json!(plan_type));
         }
     }
-    if !result.contains_key("primary_reset_at") {
-        if let Some(reset_at) = error.get("resets_at").and_then(coerce_json_u64) {
-            result.insert("primary_reset_at".to_string(), json!(reset_at));
+    // `resets_at` describes whichever limit rejected the request. When a named per-model limit
+    // owned the window headers it owns this timing too, so backfilling it into the account slot
+    // would put a model window's reset on the account's own quota.
+    if codex_headers_carry_account_windows(&headers) {
+        if !result.contains_key("primary_reset_at") {
+            if let Some(reset_at) = error.get("resets_at").and_then(coerce_json_u64) {
+                result.insert("primary_reset_at".to_string(), json!(reset_at));
+            }
         }
-    }
-    if !result.contains_key("primary_reset_after_seconds") {
-        if let Some(reset_after_seconds) = error.get("resets_in_seconds").and_then(coerce_json_u64)
-        {
-            result.insert(
-                "primary_reset_after_seconds".to_string(),
-                json!(reset_after_seconds),
-            );
+        if !result.contains_key("primary_reset_after_seconds") {
+            if let Some(reset_after_seconds) =
+                error.get("resets_in_seconds").and_then(coerce_json_u64)
+            {
+                result.insert(
+                    "primary_reset_after_seconds".to_string(),
+                    json!(reset_after_seconds),
+                );
+            }
         }
     }
 
@@ -2541,6 +2547,23 @@ pub fn parse_codex_backend_me_response(
     Some(serde_json::Value::Object(result))
 }
 
+fn codex_normalized_headers(headers: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    headers
+        .iter()
+        .map(|(key, value)| (key.trim().to_ascii_lowercase(), value.trim().to_string()))
+        .collect()
+}
+
+/// Whether the account's own quota windows can be read from these headers' unprefixed fields.
+///
+/// False when a named per-model limit governed the request: the unprefixed fields — and any reset
+/// timing reported alongside them — then describe that limit instead.
+fn codex_headers_carry_account_windows(headers: &BTreeMap<String, String>) -> bool {
+    let normalized = codex_normalized_headers(headers);
+    let named_limits = codex_named_limit_headers(&normalized);
+    !codex_named_limit_owns_unprefixed_windows(&normalized, &named_limits)
+}
+
 /// Lists the named per-model limits the response headers announce, as `(feature, limit_name)`.
 ///
 /// `feature` is the header segment that carries the limit's windows
@@ -2588,11 +2611,11 @@ pub fn parse_codex_usage_headers(
     updated_at_unix_secs: u64,
 ) -> Option<serde_json::Value> {
     let mut result = serde_json::Map::new();
-    let normalized = headers
-        .iter()
-        .map(|(key, value)| (key.trim().to_ascii_lowercase(), value.trim().to_string()))
-        .collect::<BTreeMap<_, _>>();
-    if !normalized.keys().any(|key| key.starts_with("x-codex-")) {
+    let normalized = codex_normalized_headers(headers);
+    if !normalized
+        .keys()
+        .any(|key| key.starts_with(CODEX_HEADER_PREFIX))
+    {
         return None;
     }
 
@@ -5925,6 +5948,45 @@ mod tests {
             Some(&json!(1_787_274_385u64))
         );
         assert!(codex_rate_limit_metadata_exhausted(&parsed));
+    }
+
+    #[test]
+    fn codex_usage_limit_error_does_not_backfill_a_model_scoped_reset_into_the_account() {
+        let parsed = parse_codex_websocket_rate_limits_response(
+            &json!({
+                "type": "error",
+                "error": {
+                    "type": "usage_limit_reached",
+                    "plan_type": "pro",
+                    "resets_at": 1_787_430_252u64,
+                    "resets_in_seconds": 20_722u64,
+                },
+                "status_code": 429,
+                "headers": {
+                    "X-Codex-Plan-Type": "pro",
+                    "X-Codex-Active-Limit": "codex_bengalfox",
+                    "X-Codex-Primary-Used-Percent": "100",
+                    "X-Codex-Primary-Window-Minutes": "300",
+                    "X-Codex-Primary-Reset-At": "1787430252",
+                    "X-Codex-Bengalfox-Limit-Name": "GPT-5.3-Codex-Spark",
+                    "X-Codex-Bengalfox-Primary-Used-Percent": "100",
+                    "X-Codex-Bengalfox-Primary-Window-Minutes": "300",
+                    "X-Codex-Bengalfox-Primary-Reset-At": "1787430252",
+                },
+            }),
+            1_787_409_530,
+        )
+        .expect("Codex usage-limit error should parse as quota metadata");
+
+        assert!(
+            parsed.get("primary_reset_at").is_none(),
+            "the Spark limit rejected this request, so its reset timing must not claim the account window: {parsed}"
+        );
+        assert!(parsed.get("primary_reset_after_seconds").is_none());
+        assert_eq!(
+            parsed.get("spark_primary_reset_at"),
+            Some(&json!(1_787_430_252u64))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #746

## 问题

Codex key 显示的「周额度」不是账号的套餐周额度，而是 `GPT-5.3-Codex-Spark` 的周额度；账号真正的套餐周额度从来没有落库。同时 Spark 的两个窗口停留在 39 小时前的快照上——`spark_5h` 显示满格，而上游此刻是 100% 用尽。

生产实测（`pro` 计划，同一 key 上并行跑 `gpt-5.6-sol` 和 `gpt-5.3-codex-spark`）：

| 窗口 | 上游真实值 | Aether |
|---|---|---|
| 套餐周额度 | 55% used，reset `1787801347`（8-27 11:29） | **不存在** |
| Spark 5h | **100% used**，reset `1787430557` | 0% used，reset `1787293182`（39 小时前） |
| Spark 周 | 56% used，reset `1787833868`（8-27 20:31） | 1% used（39 小时前） |
| 「周 / account」槽位 | — | 55% used，reset `1787833866`（8-27 **20:31**） |

## 根因

上游报头是自描述的，`x-codex-active-limit` 指明本次请求命中了哪条限额：

**`gpt-5.6-sol`（22:38:49）**
```
x-codex-active-limit:                     premium
x-codex-primary-used-percent:             50     (window-minutes 10080, reset-at 1787801347)
x-codex-secondary-*:                      全零/空（禁用）
x-codex-bengalfox-limit-name:             GPT-5.3-Codex-Spark
x-codex-bengalfox-primary-used-percent:   17     (window-minutes 300)
x-codex-bengalfox-secondary-used-percent: 8      (window-minutes 10080)
```

**`gpt-5.3-codex-spark`（22:38:52，同一 key，相隔 3 秒）**
```
x-codex-active-limit:                     codex_bengalfox
x-codex-primary-used-percent:             22     (window-minutes 300)      ← Spark 5h
x-codex-secondary-used-percent:           11     (window-minutes 10080)    ← Spark 周
x-codex-bengalfox-primary/secondary-*:    与无前缀那组逐字节相同
```

`wham/usage` 报文的 `metered_feature: "codex_bengalfox"` 与 `limit_name: "GPT-5.3-Codex-Spark"` 和报头前缀、`-limit-name` 一一对应。

三处连锁：

1. **`parse_codex_usage_headers` 只读无前缀的那组**，不读 `x-codex-active-limit`，也不读整个 `x-codex-<feature>-*` 家族。于是命名限额的窗口被当成账号额度写进 `primary_*` / `secondary_*`。

2. **`use_paid_windows` 换位把它推到「周」槽位。** 套餐自身的 secondary 是全零禁用标记 → 不换位 → `primary_*` 正确拿到套餐周额度。命名限额的 secondary 是有效窗口 → 换位成立 → 该模型的周窗口被写进 `primary_*`，也就是 UI 标「周」、调度器读 `quota_usage_ratio` 的槽位。

   实测那条 spark 响应之后，库里立刻变成 `primary_used_percent = 11.0` / `primary_window_minutes = 10080` / `primary_reset_after_seconds = 424336`，与 `x-codex-secondary-*` 逐字节相同。

3. **deadline 规则让污染卡到窗口过期。** 两个周窗口的 `window_minutes` 都是 `10080`，`codex_quota_same_window_identity` 认成同一个窗口；`codex_quota_merge_same_window` 的第一条规则会丢弃 deadline 早于当前值的观测。两个「周」的起点不同（相差 9 小时），因此之后每一条套餐限额观测都被当成「已滚过窗口的迟到样本」丢弃。实测污染后 100 分钟内约 3000 条 `premium` 响应全部无效。

## 改动

`crates/aether-admin/src/provider/quota.rs`

- 新增 `codex_named_limit_headers`：扫描 `x-codex-<feature>-limit-name` 列出所有命名限额。`<feature>` 即 `metered_feature` 去掉 `codex_` 前缀。
- 新增 `codex_named_limit_owns_unprefixed_windows`：`x-codex-active-limit` 指向某个已发现的命名限额时，无前缀窗口属于该限额而非账号。
- `parse_codex_usage_headers`：
  - 命名限额中 `limit_name == "GPT-5.3-Codex-Spark"` 的，其 `<feature>-{primary,secondary}-*` 写入现有的 `spark_primary_*` / `spark_secondary_*`，保持既有键名兼容。
  - 无前缀窗口（含 `primary_over_secondary_limit_percent`）只在没有命名限额认领时才写入账号槽位。换位逻辑本身不动。

`x-codex-active-limit` 缺失时行为与改动前完全一致，不影响老版本上游。

第二个 commit 补上同一归属规则在 429 路径上的缺口：`parse_codex_websocket_usage_limit_error` 会在 embedded headers 没给出 `primary_reset_at` 时，用 `error.resets_at` / `resets_in_seconds` 回填。命名限额不再认领无前缀窗口之后，这个「没给出」恰好成为 Spark 429 的常态，而此时 `resets_at` 是 Spark 窗口的重置时刻——回填等于把模型级时序又写回账号槽位。抽出 `codex_normalized_headers` / `codex_headers_carry_account_windows`，让两处回填共用同一判定。

顺带解决 Spark 陈旧：此前 Spark 家族只有管理端 `wham/usage` 探测会写，而上游每一条响应都在推 `x-codex-bengalfox-*`。

## 测试

`crates/aether-admin/src/provider/quota.rs` 新增 5 个用例，报头取自生产实测的两条真实响应：

- `codex_usage_headers_keep_the_account_window_when_the_plan_limit_is_active`
- `codex_usage_headers_capture_named_limit_windows_alongside_the_account_window`
- `codex_usage_headers_keep_model_scoped_windows_out_of_the_account_family`（回归本 bug）
- `codex_usage_headers_without_an_active_limit_still_fill_the_account_window`（向后兼容）
- `codex_usage_headers_ignore_an_active_limit_that_matches_no_announced_family`
- `codex_usage_limit_error_does_not_backfill_a_model_scoped_reset_into_the_account`

## 验证

```
cargo fmt --all --check
cargo clippy -p aether-admin --lib -- -D warnings
cargo test -p aether-admin --lib        # 222 passed, 0 failed
cargo test -p aether-gateway --lib      # 4164 passed, 0 failed
cargo test --workspace                  # 0 failed
```

## 未覆盖

`parse_codex_websocket_rate_limits_chunk` 处理的 `codex.rate_limits` 事件同样没有限额维度，存在相同的错配风险。我手上没有该事件的报文样本，本 PR 不动它。

`parse_codex_websocket_usage_limit_error` 里的 `allowed: false` / `limit_reached: true` 是无条件写入的，注释说明理由是「`usage_limit_reached` 是账号级终结信号」。但 Spark 5h 打满触发的 429 只封锁 spark 模型，账号总额度仍可用，这么标会把整个 key 移出轮转。该行为在本 PR 前后完全一致，同样缺少真实报文样本，一并记录不改。
