### PR TITLE
fix(codex): isolate Spark quotas and repair contaminated account state

### DIFF
--- a/apps/aether-gateway/src/handlers/proxy/websocket/responses/adapters/codex.rs
+++ b/apps/aether-gateway/src/handlers/proxy/websocket/responses/adapters/codex.rs
@@ -13,8 +13,9 @@ use crate::ai_serving::AiExecutionDecision;
 use crate::clock::current_unix_secs;
 use crate::handlers::proxy::websocket::transport::UpstreamWebSocketErrorCodes;
 use crate::orchestration::{
-    codex_account_id_from_headers, codex_quota_exhaustion_reset_at,
-    sync_codex_websocket_quota_metadata, ResponsesWebSocketAdapter,
+    codex_account_id_from_headers, codex_model_quota_exhaustion_reset_at,
+    codex_quota_exhaustion_reset_at, sync_codex_websocket_quota_metadata,
+    ResponsesWebSocketAdapter,
 };
 use crate::AppState;
 
@@ -114,16 +115,37 @@ impl ResponsesWebSocketProtocolAdapter for CodexResponsesWebSocketAdapter {
         event: &Value,
     ) -> Option<ResponsesWebSocketAdapterObservation> {
         let rate_limits = parse_codex_rate_limits(event)?;
-        let exhausted =
+        let account_exhausted =
             aether_admin::provider::quota::codex_rate_limit_metadata_exhausted(&rate_limits);
-        let retry_exclusion_until_unix_secs =
-            codex_quota_exhaustion_reset_at(&rate_limits, current_unix_secs());
+        let active_limit_exhausted =
+            aether_admin::provider::quota::codex_websocket_response_has_usage_limit_error(event);
+        let now_unix_secs = current_unix_secs();
+        let scoped_reset_at = if account_exhausted {
+            codex_quota_exhaustion_reset_at(&rate_limits, now_unix_secs)
+        } else {
+            codex_model_quota_exhaustion_reset_at(&rate_limits, now_unix_secs)
+        };
+        let retry_exclusion_until_unix_secs = active_limit_exhausted
+            .then(|| {
+                aether_admin::provider::quota::codex_websocket_usage_limit_reset_at(
+                    event,
+                    now_unix_secs,
+                )
+            })
+            .flatten()
+            .or(scoped_reset_at);
         Some(ResponsesWebSocketAdapterObservation {
-            drain: exhausted.then_some(ResponsesWebSocketDrainDirective {
-                error_code: "codex_account_quota_exhausted",
-                retry_current_turn: true,
-                retry_exclusion_until_unix_secs,
-            }),
+            drain: (account_exhausted || active_limit_exhausted).then_some(
+                ResponsesWebSocketDrainDirective {
+                    error_code: if account_exhausted {
+                        "codex_account_quota_exhausted"
+                    } else {
+                        "codex_active_limit_exhausted"
+                    },
+                    retry_current_turn: true,
+                    retry_exclusion_until_unix_secs,
+                },
+            ),
             quota_metadata: Some(rate_limits),
         })
     }
@@ -335,6 +357,91 @@ mod tests {
             }),
             Some(&json!(100.0))
         );
+    }
+
+    #[test]
+    fn model_scoped_usage_limit_error_drains_without_account_exhaustion() {
+        let adapter = CodexResponsesWebSocketAdapter;
+        let event = json!({
+            "type": "error",
+            "error": {
+                "type": "usage_limit_reached",
+                "plan_type": "pro",
+            },
+            "status_code": 429,
+            "headers": {
+                "X-Codex-Plan-Type": "pro",
+                "X-Codex-Active-Limit": "codex_bengalfox",
+                "X-Codex-Primary-Used-Percent": "100",
+                "X-Codex-Primary-Window-Minutes": "300",
+                "X-Codex-Primary-Reset-At": "4000000000",
+                "X-Codex-Bengalfox-Limit-Name": "GPT-5.3-Codex-Spark",
+                "X-Codex-Bengalfox-Primary-Used-Percent": "100",
+                "X-Codex-Bengalfox-Primary-Window-Minutes": "300",
+                "X-Codex-Bengalfox-Primary-Reset-At": "4000000000",
+            },
+        });
+
+        let observation = adapter
+            .observe_upstream_event(&event)
+            .expect("model-scoped quota error should be observed");
+        let drain = observation
+            .drain
+            .expect("model-scoped quota error should retry the current turn");
+        let quota = observation
+            .quota_metadata
+            .expect("model-scoped quota metadata should be retained");
+
+        assert_eq!(drain.error_code, "codex_active_limit_exhausted");
+        assert!(drain.retry_current_turn);
+        assert_eq!(
+            drain.retry_exclusion_until_unix_secs,
+            Some(4_000_000_000u64)
+        );
+        assert_eq!(quota["spark_primary_used_percent"], json!(100.0));
+        assert!(quota.get("allowed").is_none());
+        assert!(quota.get("limit_reached").is_none());
+        assert!(!aether_admin::provider::quota::codex_rate_limit_metadata_exhausted(&quota));
+    }
+
+    #[test]
+    fn account_scoped_usage_limit_error_keeps_account_drain_semantics() {
+        let adapter = CodexResponsesWebSocketAdapter;
+        let event = json!({
+            "type": "error",
+            "error": {
+                "type": "usage_limit_reached",
+                "plan_type": "free",
+                "resets_at": 4_000_000_000u64,
+            },
+            "status_code": 429,
+            "headers": {
+                "X-Codex-Plan-Type": "free",
+                "X-Codex-Primary-Used-Percent": "100",
+                "X-Codex-Primary-Window-Minutes": "43200",
+                "X-Codex-Primary-Reset-At": "4000000000",
+            },
+        });
+
+        let observation = adapter
+            .observe_upstream_event(&event)
+            .expect("account quota error should be observed");
+        let drain = observation
+            .drain
+            .expect("account quota error should retry the current turn");
+        let quota = observation
+            .quota_metadata
+            .expect("account quota metadata should be retained");
+
+        assert_eq!(drain.error_code, "codex_account_quota_exhausted");
+        assert!(drain.retry_current_turn);
+        assert_eq!(
+            drain.retry_exclusion_until_unix_secs,
+            Some(4_000_000_000u64)
+        );
+        assert_eq!(quota["allowed"], json!(false));
+        assert_eq!(quota["limit_reached"], json!(true));
+        assert!(aether_admin::provider::quota::codex_rate_limit_metadata_exhausted(&quota));
     }
 
     #[test]

--- a/apps/aether-gateway/src/orchestration/codex_quota_breaker.rs
+++ b/apps/aether-gateway/src/orchestration/codex_quota_breaker.rs
@@ -168,16 +168,42 @@ pub(crate) fn codex_quota_exhaustion_reset_at(
     quota_metadata: &Value,
     now_unix_secs: u64,
 ) -> Option<u64> {
+    codex_quota_exhaustion_reset_at_for_prefixes(
+        quota_metadata,
+        now_unix_secs,
+        &["primary", "secondary"],
+    )
+}
+
+/// Returns the reset deadline for an exhausted model-scoped Codex window without promoting that
+/// window to account-wide exhaustion.
+pub(crate) fn codex_model_quota_exhaustion_reset_at(
+    quota_metadata: &Value,
+    now_unix_secs: u64,
+) -> Option<u64> {
+    codex_quota_exhaustion_reset_at_for_prefixes(
+        quota_metadata,
+        now_unix_secs,
+        &["spark_primary", "spark_secondary"],
+    )
+}
+
+fn codex_quota_exhaustion_reset_at_for_prefixes(
+    quota_metadata: &Value,
+    now_unix_secs: u64,
+    window_prefixes: &[&str],
+) -> Option<u64> {
     let Some(metadata) = quota_metadata.as_object() else {
         return None;
     };
 
-    let exhausted_windows = ["primary", "secondary"]
-        .into_iter()
+    let exhausted_windows = window_prefixes
+        .iter()
+        .copied()
         .filter(|prefix| codex_window_is_exhausted(metadata, prefix))
         .collect::<Vec<_>>();
     let prefixes = if exhausted_windows.is_empty() {
-        vec!["primary", "secondary"]
+        window_prefixes.to_vec()
     } else {
         exhausted_windows
     };

--- a/apps/aether-gateway/src/orchestration/mod.rs
+++ b/apps/aether-gateway/src/orchestration/mod.rs
@@ -34,9 +34,10 @@ pub(crate) use self::classifier::{
     LocalTransportFailoverClassification,
 };
 pub(crate) use self::codex_quota_breaker::{
-    codex_account_id_from_headers, codex_quota_breaker_blocks_candidate,
-    codex_quota_exhaustion_reset_at, install_codex_quota_exhaustion_breaker,
-    log_codex_quota_breaker_check_failure, log_codex_quota_breaker_install_failure,
+    codex_account_id_from_headers, codex_model_quota_exhaustion_reset_at,
+    codex_quota_breaker_blocks_candidate, codex_quota_exhaustion_reset_at,
+    install_codex_quota_exhaustion_breaker, log_codex_quota_breaker_check_failure,
+    log_codex_quota_breaker_install_failure,
 };
 pub(crate) use self::effects::{
     apply_local_execution_effect, apply_local_stream_failure_effects,

--- a/crates/aether-admin/src/provider/quota.rs
+++ b/crates/aether-admin/src/provider/quota.rs
@@ -10,6 +10,9 @@ const OAUTH_REFRESH_FAILED_PREFIX: &str = "[REFRESH_FAILED] ";
 const OAUTH_EXPIRED_PREFIX: &str = "[OAUTH_EXPIRED] ";
 const OAUTH_REQUEST_FAILED_PREFIX: &str = "[REQUEST_FAILED] ";
 const CODEX_SPARK_LIMIT_NAME: &str = "GPT-5.3-Codex-Spark";
+const CODEX_ACTIVE_LIMIT_HEADER: &str = "x-codex-active-limit";
+const CODEX_HEADER_PREFIX: &str = "x-codex-";
+const CODEX_LIMIT_NAME_HEADER_SUFFIX: &str = "-limit-name";
 
 pub fn provider_auto_remove_banned_keys(config: Option<&serde_json::Value>) -> bool {
     config
@@ -2538,6 +2541,48 @@ pub fn parse_codex_backend_me_response(
     Some(serde_json::Value::Object(result))
 }
 
+/// Lists the named per-model limits the response headers announce, as `(feature, limit_name)`.
+///
+/// `feature` is the header segment that carries the limit's windows
+/// (`x-codex-bengalfox-primary-used-percent`), and matches the `metered_feature` reported by
+/// `wham/usage` minus its `codex_` prefix.
+fn codex_named_limit_headers(normalized: &BTreeMap<String, String>) -> Vec<(String, String)> {
+    normalized
+        .iter()
+        .filter_map(|(key, value)| {
+            let feature = key
+                .strip_prefix(CODEX_HEADER_PREFIX)?
+                .strip_suffix(CODEX_LIMIT_NAME_HEADER_SUFFIX)?;
+            let limit_name = value.trim();
+            (!feature.is_empty() && !limit_name.is_empty())
+                .then(|| (feature.to_string(), limit_name.to_string()))
+        })
+        .collect()
+}
+
+/// Whether one of the announced named limits owns the unprefixed `x-codex-primary/secondary-*`
+/// windows.
+///
+/// `x-codex-active-limit` names the metered feature this request was billed against, and reports
+/// the plan's own limit as `premium`, which matches no announced feature. The account therefore
+/// keeps the unprefixed windows unless the active limit is one of the named ones.
+fn codex_named_limit_owns_unprefixed_windows(
+    normalized: &BTreeMap<String, String>,
+    named_limits: &[(String, String)],
+) -> bool {
+    let Some(active_limit) = normalized
+        .get(CODEX_ACTIVE_LIMIT_HEADER)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    else {
+        return false;
+    };
+    named_limits.iter().any(|(feature, _)| {
+        active_limit.eq_ignore_ascii_case(feature)
+            || active_limit.eq_ignore_ascii_case(&format!("codex_{feature}"))
+    })
+}
+
 pub fn parse_codex_usage_headers(
     headers: &BTreeMap<String, String>,
     updated_at_unix_secs: u64,
@@ -2597,28 +2642,52 @@ pub fn parse_codex_usage_headers(
         object
     };
 
-    let primary_window = read_window("primary");
-    let secondary_window = read_window("secondary");
-    let use_paid_windows =
-        codex_window_has_active_limit(&secondary_window) && plan_type.as_deref() != Some("free");
-    if use_paid_windows {
-        codex_write_window(&mut result, &secondary_window, "primary");
-        codex_write_window(&mut result, &primary_window, "secondary");
-    } else {
-        codex_write_window(&mut result, &primary_window, "primary");
-        if codex_window_is_explicitly_disabled(&secondary_window) {
-            codex_write_disabled_window(&mut result, "secondary");
+    // Every named limit is announced by its own `x-codex-<feature>-limit-name` header and carries
+    // its windows under the same `<feature>` prefix, so the header set describes itself.
+    let named_limits = codex_named_limit_headers(&normalized);
+    for (feature, limit_name) in &named_limits {
+        if limit_name != CODEX_SPARK_LIMIT_NAME {
+            continue;
+        }
+        let spark_primary_window = read_window(&format!("{feature}-primary"));
+        if !spark_primary_window.is_empty() {
+            codex_write_window(&mut result, &spark_primary_window, "spark_primary");
+        }
+        let spark_secondary_window = read_window(&format!("{feature}-secondary"));
+        if !spark_secondary_window.is_empty() {
+            codex_write_window(&mut result, &spark_secondary_window, "spark_secondary");
         }
     }
 
-    if let Some(value) = normalized
-        .get("x-codex-primary-over-secondary-limit-percent")
-        .and_then(|value| value.parse::<f64>().ok())
-    {
-        result.insert(
-            "primary_over_secondary_limit_percent".to_string(),
-            json!(value),
-        );
+    // The unprefixed windows describe whichever limit governed this request, not the account:
+    // on a request metered against a named limit they repeat that limit's windows verbatim.
+    // `x-codex-active-limit` is the only thing that tells the two apart, so an account window is
+    // only claimed when no named limit owns the unprefixed set. Upstreams that do not send the
+    // header keep the previous behaviour.
+    if !codex_named_limit_owns_unprefixed_windows(&normalized, &named_limits) {
+        let primary_window = read_window("primary");
+        let secondary_window = read_window("secondary");
+        let use_paid_windows = codex_window_has_active_limit(&secondary_window)
+            && plan_type.as_deref() != Some("free");
+        if use_paid_windows {
+            codex_write_window(&mut result, &secondary_window, "primary");
+            codex_write_window(&mut result, &primary_window, "secondary");
+        } else {
+            codex_write_window(&mut result, &primary_window, "primary");
+            if codex_window_is_explicitly_disabled(&secondary_window) {
+                codex_write_disabled_window(&mut result, "secondary");
+            }
+        }
+
+        if let Some(value) = normalized
+            .get("x-codex-primary-over-secondary-limit-percent")
+            .and_then(|value| value.parse::<f64>().ok())
+        {
+            result.insert(
+                "primary_over_secondary_limit_percent".to_string(),
+                json!(value),
+            );
+        }
     }
     if let Some(value) = normalized
         .get("x-codex-credits-has-credits")
@@ -5356,6 +5425,223 @@ mod tests {
         assert!(!should_auto_remove_structured_reason(Some(
             "[REFRESH_FAILED] Token 续期失败 (401): refresh_token 已失效"
         )));
+    }
+
+    /// Header set captured from a `gpt-5.6-sol` response: the request was metered against the
+    /// plan's own limit, so the unprefixed windows are the account's and the Spark limit is
+    /// announced separately.
+    fn codex_premium_response_headers() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("x-codex-plan-type".to_string(), "pro".to_string()),
+            ("x-codex-active-limit".to_string(), "premium".to_string()),
+            ("x-codex-primary-used-percent".to_string(), "50".to_string()),
+            (
+                "x-codex-primary-window-minutes".to_string(),
+                "10080".to_string(),
+            ),
+            (
+                "x-codex-primary-reset-at".to_string(),
+                "1787801347".to_string(),
+            ),
+            (
+                "x-codex-secondary-used-percent".to_string(),
+                "0".to_string(),
+            ),
+            (
+                "x-codex-secondary-window-minutes".to_string(),
+                "0".to_string(),
+            ),
+            ("x-codex-secondary-reset-at".to_string(), "".to_string()),
+            (
+                "x-codex-secondary-reset-after-seconds".to_string(),
+                "0".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-limit-name".to_string(),
+                "GPT-5.3-Codex-Spark".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-used-percent".to_string(),
+                "17".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-window-minutes".to_string(),
+                "300".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-reset-at".to_string(),
+                "1787410252".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-used-percent".to_string(),
+                "8".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-window-minutes".to_string(),
+                "10080".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-reset-at".to_string(),
+                "1787833868".to_string(),
+            ),
+        ])
+    }
+
+    /// Header set captured from a `gpt-5.3-codex-spark` response three seconds later on the same
+    /// key: the unprefixed windows now repeat the Spark limit verbatim, and only
+    /// `x-codex-active-limit` says so.
+    fn codex_spark_response_headers() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            ("x-codex-plan-type".to_string(), "pro".to_string()),
+            (
+                "x-codex-active-limit".to_string(),
+                "codex_bengalfox".to_string(),
+            ),
+            ("x-codex-primary-used-percent".to_string(), "22".to_string()),
+            (
+                "x-codex-primary-window-minutes".to_string(),
+                "300".to_string(),
+            ),
+            (
+                "x-codex-primary-reset-at".to_string(),
+                "1787410252".to_string(),
+            ),
+            (
+                "x-codex-secondary-used-percent".to_string(),
+                "11".to_string(),
+            ),
+            (
+                "x-codex-secondary-window-minutes".to_string(),
+                "10080".to_string(),
+            ),
+            (
+                "x-codex-secondary-reset-at".to_string(),
+                "1787833868".to_string(),
+            ),
+            (
+                "x-codex-secondary-reset-after-seconds".to_string(),
+                "424336".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-limit-name".to_string(),
+                "GPT-5.3-Codex-Spark".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-used-percent".to_string(),
+                "22".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-window-minutes".to_string(),
+                "300".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-primary-reset-at".to_string(),
+                "1787410252".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-used-percent".to_string(),
+                "11".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-window-minutes".to_string(),
+                "10080".to_string(),
+            ),
+            (
+                "x-codex-bengalfox-secondary-reset-at".to_string(),
+                "1787833868".to_string(),
+            ),
+        ])
+    }
+
+    #[test]
+    fn codex_usage_headers_keep_the_account_window_when_the_plan_limit_is_active() {
+        let parsed = parse_codex_usage_headers(&codex_premium_response_headers(), 1_787_409_530)
+            .expect("Codex usage headers should parse");
+
+        assert_eq!(parsed.get("primary_used_percent"), Some(&json!(50.0)));
+        assert_eq!(
+            parsed.get("primary_window_minutes"),
+            Some(&json!(10_080u64))
+        );
+        assert_eq!(
+            parsed.get("primary_reset_at"),
+            Some(&json!(1_787_801_347u64))
+        );
+        assert_eq!(parsed.get("secondary_window_minutes"), Some(&json!(0u64)));
+    }
+
+    #[test]
+    fn codex_usage_headers_capture_named_limit_windows_alongside_the_account_window() {
+        let parsed = parse_codex_usage_headers(&codex_premium_response_headers(), 1_787_409_530)
+            .expect("Codex usage headers should parse");
+
+        assert_eq!(parsed.get("spark_primary_used_percent"), Some(&json!(17.0)));
+        assert_eq!(
+            parsed.get("spark_primary_window_minutes"),
+            Some(&json!(300u64))
+        );
+        assert_eq!(
+            parsed.get("spark_primary_reset_at"),
+            Some(&json!(1_787_410_252u64))
+        );
+        assert_eq!(
+            parsed.get("spark_secondary_used_percent"),
+            Some(&json!(8.0))
+        );
+        assert_eq!(
+            parsed.get("spark_secondary_window_minutes"),
+            Some(&json!(10_080u64))
+        );
+    }
+
+    #[test]
+    fn codex_usage_headers_keep_model_scoped_windows_out_of_the_account_family() {
+        let parsed = parse_codex_usage_headers(&codex_spark_response_headers(), 1_787_409_530)
+            .expect("Codex usage headers should parse");
+
+        // Without this the paid-window swap promotes the Spark weekly window into the account's
+        // own weekly slot, which is what the scheduler reads.
+        assert!(
+            parsed.get("primary_used_percent").is_none(),
+            "the Spark limit governed this request, so it must not claim the account window: {parsed}"
+        );
+        assert!(parsed.get("primary_window_minutes").is_none());
+        assert!(parsed.get("primary_reset_at").is_none());
+        assert!(parsed.get("secondary_used_percent").is_none());
+        assert!(parsed.get("primary_over_secondary_limit_percent").is_none());
+
+        assert_eq!(parsed.get("spark_primary_used_percent"), Some(&json!(22.0)));
+        assert_eq!(
+            parsed.get("spark_secondary_used_percent"),
+            Some(&json!(11.0))
+        );
+        assert_eq!(parsed.get("plan_type"), Some(&json!("pro")));
+    }
+
+    #[test]
+    fn codex_usage_headers_without_an_active_limit_still_fill_the_account_window() {
+        let mut headers = codex_premium_response_headers();
+        headers.remove("x-codex-active-limit");
+
+        let parsed = parse_codex_usage_headers(&headers, 1_787_409_530)
+            .expect("Codex usage headers should parse");
+
+        assert_eq!(parsed.get("primary_used_percent"), Some(&json!(50.0)));
+        assert_eq!(parsed.get("spark_primary_used_percent"), Some(&json!(17.0)));
+    }
+
+    #[test]
+    fn codex_usage_headers_ignore_an_active_limit_that_matches_no_announced_family() {
+        let mut headers = codex_premium_response_headers();
+        headers.insert(
+            "x-codex-active-limit".to_string(),
+            "codex_unknown_feature".to_string(),
+        );
+
+        let parsed = parse_codex_usage_headers(&headers, 1_787_409_530)
+            .expect("Codex usage headers should parse");
+
+        assert_eq!(parsed.get("primary_used_percent"), Some(&json!(50.0)));
     }
 
     #[test]

--- a/crates/aether-admin/src/provider/quota.rs
+++ b/crates/aether-admin/src/provider/quota.rs
@@ -2167,18 +2167,24 @@ fn parse_codex_websocket_usage_limit_error(
             result.insert("plan_type".to_string(), json!(plan_type));
         }
     }
-    if !result.contains_key("primary_reset_at") {
-        if let Some(reset_at) = error.get("resets_at").and_then(coerce_json_u64) {
-            result.insert("primary_reset_at".to_string(), json!(reset_at));
+    // `resets_at` describes whichever limit rejected the request. When a named per-model limit
+    // owned the window headers it owns this timing too, so backfilling it into the account slot
+    // would put a model window's reset on the account's own quota.
+    if codex_headers_carry_account_windows(&headers) {
+        if !result.contains_key("primary_reset_at") {
+            if let Some(reset_at) = error.get("resets_at").and_then(coerce_json_u64) {
+                result.insert("primary_reset_at".to_string(), json!(reset_at));
+            }
         }
-    }
-    if !result.contains_key("primary_reset_after_seconds") {
-        if let Some(reset_after_seconds) = error.get("resets_in_seconds").and_then(coerce_json_u64)
-        {
-            result.insert(
-                "primary_reset_after_seconds".to_string(),
-                json!(reset_after_seconds),
-            );
+        if !result.contains_key("primary_reset_after_seconds") {
+            if let Some(reset_after_seconds) =
+                error.get("resets_in_seconds").and_then(coerce_json_u64)
+            {
+                result.insert(
+                    "primary_reset_after_seconds".to_string(),
+                    json!(reset_after_seconds),
+                );
+            }
         }
     }
 
@@ -2541,6 +2547,23 @@ pub fn parse_codex_backend_me_response(
     Some(serde_json::Value::Object(result))
 }
 
+fn codex_normalized_headers(headers: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    headers
+        .iter()
+        .map(|(key, value)| (key.trim().to_ascii_lowercase(), value.trim().to_string()))
+        .collect()
+}
+
+/// Whether the account's own quota windows can be read from these headers' unprefixed fields.
+///
+/// False when a named per-model limit governed the request: the unprefixed fields — and any reset
+/// timing reported alongside them — then describe that limit instead.
+fn codex_headers_carry_account_windows(headers: &BTreeMap<String, String>) -> bool {
+    let normalized = codex_normalized_headers(headers);
+    let named_limits = codex_named_limit_headers(&normalized);
+    !codex_named_limit_owns_unprefixed_windows(&normalized, &named_limits)
+}
+
 /// Lists the named per-model limits the response headers announce, as `(feature, limit_name)`.
 ///
 /// `feature` is the header segment that carries the limit's windows
@@ -2588,11 +2611,11 @@ pub fn parse_codex_usage_headers(
     updated_at_unix_secs: u64,
 ) -> Option<serde_json::Value> {
     let mut result = serde_json::Map::new();
-    let normalized = headers
-        .iter()
-        .map(|(key, value)| (key.trim().to_ascii_lowercase(), value.trim().to_string()))
-        .collect::<BTreeMap<_, _>>();
-    if !normalized.keys().any(|key| key.starts_with("x-codex-")) {
+    let normalized = codex_normalized_headers(headers);
+    if !normalized
+        .keys()
+        .any(|key| key.starts_with(CODEX_HEADER_PREFIX))
+    {
         return None;
     }
 
@@ -5925,6 +5948,45 @@ mod tests {
             Some(&json!(1_787_274_385u64))
         );
         assert!(codex_rate_limit_metadata_exhausted(&parsed));
+    }
+
+    #[test]
+    fn codex_usage_limit_error_does_not_backfill_a_model_scoped_reset_into_the_account() {
+        let parsed = parse_codex_websocket_rate_limits_response(
+            &json!({
+                "type": "error",
+                "error": {
+                    "type": "usage_limit_reached",
+                    "plan_type": "pro",
+                    "resets_at": 1_787_430_252u64,
+                    "resets_in_seconds": 20_722u64,
+                },
+                "status_code": 429,
+                "headers": {
+                    "X-Codex-Plan-Type": "pro",
+                    "X-Codex-Active-Limit": "codex_bengalfox",
+                    "X-Codex-Primary-Used-Percent": "100",
+                    "X-Codex-Primary-Window-Minutes": "300",
+                    "X-Codex-Primary-Reset-At": "1787430252",
+                    "X-Codex-Bengalfox-Limit-Name": "GPT-5.3-Codex-Spark",
+                    "X-Codex-Bengalfox-Primary-Used-Percent": "100",
+                    "X-Codex-Bengalfox-Primary-Window-Minutes": "300",
+                    "X-Codex-Bengalfox-Primary-Reset-At": "1787430252",
+                },
+            }),
+            1_787_409_530,
+        )
+        .expect("Codex usage-limit error should parse as quota metadata");
+
+        assert!(
+            parsed.get("primary_reset_at").is_none(),
+            "the Spark limit rejected this request, so its reset timing must not claim the account window: {parsed}"
+        );
+        assert!(parsed.get("primary_reset_after_seconds").is_none());
+        assert_eq!(
+            parsed.get("spark_primary_reset_at"),
+            Some(&json!(1_787_430_252u64))
+        );
     }
 
     #[test]

--- a/crates/aether-admin/src/provider/quota.rs
+++ b/crates/aether-admin/src/provider/quota.rs
@@ -628,6 +628,10 @@ const CODEX_QUOTA_WINDOW_SUFFIXES: &[&str] = &[
     "window_minutes",
 ];
 const CODEX_QUOTA_RESET_DEADLINE_TOLERANCE_SECONDS: u64 = 30;
+// Header and WHAM observations for the same active limit can be a few requests apart. Keep the
+// historical-contamination fingerprint tolerant of that small movement, but require a close
+// usage match so coincidentally aligned account and Spark reset deadlines are not enough.
+const CODEX_QUOTA_CONTAMINATION_USAGE_TOLERANCE_PERCENT: f64 = 5.0;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CodexQuotaWindowCoverage {
@@ -1170,6 +1174,41 @@ fn codex_quota_same_window_identity(
     }
 }
 
+fn codex_quota_same_window_generation(
+    left: &CodexQuotaWindowObservation,
+    right: &CodexQuotaWindowObservation,
+) -> bool {
+    codex_quota_same_window_duration(left, right)
+        && left
+            .deadline
+            .zip(right.deadline)
+            .is_some_and(|(left, right)| {
+                left.abs_diff(right) <= CODEX_QUOTA_RESET_DEADLINE_TOLERANCE_SECONDS
+            })
+}
+
+fn codex_quota_same_contamination_fingerprint(
+    account: &CodexQuotaWindowObservation,
+    spark: &CodexQuotaWindowObservation,
+) -> bool {
+    codex_quota_same_window_generation(account, spark)
+        && account
+            .used_percent()
+            .zip(spark.used_percent())
+            .is_some_and(|(account, spark)| {
+                (account - spark).abs() <= CODEX_QUOTA_CONTAMINATION_USAGE_TOLERANCE_PERCENT
+            })
+}
+
+fn codex_quota_same_window_duration(
+    left: &CodexQuotaWindowObservation,
+    right: &CodexQuotaWindowObservation,
+) -> bool {
+    left.window_minutes
+        .zip(right.window_minutes)
+        .is_some_and(|(left, right)| left > 0 && left == right)
+}
+
 fn codex_quota_merge_same_window(
     current: &CodexQuotaWindowObservation,
     incoming: &CodexQuotaWindowObservation,
@@ -1597,6 +1636,31 @@ fn codex_quota_apply_family(
     let stale_family = !reset_baseline
         && codex_quota_request_order_is_stale(context.request_order(), stored_watermark);
     let window_matches = (!reset_baseline).then(|| codex_quota_match_windows(&current, &incoming));
+    // A full wham snapshot reports the account and named model families together. Older
+    // releases could copy the active Spark window into the account slot, after which its later
+    // deadline made the normal monotonic merge reject the real account window forever. Keep the
+    // conservative deadline rule unless both the stored Spark family and this authoritative
+    // response prove that the stored account generation is actually a Spark generation.
+    let incoming_spark = if family == CodexQuotaWindowFamily::Account
+        && context.coverage == CodexQuotaWindowCoverage::FullSnapshot
+    {
+        codex_quota_read_family_windows(
+            incoming_object,
+            CodexQuotaWindowFamily::Spark,
+            Some(context.observed_at_unix_secs),
+        )
+    } else {
+        Vec::new()
+    };
+    let current_spark = if !incoming_spark.is_empty() {
+        codex_quota_read_family_windows(
+            current_object,
+            CodexQuotaWindowFamily::Spark,
+            current_observed_at,
+        )
+    } else {
+        Vec::new()
+    };
     let mut next = if reset_baseline || (authoritative && !stale_family) {
         Vec::new()
     } else {
@@ -1624,7 +1688,25 @@ fn codex_quota_apply_family(
             }
             continue;
         };
-        let mut merged_window = if stale_family {
+        let repairs_model_scoped_account_window = !stale_family
+            && codex_quota_same_window_duration(&current[current_index], incoming_window)
+            && current[current_index]
+                .deadline
+                .zip(incoming_window.deadline)
+                .is_some_and(|(current, incoming)| {
+                    incoming.saturating_add(CODEX_QUOTA_RESET_DEADLINE_TOLERANCE_SECONDS) < current
+                })
+            && current_spark.iter().any(|spark_window| {
+                codex_quota_same_contamination_fingerprint(&current[current_index], spark_window)
+            })
+            && incoming_spark.iter().any(|spark_window| {
+                codex_quota_same_contamination_fingerprint(&current[current_index], spark_window)
+            });
+        let mut merged_window = if repairs_model_scoped_account_window {
+            let mut accepted = incoming_window.clone();
+            accepted.persist_deadline();
+            accepted
+        } else if stale_family {
             codex_quota_merge_stale_same_window_usage(&current[current_index], incoming_window)
         } else {
             codex_quota_merge_same_window(&current[current_index], incoming_window)
@@ -1682,6 +1764,10 @@ fn codex_quota_semantic_metadata(
         .collect()
 }
 
+fn codex_quota_is_account_status_key(key: &str) -> bool {
+    matches!(key, "allowed" | "limit_reached")
+}
+
 /// Merge a parsed Codex quota observation into the stored flat metadata.
 ///
 /// Positive `window_minutes` values identify windows independently of the
@@ -1732,6 +1818,7 @@ pub fn merge_codex_quota_metadata_snapshot(
     .max();
     let has_incoming_metadata = incoming_object.keys().any(|key| {
         key != "updated_at"
+            && !codex_quota_is_account_status_key(key)
             && !codex_quota_is_request_order_key(key)
             && !codex_quota_is_reset_fence_key(key)
             && !codex_quota_is_window_key(key)
@@ -1748,6 +1835,7 @@ pub fn merge_codex_quota_metadata_snapshot(
     if has_incoming_metadata && !stale_metadata {
         for (key, value) in incoming_object {
             if key == "updated_at"
+                || codex_quota_is_account_status_key(key)
                 || codex_quota_is_request_order_key(key)
                 || codex_quota_is_reset_fence_key(key)
                 || codex_quota_is_window_key(key)
@@ -1763,6 +1851,44 @@ pub fn merge_codex_quota_metadata_snapshot(
                 &mut merged,
                 CODEX_QUOTA_METADATA_REQUEST_WATERMARK_KEY,
                 CODEX_QUOTA_METADATA_REQUEST_WATERMARK_ID_KEY,
+                incoming_order,
+            );
+        }
+    }
+
+    // `allowed` and `limit_reached` describe the account family in WHAM and account-scoped
+    // WebSocket observations. A newer Spark-only patch must not make those account signals look
+    // stale, so order them against the account watermark rather than the newest watermark from
+    // any quota family.
+    let has_incoming_account_status = incoming_object
+        .keys()
+        .any(|key| codex_quota_is_account_status_key(key));
+    let stored_account_watermark = codex_quota_read_request_order(
+        &current_object,
+        CodexQuotaWindowFamily::Account.watermark_key(),
+        CodexQuotaWindowFamily::Account.watermark_id_key(),
+    );
+    let stale_account_status = has_incoming_account_status
+        && (codex_quota_request_order_is_stale(context.request_order(), stored_account_watermark)
+            || !codex_quota_observation_matches_reset_generation(&current_object, context)
+            || (codex_quota_account_reset_generation(Some(&serde_json::Value::Object(
+                current_object.clone(),
+            ))) == 0
+                && codex_quota_account_reset_fence(&current_object)
+                    .is_some_and(|fence| codex_quota_reset_fence_blocks(fence, context))));
+    if has_incoming_account_status && !stale_account_status {
+        for key in ["allowed", "limit_reached"] {
+            if let Some(value) = incoming_object.get(key) {
+                merged.insert(key.to_string(), value.clone());
+            }
+        }
+        if let Some(incoming_order) = context.request_order().filter(|incoming| {
+            codex_quota_request_order_is_newer(*incoming, stored_account_watermark)
+        }) {
+            codex_quota_write_request_order(
+                &mut merged,
+                CodexQuotaWindowFamily::Account.watermark_key(),
+                CodexQuotaWindowFamily::Account.watermark_id_key(),
                 incoming_order,
             );
         }
@@ -1958,6 +2084,12 @@ pub fn parse_codex_wham_usage_response(
         .and_then(serde_json::Value::as_object)
         .cloned()
         .unwrap_or_default();
+    if let Some(allowed) = rate_limit.get("allowed").and_then(coerce_json_bool) {
+        result.insert("allowed".to_string(), json!(allowed));
+    }
+    if let Some(limit_reached) = rate_limit.get("limit_reached").and_then(coerce_json_bool) {
+        result.insert("limit_reached".to_string(), json!(limit_reached));
+    }
     let primary_window = rate_limit
         .get("primary_window")
         .and_then(serde_json::Value::as_object)
@@ -2046,6 +2178,74 @@ pub fn parse_codex_websocket_rate_limits_response(
     latest
 }
 
+fn codex_websocket_usage_limit_error(
+    value: &serde_json::Value,
+) -> Option<&serde_json::Map<String, serde_json::Value>> {
+    let root = value.as_object()?;
+    if root.get("type").and_then(serde_json::Value::as_str) != Some("error") {
+        return None;
+    }
+    let status_code = root
+        .get("status_code")
+        .or_else(|| root.get("status"))
+        .and_then(coerce_json_u64);
+    if status_code != Some(429) {
+        return None;
+    }
+    let error = root.get("error").and_then(serde_json::Value::as_object)?;
+    (error.get("type").and_then(serde_json::Value::as_str) == Some("usage_limit_reached"))
+        .then_some(error)
+}
+
+/// Returns whether a Codex WebSocket response contains the terminal quota error for the limit
+/// used by this request. This is intentionally request-scoped: callers must not interpret it as
+/// proof that the account-wide Codex quota is exhausted.
+pub fn codex_websocket_response_has_usage_limit_error(value: &serde_json::Value) -> bool {
+    codex_websocket_usage_limit_error(value).is_some()
+        || value
+            .get("chunks")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|chunks| {
+                chunks
+                    .iter()
+                    .any(|chunk| codex_websocket_usage_limit_error(chunk).is_some())
+            })
+}
+
+/// Reads the reset deadline attached to the latest terminal quota error in a Codex WebSocket
+/// response. The error body follows the active limit, so this is suitable for a current-turn
+/// retry exclusion even when that limit is model-scoped.
+pub fn codex_websocket_usage_limit_reset_at(
+    value: &serde_json::Value,
+    observed_at_unix_secs: u64,
+) -> Option<u64> {
+    let read_reset = |event: &serde_json::Value| {
+        let error = codex_websocket_usage_limit_error(event)?;
+        error
+            .get("resets_at")
+            .and_then(coerce_json_u64)
+            .or_else(|| {
+                error
+                    .get("resets_in_seconds")
+                    .and_then(coerce_json_u64)
+                    .map(|seconds| observed_at_unix_secs.saturating_add(seconds))
+            })
+    };
+
+    let mut latest = read_reset(value);
+    for chunk in value
+        .get("chunks")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        if codex_websocket_usage_limit_error(chunk).is_some() {
+            latest = read_reset(chunk);
+        }
+    }
+    latest
+}
+
 fn parse_codex_websocket_quota_event(
     value: &serde_json::Value,
     updated_at_unix_secs: u64,
@@ -2125,20 +2325,7 @@ fn parse_codex_websocket_usage_limit_error(
     updated_at_unix_secs: u64,
 ) -> Option<serde_json::Value> {
     let root = value.as_object()?;
-    if root.get("type").and_then(serde_json::Value::as_str) != Some("error") {
-        return None;
-    }
-    let status_code = root
-        .get("status_code")
-        .or_else(|| root.get("status"))
-        .and_then(coerce_json_u64);
-    if status_code != Some(429) {
-        return None;
-    }
-    let error = root.get("error").and_then(serde_json::Value::as_object)?;
-    if error.get("type").and_then(serde_json::Value::as_str) != Some("usage_limit_reached") {
-        return None;
-    }
+    let error = codex_websocket_usage_limit_error(value)?;
 
     let headers = root
         .get("headers")
@@ -2157,6 +2344,7 @@ fn parse_codex_websocket_usage_limit_error(
     let mut result = parse_codex_usage_headers(&headers, updated_at_unix_secs)
         .and_then(|value| value.as_object().cloned())
         .unwrap_or_default();
+    let account_scoped = codex_headers_carry_account_windows(&headers);
 
     if !result.contains_key("plan_type") {
         if let Some(plan_type) = error
@@ -2170,7 +2358,7 @@ fn parse_codex_websocket_usage_limit_error(
     // `resets_at` describes whichever limit rejected the request. When a named per-model limit
     // owned the window headers it owns this timing too, so backfilling it into the account slot
     // would put a model window's reset on the account's own quota.
-    if codex_headers_carry_account_windows(&headers) {
+    if account_scoped {
         if !result.contains_key("primary_reset_at") {
             if let Some(reset_at) = error.get("resets_at").and_then(coerce_json_u64) {
                 result.insert("primary_reset_at".to_string(), json!(reset_at));
@@ -2188,10 +2376,14 @@ fn parse_codex_websocket_usage_limit_error(
         }
     }
 
-    // `usage_limit_reached` is a definitive, account-wide terminal signal.
-    // Preserve that fact even if an intermediary strips some Codex headers.
-    result.insert("allowed".to_string(), json!(false));
-    result.insert("limit_reached".to_string(), json!(true));
+    // `usage_limit_reached` is terminal for the active limit. Only project it onto the account
+    // when the unprefixed headers belong to the account; a named model limit (for example Spark)
+    // must not make every Codex model on the credential look exhausted. With no ownership headers
+    // the legacy account-wide fallback remains intact.
+    if account_scoped {
+        result.insert("allowed".to_string(), json!(false));
+        result.insert("limit_reached".to_string(), json!(true));
+    }
     result.insert("updated_at".to_string(), json!(updated_at_unix_secs));
     Some(serde_json::Value::Object(result))
 }
@@ -3635,6 +3827,7 @@ mod tests {
     use super::{
         codex_build_invalid_state, codex_oauth_success_request_order_is_stale,
         codex_rate_limit_metadata_exhausted, codex_runtime_invalid_reason,
+        codex_websocket_response_has_usage_limit_error, codex_websocket_usage_limit_reset_at,
         extract_execution_error_detail, merge_codex_quota_metadata_snapshot,
         normalize_codex_reset_credit_consume_outcome, parse_antigravity_usage_response,
         parse_chatgpt_web_conversation_init_response, parse_codex_backend_me_response,
@@ -4027,6 +4220,256 @@ mod tests {
         assert_eq!(outcome.metadata["primary_used_percent"], json!(2.0));
         assert_eq!(outcome.metadata["primary_reset_at"], json!(20_000u64));
         assert_eq!(outcome.metadata["updated_at"], json!(101u64));
+    }
+
+    #[test]
+    fn codex_quota_full_snapshot_repairs_account_window_copied_from_spark() {
+        let current = json!({
+            "primary_used_percent": 32.0,
+            "primary_reset_at": 1_788_153_237u64,
+            "primary_window_minutes": 10_080u64,
+            // Adjacent runtime and WHAM observations can move slightly while still proving
+            // that the account window was copied from this Spark generation.
+            "spark_secondary_used_percent": 30.0,
+            "spark_secondary_reset_at": 1_788_153_238u64,
+            "spark_secondary_window_minutes": 10_080u64,
+            "account_quota_request_started_at_unix_ms": 100_000u64,
+            "spark_quota_request_started_at_unix_ms": 100_000u64,
+            "updated_at": 100u64
+        });
+        let authoritative_wham = parse_codex_wham_usage_response(
+            &json!({
+                "plan_type": "pro",
+                "rate_limit": {
+                    "allowed": false,
+                    "limit_reached": true,
+                    "primary_window": {
+                        "limit_window_seconds": 604_800u64,
+                        "used_percent": 100.0,
+                        "reset_at": 1_788_137_653u64
+                    },
+                    "secondary_window": null
+                },
+                "additional_rate_limits": [{
+                    "limit_name": "GPT-5.3-Codex-Spark",
+                    "metered_feature": "codex_bengalfox",
+                    "rate_limit": {
+                        "primary_window": {
+                            "limit_window_seconds": 18_000u64,
+                            "used_percent": 0.0
+                        },
+                        "secondary_window": {
+                            "limit_window_seconds": 604_800u64,
+                            "used_percent": 32.0,
+                            "reset_at": 1_788_153_238u64
+                        }
+                    }
+                }]
+            }),
+            110,
+        )
+        .expect("production-shaped WHAM response should parse");
+
+        let outcome = merge_codex_quota(
+            Some(&current),
+            &authoritative_wham,
+            110,
+            110_000,
+            CodexQuotaWindowCoverage::FullSnapshot,
+        );
+
+        assert!(outcome.changed);
+        assert_eq!(outcome.metadata["primary_used_percent"], json!(100.0));
+        assert_eq!(outcome.metadata["primary_window_minutes"], json!(10_080u64));
+        assert_eq!(outcome.metadata["allowed"], json!(false));
+        assert_eq!(outcome.metadata["limit_reached"], json!(true));
+        assert!(codex_rate_limit_metadata_exhausted(&outcome.metadata));
+        assert_eq!(
+            outcome.metadata["primary_reset_at"],
+            json!(1_788_137_653u64)
+        );
+        assert_eq!(outcome.metadata["spark_primary_used_percent"], json!(0.0));
+        assert_eq!(
+            outcome.metadata["spark_secondary_used_percent"],
+            json!(32.0)
+        );
+        assert_eq!(
+            outcome.metadata["spark_secondary_reset_at"],
+            json!(1_788_153_238u64)
+        );
+    }
+
+    #[test]
+    fn codex_quota_full_snapshot_rejects_deadline_only_contamination_fingerprint() {
+        let current = json!({
+            "primary_used_percent": 72.0,
+            "primary_reset_at": 1_788_153_237u64,
+            "primary_window_minutes": 10_080u64,
+            "spark_secondary_used_percent": 32.0,
+            "spark_secondary_reset_at": 1_788_153_238u64,
+            "spark_secondary_window_minutes": 10_080u64,
+            "account_quota_request_started_at_unix_ms": 100_000u64,
+            "spark_quota_request_started_at_unix_ms": 100_000u64,
+            "updated_at": 100u64
+        });
+        let authoritative_wham = json!({
+            "primary_used_percent": 100.0,
+            "primary_reset_at": 1_788_137_653u64,
+            "primary_window_minutes": 10_080u64,
+            "spark_secondary_used_percent": 32.0,
+            "spark_secondary_reset_at": 1_788_153_238u64,
+            "spark_secondary_window_minutes": 10_080u64
+        });
+
+        let outcome = merge_codex_quota(
+            Some(&current),
+            &authoritative_wham,
+            110,
+            110_000,
+            CodexQuotaWindowCoverage::FullSnapshot,
+        );
+
+        assert_eq!(outcome.metadata["primary_used_percent"], json!(72.0));
+        assert_eq!(
+            outcome.metadata["primary_reset_at"],
+            json!(1_788_153_237u64)
+        );
+    }
+
+    #[test]
+    fn codex_quota_full_snapshot_does_not_replace_unrelated_later_account_generation() {
+        let current = json!({
+            "primary_used_percent": 32.0,
+            "primary_reset_at": 1_788_153_237u64,
+            "primary_window_minutes": 10_080u64,
+            "account_quota_request_started_at_unix_ms": 100_000u64,
+            "updated_at": 100u64
+        });
+        let authoritative_wham = json!({
+            "primary_used_percent": 100.0,
+            "primary_reset_at": 1_788_137_653u64,
+            "primary_window_minutes": 10_080u64,
+            "spark_secondary_used_percent": 33.0,
+            "spark_secondary_reset_at": 1_788_190_000u64,
+            "spark_secondary_window_minutes": 10_080u64
+        });
+
+        let outcome = merge_codex_quota(
+            Some(&current),
+            &authoritative_wham,
+            110,
+            110_000,
+            CodexQuotaWindowCoverage::FullSnapshot,
+        );
+
+        assert_eq!(outcome.metadata["primary_used_percent"], json!(32.0));
+        assert_eq!(
+            outcome.metadata["primary_reset_at"],
+            json!(1_788_153_237u64)
+        );
+    }
+
+    #[test]
+    fn codex_quota_full_snapshot_requires_stored_spark_contamination_fingerprint() {
+        let current = json!({
+            "primary_used_percent": 32.0,
+            "primary_reset_at": 1_788_153_237u64,
+            "primary_window_minutes": 10_080u64,
+            "spark_secondary_used_percent": 32.0,
+            "spark_secondary_reset_at": 1_788_190_000u64,
+            "spark_secondary_window_minutes": 10_080u64,
+            "account_quota_request_started_at_unix_ms": 100_000u64,
+            "spark_quota_request_started_at_unix_ms": 100_000u64,
+            "updated_at": 100u64
+        });
+        let authoritative_wham = json!({
+            "primary_used_percent": 100.0,
+            "primary_reset_at": 1_788_137_653u64,
+            "primary_window_minutes": 10_080u64,
+            "spark_secondary_used_percent": 32.0,
+            "spark_secondary_reset_at": 1_788_153_238u64,
+            "spark_secondary_window_minutes": 10_080u64
+        });
+
+        let outcome = merge_codex_quota(
+            Some(&current),
+            &authoritative_wham,
+            110,
+            110_000,
+            CodexQuotaWindowCoverage::FullSnapshot,
+        );
+
+        assert_eq!(outcome.metadata["primary_used_percent"], json!(32.0));
+        assert_eq!(
+            outcome.metadata["primary_reset_at"],
+            json!(1_788_153_237u64)
+        );
+    }
+
+    #[test]
+    fn codex_quota_full_snapshot_without_account_duration_cannot_repair_account_window() {
+        let current = json!({
+            "primary_used_percent": 32.0,
+            "primary_reset_at": 1_788_153_237u64,
+            "primary_window_minutes": 10_080u64,
+            "account_quota_request_started_at_unix_ms": 100_000u64,
+            "updated_at": 100u64
+        });
+        let authoritative_wham = json!({
+            "primary_used_percent": 100.0,
+            "primary_reset_at": 1_788_137_653u64,
+            "spark_secondary_used_percent": 33.0,
+            "spark_secondary_reset_at": 1_788_153_238u64,
+            "spark_secondary_window_minutes": 10_080u64
+        });
+
+        let outcome = merge_codex_quota(
+            Some(&current),
+            &authoritative_wham,
+            110,
+            110_000,
+            CodexQuotaWindowCoverage::FullSnapshot,
+        );
+
+        assert_eq!(outcome.metadata["primary_used_percent"], json!(32.0));
+        assert_eq!(
+            outcome.metadata["primary_reset_at"],
+            json!(1_788_153_237u64)
+        );
+    }
+
+    #[test]
+    fn codex_quota_stale_full_snapshot_cannot_repair_account_window_copied_from_spark() {
+        let current = json!({
+            "primary_used_percent": 32.0,
+            "primary_reset_at": 1_788_153_237u64,
+            "primary_window_minutes": 10_080u64,
+            "spark_secondary_used_percent": 31.0,
+            "spark_secondary_reset_at": 1_788_153_238u64,
+            "spark_secondary_window_minutes": 10_080u64,
+            "account_quota_request_started_at_unix_ms": 120_000u64,
+            "spark_quota_request_started_at_unix_ms": 120_000u64,
+            "updated_at": 100u64
+        });
+        let stale_wham = json!({
+            "primary_used_percent": 100.0,
+            "primary_reset_at": 1_788_137_653u64,
+            "primary_window_minutes": 10_080u64,
+            "spark_secondary_used_percent": 31.0,
+            "spark_secondary_reset_at": 1_788_153_238u64,
+            "spark_secondary_window_minutes": 10_080u64
+        });
+
+        let outcome = merge_codex_quota(
+            Some(&current),
+            &stale_wham,
+            110,
+            110_000,
+            CodexQuotaWindowCoverage::FullSnapshot,
+        );
+
+        assert!(!outcome.changed);
+        assert_eq!(outcome.metadata, current);
     }
 
     #[test]
@@ -4980,6 +5423,86 @@ mod tests {
     }
 
     #[test]
+    fn codex_account_status_ignores_a_newer_spark_only_watermark() {
+        let current = json!({
+            "allowed": true,
+            "limit_reached": false,
+            "primary_used_percent": 99.0,
+            "primary_reset_at": 20_000u64,
+            "primary_window_minutes": 10_080u64,
+            "spark_secondary_used_percent": 40.0,
+            "spark_secondary_reset_at": 30_000u64,
+            "spark_secondary_window_minutes": 10_080u64,
+            "account_quota_request_started_at_unix_ms": 100_000u64,
+            "spark_quota_request_started_at_unix_ms": 200_000u64,
+            "updated_at": 200u64
+        });
+        let wham = json!({
+            "allowed": false,
+            "limit_reached": true,
+            "primary_used_percent": 99.0,
+            "primary_reset_at": 20_000u64,
+            "primary_window_minutes": 10_080u64,
+            "spark_secondary_used_percent": 40.0,
+            "spark_secondary_reset_at": 30_000u64,
+            "spark_secondary_window_minutes": 10_080u64
+        });
+
+        let outcome = merge_codex_quota(
+            Some(&current),
+            &wham,
+            210,
+            150_000,
+            CodexQuotaWindowCoverage::FullSnapshot,
+        );
+
+        assert!(outcome.changed);
+        assert_eq!(outcome.metadata["primary_used_percent"], json!(99.0));
+        assert_eq!(outcome.metadata["allowed"], json!(false));
+        assert_eq!(outcome.metadata["limit_reached"], json!(true));
+        assert!(codex_rate_limit_metadata_exhausted(&outcome.metadata));
+        assert_eq!(
+            outcome.metadata["account_quota_request_started_at_unix_ms"],
+            json!(150_000u64)
+        );
+        assert_eq!(
+            outcome.metadata["spark_quota_request_started_at_unix_ms"],
+            json!(200_000u64)
+        );
+    }
+
+    #[test]
+    fn stale_codex_account_status_cannot_override_newer_account_signal() {
+        let current = json!({
+            "allowed": false,
+            "limit_reached": true,
+            "primary_used_percent": 99.0,
+            "primary_reset_at": 20_000u64,
+            "primary_window_minutes": 10_080u64,
+            "account_quota_request_started_at_unix_ms": 200_000u64,
+            "updated_at": 200u64
+        });
+        let stale = json!({
+            "allowed": true,
+            "limit_reached": false,
+            "primary_used_percent": 99.0,
+            "primary_reset_at": 20_000u64,
+            "primary_window_minutes": 10_080u64
+        });
+
+        let outcome = merge_codex_quota(
+            Some(&current),
+            &stale,
+            210,
+            150_000,
+            CodexQuotaWindowCoverage::AccountSnapshot,
+        );
+
+        assert!(!outcome.changed);
+        assert_eq!(outcome.metadata, current);
+    }
+
+    #[test]
     fn execution_error_detail_preserves_structured_code_and_message() {
         let result = ExecutionResult {
             request_id: "quota-agent-identity".to_string(),
@@ -5673,6 +6196,8 @@ mod tests {
             &json!({
                 "plan_type": "plus",
                 "rate_limit": {
+                    "allowed": false,
+                    "limit_reached": true,
                     "primary_window": {
                         "used_percent": 25.0,
                         "reset_after_seconds": 604800,
@@ -5707,6 +6232,8 @@ mod tests {
         )
         .expect("codex wham usage should parse");
 
+        assert_eq!(parsed.get("allowed"), Some(&json!(false)));
+        assert_eq!(parsed.get("limit_reached"), Some(&json!(true)));
         assert_eq!(parsed.get("primary_used_percent"), Some(&json!(10.0)));
         assert_eq!(parsed.get("secondary_used_percent"), Some(&json!(25.0)));
         assert_eq!(parsed.get("spark_primary_used_percent"), Some(&json!(40.0)));
@@ -5952,31 +6479,29 @@ mod tests {
 
     #[test]
     fn codex_usage_limit_error_does_not_backfill_a_model_scoped_reset_into_the_account() {
-        let parsed = parse_codex_websocket_rate_limits_response(
-            &json!({
-                "type": "error",
-                "error": {
-                    "type": "usage_limit_reached",
-                    "plan_type": "pro",
-                    "resets_at": 1_787_430_252u64,
-                    "resets_in_seconds": 20_722u64,
-                },
-                "status_code": 429,
-                "headers": {
-                    "X-Codex-Plan-Type": "pro",
-                    "X-Codex-Active-Limit": "codex_bengalfox",
-                    "X-Codex-Primary-Used-Percent": "100",
-                    "X-Codex-Primary-Window-Minutes": "300",
-                    "X-Codex-Primary-Reset-At": "1787430252",
-                    "X-Codex-Bengalfox-Limit-Name": "GPT-5.3-Codex-Spark",
-                    "X-Codex-Bengalfox-Primary-Used-Percent": "100",
-                    "X-Codex-Bengalfox-Primary-Window-Minutes": "300",
-                    "X-Codex-Bengalfox-Primary-Reset-At": "1787430252",
-                },
-            }),
-            1_787_409_530,
-        )
-        .expect("Codex usage-limit error should parse as quota metadata");
+        let event = json!({
+            "type": "error",
+            "error": {
+                "type": "usage_limit_reached",
+                "plan_type": "pro",
+                "resets_at": 1_787_430_252u64,
+                "resets_in_seconds": 20_722u64,
+            },
+            "status_code": 429,
+            "headers": {
+                "X-Codex-Plan-Type": "pro",
+                "X-Codex-Active-Limit": "codex_bengalfox",
+                "X-Codex-Primary-Used-Percent": "100",
+                "X-Codex-Primary-Window-Minutes": "300",
+                "X-Codex-Primary-Reset-At": "1787430252",
+                "X-Codex-Bengalfox-Limit-Name": "GPT-5.3-Codex-Spark",
+                "X-Codex-Bengalfox-Primary-Used-Percent": "100",
+                "X-Codex-Bengalfox-Primary-Window-Minutes": "300",
+                "X-Codex-Bengalfox-Primary-Reset-At": "1787430252",
+            },
+        });
+        let parsed = parse_codex_websocket_rate_limits_response(&event, 1_787_409_530)
+            .expect("Codex usage-limit error should parse as quota metadata");
 
         assert!(
             parsed.get("primary_reset_at").is_none(),
@@ -5986,6 +6511,18 @@ mod tests {
         assert_eq!(
             parsed.get("spark_primary_reset_at"),
             Some(&json!(1_787_430_252u64))
+        );
+        assert_eq!(
+            parsed.get("spark_primary_used_percent"),
+            Some(&json!(100.0))
+        );
+        assert!(parsed.get("allowed").is_none());
+        assert!(parsed.get("limit_reached").is_none());
+        assert!(!codex_rate_limit_metadata_exhausted(&parsed));
+        assert!(codex_websocket_response_has_usage_limit_error(&event));
+        assert_eq!(
+            codex_websocket_usage_limit_reset_at(&event, 1_787_409_530),
+            Some(1_787_430_252u64)
         );
     }
 

--- a/crates/aether-data/runtime/backfills/postgres/20260722140744_sync_legacy_enabled_from_is_active.sql
+++ b/crates/aether-data/runtime/backfills/postgres/20260722140744_sync_legacy_enabled_from_is_active.sql
@@ -1,0 +1,59 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'providers'
+          AND column_name = 'enabled'
+    ) AND EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'providers'
+          AND column_name = 'is_active'
+    ) THEN
+        UPDATE public.providers
+        SET enabled = is_active
+        WHERE is_active IS NOT NULL
+          AND enabled IS DISTINCT FROM is_active;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'provider_endpoints'
+          AND column_name = 'enabled'
+    ) AND EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'provider_endpoints'
+          AND column_name = 'is_active'
+    ) THEN
+        UPDATE public.provider_endpoints
+        SET enabled = is_active
+        WHERE is_active IS NOT NULL
+          AND enabled IS DISTINCT FROM is_active;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'models'
+          AND column_name = 'enabled'
+    ) AND EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'models'
+          AND column_name = 'is_active'
+    ) THEN
+        UPDATE public.models
+        SET enabled = is_active
+        WHERE is_active IS NOT NULL
+          AND enabled IS DISTINCT FROM is_active;
+    END IF;
+END $$;

--- a/crates/aether-data/runtime/src/lifecycle/backfill/tests.rs
+++ b/crates/aether-data/runtime/src/lifecycle/backfill/tests.rs
@@ -47,7 +47,8 @@ fn pending_backfills_from_applied_returns_all_versions_when_none_applied() {
             20260504120000,
             20260505120000,
             20260517012000,
-            20260716010000
+            20260716010000,
+            20260722140744
         ]
     );
 }
@@ -68,7 +69,8 @@ fn pending_backfills_from_applied_skips_versions_already_applied() {
             20260504120000,
             20260505120000,
             20260517012000,
-            20260716010000
+            20260716010000,
+            20260722140744
         ]
     );
 }
@@ -965,13 +967,14 @@ async fn run_backfills_rebuilds_stats_and_records_execution() {
     let pending_before = pending_backfills(&pool)
         .await
         .expect("pending backfills should load");
-    assert_eq!(pending_before.len(), 6);
+    assert_eq!(pending_before.len(), 7);
     assert_eq!(pending_before[0].version, 20260422110000);
     assert_eq!(pending_before[1].version, 20260422120000);
     assert_eq!(pending_before[2].version, 20260504120000);
     assert_eq!(pending_before[3].version, 20260505120000);
     assert_eq!(pending_before[4].version, 20260517012000);
     assert_eq!(pending_before[5].version, 20260716010000);
+    assert_eq!(pending_before[6].version, 20260722140744);
 
     run_backfills(&pool)
         .await
@@ -995,7 +998,8 @@ async fn run_backfills_rebuilds_stats_and_records_execution() {
             20260504120000,
             20260505120000,
             20260517012000,
-            20260716010000
+            20260716010000,
+            20260722140744
         ]
     );
 
@@ -1669,5 +1673,5 @@ ORDER BY total_tokens
         .fetch_one(&pool)
         .await
         .expect("backfill count should load");
-    assert_eq!(applied_count, 6);
+    assert_eq!(applied_count, 7);
 }


### PR DESCRIPTION
Supersedes #748. Closes #746.

This carries forward the two commits from #748 unchanged, retaining @stabey's
authorship, and adds recovery for records that were already contaminated plus
correct exhaustion and retry behavior.

## Root cause

When OpenAI returns `x-codex-active-limit=codex_bengalfox`, the unprefixed
`x-codex-primary-*` and `x-codex-secondary-*` headers describe the active
Spark limit; they are not the account-wide Codex windows. Aether always parsed
those headers as account quota, so Spark's weekly window could be copied into
the account slot.

Both weekly windows have the same duration, while Spark can have the later
reset deadline. The monotonic merge therefore treated subsequent official
account snapshots as older observations and kept the bad value until the
Spark generation rolled over. In the reproduced case, WHAM reported account
weekly usage at 100% with `allowed=false` and `limit_reached=true`, and Spark
weekly usage at 32%, while Aether persisted 32% as the account value and showed
68% remaining. The WHAM parser also discarded the two terminal account flags.

## Changes

- Respect `x-codex-active-limit` and announced named-limit headers, keeping
  model-scoped windows out of the account family.
- Keep a model-scoped 429 reset out of the account reset fields.
- Self-heal an existing Spark-contaminated account window on the next
  authoritative WHAM full snapshot, but only when stored and incoming Spark
  generation, duration, deadline, and usage fingerprints prove the
  contamination and the snapshot is not stale. Partial snapshots, unrelated
  later windows, and stale requests retain the existing monotonic protection.
- Preserve WHAM `allowed` and `limit_reached`, ordering them by the account
  watermark rather than a newer Spark-only watermark.
- Treat a Spark `usage_limit_reached` response as terminal for the active
  request, not the whole credential. The gateway still drains and retries that
  turn with the model-scoped reset deadline, while account-scoped 429 behavior
  remains unchanged.

No database rewrite is required; a normal successful WHAM refresh repairs a
matching contaminated record.
## Upgrade compatibility

Deployment validation against an existing PostgreSQL database initially failed at startup with `VersionMissing(20260722140744)`: its backfill ledger already contained that applied version with SQLx SHA-384 checksum `122c7c7056aaf228e334c8928418895967bbd2ee84b3c6c96ee4afc666c0b32976ece98aaa41a2c21c4710eb9dccada7`, while the source manifest had deleted the corresponding file. This PR restores the exact original SQL asset without rewriting or reapplying it; in the reproduced production environment, database preparation found no failed or pending work and the rebuilt gateway reached healthy state with both public health routes returning HTTP 200.

## Regression coverage

- plan-, named-limit-, missing-active-limit-, and unknown-active-limit header
  ownership;
- successful self-repair plus same-deadline/different-usage,
  unrelated-window, missing-fingerprint, missing-duration, and stale-snapshot
  guards;
- WHAM terminal flags and account-vs-Spark request ordering;
- Spark-scoped 429 drain/retry/reset behavior and unchanged account-scoped 429
  semantics.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p aether-admin` (230 passed)
- `cargo test -p aether-data --all-features --lib pending_backfills_from_applied` (2 passed)
- GitHub Actions: all PR checks passed, including formatting, Clippy, gateway/data/workspace tests, all-driver checks, and SQLite/PostgreSQL/MySQL smoke tests
- `cargo test --locked -p aether-gateway` on Linux
  (4,194 library tests plus all binary, probe, integration, and doc tests passed)
- `cargo clippy -p aether-admin --all-targets -- -D warnings`
- `cargo clippy -p aether-gateway --lib -- -D warnings`

`cargo clippy -p aether-gateway --all-targets -- -D warnings` reaches the full
test target but is currently blocked by 11 pre-existing Rust 1.95 Clippy
warnings in untouched `upstream/main` files. The first warning's upstream and
branch Git blobs are identical; after allowing that lint, the remaining 10
warnings are likewise confined to files in untouched files outside this PR's six-file diff.