### PR TITLE
fix(gemini): normalize mixed tools for same-format providers

### DIFF
--- a/crates/aether-ai/formats/src/formats/gemini/generate_content/request.rs
+++ b/crates/aether-ai/formats/src/formats/gemini/generate_content/request.rs
@@ -218,6 +218,18 @@ fn enable_server_side_tool_invocations_for_mixed_tools(
     if !gemini_model_supports_mixed_tools(mapped_model) {
         return None;
     }
+    ensure_server_side_tool_invocations_for_mixed_tools(output)
+}
+
+pub fn ensure_server_side_tool_invocations_for_mixed_tools(output: &mut Value) -> Option<()> {
+    let output_object = output.as_object_mut()?;
+    let tools = output_object.get("tools").and_then(Value::as_array);
+    let Some(tools) = tools else {
+        return Some(());
+    };
+    if !gemini_tools_are_mixed(tools) {
+        return Some(());
+    }
 
     let tool_config = output_object
         .entry("toolConfig".to_string())

--- a/crates/aether-ai/formats/src/lib.rs
+++ b/crates/aether-ai/formats/src/lib.rs
@@ -12,6 +12,7 @@ pub use formats::context::{
     ConversionFieldRecord, ConversionFieldStatus, ConversionReport, Converted, FormatContext,
     FormatError,
 };
+pub use formats::gemini::generate_content::request::ensure_server_side_tool_invocations_for_mixed_tools;
 pub use formats::id::{
     api_format_alias_matches, api_format_defaults_to_client_error_failover,
     api_format_defaults_to_non_stream, api_format_permission_covers,

--- a/crates/aether-provider/transport/src/antigravity/request.rs
+++ b/crates/aether-provider/transport/src/antigravity/request.rs
@@ -78,6 +78,7 @@ pub fn build_antigravity_safe_v1internal_request(
         inner_request.remove("model");
         inner_request.remove("safetySettings");
         inner_request.remove("safety_settings");
+        normalize_antigravity_function_declaration_schemas(&mut inner_request);
         let request_id = non_empty_string_field(source, "requestId").unwrap_or(request_id);
         let user_agent =
             non_empty_string_field(source, "userAgent").unwrap_or(ANTIGRAVITY_REQUEST_USER_AGENT);
@@ -98,6 +99,7 @@ pub fn build_antigravity_safe_v1internal_request(
     inner_request.remove("model");
     inner_request.remove("safetySettings");
     inner_request.remove("safety_settings");
+    normalize_antigravity_function_declaration_schemas(&mut inner_request);
 
     AntigravityRequestEnvelopeSupport::Supported(serde_json::json!({
         "project": auth.project_id,
@@ -107,6 +109,33 @@ pub fn build_antigravity_safe_v1internal_request(
         "userAgent": ANTIGRAVITY_REQUEST_USER_AGENT,
         "requestType": request_type.as_str(),
     }))
+}
+
+fn normalize_antigravity_function_declaration_schemas(request: &mut Map<String, Value>) {
+    let Some(tools) = request.get_mut("tools").and_then(Value::as_array_mut) else {
+        return;
+    };
+
+    for tool in tools {
+        let Some(tool_object) = tool.as_object_mut() else {
+            continue;
+        };
+        for key in ["functionDeclarations", "function_declarations"] {
+            let Some(declarations) = tool_object.get_mut(key).and_then(Value::as_array_mut) else {
+                continue;
+            };
+            for declaration in declarations {
+                let Some(declaration_object) = declaration.as_object_mut() else {
+                    continue;
+                };
+                if let Some(parameters) = declaration_object.remove("parameters") {
+                    declaration_object
+                        .entry("parametersJsonSchema".to_string())
+                        .or_insert(parameters);
+                }
+            }
+        }
+    }
 }
 
 fn existing_v1internal_request_object(source: &Map<String, Value>) -> Option<&Map<String, Value>> {
@@ -184,6 +213,9 @@ mod tests {
             },
             "tools": [
                 {
+                    "googleSearch": {}
+                },
+                {
                     "functionDeclarations": [
                         {
                             "name": "run_command",
@@ -254,9 +286,17 @@ mod tests {
             .get("include_server_side_tool_invocations")
             .is_none());
         assert_eq!(
-            envelope["request"]["tools"][0]["functionDeclarations"][0]["name"],
+            envelope["request"]["tools"][1]["functionDeclarations"][0]["name"],
             "run_command"
         );
+        assert_eq!(
+            envelope["request"]["tools"][1]["functionDeclarations"][0]["parametersJsonSchema"]
+                ["properties"]["cmd"]["type"],
+            "string"
+        );
+        assert!(envelope["request"]["tools"][1]["functionDeclarations"][0]
+            .get("parameters")
+            .is_none());
         assert_eq!(
             envelope["request"]["labels"]["trajectory_id"],
             "trajectory-123"

--- a/crates/aether-provider/transport/src/antigravity/request.rs
+++ b/crates/aether-provider/transport/src/antigravity/request.rs
@@ -78,7 +78,7 @@ pub fn build_antigravity_safe_v1internal_request(
         inner_request.remove("model");
         inner_request.remove("safetySettings");
         inner_request.remove("safety_settings");
-        normalize_antigravity_function_declaration_schemas(&mut inner_request);
+        normalize_antigravity_function_declaration_parameters(&mut inner_request);
         let request_id = non_empty_string_field(source, "requestId").unwrap_or(request_id);
         let user_agent =
             non_empty_string_field(source, "userAgent").unwrap_or(ANTIGRAVITY_REQUEST_USER_AGENT);
@@ -99,7 +99,7 @@ pub fn build_antigravity_safe_v1internal_request(
     inner_request.remove("model");
     inner_request.remove("safetySettings");
     inner_request.remove("safety_settings");
-    normalize_antigravity_function_declaration_schemas(&mut inner_request);
+    normalize_antigravity_function_declaration_parameters(&mut inner_request);
 
     AntigravityRequestEnvelopeSupport::Supported(serde_json::json!({
         "project": auth.project_id,
@@ -111,7 +111,7 @@ pub fn build_antigravity_safe_v1internal_request(
     }))
 }
 
-fn normalize_antigravity_function_declaration_schemas(request: &mut Map<String, Value>) {
+fn normalize_antigravity_function_declaration_parameters(request: &mut Map<String, Value>) {
     let Some(tools) = request.get_mut("tools").and_then(Value::as_array_mut) else {
         return;
     };
@@ -128,9 +128,14 @@ fn normalize_antigravity_function_declaration_schemas(request: &mut Map<String, 
                 let Some(declaration_object) = declaration.as_object_mut() else {
                     continue;
                 };
-                if let Some(parameters) = declaration_object.remove("parameters") {
+                if let Some(parameters) = declaration_object.remove("parametersJsonSchema") {
                     declaration_object
-                        .entry("parametersJsonSchema".to_string())
+                        .entry("parameters".to_string())
+                        .or_insert(parameters);
+                }
+                if let Some(parameters) = declaration_object.remove("parameters_json_schema") {
+                    declaration_object
+                        .entry("parameters".to_string())
                         .or_insert(parameters);
                 }
             }
@@ -290,12 +295,12 @@ mod tests {
             "run_command"
         );
         assert_eq!(
-            envelope["request"]["tools"][1]["functionDeclarations"][0]["parametersJsonSchema"]
-                ["properties"]["cmd"]["type"],
+            envelope["request"]["tools"][1]["functionDeclarations"][0]["parameters"]["properties"]
+                ["cmd"]["type"],
             "string"
         );
         assert!(envelope["request"]["tools"][1]["functionDeclarations"][0]
-            .get("parameters")
+            .get("parametersJsonSchema")
             .is_none());
         assert_eq!(
             envelope["request"]["labels"]["trajectory_id"],
@@ -411,5 +416,43 @@ mod tests {
             envelope["request"]["toolConfig"]["functionCallingConfig"]["mode"],
             "NONE"
         );
+    }
+
+    #[test]
+    fn antigravity_envelope_normalizes_json_schema_parameter_spellings() {
+        let request_body = json!({
+            "contents": [{
+                "role": "user",
+                "parts": [{ "text": "hello" }]
+            }],
+            "tools": [{
+                "function_declarations": [{
+                    "name": "lookup",
+                    "parametersJsonSchema": { "type": "object" }
+                }, {
+                    "name": "weather",
+                    "parameters_json_schema": { "type": "object" }
+                }]
+            }]
+        });
+
+        let envelope = match build_antigravity_safe_v1internal_request(
+            &sample_auth(),
+            "request-ant-schema-123",
+            "gemini-3.5-flash-low",
+            &request_body,
+            AntigravityEnvelopeRequestType::Agent,
+        ) {
+            AntigravityRequestEnvelopeSupport::Supported(envelope) => envelope,
+            AntigravityRequestEnvelopeSupport::Unsupported(reason) => {
+                panic!("schema envelope should be supported: {reason:?}")
+            }
+        };
+
+        let declarations = &envelope["request"]["tools"][0]["function_declarations"];
+        assert_eq!(declarations[0]["parameters"]["type"], "object");
+        assert_eq!(declarations[1]["parameters"]["type"], "object");
+        assert!(declarations[0].get("parametersJsonSchema").is_none());
+        assert!(declarations[1].get("parameters_json_schema").is_none());
     }
 }

--- a/crates/aether-provider/transport/src/same_format_provider/mod.rs
+++ b/crates/aether-provider/transport/src/same_format_provider/mod.rs
@@ -419,6 +419,27 @@ fn build_same_format_provider_request_body_inner(
             "gemini:generate_content",
         )
     {
+        let before_mixed_tool_compatibility = compatibility_edits
+            .is_some()
+            .then(|| provider_request_body.clone());
+        aether_ai_formats::ensure_server_side_tool_invocations_for_mixed_tools(
+            &mut provider_request_body,
+        )?;
+        if before_mixed_tool_compatibility.is_some_and(|before| before != provider_request_body) {
+            record_compatibility_edit(
+                &mut compatibility_edits,
+                "toolConfig.includeServerSideToolInvocations",
+                SameFormatProviderCompatibilityEditAction::ProviderCompatibilityRewrite,
+                "enabled Gemini server-side tool invocations for mixed built-in and function tools",
+            );
+        }
+    }
+    if matches!(input.family, SameFormatProviderFamily::Gemini)
+        && aether_ai_formats::api_format_alias_matches(
+            input.provider_api_format,
+            "gemini:generate_content",
+        )
+    {
         let stripped = strip_gemini_function_response_ids(&mut provider_request_body);
         if stripped > 0 {
             record_compatibility_edit(
@@ -2055,6 +2076,60 @@ mod tests {
         let function_response = &body["contents"][0]["parts"][1]["function_response"];
         assert!(function_response.get("id").is_none());
         assert_eq!(function_response["name"], "lookup_snake");
+    }
+
+    #[test]
+    fn same_format_gemini_body_enables_mixed_tool_invocations() {
+        let output = build_same_format_provider_request_body_with_compatibility_report(
+            SameFormatProviderRequestBodyInput {
+                body_json: &json!({
+                    "contents": [{
+                        "role": "user",
+                        "parts": [{"text": "Search, then save the result."}]
+                    }],
+                    "tools": [
+                        {"googleSearch": {}},
+                        {
+                            "functionDeclarations": [{
+                                "name": "save_result",
+                                "parameters": {"type": "object"}
+                            }]
+                        }
+                    ],
+                    "toolConfig": {
+                        "functionCallingConfig": {"mode": "AUTO"}
+                    }
+                }),
+                mapped_model: "gemini-3.7-flash",
+                client_api_format: "gemini:generate_content",
+                provider_api_format: "gemini:generate_content",
+                source_model: Some("gemini-3.7-flash"),
+                family: SameFormatProviderFamily::Gemini,
+                body_rules: None,
+                request_headers: None,
+                upstream_is_stream: true,
+                force_body_stream_field: false,
+                kiro_auth_config: None,
+                is_claude_code: false,
+                enable_model_directives: false,
+            },
+        )
+        .expect("same-format Gemini body should build");
+
+        assert_eq!(output.body["tools"][0]["googleSearch"], json!({}));
+        assert_eq!(
+            output.body["tools"][1]["functionDeclarations"][0]["name"],
+            "save_result"
+        );
+        assert_eq!(
+            output.body["toolConfig"]["includeServerSideToolInvocations"],
+            true
+        );
+        assert!(output.compatibility_edits.iter().any(|edit| {
+            edit.field == "toolConfig.includeServerSideToolInvocations"
+                && edit.action
+                    == SameFormatProviderCompatibilityEditAction::ProviderCompatibilityRewrite
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary`n`n- Normalize Gemini mixed built-in and function tools in the same-format provider runtime path.`n- Preserve the standard camelCase toolConfig.includeServerSideToolInvocations field.`n- Add format and provider transport regression coverage.`n`n## Validation`n`n- cargo test --manifest-path Aether/Cargo.toml -p aether-ai-formats --lib`n- cargo test --manifest-path Aether/Cargo.toml -p aether-provider-transport --lib`n- cargo fmt --manifest-path Aether/Cargo.toml --all -- --check