### PR TITLE
feat(provider-ops): 新增通用 API Key 用量查询模板

### DIFF
--- a/crates/aether-admin/src/provider/ops/actions.rs
+++ b/crates/aether-admin/src/provider/ops/actions.rs
@@ -17,6 +17,7 @@ pub fn parse_query_balance_payload(
         "generic_api" | "new_api" | "anyrouter" | "done_hub" => {
             parse_new_api_balance_payload(action_config, response_json)
         }
+        "usage_api" => parse_usage_api_balance_payload(action_config, response_json),
         "cubence" => parse_cubence_balance_payload(action_config, response_json),
         "nekocode" => parse_nekocode_balance_payload(response_json),
         _ => Err("Provider 操作仅支持 Rust execution runtime".to_string()),
@@ -201,6 +202,57 @@ fn parse_new_api_balance_payload(
             .and_then(Value::as_str)
             .unwrap_or("USD"),
         Map::new(),
+    ))
+}
+
+fn parse_usage_api_balance_payload(
+    action_config: &Map<String, Value>,
+    response_json: &Value,
+) -> Result<Value, String> {
+    let data = response_json
+        .as_object()
+        .ok_or_else(|| "响应格式无效".to_string())?;
+    let is_valid = data
+        .get("is_active")
+        .and_then(Value::as_bool)
+        .or_else(|| data.get("isValid").and_then(Value::as_bool));
+    if is_valid == Some(false) {
+        return Err("API Key 无效或已停用".to_string());
+    }
+
+    let quota = data.get("quota").and_then(Value::as_object);
+    let remaining = admin_provider_ops_value_as_f64(data.get("remaining"))
+        .or_else(|| quota.and_then(|quota| admin_provider_ops_value_as_f64(quota.get("remaining"))))
+        .or_else(|| admin_provider_ops_value_as_f64(data.get("balance")))
+        .ok_or_else(|| "响应缺少余额字段".to_string())?;
+    let currency = data
+        .get("unit")
+        .and_then(Value::as_str)
+        .or_else(|| quota.and_then(|quota| quota.get("unit").and_then(Value::as_str)))
+        .or_else(|| action_config.get("currency").and_then(Value::as_str))
+        .unwrap_or("USD");
+
+    let mut extra = Map::new();
+    extra.insert(
+        "is_valid".to_string(),
+        Value::Bool(is_valid.unwrap_or(true)),
+    );
+    if let Some(value) = data.get("balance") {
+        extra.insert("balance".to_string(), value.clone());
+    }
+    if let Some(value) = data.get("planName").or_else(|| data.get("plan_name")) {
+        extra.insert("plan_name".to_string(), value.clone());
+    }
+    if let Some(value) = data.get("mode") {
+        extra.insert("mode".to_string(), value.clone());
+    }
+
+    Ok(build_balance_data(
+        None,
+        None,
+        Some(remaining),
+        currency,
+        extra,
     ))
 }
 
@@ -469,7 +521,7 @@ mod tests {
         attach_balance_checkin_outcome, parse_query_balance_payload, parse_sub2api_balance_payload,
         ProviderOpsCheckinOutcome,
     };
-    use serde_json::json;
+    use serde_json::{json, Map};
 
     #[test]
     fn anyrouter_single_request_parser_uses_usage_fields() {
@@ -488,6 +540,48 @@ mod tests {
 
         assert_eq!(payload["total_available"], json!(5.0));
         assert_eq!(payload["total_used"], json!(1.0));
+    }
+
+    #[test]
+    fn usage_api_parser_reads_remaining_and_unit() {
+        let payload = parse_query_balance_payload(
+            "usage_api",
+            &json!({ "currency": "USD" })
+                .as_object()
+                .cloned()
+                .expect("config"),
+            &json!({
+                "remaining": 42.5,
+                "balance": 42.5,
+                "unit": "USD",
+                "isValid": true,
+                "planName": "Example Plan"
+            }),
+        )
+        .expect("payload should parse");
+
+        assert_eq!(payload["total_available"], json!(42.5));
+        assert_eq!(payload["currency"], json!("USD"));
+        assert_eq!(payload["extra"]["plan_name"], json!("Example Plan"));
+        assert_eq!(payload["extra"]["is_valid"], json!(true));
+    }
+
+    #[test]
+    fn usage_api_parser_falls_back_to_nested_quota() {
+        let payload = parse_query_balance_payload(
+            "usage_api",
+            &Map::new(),
+            &json!({
+                "quota": {
+                    "remaining": "12.5",
+                    "unit": "CNY"
+                }
+            }),
+        )
+        .expect("payload should parse");
+
+        assert_eq!(payload["total_available"], json!(12.5));
+        assert_eq!(payload["currency"], json!("CNY"));
     }
 
     #[test]

--- a/crates/aether-admin/src/provider/ops/architectures/mod.rs
+++ b/crates/aether-admin/src/provider/ops/architectures/mod.rs
@@ -5,6 +5,7 @@ mod generic_api;
 mod nekocode;
 mod new_api;
 mod sub2api;
+mod usage_api;
 mod yescode;
 
 use serde_json::{json, Map, Value};
@@ -98,6 +99,7 @@ static PROVIDER_OPS_ARCHITECTURES: LazyLock<Vec<ProviderOpsArchitectureSpec>> =
             nekocode::spec(),
             new_api::spec(),
             sub2api::spec(),
+            usage_api::spec(),
             yescode::spec(),
         ]
     });
@@ -129,6 +131,7 @@ pub fn normalize_architecture_id(architecture_id: &str) -> &'static str {
         "nekocode" => "nekocode",
         "anyrouter" => "anyrouter",
         "sub2api" => "sub2api",
+        "usage_api" => "usage_api",
         _ => "generic_api",
     }
 }
@@ -186,6 +189,7 @@ fn default_action_config(architecture_id: &str, action_type: &str) -> Option<Map
         "nekocode" => nekocode::default_action_config(action_type),
         "new_api" => new_api::default_action_config(action_type),
         "sub2api" => sub2api::default_action_config(action_type),
+        "usage_api" => usage_api::default_action_config(action_type),
         "yescode" => yescode::default_action_config(action_type),
         _ => None,
     }
@@ -205,13 +209,13 @@ mod tests {
     #[test]
     fn list_architectures_hides_generic_api_by_default() {
         let visible = list_architectures(false);
-        assert_eq!(visible.len(), 7);
+        assert_eq!(visible.len(), 8);
         assert!(visible
             .iter()
             .all(|item| item.architecture_id != "generic_api"));
 
         let all = list_architectures(true);
-        assert_eq!(all.len(), 8);
+        assert_eq!(all.len(), 9);
         assert!(all.iter().any(|item| item.architecture_id == "generic_api"));
     }
 
@@ -220,6 +224,7 @@ mod tests {
         assert_eq!(normalize_architecture_id(""), "generic_api");
         assert_eq!(normalize_architecture_id("done_hub"), "done_hub");
         assert_eq!(normalize_architecture_id("new_api"), "new_api");
+        assert_eq!(normalize_architecture_id("usage_api"), "usage_api");
         assert_eq!(normalize_architecture_id("unknown"), "generic_api");
     }
 

--- a/crates/aether-admin/src/provider/ops/architectures/usage_api.rs
+++ b/crates/aether-admin/src/provider/ops/architectures/usage_api.rs
@@ -1,0 +1,92 @@
+use super::{
+    json_object, ProviderOpsActionSpec, ProviderOpsArchitectureSpec, ProviderOpsAuthSpec,
+    ProviderOpsBalanceMode, ProviderOpsCheckinMode, ProviderOpsVerifyMode,
+};
+use serde_json::{json, Map, Value};
+
+pub(super) fn spec() -> ProviderOpsArchitectureSpec {
+    let credentials_schema = json!({
+        "type": "object",
+        "properties": {
+            "api_key": {
+                "type": "string",
+                "title": "API Key",
+                "description": "提供商签发的 API Key",
+                "x-sensitive": true,
+                "x-input-type": "password"
+            },
+            "base_url": {
+                "type": "string",
+                "title": "站点地址",
+                "description": "API 基础地址"
+            }
+        },
+        "required": ["api_key"],
+        "x-auth-method": "bearer",
+        "x-auth-type": "api_key",
+        "x-currency": "USD",
+        "x-field-groups": [
+            { "fields": ["base_url"] },
+            { "fields": ["api_key"] }
+        ],
+        "x-validation": [
+            {
+                "type": "required",
+                "fields": ["api_key"],
+                "message": "请填写 API Key"
+            }
+        ]
+    });
+
+    ProviderOpsArchitectureSpec {
+        architecture_id: "usage_api",
+        display_name: "API Key 用量查询",
+        description: "使用 Provider API Key 查询兼容 /v1/usage 的用量接口",
+        hidden: false,
+        credentials_schema: credentials_schema.clone(),
+        verify_endpoint: "/v1/usage",
+        verify_mode: ProviderOpsVerifyMode::DirectGet,
+        balance_mode: ProviderOpsBalanceMode::SingleRequest,
+        checkin_mode: ProviderOpsCheckinMode::None,
+        query_balance_cookie_auth_errors: false,
+        supported_auth_types: vec![ProviderOpsAuthSpec {
+            auth_type: "api_key",
+            display_name: "Provider API Key",
+            credentials_schema,
+        }],
+        supported_actions: vec![ProviderOpsActionSpec {
+            action_type: "query_balance",
+            display_name: "查询余额",
+            description: "查询 API Key 的剩余额度",
+            config_schema: json!({
+                "type": "object",
+                "properties": {
+                    "endpoint": {
+                        "type": "string",
+                        "title": "API 路径",
+                        "description": "用量查询 API 路径",
+                        "default": "/v1/usage"
+                    },
+                    "currency": {
+                        "type": "string",
+                        "title": "默认货币单位",
+                        "default": "USD"
+                    }
+                },
+                "required": []
+            }),
+        }],
+        default_connector: Some("api_key"),
+    }
+}
+
+pub(super) fn default_action_config(action_type: &str) -> Option<Map<String, Value>> {
+    match action_type {
+        "query_balance" => Some(json_object(json!({
+            "endpoint": "/v1/usage",
+            "method": "GET",
+            "currency": "USD"
+        }))),
+        _ => None,
+    }
+}

--- a/crates/aether-admin/src/provider/ops/verify.rs
+++ b/crates/aether-admin/src/provider/ops/verify.rs
@@ -35,6 +35,7 @@ pub fn parse_verify_payload(
         "sub2api" => {
             admin_provider_ops_sub2api_verify_payload(status, response_json, updated_credentials)
         }
+        "usage_api" => admin_provider_ops_usage_api_verify_payload(status, response_json),
         _ => admin_provider_ops_generic_verify_payload(status, response_json),
     }
 }
@@ -355,7 +356,7 @@ pub fn admin_provider_ops_verify_headers(
 ) -> Result<HeaderMap, String> {
     let mut headers = HeaderMap::new();
     match normalize_architecture_id(architecture_id) {
-        "generic_api" => {
+        "generic_api" | "usage_api" => {
             let api_key = credentials
                 .get("api_key")
                 .and_then(Value::as_str)
@@ -509,6 +510,78 @@ pub fn admin_provider_ops_generic_verify_payload(
         response_json,
         "认证失败：无效的凭据",
         "认证失败：权限不足",
+    )
+}
+
+pub fn admin_provider_ops_usage_api_verify_payload(
+    status: StatusCode,
+    response_json: &Value,
+) -> Value {
+    if status == StatusCode::UNAUTHORIZED {
+        return admin_provider_ops_verify_failure("认证失败：API Key 无效");
+    }
+    if status == StatusCode::FORBIDDEN {
+        return admin_provider_ops_verify_failure("认证失败：API Key 无权查询用量");
+    }
+    if status != StatusCode::OK {
+        return admin_provider_ops_verify_failure(format!("验证失败：HTTP {}", status.as_u16()));
+    }
+
+    let Some(data) = response_json.as_object() else {
+        return admin_provider_ops_verify_failure("响应格式无效");
+    };
+    let is_valid = data
+        .get("is_active")
+        .and_then(Value::as_bool)
+        .or_else(|| data.get("isValid").and_then(Value::as_bool));
+    if is_valid == Some(false) {
+        return admin_provider_ops_verify_failure("API Key 无效或已停用");
+    }
+
+    let quota = data.get("quota").and_then(Value::as_object);
+    let remaining = admin_provider_ops_value_as_f64(data.get("remaining"))
+        .or_else(|| quota.and_then(|quota| admin_provider_ops_value_as_f64(quota.get("remaining"))))
+        .or_else(|| admin_provider_ops_value_as_f64(data.get("balance")));
+    let Some(remaining) = remaining else {
+        return admin_provider_ops_verify_failure("响应缺少余额字段");
+    };
+    let unit = data
+        .get("unit")
+        .and_then(Value::as_str)
+        .or_else(|| quota.and_then(|quota| quota.get("unit").and_then(Value::as_str)))
+        .unwrap_or("USD")
+        .to_string();
+    let plan_name = data
+        .get("planName")
+        .and_then(Value::as_str)
+        .or_else(|| data.get("plan_name").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("API Key")
+        .to_string();
+
+    let mut extra = Map::new();
+    extra.insert("unit".to_string(), Value::String(unit));
+    if let Some(value) = data.get("balance") {
+        extra.insert("balance".to_string(), value.clone());
+    }
+    if let Some(value) = data.get("mode") {
+        extra.insert("mode".to_string(), value.clone());
+    }
+    extra.insert(
+        "is_valid".to_string(),
+        Value::Bool(is_valid.unwrap_or(true)),
+    );
+
+    admin_provider_ops_verify_success(
+        admin_provider_ops_verify_user_payload(
+            Some(plan_name.clone()),
+            Some(plan_name),
+            None,
+            Some(remaining),
+            Some(extra),
+        ),
+        None,
     )
 }
 
@@ -843,7 +916,8 @@ mod tests {
         admin_provider_ops_anyrouter_parse_session_user_id,
         admin_provider_ops_anyrouter_verify_payload, admin_provider_ops_cubence_verify_payload,
         admin_provider_ops_frontend_updated_credentials, admin_provider_ops_sub2api_verify_payload,
-        admin_provider_ops_verify_headers, parse_verify_payload, ADMIN_PROVIDER_OPS_USER_AGENT,
+        admin_provider_ops_usage_api_verify_payload, admin_provider_ops_verify_headers,
+        parse_verify_payload, ADMIN_PROVIDER_OPS_USER_AGENT,
     };
     use http::StatusCode;
     use reqwest::header::COOKIE;
@@ -949,6 +1023,57 @@ mod tests {
         assert_eq!(payload["data"]["username"], json!("user@example.com"));
         assert_eq!(payload["data"]["display_name"], json!("user@example.com"));
         assert_eq!(payload["data"]["email"], json!("user@example.com"));
+    }
+
+    #[test]
+    fn usage_api_headers_use_bearer_api_key() {
+        let headers = admin_provider_ops_verify_headers(
+            "usage_api",
+            &Map::new(),
+            &Map::from_iter([("api_key".to_string(), json!("example-api-key"))]),
+        )
+        .expect("headers should build");
+
+        assert_eq!(
+            headers
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer example-api-key")
+        );
+    }
+
+    #[test]
+    fn usage_api_verify_payload_reads_remaining_and_plan() {
+        let payload = admin_provider_ops_usage_api_verify_payload(
+            StatusCode::OK,
+            &json!({
+                "remaining": 42.5,
+                "balance": 42.5,
+                "unit": "USD",
+                "isValid": true,
+                "planName": "Example Plan"
+            }),
+        );
+
+        assert_eq!(payload["success"], json!(true));
+        assert_eq!(payload["data"]["username"], json!("Example Plan"));
+        assert_eq!(payload["data"]["quota"], json!(42.5));
+        assert_eq!(payload["data"]["extra"]["unit"], json!("USD"));
+        assert_eq!(payload["data"]["extra"]["is_valid"], json!(true));
+    }
+
+    #[test]
+    fn usage_api_verify_payload_rejects_inactive_key() {
+        let payload = admin_provider_ops_usage_api_verify_payload(
+            StatusCode::OK,
+            &json!({
+                "remaining": 0,
+                "isValid": false
+            }),
+        );
+
+        assert_eq!(payload["success"], json!(false));
+        assert_eq!(payload["message"], json!("API Key 无效或已停用"));
     }
 
     #[test]


### PR DESCRIPTION
## 背景

在实际接入第三方模型 Provider 时，有一类服务并不采用 New API 的用户接口，也不提供 Cookie 登录态，而是直接复用 Provider API Key 查询当前密钥的有效性与剩余额度。

这类服务通常提供如下契约：

- 使用 `Authorization: Bearer <API Key>` 认证
- 通过 `GET /v1/usage` 查询用量
- 返回 `remaining`、`balance`、`unit`、`isValid`、`planName` 等字段
- 部分兼容实现会将剩余额度放在 `quota.remaining`，单位放在 `quota.unit`

模型调用本身可以正常工作，但 Aether 现有用户认证模板主要面向 New API、Sub2API 或 Cookie 型站点。遇到上述接口时，无法直接完成 Provider 凭据验证和余额刷新，只能选择语义不匹配的模板，且解析结果也不正确。

## 问题

现有通用 API 模板默认验证 `/api/user/self`，余额解析遵循 New API 的 `quota / quota_divisor` 结构。它无法覆盖以下差异：

1. 验证端点是 `/v1/usage`，而不是 New API 用户端点。
2. 认证主体是 Provider API Key，不需要用户 ID 或 Cookie。
3. 余额字段已经是实际额度，不应再经过 `quota_divisor` 换算。
4. 有效状态可能使用 `isValid`，也可能使用 `is_active`。
5. 剩余额度可能位于 `remaining`、`quota.remaining` 或 `balance`。
6. 单位可能位于 `unit`、`quota.unit`，也可能需要使用配置默认值。
7. 401、403、密钥停用和响应缺少余额字段时，需要给出明确的验证错误。

## 解决方案

本 PR 新增一个独立且通用的 Provider Ops 架构：

- 内部标识：`usage_api`
- 显示名称：`API Key 用量查询`
- 默认验证端点：`GET /v1/usage`
- 默认认证：`Authorization: Bearer <API Key>`
- 默认余额动作：`query_balance`
- 默认单位：`USD`
- 不启用签到逻辑

该模板没有绑定任何具体 Provider，可以供所有实现相同或兼容用量接口的服务复用。

### 响应兼容策略

剩余额度按以下优先级读取：

1. `remaining`
2. `quota.remaining`
3. `balance`

单位按以下优先级读取：

1. `unit`
2. `quota.unit`
3. 动作配置中的 `currency`
4. `USD`

有效状态同时兼容：

- `is_active`
- `isValid`
- 字段缺失时保持向后兼容，视为有效

套餐名称同时兼容：

- `planName`
- `plan_name`
- 缺失时显示为 `API Key`

另外保留 `balance`、套餐名称、`mode` 和有效状态到余额结果的 `extra` 字段，方便前端展示和后续扩展。

### 错误处理

- HTTP 401：明确提示 API Key 无效
- HTTP 403：明确提示 API Key 无权查询用量
- 其他非 200：返回对应 HTTP 状态码
- `is_active=false` 或 `isValid=false`：提示密钥无效或已停用
- 响应不是 JSON 对象：提示响应格式无效
- 无法解析剩余额度：提示响应缺少余额字段

## 示例契约

以下仅为虚构数据，用于说明兼容格式：

```json
{
  "remaining": 42.5,
  "balance": 42.5,
  "unit": "USD",
  "isValid": true,
  "planName": "Example Plan"
}
```

也兼容嵌套格式：

```json
{
  "quota": {
    "remaining": "12.5",
    "unit": "CNY"
  }
}
```

## 实现范围

- 注册新的 `usage_api` 架构及默认动作配置
- 为验证请求生成 Bearer Authorization 请求头
- 增加验证响应解析与错误映射
- 增加余额响应解析与字段回退
- 增加架构注册、认证头、验证结果和余额解析测试
- 不涉及数据库迁移
- 不增加前端特判，继续复用现有动态 Schema 表单
- 不改变现有 Provider 模板行为

## 测试

已在当前 `main` 基线执行：

```text
cargo test -p aether-admin usage_api --lib
5 passed; 0 failed

cargo test -p aether-admin provider::ops --lib
27 passed; 0 failed
```

同时已通过 `cargo fmt --all` 和 `git diff --check`。

## 脱敏说明

本 PR 不包含真实 Provider 名称、域名、API Key、账户标识或实际余额数据。测试和文档中的名称、密钥与金额均为通用占位示例。