### PR TITLE
fix(pool): restore Antigravity quota progress bars

### DIFF
--- a/frontend/src/features/pool/components/__tests__/PoolKeyDisplayPanels.spec.ts
+++ b/frontend/src/features/pool/components/__tests__/PoolKeyDisplayPanels.spec.ts
@@ -90,7 +90,7 @@ describe('pool key display panels', () => {
     root.remove()
   })
 
-  it('renders Antigravity quota summaries in a compact numeric grid', () => {
+  it('renders Antigravity quota summaries with progress tracks', () => {
     const root = document.createElement('div')
     document.body.appendChild(root)
     const app = createApp(PoolKeyQuotaPanel, {
@@ -102,7 +102,6 @@ describe('pool key display panels', () => {
           meterText: '90.6–100',
           barClass: 'bg-emerald-500',
           meterClass: 'text-emerald-600',
-          numericOnly: true,
         },
         {
           label: 'Claude额度',
@@ -111,21 +110,19 @@ describe('pool key display panels', () => {
           meterText: '100',
           barClass: 'bg-emerald-500',
           meterClass: 'text-emerald-600',
-          numericOnly: true,
         },
       ],
     })
     app.use(createI18n())
     app.mount(root)
 
-    expect(root.querySelector('[data-testid="pool-quota-rows"]')?.className).toContain('grid-cols-2')
+    expect(root.querySelector('[data-testid="pool-quota-rows"]')?.className).toContain('space-y-2')
     expect(Array.from(root.querySelectorAll('[data-testid="pool-quota-period-label"]')).map(node => node.textContent)).toEqual([
       'Gemini额度',
       'Claude额度',
     ])
     expect(Array.from(root.querySelectorAll('[data-testid="pool-quota-meter-text"]')).map(node => node.textContent)).toEqual(['90.6–100', '100'])
-    expect(root.textContent).not.toContain('1h 后重置')
-    expect(root.querySelector('[data-testid="pool-quota-progress-track"]')).toBeNull()
+    expect(root.querySelectorAll('[data-testid="pool-quota-progress-track"]')).toHaveLength(2)
 
     app.unmount()
     root.remove()

--- a/frontend/src/views/admin/PoolManagement.vue
+++ b/frontend/src/views/admin/PoolManagement.vue
@@ -3876,7 +3876,6 @@ function buildQuotaProgressItemsFromSnapshot(key: PoolKeyDetail): QuotaProgressI
           model,
           label: resolveAntigravityQuotaLabel(model, window.label, opaqueDisplayIndex),
           remainingPercent,
-          numericOnly: true,
           resetAtSeconds: normalizeUnixSeconds(window.reset_at ?? quota.reset_at ?? null),
           resetSeconds: normalizeRemainingSeconds(window.reset_seconds ?? quota.reset_seconds ?? null),
           updatedAtSeconds: getQuotaSnapshotUpdatedAtSeconds(quota),
@@ -3884,6 +3883,12 @@ function buildQuotaProgressItemsFromSnapshot(key: PoolKeyDetail): QuotaProgressI
         }
       })
         .filter((item): item is QuotaProgressItem & { model: string, resetSeconds: number | null } => item != null)))
+      .map(item => ({
+        ...item,
+        resetAtSeconds: null,
+        resetSeconds: null,
+        allowDynamicReset: false,
+      }))
   }
 
   if (providerType === 'gemini_cli') {


### PR DESCRIPTION
## Summary
- restore progress bars for grouped Antigravity Gemini and Claude quota summaries
- keep the compact two-group display and independent quota ranges
- avoid showing a single model reset countdown on a grouped quota row

## Validation
- npm exec vitest run -- src/features/providers/utils/__tests__/antigravityQuotaSummary.spec.ts src/features/pool/components/__tests__/PoolKeyDisplayPanels.spec.ts
- npm run type-check
- npm run build
- git diff --check