### PR TITLE
fix(formats): ignore Responses ping stream events

### DIFF
--- a/crates/aether-ai/formats/src/formats/openai/chat/stream.rs
+++ b/crates/aether-ai/formats/src/formats/openai/chat/stream.rs
@@ -1840,7 +1840,7 @@ impl OpenAIResponsesProviderState {
                 });
                 self.finished = true;
             }
-            "keepalive" => {}
+            "keepalive" | "ping" => {}
             event_type if openai_responses_stream_event_is_known_noop(event_type) => {
                 self.ensure_started(report_context, &mut out);
             }

--- a/crates/aether-ai/formats/src/formats/shared/stream_core/format_matrix.rs
+++ b/crates/aether-ai/formats/src/formats/shared/stream_core/format_matrix.rs
@@ -1367,6 +1367,17 @@ mod tests {
             .expect("keepalive should be ignored");
         assert!(keepalive.is_empty());
 
+        let ping = matrix
+            .transform_line(
+                &report_context,
+                data_line(json!({
+                    "type": "ping",
+                    "cost": "0",
+                })),
+            )
+            .expect("provider ping should be ignored");
+        assert!(ping.is_empty());
+
         for line in [
             data_line(json!({
                 "type": "response.output_text.delta",


### PR DESCRIPTION
## Summary
- Treat OpenAI Responses provider ping events as keepalive no-ops during stream conversion.
- Add a regression test using the provider payload shape observed in production: type=ping with a cost field.

## Root cause
A provider can append a ping event after response.completed. The parser already ignored keepalive events, but classified ping as unknown. Cross-format finalization then emitted unsupported_stream_event after HTTP 200 had already been committed, leaving chat clients with a 200 response containing an error body.

## Testing
- cargo fmt --all --check
- cargo test -p aether-ai-formats --lib
- cargo clippy -p aether-ai-formats --lib --all-targets