### PR TITLE
fix(oauth): keep antigravity import email for account naming

### DIFF
--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/batch/parse.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/batch/parse.rs
@@ -808,6 +808,13 @@ pub(super) fn apply_admin_provider_oauth_batch_import_hints(
         return;
     }
     if provider_type == "antigravity" {
+        // Antigravity 的 refresh_token 交换只返回 Google token 响应，不含账号邮箱，
+        // 邮箱只能来自导入 JSON 本身，否则账号名会退化成 antigravity_<ts>_<index>。
+        if let Some(email) = entry.email.as_ref() {
+            auth_config
+                .entry("email".to_string())
+                .or_insert_with(|| json!(email));
+        }
         if let Some(project_id) = entry.project_id.as_ref() {
             auth_config
                 .entry("project_id".to_string())
@@ -1433,7 +1440,7 @@ mod tests {
     fn applies_antigravity_project_and_user_agent_hints_to_auth_config() {
         let entries = parse_admin_provider_oauth_batch_import_entries(
             "antigravity",
-            r#"{"refreshToken":"rt-1","cloudaicompanionProject":{"id":"project-antigravity-2"},"userAgent":"antigravity"}"#,
+            r#"{"refreshToken":"rt-1","email":"anti@example.com","cloudaicompanionProject":{"id":"project-antigravity-2"},"userAgent":"antigravity"}"#,
         );
         let mut auth_config = serde_json::Map::new();
 
@@ -1444,6 +1451,35 @@ mod tests {
             Some(&json!("project-antigravity-2"))
         );
         assert_eq!(auth_config.get("user_agent"), Some(&json!("antigravity")));
+        assert_eq!(auth_config.get("email"), Some(&json!("anti@example.com")));
+    }
+
+    #[test]
+    fn antigravity_batch_import_keeps_json_email_for_key_naming() {
+        let entries = parse_admin_provider_oauth_batch_import_entries(
+            "antigravity",
+            r#"{"access_token":"at-1","refresh_token":"rt-1","email":"anti@example.com","project_id":"project-antigravity-3","type":"antigravity"}"#,
+        );
+        // Google 的 refresh_token 交换响应不带邮箱，模拟这种 auth_config。
+        let mut auth_config = json!({
+            "provider_type": "antigravity",
+            "refresh_token": "rt-1",
+        })
+        .as_object()
+        .cloned()
+        .expect("auth config should be an object");
+
+        apply_admin_provider_oauth_batch_import_hints("antigravity", &entries[0], &mut auth_config);
+
+        assert_eq!(auth_config.get("email"), Some(&json!("anti@example.com")));
+        assert_eq!(
+            super::super::super::helpers::admin_provider_oauth_key_name_from_auth_config(
+                "antigravity",
+                &auth_config,
+                Some(0),
+            ),
+            "antigravity_anti@example.com"
+        );
     }
 
     #[test]

--- a/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/import.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/oauth/dispatch/import.rs
@@ -460,6 +460,9 @@ fn apply_single_import_hints(
                 .or_insert_with(|| json!(project_id));
         }
         for (target, keys) in [
+            // Antigravity 的 token 响应不带账号邮箱，只能从导入 JSON 里取，
+            // 否则账号名会退化成 antigravity_<timestamp>。
+            ("email", &["email", "oauth_email"][..]),
             (
                 "client_version",
                 &[
@@ -1461,7 +1464,8 @@ mod tests {
             },
             "clientVersion": "1.99.0",
             "sessionId": "session-antigravity-1",
-            "userAgent": "antigravity"
+            "userAgent": "antigravity",
+            "email": "anti@example.com"
         })
         .as_object()
         .cloned()
@@ -1470,6 +1474,7 @@ mod tests {
 
         apply_single_import_hints("antigravity", &payload, &mut auth_config);
 
+        assert_eq!(auth_config.get("email"), Some(&json!("anti@example.com")));
         assert_eq!(
             auth_config.get("project_id"),
             Some(&json!("project-antigravity-1"))


### PR DESCRIPTION
## 问题

Antigravity provider 用 JSON 批量/单条导入账号时，JSON 里的邮箱识别不出来，导入后每个账号的名字都是自动生成的 `antigravity_<timestamp>_<index>`。

线上实测（自建镜像）：

```
antigravity_1788413654_0
antigravity_1788413654_1
```

而源 JSON 顶层是带邮箱的：

```json
{"access_token":"...","refresh_token":"...","email":"xxx@gmail.com","project_id":"...","expired":"...","type":"antigravity"}
```

## 原因

解析阶段其实读到了 `email`（存进了 `AdminProviderOAuthBatchImportEntry::email`），但回填 `auth_config` 时被 provider 分支挡掉了：

- `apply_admin_provider_oauth_batch_import_hints`（`dispatch/batch/parse.rs`）：`antigravity` 分支只回填 `project_id / client_version / session_id / user_agent` 就 `return`，而 `email` 的回填在后面 `codex | chatgpt_web | grok` 的分支里，走不到。
- `apply_single_import_hints`（`dispatch/import.rs`）：同样的结构、同样的早退。

同时 refresh_token 交换得到的 `auth_config` 完全由 Google token 响应构造，那个响应不带邮箱；`enrich_admin_provider_oauth_auth_config` 里解 `id_token` claims 的逻辑又只对 OpenAI/ChatGPT 系 provider 生效。

于是 `auth_config["email"]` 始终为空，`admin_provider_oauth_key_name_from_auth_config` 落到兜底命名。

## 改动

两个 `antigravity` 分支各补一次 `email` 回填（沿用现有的 `or_insert_with` 语义，不覆盖已有值）。

顺带的正向影响：`auth_config.email` 也是 `find_duplicate_provider_oauth_key` 的匹配字段，补上之后同邮箱重复导入会走「替换」而不是新建重复账号，与 codex / claude_code 的行为一致。

`gemini_cli` 分支有同样的缺口（批量只回填 `project_id / plan_type`，单条导入没有 `gemini_cli` 分支），本 PR 未改动，如果需要可以另开。

## 测试

- 扩展 `applies_antigravity_project_and_user_agent_hints_to_auth_config`，断言 email 被回填
- 新增 `antigravity_batch_import_keeps_json_email_for_key_naming`：模拟「token 响应不带邮箱」的 auth_config，断言回填后账号名为 `antigravity_<邮箱>`
- 扩展 `single_import_applies_antigravity_identity_hints`

`cargo test -p aether-gateway --lib -- oauth::dispatch` 82 项全过，`cargo fmt --check` 干净。

（`tests::ai_execute::*` 下有 5 项在当前 main 上就是红的，与本改动无关。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
