### PR TITLE
fix(antigravity): wrap cross-format requests in the v1internal envelope

### DIFF
--- a/apps/aether-gateway/src/ai_serving/planner/specialized/image/request.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/specialized/image/request.rs
@@ -9,6 +9,7 @@ use crate::ai_serving::planner::candidate_preparation::{
 };
 use crate::ai_serving::planner::spec_metadata::local_openai_image_spec_metadata;
 use crate::ai_serving::pure::normalize_openai_image_request_with_options;
+use crate::ai_serving::transport::antigravity::is_antigravity_provider_transport;
 use crate::ai_serving::transport::{
     build_grok_browser_headers, build_grok_upstream_url, build_openai_image_headers,
     build_openai_image_upstream_url, build_standard_provider_request_headers,
@@ -338,6 +339,25 @@ async fn resolve_local_openai_image_to_gemini_candidate_payload_parts(
     let candidate = &attempt.eligible.candidate;
     let transport = &attempt.eligible.transport;
     let provider_api_format = "gemini:generate_content";
+
+    // The gemini:generate_content URL hook rewrites an Antigravity endpoint to
+    // /v1internal:, and this image path has no v1internal envelope to match it.
+    // Skip the candidate instead of posting a bare Gemini body that upstream
+    // would only reject.
+    if is_antigravity_provider_transport(transport) {
+        mark_skipped_local_openai_image_candidate(
+            state,
+            input,
+            trace_id,
+            candidate,
+            attempt.candidate_index,
+            &attempt.candidate_id,
+            "transport_unsupported",
+        )
+        .await;
+        return None;
+    }
+
     let effective_headers = input.effective_headers(&parts.headers);
 
     let prepared_candidate = match prepare_header_authenticated_candidate(

--- a/apps/aether-gateway/src/ai_serving/planner/standard/family/request.rs
+++ b/apps/aether-gateway/src/ai_serving/planner/standard/family/request.rs
@@ -4,6 +4,10 @@ use std::sync::Arc;
 use aether_contracts::ResolvedTransportProfile;
 use serde_json::Value;
 
+use crate::ai_serving::planner::antigravity::{
+    build_antigravity_v1internal_provider_request, AntigravityV1InternalRequestError,
+    AntigravityV1InternalRequestInput, ANTIGRAVITY_V1INTERNAL_ENVELOPE_NAME,
+};
 use crate::ai_serving::planner::candidate_preparation::{
     prepare_header_authenticated_candidate, prepare_header_authenticated_candidate_from_auth,
     OauthPreparationContext,
@@ -26,6 +30,7 @@ use crate::ai_serving::planner::standard::{
     openai_provider_request_contract_failure_extra_data, openai_responses_reasoning_replay_policy,
     request_body_build_failure_extra_data, request_conversion_failure_extra_data,
 };
+use crate::ai_serving::transport::antigravity::is_antigravity_provider_transport;
 use crate::ai_serving::transport::kiro::{
     build_kiro_provider_headers, build_kiro_provider_request_body,
     is_kiro_claude_messages_transport, KiroProviderHeadersInput, KiroRequestAuth,
@@ -838,6 +843,29 @@ pub(crate) async fn resolve_local_standard_candidate_payload_parts(
     }
 
     if normalized_provider_api_format == "gemini:generate_content"
+        && is_antigravity_provider_transport(transport)
+    {
+        return Ok(build_antigravity_cross_format_payload_parts(
+            state,
+            parts,
+            trace_id,
+            body_json,
+            input,
+            attempt,
+            transport,
+            spec_metadata.api_format,
+            provider_api_format,
+            prepared_candidate.mapped_model,
+            prepared_candidate.auth_header,
+            prepared_candidate.auth_value,
+            provider_request_body,
+            upstream_is_stream,
+            redaction.redacted,
+        )
+        .await);
+    }
+
+    if normalized_provider_api_format == "gemini:generate_content"
         && is_gemini_cli_provider_transport(transport)
     {
         return Ok(build_gemini_cli_cross_format_payload_parts(
@@ -961,6 +989,145 @@ fn apply_transport_request_body_semantics(
         transport,
         provider_api_format,
     )
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn build_antigravity_cross_format_payload_parts(
+    state: &AppState,
+    parts: &http::request::Parts,
+    trace_id: &str,
+    original_body_json: &serde_json::Value,
+    input: &LocalStandardDecisionInput,
+    attempt: &LocalStandardCandidateAttempt,
+    transport: &Arc<GatewayProviderTransportSnapshot>,
+    client_api_format: &str,
+    provider_api_format: &str,
+    mapped_model: String,
+    auth_header: String,
+    auth_value: String,
+    gemini_request_body: Value,
+    upstream_is_stream: bool,
+    request_redacted: bool,
+) -> Option<LocalStandardCandidatePayloadParts> {
+    let candidate = &attempt.eligible.candidate;
+    let effective_headers = input.effective_headers(&parts.headers);
+    let resolved =
+        match build_antigravity_v1internal_provider_request(AntigravityV1InternalRequestInput {
+            state,
+            parts,
+            transport,
+            trace_id,
+            mapped_model: &mapped_model,
+            provider_api_format,
+            auth_header: &auth_header,
+            auth_value: &auth_value,
+            request_headers: effective_headers,
+            original_request_body: original_body_json,
+            gemini_request_body: &gemini_request_body,
+            upstream_is_stream,
+            same_format: false,
+        })
+        .await
+        {
+            Ok(resolved) => resolved,
+            Err(AntigravityV1InternalRequestError::TransportUnsupported) => {
+                mark_skipped_local_standard_candidate(
+                    state,
+                    input,
+                    trace_id,
+                    candidate,
+                    attempt.candidate_index,
+                    &attempt.candidate_id,
+                    "transport_unsupported",
+                )
+                .await;
+                return None;
+            }
+            Err(AntigravityV1InternalRequestError::EnvelopeUnsupported) => {
+                mark_skipped_local_standard_candidate_with_extra_data(
+                    state,
+                    input,
+                    trace_id,
+                    candidate,
+                    attempt.candidate_index,
+                    &attempt.candidate_id,
+                    "provider_request_body_build_failed",
+                    request_body_build_failure_extra_data(
+                        original_body_json,
+                        client_api_format,
+                        provider_api_format,
+                    ),
+                )
+                .await;
+                return None;
+            }
+            Err(AntigravityV1InternalRequestError::UpstreamUrlUnavailable) => {
+                mark_skipped_local_standard_candidate_with_failure_diagnostic(
+                    state,
+                    input,
+                    trace_id,
+                    candidate,
+                    attempt.candidate_index,
+                    &attempt.candidate_id,
+                    "upstream_url_missing",
+                    CandidateFailureDiagnostic::upstream_url_missing(
+                        client_api_format,
+                        provider_api_format,
+                        "standard_family_antigravity_url",
+                    ),
+                )
+                .await;
+                return None;
+            }
+            Err(AntigravityV1InternalRequestError::HeaderRulesApplyFailed) => {
+                mark_skipped_local_standard_candidate_with_failure_diagnostic(
+                    state,
+                    input,
+                    trace_id,
+                    candidate,
+                    attempt.candidate_index,
+                    &attempt.candidate_id,
+                    "transport_header_rules_apply_failed",
+                    CandidateFailureDiagnostic::header_rules_apply_failed(
+                        client_api_format,
+                        provider_api_format,
+                        "standard_family_antigravity_headers",
+                    ),
+                )
+                .await;
+                return None;
+            }
+        };
+
+    let mut provider_request_headers = resolved.headers.headers;
+    apply_codex_openai_special_headers(
+        &mut provider_request_headers,
+        &resolved.body,
+        effective_headers,
+        resolved.transport.provider.provider_type.as_str(),
+        provider_api_format,
+        Some(trace_id),
+        resolved.transport.key.decrypted_auth_config.as_deref(),
+    );
+    request_identity_response_encoding_when_redacted(
+        &mut provider_request_headers,
+        request_redacted,
+    );
+
+    Some(LocalStandardCandidatePayloadParts {
+        auth_header: resolved.headers.auth_header,
+        auth_value: resolved.headers.auth_value,
+        mapped_model,
+        provider_api_format: provider_api_format.to_string(),
+        provider_request_body: resolved.body,
+        provider_request_headers,
+        upstream_url: resolved.upstream_url,
+        upstream_is_stream,
+        envelope_name: Some(ANTIGRAVITY_V1INTERNAL_ENVELOPE_NAME),
+        transport: resolved.transport,
+        transport_profile: None,
+        request_redacted,
+    })
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/apps/aether-gateway/src/tests/architecture/ai_serving.rs
+++ b/apps/aether-gateway/src/tests/architecture/ai_serving.rs
@@ -2893,6 +2893,22 @@ fn ai_serving_standard_attempts_consume_eligible_local_candidates_without_transp
         );
     }
 
+    let standard_family_request = read_workspace_file(
+        "apps/aether-gateway/src/ai_serving/planner/standard/family/request.rs",
+    );
+    for pattern in [
+        "is_antigravity_provider_transport(",
+        "build_antigravity_v1internal_provider_request(",
+        "is_gemini_cli_provider_transport(",
+        "build_gemini_cli_v1internal_provider_request(",
+    ] {
+        assert!(
+            standard_family_request.contains(pattern),
+            "standard family request preparation should build v1internal envelopes through {pattern} \
+             so a cross-format client never posts a bare Gemini body to a v1internal URL"
+        );
+    }
+
     let provider_transport_standard =
         read_workspace_file("crates/aether-provider/transport/src/standard/mod.rs");
     for pattern in [

--- a/crates/aether-provider/transport/src/antigravity/policy.rs
+++ b/crates/aether-provider/transport/src/antigravity/policy.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 use super::super::snapshot::GatewayProviderTransportSnapshot;
+use super::super::transport_proxy_is_locally_supported;
 use super::auth::{
     resolve_local_antigravity_request_auth, AntigravityRequestAuth, AntigravityRequestAuthSupport,
     AntigravityRequestAuthUnsupportedReason, ANTIGRAVITY_PROVIDER_TYPE,
@@ -87,11 +88,11 @@ pub fn classify_local_antigravity_request_support(
             AntigravityRequestSideUnsupportedReason::UnsupportedBodyRules,
         );
     }
-    if transport.provider.proxy.is_some()
-        || transport.endpoint.proxy.is_some()
-        || transport.key.proxy.is_some()
-        || transport.key.fingerprint.is_some()
-    {
+    // A configured proxy is carried by the execution plan itself, so it only
+    // disqualifies the local request when it cannot be resolved into a usable
+    // snapshot. Transport profiles stay unsupported because the v1internal
+    // payload never carries one.
+    if !transport_proxy_is_locally_supported(transport) || transport.key.fingerprint.is_some() {
         return AntigravityRequestSideSupport::Unsupported(
             AntigravityRequestSideUnsupportedReason::UnsupportedNetworkConfig,
         );
@@ -113,4 +114,146 @@ pub fn classify_local_antigravity_request_support(
     }
 
     AntigravityRequestSideSupport::Supported(AntigravityRequestSideSpec { auth, request_type })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::super::request::AntigravityEnvelopeRequestType;
+    use super::{
+        classify_local_antigravity_request_support, AntigravityRequestSideSupport,
+        AntigravityRequestSideUnsupportedReason,
+    };
+    use crate::snapshot::{
+        GatewayProviderTransportEndpoint, GatewayProviderTransportKey,
+        GatewayProviderTransportProvider, GatewayProviderTransportSnapshot,
+    };
+
+    fn sample_transport() -> GatewayProviderTransportSnapshot {
+        GatewayProviderTransportSnapshot {
+            provider: GatewayProviderTransportProvider {
+                id: "provider-1".to_string(),
+                name: "Antigravity".to_string(),
+                provider_type: "antigravity".to_string(),
+                website: None,
+                is_active: true,
+                keep_priority_on_conversion: false,
+                enable_format_conversion: true,
+                concurrent_limit: None,
+                max_retries: None,
+                proxy: None,
+                request_timeout_secs: None,
+                stream_first_byte_timeout_secs: None,
+                config: None,
+            },
+            endpoint: GatewayProviderTransportEndpoint {
+                id: "endpoint-1".to_string(),
+                provider_id: "provider-1".to_string(),
+                api_format: "gemini:generate_content".to_string(),
+                api_family: Some("gemini".to_string()),
+                endpoint_kind: Some("generate_content".to_string()),
+                is_active: true,
+                base_url: "https://daily-cloudcode-pa.googleapis.com".to_string(),
+                header_rules: None,
+                body_rules: None,
+                max_retries: None,
+                custom_path: None,
+                config: None,
+                format_acceptance_config: None,
+                proxy: None,
+            },
+            key: GatewayProviderTransportKey {
+                id: "key-1".to_string(),
+                provider_id: "provider-1".to_string(),
+                name: "key".to_string(),
+                auth_type: "oauth".to_string(),
+                is_active: true,
+                api_formats: Some(vec!["gemini:generate_content".to_string()]),
+                auth_type_by_format: None,
+                allow_auth_channel_mismatch_formats: None,
+                allowed_models: None,
+                capabilities: None,
+                rate_multipliers: None,
+                global_priority_by_format: None,
+                expires_at_unix_secs: None,
+                proxy: None,
+                fingerprint: None,
+                upstream_metadata: None,
+                decrypted_api_key: "__placeholder__".to_string(),
+                decrypted_auth_config: Some(
+                    r#"{"provider_type":"antigravity","refresh_token":"rt","cloudaicompanionProject":"project-1"}"#
+                        .to_string(),
+                ),
+            },
+        }
+    }
+
+    fn classify(transport: &GatewayProviderTransportSnapshot) -> AntigravityRequestSideSupport {
+        classify_local_antigravity_request_support(
+            transport,
+            &json!({"contents": []}),
+            AntigravityEnvelopeRequestType::Agent,
+        )
+    }
+
+    fn assert_unsupported_network_config(support: AntigravityRequestSideSupport) {
+        assert_eq!(
+            support,
+            AntigravityRequestSideSupport::Unsupported(
+                AntigravityRequestSideUnsupportedReason::UnsupportedNetworkConfig,
+            )
+        );
+    }
+
+    #[test]
+    fn a_resolvable_tunnel_node_proxy_keeps_the_envelope_supported() {
+        let mut transport = sample_transport();
+        transport.provider.proxy = Some(json!({
+            "enabled": true,
+            "node_id": "702d158b-a432-4694-94cc-3bec13dbbc20",
+        }));
+
+        assert!(matches!(
+            classify(&transport),
+            AntigravityRequestSideSupport::Supported(_)
+        ));
+    }
+
+    #[test]
+    fn a_resolvable_url_proxy_keeps_the_envelope_supported() {
+        for proxy_owner in ["provider", "endpoint", "key"] {
+            let mut transport = sample_transport();
+            let proxy = Some(json!({"enabled": true, "url": "http://127.0.0.1:17000"}));
+            match proxy_owner {
+                "provider" => transport.provider.proxy = proxy,
+                "endpoint" => transport.endpoint.proxy = proxy,
+                _ => transport.key.proxy = proxy,
+            }
+
+            assert!(
+                matches!(
+                    classify(&transport),
+                    AntigravityRequestSideSupport::Supported(_)
+                ),
+                "a {proxy_owner} proxy should not disqualify the antigravity envelope"
+            );
+        }
+    }
+
+    #[test]
+    fn a_proxy_without_a_route_still_disqualifies_the_envelope() {
+        let mut transport = sample_transport();
+        transport.provider.proxy = Some(json!({"enabled": true}));
+
+        assert_unsupported_network_config(classify(&transport));
+    }
+
+    #[test]
+    fn a_key_fingerprint_still_disqualifies_the_envelope() {
+        let mut transport = sample_transport();
+        transport.key.fingerprint = Some(json!({"transport_profile": "chrome"}));
+
+        assert_unsupported_network_config(classify(&transport));
+    }
 }


### PR DESCRIPTION
## Problem

Every request that reaches an Antigravity provider through the standard family
planner — a Claude Messages or Gemini client, anything that is not OpenAI Chat,
OpenAI Responses, or same-format passthrough — fails upstream with:

```
Invalid JSON payload received. Unknown name "contents": Cannot find field.
Invalid JSON payload received. Unknown name "systemInstruction": Cannot find field.
Invalid JSON payload received. Unknown name "generationConfig": Cannot find field.
Invalid JSON payload received. Unknown name "tools": Cannot find field.
Invalid JSON payload received. Unknown name "toolConfig": Cannot find field.
```

400 is classified as `retryable_upstream_status`, so the request burns four
attempts across every account in the pool before surfacing as a 503
`no_local_stream_plans` — which names none of the actual problem. Observed in
production over 48 consecutive candidates, all `failed`/400, and **zero**
`skipped`: no policy gate was ever consulted.

## Cause

`request_url/mod.rs` rewrites any Antigravity endpoint to `/v1internal:{action}`
gated only on provider type and API format:

```rust
if is_antigravity_provider_transport(transport)
    && normalized_provider_api_format == "gemini:generate_content"
{
    return build_antigravity_v1internal_url(...);
}
```

The matching envelope is built in three places: the same-format passthrough, and
the OpenAI Chat and Responses decision paths. `planner/standard/` mentions
Antigravity nowhere outside `openai/`, so `standard/claude` and `standard/gemini`
delegate to the standard family builder, which reaches
`build_standard_upstream_url`, inherits the rewritten URL, and posts a bare
Gemini body. Right URL, wrong body, guaranteed 400.

`gemini_cli` has the identical shape — it also rewrites to a `/v1internal:` URL
and also needs an envelope — and it *is* wired into the standard family. This is
the branch Antigravity is missing.

## Changes

**Route the standard family through the shared v1internal builder**, mirroring
the existing `gemini_cli` branch and its error mapping, so the URL and the body
come from one decision instead of two.

**Skip Antigravity candidates in the OpenAI-image path.**
`specialized/image/request.rs` hardcodes `provider_api_format =
"gemini:generate_content"`, so the URL hook fires there too, and that path has no
envelope to offer. A `transport_unsupported` skip lets another provider serve the
request rather than sending one upstream can only reject.

**Stop treating a configured proxy as locally unsupported.**
`classify_local_antigravity_request_support` rejected on `proxy.is_some()`. That
premise no longer holds: `ExecutionPlan` carries `plan.proxy`, and the local
executor's only special handling is disabling an h2c fast path when one is set.
The generic gate (`policy.rs`) and the Vertex gate (`vertex/policy.rs`) both
moved to `transport_proxy_is_locally_supported()`; Antigravity kept the older
blanket rejection. Production confirms the capability — the failing candidates
carry `proxy: {url, node_id, node_name}` and did reach Google through the tunnel
node.

A proxy that resolves to no route still disqualifies the request. Transport
profiles stay unsupported, because the v1internal payload sets
`transport_profile: None` and would otherwise drop a configured profile silently.

## Scope

None of the three Antigravity commits since v0.7.13 (`b35364d7f`, `36daba7a3`,
`9837ce119`) touch either gate — all three only adjust tool schemas in
`antigravity/request.rs`.

## Tests

Four unit tests in `antigravity/policy.rs`. Verified as genuine regression tests:
with the old condition restored, the two "a resolvable proxy should stay
supported" cases fail and the two "still rejected" cases pass, so they pin the
behaviour change in both directions.

An architecture assertion pins the standard family to the shared v1internal
builders for both Antigravity and `gemini_cli`, so the next planner that grows a
`/v1internal:` URL cannot quietly ship without its envelope.

## Validation

Rebased onto `77f93c638`.

- `cargo fmt --all --check` — clean
- `cargo clippy -p aether-provider-transport -p aether-gateway --all-targets` —
  zero warnings on the changed files
- `cargo test -p aether-provider-transport` — 453 passed, 0 failed
- `cargo test -p aether-gateway --lib -- antigravity <architecture test>` —
  28 passed, 5 failed

Those 5 failures are all `tests::ai_execute::*` end-to-end tests, and they are
pre-existing on this base. The same filter on an **unmodified `77f93c638`** gives
27 passed / 5 failed — the identical five:

```
tests::ai_execute::finalize_local_provider::gemini::gateway_executes_antigravity_gemini_cli_sync_upstream_stream_via_local_finalize_response
tests::ai_execute::sync::gemini::cli::gateway_executes_antigravity_gemini_cli_sync_via_local_decision_gate_after_oauth_refresh
tests::ai_execute::finalize_local_cli::cross_format::gateway_executes_openai_responses_antigravity_cross_format_upstream_stream_via_local_finalize_response
tests::ai_execute::finalize_local::gateway_executes_openai_chat_antigravity_cross_format_sync_via_local_finalize_response
tests::ai_execute::stream_provider_gemini::local_cli::gateway_executes_antigravity_gemini_cli_stream_via_local_decision_gate_after_oauth_refresh
```

So this branch adds one passing test and introduces no new failures. The e2e
breakage is wider than Antigravity — on an unmodified `77f93c638` the
`lifecycle` e2e tests fail 3/3, `scheduler_affinity` and
`candidate_materialization` tests fail, and a full `cargo test -p aether-gateway
--lib` hangs rather than finishing. It appears to arrive with the
routing-strategy consolidation merge.

On `cae9aa413`, the last base where the suite runs clean, this branch is fully
green: `cargo test -p aether-gateway` 4225 passed / 0 failed.

`--lib` needs `RUST_MIN_STACK=33554432` on macOS; that reproduces on unmodified
upstream and is unrelated to this change.

## Verified in production

Deployed to a live gateway. The 400s became 404 `Requested entity was not found.`
— the protobuf field errors are gone and the response now carries
`x-cloudaicompanion-trace-id`, so CloudCode is accepting and processing the
envelope. The remaining 404 was a stale model name in that deployment's own
provider config, not a gateway problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
