### PR TITLE
fix(ci): route Codex fingerprint through ai_serving facade

### DIFF
--- a/apps/aether-gateway/src/handlers/admin/provider/query/models/mod.rs
+++ b/apps/aether-gateway/src/handlers/admin/provider/query/models/mod.rs
@@ -589,7 +589,7 @@ async fn provider_query_fetch_models_for_key(
         codex_catalog
             .as_ref()
             .map(|catalog| catalog.client_version.as_str())
-            .unwrap_or(aether_ai_formats::CODEX_CLIENT_VERSION)
+            .unwrap_or(crate::ai_serving::CODEX_CLIENT_VERSION)
     });
     let outcome =
         match fetch_models_from_transports_for_management(state.app(), &transports, client_version)


### PR DESCRIPTION
## Summary

Follow-up to merged #801. Fix the gateway architecture test without changing behavior or weakening the test.

The admin model query handler referenced `aether_ai_formats::CODEX_CLIENT_VERSION` directly. Gateway consumers must access format-layer exports through the `crate::ai_serving` facade. Use its existing re-export instead; this remains the same `0.153.3` constant.

## Failure

[Test (Gateway)](https://github.com/fawney19/Aether/actions/runs/33946729675/job/101254069445) failed in `tests::architecture::ai_serving::ai_serving_crate_api_is_confined_to_root_seams`. The downstream `Test` and `check` jobs failed as a consequence.

## Validation

- Reproduced the exact failure locally in WSL before the fix.
- The same architecture test passes after the fix.
- `cargo fmt --all --check` and `git diff --check` pass.
- `cargo nextest run -p aether-gateway --lib --no-fail-fast --test-threads=4` — **4246 passed, 0 skipped** in WSL.
- `cargo nextest run -p aether-gateway --bins --no-fail-fast --test-threads=4` — **67 passed, 0 skipped** in WSL.
- Both nextest runs used `RUST_MIN_STACK=16777216`, matching the CI stack setting. These are local branch results, not a claim that GitHub CI has completed.

One-line production change; no CI configuration changes, test exclusions, database migrations, or production deployment.