### PR TITLE
fix(frontend): show Anti Gravity v1internal endpoint path

### DIFF
--- a/frontend/src/features/providers/components/__tests__/endpoint-default-paths.spec.ts
+++ b/frontend/src/features/providers/components/__tests__/endpoint-default-paths.spec.ts
@@ -69,6 +69,14 @@ describe('endpoint default paths', () => {
       apiFormats,
     })).toBe('/v1internal:{action}')
   })
+  it('uses Anti Gravity v1internal paths for fixed Anti Gravity endpoints', () => {
+    expect(getDefaultEndpointPath({
+      apiFormat: 'gemini:generate_content',
+      providerType: 'antigravity',
+      baseUrl: 'https://daily-cloudcode-pa.googleapis.com',
+      apiFormats,
+    })).toBe('/v1internal:{action}')
+  })
 
   it('keeps Codex Responses root path without duplicating /v1', () => {
     expect(getDefaultEndpointPath({

--- a/frontend/src/features/providers/components/endpoint-default-paths.ts
+++ b/frontend/src/features/providers/components/endpoint-default-paths.ts
@@ -182,6 +182,11 @@ export function getDefaultEndpointPath(params: {
       return '/v1internal:{action}'
     }
   }
+  if (providerType === 'antigravity') {
+    if (normalizedApiFormat === 'gemini:generate_content') {
+      return '/v1internal:{action}'
+    }
+  }
   if (providerType === 'vertex_ai') {
     if (normalizedApiFormat === 'gemini:generate_content') {
       return '/v1/projects/{project_id}/locations/{region}/publishers/google/models/{model}:{action}'


### PR DESCRIPTION
## Summary

- Show `/v1internal:{action}` for Anti Gravity Gemini Generate Content endpoints.
- Keep the existing Gemini CLI behavior unchanged.
- Preserve the generic Gemini path for custom providers.
- Add a regression test for the Anti Gravity provider type.

## Root cause

The frontend endpoint default-path resolver handled `gemini_cli` but not `antigravity`, so Anti Gravity fell back to the generic Gemini path `/models/{model}:{action}` even though the backend uses `/v1internal:{action}`.

## Verification

- `npm run test:run -- src/features/providers/components/__tests__/endpoint-default-paths.spec.ts` (11 passed)
- `npx vite build` (passed)

The regular `npm run build` hook is currently blocked by the repository's `sync:vscodex` script failing to spawn `npm.cmd` with `EINVAL` on this Windows/Node environment; the direct Vite production build passed.